### PR TITLE
Fix segfault in host-ctr

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -1105,6 +1105,8 @@ func pullImage(ctx context.Context, source string, client *containerd.Client, re
 				Error("failed to read registry config")
 			return nil, err
 		}
+	} else {
+		registryConfig = NewBlankRegistryConfig()
 	}
 
 	// Pull the image
@@ -1225,9 +1227,12 @@ func withDynamicResolver(ctx context.Context, ref string, registryConfig *Regist
 		}
 	// For Amazon ECR Public registries, we should try and fetch credentials before resolving the image reference
 	case strings.HasPrefix(ref, "public.ecr.aws/"):
-		// ... not if the user has specified their own registry credentials for 'public.ecr.aws'; In that case we use the default resolver.
-		if _, found := registryConfig.Credentials["public.ecr.aws"]; found {
-			return defaultResolver
+		// if we have registryConfig, and the user specified credentials for
+		// 'public.ecr.aws', then use defaultResolver.
+		if registryConfig != nil {
+			if _, found := registryConfig.Credentials["public.ecr.aws"]; found {
+				return defaultResolver
+			}
 		}
 
 		// Try to get credentials for authenticated pulls from ECR Public


### PR DESCRIPTION
Bottlerocket invokes the host-ctr executable with an optional "--registry-config" parameter. If this parameter was omitted (for instance, in customer code), host-ctr would segfault. Now it will behave as it would for an empty registry-config file.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #4059

**Description of changes:**

Protect two locations where we tried to dereference the registryConfig pointer. The pointer is nil if host-ctr is invoked
without the optional `--registry-config` parameter.

**Testing done:**

Built an image and demonstrated that the command in issue #4059 could load a container from a public ECR repository without segfaulting.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
