### PR TITLE
fix and improve GitHub cache action

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -20,11 +20,17 @@ runs:
           ~/.cargo
         key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}
     - uses: actions/cache@v4
-      # Cache first-party code dependencies
+      # Cache Rust dependencies
       with:
         path: |
           .cargo
         key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('sources/Cargo.lock') }}
+    - uses: actions/cache@v4
+      # Cache Go dependencies
+      with:
+        path: |
+          .gomodcache
+        key: ${{ hashFiles('.github/workflows/cache.yml') }}-${{ runner.os }}-${{ env.OS_ARCH }}-${{ hashFiles('sources/**/go.sum') }}
     - run: cargo install cargo-make
       shell: bash
     - if: ${{ inputs.perform-cache-cleanup }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,4 +1,4 @@
-# This workflow caches crate dependencies and build artifacts for tools (except 'test-tools' since we don't use them in build workflows).
+# This workflow caches crate dependencies, build tools, and external kits.
 # The cache is only usable by workflows started from pull requests against the develop branch.
 name: CacheDepsAndTools
 on:
@@ -7,6 +7,7 @@ on:
     paths:
       - '.github/**'
       - 'sources/Cargo.lock'
+      - 'sources/**/go.sum'
       - 'Twoliter.toml'
       - 'Twoliter.lock'
       - 'Makefile'
@@ -23,6 +24,13 @@ jobs:
         uses: ./.github/actions/setup-node
         with:
           perform-cache-cleanup: true
-      - run: cargo make install-twoliter
+      # This installs twoliter.
+      - run: make prep
+      # This fetches any external kit dependencies.
+      - run: make fetch
+      # This cleans the existing project local caches.
+      - run: make twoliter purge-cache
+      # This fetches Rust crate and Go module dependencies.
+      - run: make twoliter fetch
       # This cleans the cargo cache in ~/.cargo
       - run: cargo-cache


### PR DESCRIPTION
**Issue number:**
Failure observed after merging the first PR.

**Description of changes:**
The previous cache action failed because `Makefile.toml` was removed from the kit. Switch it to use the Makefile targets instead.

While we're at it, modify the cache action to cache Rust and Go deps, to see if this helps to speed up builds.


**Testing done:**
Ran through the `make` steps locally.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
