### PR TITLE
kubernetes: move dockershim link to relative path

### DIFF
--- a/packages/kubernetes-1.23/dockershim-symlink.conf
+++ b/packages/kubernetes-1.23/dockershim-symlink.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
+ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock

--- a/packages/kubernetes-1.24/dockershim-symlink.conf
+++ b/packages/kubernetes-1.24/dockershim-symlink.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
+ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock

--- a/packages/kubernetes-1.25/dockershim-symlink.conf
+++ b/packages/kubernetes-1.25/dockershim-symlink.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
+ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock

--- a/packages/kubernetes-1.26/dockershim-symlink.conf
+++ b/packages/kubernetes-1.26/dockershim-symlink.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
+ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock

--- a/packages/kubernetes-1.27/dockershim-symlink.conf
+++ b/packages/kubernetes-1.27/dockershim-symlink.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
+ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock

--- a/packages/kubernetes-1.28/dockershim-symlink.conf
+++ b/packages/kubernetes-1.28/dockershim-symlink.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
+ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock

--- a/packages/kubernetes-1.29/dockershim-symlink.conf
+++ b/packages/kubernetes-1.29/dockershim-symlink.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
+ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock

--- a/packages/kubernetes-1.30/dockershim-symlink.conf
+++ b/packages/kubernetes-1.30/dockershim-symlink.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
+ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock


### PR DESCRIPTION

**Issue number:** https://github.com/bottlerocket-os/bottlerocket/issues/4074

Closes # https://github.com/bottlerocket-os/bottlerocket/issues/4074

**Description of changes:**
The link created for dockershim.sock was an absolute path which worked fine until that link is mounted into a container under a different path. This would break use cases where the container needs to follow that link to get to the containerd socket. This commit moves to a relative symlink so that this will work via paths such as /host/run/dockershim.sock.


**Testing done:**
I tested the specific use case of datadog where the agent code was failing to follow the link, before:
```
CORE | ERROR | (pkg/util/containerd/containerd_util.go:109 in NewContainerdUtil) | Containerd init error: temporary failure in containerdutil, will retry later: failed to dial "/host/run/dockershim.sock": context deadline exceeded
```
after this change, the agent doesn't emit this failure.

The link can be followed now from within the container, before:
```
file /host/run/dockershim.sock
/host/run/dockershim.sock: broken symbolic link to /run/containerd/containerd.sock
```
after:
```
# file /host/run/dockershim.sock
/host/run/dockershim.sock: symbolic link to ./containerd/containerd.sock
```

You can still use the file from within the host as well:
```
# First the actual socket
bash-5.1# ctr -a /run/containerd/containerd.sock version
Client:
  Version:  1.7.17+bottlerocket
  Revision: 3a4de459a68952ffb703bbe7f2290861a75b6b67
  Go version: go1.21.11

Server:
  Version:  1.7.17+bottlerocket
  Revision: 3a4de459a68952ffb703bbe7f2290861a75b6b67
  UUID: a7389acf-5e78-4206-94a2-cec58057cfda

# Then the link
bash-5.1# ctr -a /run/dockershim.sock version
Client:
  Version:  1.7.17+bottlerocket
  Revision: 3a4de459a68952ffb703bbe7f2290861a75b6b67
  Go version: go1.21.11

Server:
  Version:  1.7.17+bottlerocket
  Revision: 3a4de459a68952ffb703bbe7f2290861a75b6b67
  UUID: a7389acf-5e78-4206-94a2-cec58057cfda
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
