### PR TITLE
Makefile: remove version from publish command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@ TOOLS_DIR := $(TOP)tools
 TWOLITER_DIR := $(TOOLS_DIR)/twoliter
 TWOLITER := $(TWOLITER_DIR)/twoliter
 CARGO_HOME := $(TOP).cargo
-VERSION := $(shell awk '/^release-version = /{ print $$3 }' $(TOP)Twoliter.toml)
-GIT_HASH := $(shell git describe --always --dirty --exclude '*' || echo 00000000 )
 
 TWOLITER_VERSION ?= "0.3.0"
 KIT ?= bottlerocket-core-kit
@@ -34,7 +32,7 @@ build: fetch
 	@$(TWOLITER) build kit $(KIT) --arch $(ARCH)
 
 publish: prep
-	@$(TWOLITER) publish kit $(KIT) $(VENDOR) v$(VERSION)-$(GIT_HASH)
+	@$(TWOLITER) publish kit $(KIT) $(VENDOR)
 
 TWOLITER_MAKE = $(TWOLITER) make --cargo-home $(CARGO_HOME) --arch $(ARCH)
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

`twoliter publish` no longer takes the version as an argument and instead gets it from `Twoliter.toml` and gets the build id as generated in `Makefile.toml`

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
