### PR TITLE
don't cache debug and nvidia packages

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -34,12 +34,18 @@ jobs:
       # This builds the current packages and kits.
       - run: make ARCH=x86_64
       - run: make ARCH=aarch64
-      # Remove the previous cache.
+      # Delete packages that aren't needed for other builds.
+      - run: |
+          find build/rpms -name '*debugsource*' -type f -print -delete
+          find build/rpms -name '*debuginfo*' -type f -print -delete
+          find build/rpms -name '*kmod*nvidia*' -type f -print -delete
+      # Remove the previous cache (if it exists).
       - run: |
           gh extension install actions/gh-actions-cache
           gh actions-cache delete "${{ env.cache-key }}" --confirm
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
       # This caches the reusable artifacts for future CI runs.
       - uses: actions/cache/save@v4
         # Save Rust dependencies


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
These packages significantly increase the size of the cache, and aren't needed when rebuilding packages.

Also, try to fix another bug that prevents the cache from working, by ignoring errors in that step:
```
Run gh extension install actions/gh-actions-cache
...
Error: Cache with input key 'build-cache' does not exist
Error: Process completed with exit code 1.
```

**Testing done:**
😬 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
