### PR TITLE
enable host containers and in-place updates to be optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,6 @@ dependencies = [
  "glibc",
  "grep",
  "grub",
- "host-ctr",
  "iproute",
  "iptables",
  "kexec-tools",

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -33,8 +33,8 @@ glibc = { path = "../glibc" }
 
 # RPM Requires
 [dependencies]
-# We depend on these packages at runtime, and are expected to be pulled in
-# by way of the `release` package.
+# We depend on these packages at runtime, and they are expected to be built
+# because they are included in the core kit.
 # `host-ctr` for host containers functionality
 # host-ctr = { path = "../host-ctr" }
 # kexec-tools and makedumpfile required for prairiedog functionality

--- a/packages/os/apiserver.service
+++ b/packages/os/apiserver.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Bottlerocket API server
-After=storewolf.service migrator.service
-Requires=storewolf.service migrator.service
+After=storewolf.service
+Requires=storewolf.service
 
 [Service]
 Type=notify

--- a/packages/os/mark-successful-boot.service
+++ b/packages/os/mark-successful-boot.service
@@ -3,7 +3,6 @@ Description=Call signpost to mark the boot as successful after all required targ
 # This unit is in charge of updating the partitions on successful boots. Use other service
 # units instead of adding more `ExecStart*` lines to prevent indirect dependencies on
 # other units not listed in the `RequiredBy` section.
-Requires=migrator.service
 # Block manual interactions with this service, manually running it could leave the system in an
 # unexpected state
 RefuseManualStart=true

--- a/packages/os/migrator.service
+++ b/packages/os/migrator.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Bottlerocket data store migrator
+Before=apiserver.service mark-successful-boot.service storewolf.service
+
 RefuseManualStart=true
 RefuseManualStop=true
 
@@ -16,4 +18,4 @@ StandardOutput=journal+console
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=preconfigured.target apiserver.service mark-successful-boot.service storewolf.service

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -74,15 +74,11 @@ BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}apiclient
 Requires: %{_cross_os}apiserver
 Requires: %{_cross_os}bloodhound
-Requires: %{_cross_os}bootstrap-containers
-Requires: %{_cross_os}bork
 Requires: %{_cross_os}corndog
 Requires: %{_cross_os}certdog
 Requires: %{_cross_os}ghostdog
-Requires: %{_cross_os}host-containers
 Requires: %{_cross_os}logdog
 Requires: %{_cross_os}metricdog
-Requires: %{_cross_os}migration
 Requires: %{_cross_os}prairiedog
 Requires: %{_cross_os}schnauzer
 Requires: %{_cross_os}settings-committer
@@ -92,8 +88,14 @@ Requires: %{_cross_os}storewolf
 Requires: %{_cross_os}sundog
 Requires: %{_cross_os}xfscli
 Requires: %{_cross_os}thar-be-settings
-Requires: %{_cross_os}thar-be-updates
-Requires: %{_cross_os}updog
+
+Requires: (%{_cross_os}bootstrap-containers or %{_cross_os}image-feature(no-host-containers))
+Requires: (%{_cross_os}host-containers or %{_cross_os}image-feature(no-host-containers))
+
+Requires: (%{_cross_os}bork or %{_cross_os}image-feature(no-in-place-updates))
+Requires: (%{_cross_os}migration or %{_cross_os}image-feature(no-in-place-updates))
+Requires: (%{_cross_os}thar-be-updates or %{_cross_os}image-feature(no-in-place-updates))
+Requires: (%{_cross_os}updog or %{_cross_os}image-feature(no-in-place-updates))
 
 Requires: (%{_cross_os}pluto if %{_cross_os}variant-family(aws-k8s))
 Requires: (%{_cross_os}shibaken if %{_cross_os}variant-platform(aws))
@@ -124,6 +126,7 @@ Summary: Updates settings dynamically based on user-specified generators
 
 %package -n %{_cross_os}bork
 Summary: Dynamic setting generator for updog
+Conflicts: %{_cross_os}image-feature(no-in-place-updates)
 %description -n %{_cross_os}bork
 %{summary}.
 
@@ -144,12 +147,14 @@ Summary: Applies changed settings to a Bottlerocket system
 
 %package -n %{_cross_os}thar-be-updates
 Summary: Dispatches Bottlerocket update commands
