### PR TITLE
Kernel updates: 5.10.219 and 6.1.94

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/b5fd278db7388155390664828137d2628fc514d69cabad6476b60908577f7ed8/kernel-5.10.218-208.862.amzn2.src.rpm"
-sha512 = "3cc192e5862faa0b3ae9f1c80f65984e8bf96a7f19e9322577d4fe3a564d17668971ac480dc4982cb065f1fac1b18ca8bcf4bd2bd9156671f6d9d68aa053b339"
+url = "https://cdn.amazonlinux.com/blobstore/a76ae585dd09b2f986aa20d7b48f6a8557ac9a63265972464dcae464925ec700/kernel-5.10.219-208.866.amzn2.src.rpm"
+sha512 = "7669cab43a35f7b5a7feaf0f4e5349bbe940d7eb2a52c0c5f647e91c645ecb364c81282f17d2be47be60122f470736378fec0935c002cc30a214dd50d6c6ae29"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.218
+Version: 5.10.219
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/b5fd278db7388155390664828137d2628fc514d69cabad6476b60908577f7ed8/kernel-5.10.218-208.862.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/a76ae585dd09b2f986aa20d7b48f6a8557ac9a63265972464dcae464925ec700/kernel-5.10.219-208.866.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/56c452d9992a4b8c25e5ff09f38a1464761196c1462a341e438301b6d56bfe50/kernel-6.1.92-99.174.amzn2023.src.rpm"
-sha512 = "134d231c7c87e9136a6ceb2f125bd7d2163d7b73590d821f0d2192effd1a5f0850c612e0f9e03bcbd92f47014fd99fe6e9e8a1b45c5e01dab6d074faf74b4df4"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/b36ee10673c56c67b1f1a12e9afe3794a81ab7ff630c09abd2295c1d46a36e40/kernel-6.1.94-99.176.amzn2023.src.rpm"
+sha512 = "d487b50ebc11b1492f5dd5e28ce1ee73d9311bc5e3fae7a4278a25096ebff821fc6b167279d9bcd5d8ea59c36f93316b1b48454465209356b7a8597e0750f0ba"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -653,9 +653,12 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/kernel/drivers/net/ethernet/intel/e1000/e1000.ko.*
 %{_cross_kmoddir}/kernel/drivers/net/ethernet/intel/e1000e/e1000e.ko.*
 %{_cross_kmoddir}/kernel/drivers/net/ethernet/intel/igb/igb.ko.*
+%{_cross_kmoddir}/kernel/drivers/net/ethernet/intel/igc/igc.ko.*
 %{_cross_kmoddir}/kernel/drivers/net/ethernet/intel/ixgbevf/ixgbevf.ko.*
 %{_cross_kmoddir}/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.*
 %{_cross_kmoddir}/kernel/drivers/net/ethernet/mellanox/mlxfw/mlxfw.ko.*
+%{_cross_kmoddir}/kernel/drivers/net/ethernet/realtek/r8169.ko.gz
+%{_cross_kmoddir}/kernel/drivers/net/phy/realtek.ko.gz
 %{_cross_kmoddir}/kernel/drivers/net/geneve.ko.*
 %if "%{_cross_arch}" == "x86_64"
 %{_cross_kmoddir}/kernel/drivers/net/hyperv/hv_netvsc.ko.*

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.92
+Version: 6.1.94
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/56c452d9992a4b8c25e5ff09f38a1464761196c1462a341e438301b6d56bfe50/kernel-6.1.92-99.174.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/b36ee10673c56c67b1f1a12e9afe3794a81ab7ff630c09abd2295c1d46a36e40/kernel-6.1.94-99.176.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs


### PR DESCRIPTION
**Description of changes:**

Update kernels to the latest upstream versions:
* 5.10.219-208.866
* 6.1.94-99.176

**Patch changes**

* 5.10 added four patches.
  * arm: speed up memory mapping during boot.
  * arm: also speed up memory mapping, only even more.
  * acpi: Support CONFIG_ACPI without CONFIG_PCI
  * lustre: upstream commit caused build errors in AL 5.10 lustre
* 6.1 added two patches: the arm memory mapping patches described for 5.10

**Configuration changes**
* 6.1 only:
  * CONFIG_IGC=m (build Intel ethernet driver igc)
  * CONFIG_NET_VENDOR_REALTEK=y (build some Realtek network drivers)
  * CONFIG_R8169=m (the Realtek R8169 driver)
  * CONFIG_REALTEK_PHY=m (the Realtek PHY driver)

These have added three driver kernel modules to the build.

**Testing done:**

Manual: built aws-k8s variants with both kernels, created nodes, demonstrated that they would join my eks cluster and run busybox.

Ran sonobuoy quick tests, and both kernels passed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
