### PR TITLE
avoid concurrent cache workflows

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on:
       group: bottlerocket
       labels: bottlerocket_ubuntu-latest_32-core
+    concurrency:
+      group: cache-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       # Install dependencies for twoliter and cargo-make.


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Try to avoid multiple cache runs in parallel. It's OK if some get interrupted. We can add a merge queue if that ends up happening a lot.


**Testing done:**
😬 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