+Conflicts: %{_cross_os}image-feature(no-in-place-updates)
 %description -n %{_cross_os}thar-be-updates
 %{summary}.
 
 %package -n %{_cross_os}host-containers
 Summary: Manages system- and user-defined host containers
 Requires: %{_cross_os}host-ctr
+Conflicts: %{_cross_os}image-feature(no-host-containers)
 %description -n %{_cross_os}host-containers
 %{summary}.
 
@@ -161,6 +166,7 @@ Requires: %{_cross_os}settings-defaults
 
 %package -n %{_cross_os}migration
 Summary: Tools to migrate version formats
+Conflicts: %{_cross_os}image-feature(no-in-place-updates)
 %description -n %{_cross_os}migration
 
 %package -n %{_cross_os}settings-committer
@@ -181,6 +187,7 @@ Summary: Bottlerocket GPT priority querier/switcher
 
 %package -n %{_cross_os}updog
 Summary: Bottlerocket updater CLI
+Conflicts: %{_cross_os}image-feature(no-in-place-updates)
 %description -n %{_cross_os}updog
 not much what's up with you
 
@@ -241,6 +248,8 @@ Requires: %{_cross_os}binutils
 
 %package -n %{_cross_os}bootstrap-containers
 Summary: Manages bootstrap-containers
+Requires: %{_cross_os}host-ctr
+Conflicts: %{_cross_os}image-feature(no-host-containers)
 %description -n %{_cross_os}bootstrap-containers
 %{summary}.
 
@@ -515,7 +524,6 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %files -n %{_cross_os}apiserver
 %{_cross_bindir}/apiserver
 %{_cross_unitdir}/apiserver.service
-%{_cross_unitdir}/migrator.service
 %{_cross_sysusersdir}/api.conf
 
 %files -n %{_cross_os}apiclient
@@ -560,6 +568,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 
 %files -n %{_cross_os}migration
 %{_cross_bindir}/migrator
+%{_cross_unitdir}/migrator.service
 %{_cross_tmpfilesdir}/migration.conf
 
 %files -n %{_cross_os}settings-committer

--- a/packages/os/storewolf.service
+++ b/packages/os/storewolf.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Datastore creator
-After=migrator.service
-Requires=migrator.service
 # Block manual interactions with this service, since it could leave the system in an
 # unexpected state
 RefuseManualStart=true

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -31,7 +31,6 @@ findutils = { path = "../findutils" }
 glibc = { path = "../glibc" }
 grep = { path = "../grep" }
 grub = { path = "../grub" }
-host-ctr = { path = "../host-ctr" }
 iproute = { path = "../iproute" }
 iptables = { path = "../iptables" }
 kexec-tools = { path = "../../packages/kexec-tools" }

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -115,7 +115,6 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}glibc
 Requires: %{_cross_os}grep
 Requires: %{_cross_os}grub
-Requires: %{_cross_os}host-ctr
 Requires: %{_cross_os}iproute
 Requires: %{_cross_os}iptables
 Requires: %{_cross_os}kexec-tools

--- a/sources/updater/signpost/src/error.rs
+++ b/sources/updater/signpost/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
         source: block_party::Error,
     },
 
+    #[snafu(display("Failed to convert vec to array"))]
+    ConvertVec {},
+
     #[snafu(display("Failed to get disk from partition {}: {}", device.display(), source))]
     DiskFromPartition {
         device: PathBuf,
@@ -42,6 +45,9 @@ pub enum Error {
 
     #[snafu(display("Inactive partition {} is already marked for upgrade", inactive.display()))]
     InactiveAlreadyMarked { inactive: PathBuf },
+
+    #[snafu(display("Inactive partition {} is not available", inactive.display()))]
+    InactiveNotAvailable { inactive: PathBuf },
 
     #[snafu(display("Inactive partition {} has not been marked valid for upgrade", inactive.display()))]
     InactiveNotValid { inactive: PathBuf },

--- a/sources/updater/signpost/src/main.rs
+++ b/sources/updater/signpost/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
         match command {
             Command::Status => println!("{state}"),
             Command::ClearInactive => {
-                state.clear_inactive();
+                state.clear_inactive()?;
                 state.write()?;
             }
             Command::MarkSuccessfulBoot => {
@@ -51,7 +51,7 @@ fn main() {
                 state.write()?;
             }
             Command::MarkInactiveValid => {
-                state.mark_inactive_valid();
+                state.mark_inactive_valid()?;
                 state.write()?;
             }
             Command::UpgradeToInactive => {
@@ -59,7 +59,7 @@ fn main() {
                 state.write()?;
             }
             Command::CancelUpgrade => {
-                state.cancel_upgrade();
+                state.cancel_upgrade()?;
                 state.write()?;
             }
             Command::RollbackToInactive => {

--- a/sources/updater/updog/src/error.rs
+++ b/sources/updater/updog/src/error.rs
@@ -60,6 +60,9 @@ pub(crate) enum Error {
     #[snafu(display("Could not mark inactive partition for boot: {}", source))]
     InactivePartitionUpgrade { source: signpost::Error },
 
+    #[snafu(display("Could not find inactive partition set"))]
+    InactivePartitionMissing {},
+
     #[snafu(display("Failed to decode LZ4-compressed target {}: {}", target, source))]
     Lz4Decode {
         target: String,


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/twoliter/pull/318

**Description of changes:**
The `signpost` half of this change allows it to work correctly if only one partition bank is available, which will be true for variants that set the `in-place-updates = false` feature flag. `signpost` has limited utility in this mode, but it's still required to mark the boot as successful and to set the "has boot ever succeeded" flag to ensure we only try to assign the `BOTTLEROCKET-DATA` partition label once.

The `os` half of this change is to make it so software related to host containers or in-place updates is only installed if those features are enabled (which they will be by default). This can be done in two ways:
* negative - "Require **this** or **not-that**, and **this** conflicts with **not-that**"
* positive - "Require **this** if **that**, and **this** requires **that**"

These are more or less equivalent, but I went with the "negative" form to avoid requiring a lockstep Twoliter upgrade here and in downstream repos. Otherwise packages built with this change would not install correctly on variants built with an older Twoliter, because the new image feature flags wouldn't be set.

**Testing done:**
Built an `aws-dev` variant without in-place upgrades or host-containers enabled. Built an unmodified `aws-k8s-1.30` variant.

For the `aws-dev` variant, I confirmed that the software wasn't installed and that `signpost` worked as expected.
```
bash-5.2# updog
bash: updog: command not found

bash-5.2# host-ctr
bash: host-ctr: command not found

bash-5.2# systemctl status migrator
Unit migrator.service could not be found.

bash-5.2# signpost status
OS disk: /dev/vda
Set A:   boot=/dev/vda3 root=/dev/vda4 hash=/dev/vda5 priority=1 tries_left=0 successful=true
Active:  Set A
Next:    Set A

bash-5.2# signpost mark-successful-boot
<succeeds>

bash-5.2# signpost clear-inactive
Inactive partition /dev/vda is not available

bash-5.2# signpost upgrade-to-inactive
Inactive partition /dev/vda is not available

bash-5.2# signpost cancel-upgrade
Inactive partition /dev/vda is not available

bash-5.2# signpost rollback-to-inactive
Inactive partition /dev/vda is not available

bash-5.2# signpost has-boot-ever-succeeded
true
```

For the `aws-k8s-1.30` variant, I upgraded and downgraded across versions and confirmed that worked as expected.

```
<before upgrade>
# signpost status
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p8 root=/dev/nvme0n1p9 hash=/dev/nvme0n1p10 priority=2 tries_left=1 successful=false
Set B:   boot=/dev/nvme0n1p3 root=/dev/nvme0n1p4 hash=/dev/nvme0n1p5 priority=1 tries_left=0 successful=true
Active:  Set B
Next:    Set A

<after upgrade>
# signpost status
OS disk: /dev/nvme0n1
Set A:   boot=/dev/nvme0n1p3 root=/dev/nvme0n1p4 hash=/dev/nvme0n1p5 priority=2 tries_left=0 successful=true
Set B:   boot=/dev/nvme0n1p8 root=/dev/nvme0n1p9 hash=/dev/nvme0n1p10 priority=1 tries_left=0 successful=true
Active:  Set A
Next:    Set A
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
