### PR TITLE
build a kube proxy binary package

### DIFF
--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -103,6 +103,32 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.23-bin)
 %description -n %{_cross_os}kubelet-1.23-fips-bin
 %{summary}.
 
+%package -n %{_cross_os}kube-proxy-1.23
+Summary: Container cluster node proxy
+Requires: %{_cross_os}kubelet-1.23
+Requires: %{_cross_os}kube-proxy-1.23(binaries)
+
+%description -n %{_cross_os}kube-proxy-1.23
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.23-bin
+Summary: Container cluster node proxy binaries
+Provides: %{_cross_os}kube-proxy-1.23(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.23)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.23-fips-bin)
+
+%description -n %{_cross_os}kube-proxy-1.23-bin
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.23-fips-bin
+Summary: Container cluster node proxy binaries, FIPS edition
+Provides: %{_cross_os}kube-proxy-1.23(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.23)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.23-bin)
+
+%description -n %{_cross_os}kube-proxy-1.23-fips-bin
+%{summary}.
+
 %prep
 %autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
 
@@ -118,18 +144,22 @@ export FORCE_HOST_GO=1
 # Build codegen programs with the host toolchain.
 make generated_files
 
-# Build kubelet with the target toolchain.
+# Build kubelet and kube-proxy with the target toolchain.
 %set_cross_go_flags
 unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
 export GOFLAGS="${GOFLAGS} -tags=dockerless"
 export GOLDFLAGS="${GOLDFLAGS}"
+# don't build kube-proxy statically as we use linkermode=external which requires CGO
+export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 export KUBE_OUTPUT_SUBPATH="_fips_output/local"
 export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 # build the pause container
 cd build/pause/linux/
@@ -152,10 +182,12 @@ install -m 0644 %{S:101} image/manifest.json
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
 fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -228,5 +260,13 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 
 %files -n %{_cross_os}kubelet-1.23-fips-bin
 %{_cross_fips_bindir}/kubelet
+
+%files -n %{_cross_os}kube-proxy-1.23
+
+%files -n %{_cross_os}kube-proxy-1.23-bin
+%{_cross_bindir}/kube-proxy
+
+%files -n %{_cross_os}kube-proxy-1.23-fips-bin
+%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -104,6 +104,32 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.24-bin)
 %description -n %{_cross_os}kubelet-1.24-fips-bin
 %{summary}.
 
+%package -n %{_cross_os}kube-proxy-1.24
+Summary: Container cluster node proxy
+Requires: %{_cross_os}kubelet-1.24
+Requires: %{_cross_os}kube-proxy-1.24(binaries)
+
+%description -n %{_cross_os}kube-proxy-1.24
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.24-bin
+Summary: Container cluster node proxy binaries
+Provides: %{_cross_os}kube-proxy-1.24(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.24)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.24-fips-bin)
+
+%description -n %{_cross_os}kube-proxy-1.24-bin
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.24-fips-bin
+Summary: Container cluster node proxy binaries, FIPS edition
+Provides: %{_cross_os}kube-proxy-1.24(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.24)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.24-bin)
+
+%description -n %{_cross_os}kube-proxy-1.24-fips-bin
+%{summary}.
+
 %prep
 %autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
 
@@ -119,18 +145,22 @@ export FORCE_HOST_GO=1
 # Build codegen programs with the host toolchain.
 make generated_files
 
-# Build kubelet with the target toolchain.
+# Build kubelet and kube-proxy with the target toolchain.
 %set_cross_go_flags
 unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
 export GOFLAGS="${GOFLAGS} -tags=dockerless"
 export GOLDFLAGS="${GOLDFLAGS}"
+# don't build kube-proxy statically as we use linkermode=external which requires CGO
+export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 export KUBE_OUTPUT_SUBPATH="_fips_output/local"
 export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 # build the pause container
 cd build/pause/linux/
@@ -153,10 +183,12 @@ install -m 0644 %{S:101} image/manifest.json
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
 fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -229,5 +261,13 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 
 %files -n %{_cross_os}kubelet-1.24-fips-bin
 %{_cross_fips_bindir}/kubelet
+
+%files -n %{_cross_os}kube-proxy-1.24
+
+%files -n %{_cross_os}kube-proxy-1.24-bin
+%{_cross_bindir}/kube-proxy
+
+%files -n %{_cross_os}kube-proxy-1.24-fips-bin
+%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -104,6 +104,32 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.25-bin)
 %description -n %{_cross_os}kubelet-1.25-fips-bin
 %{summary}.
 
+%package -n %{_cross_os}kube-proxy-1.25
+Summary: Container cluster node proxy
+Requires: %{_cross_os}kubelet-1.25
+Requires: %{_cross_os}kube-proxy-1.25(binaries)
+
+%description -n %{_cross_os}kube-proxy-1.25
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.25-bin
+Summary: Container cluster node proxy binaries
+Provides: %{_cross_os}kube-proxy-1.25(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.25)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.25-fips-bin)
+
+%description -n %{_cross_os}kube-proxy-1.25-bin
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.25-fips-bin
+Summary: Container cluster node proxy binaries, FIPS edition
+Provides: %{_cross_os}kube-proxy-1.25(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.25)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.25-bin)
+
+%description -n %{_cross_os}kube-proxy-1.25-fips-bin
+%{summary}.
+
 %prep
 %autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
 
@@ -119,18 +145,22 @@ export FORCE_HOST_GO=1
 # Build codegen programs with the host toolchain.
 make generated_files
 
-# Build kubelet with the target toolchain.
+# Build kubelet and kube-proxy with the target toolchain.
 %set_cross_go_flags
 unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
 export GOFLAGS="${GOFLAGS} -tags=dockerless"
 export GOLDFLAGS="${GOLDFLAGS}"
+# don't build kube-proxy statically as we use linkermode=external which requires CGO
+export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 export KUBE_OUTPUT_SUBPATH="_fips_output/local"
 export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 # build the pause container
 cd build/pause/linux/
@@ -153,10 +183,12 @@ install -m 0644 %{S:101} image/manifest.json
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
 fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -229,5 +261,13 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 
 %files -n %{_cross_os}kubelet-1.25-fips-bin
 %{_cross_fips_bindir}/kubelet
+
+%files -n %{_cross_os}kube-proxy-1.25
+
+%files -n %{_cross_os}kube-proxy-1.25-bin
+%{_cross_bindir}/kube-proxy
+
+%files -n %{_cross_os}kube-proxy-1.25-fips-bin
+%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -104,6 +104,32 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.26-bin)
 %description -n %{_cross_os}kubelet-1.26-fips-bin
 %{summary}.
 
+%package -n %{_cross_os}kube-proxy-1.26
+Summary: Container cluster node proxy
+Requires: %{_cross_os}kubelet-1.26
+Requires: %{_cross_os}kube-proxy-1.26(binaries)
+
+%description -n %{_cross_os}kube-proxy-1.26
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.26-bin
+Summary: Container cluster node proxy binaries
+Provides: %{_cross_os}kube-proxy-1.26(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.26)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.26-fips-bin)
+
+%description -n %{_cross_os}kube-proxy-1.26-bin
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.26-fips-bin
+Summary: Container cluster node proxy binaries, FIPS edition
+Provides: %{_cross_os}kube-proxy-1.26(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.26)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.26-bin)
+
+%description -n %{_cross_os}kube-proxy-1.26-fips-bin
+%{summary}.
+
 %prep
 %autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
 
@@ -119,18 +145,22 @@ export FORCE_HOST_GO=1
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 
-# Build kubelet with the target toolchain.
+# Build kubelet and kube-proxy with the target toolchain.
 %set_cross_go_flags
 unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
 export GOFLAGS="${GOFLAGS} -tags=dockerless"
 export GOLDFLAGS="${GOLDFLAGS}"
+# don't build kube-proxy statically so we can build a fips version
+export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 export KUBE_OUTPUT_SUBPATH="_fips_output/local"
 export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 # build the pause container
 cd build/pause/linux/
@@ -153,10 +183,12 @@ install -m 0644 %{S:101} image/manifest.json
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
 fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -229,5 +261,13 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 
 %files -n %{_cross_os}kubelet-1.26-fips-bin
 %{_cross_fips_bindir}/kubelet
+
+%files -n %{_cross_os}kube-proxy-1.26
+
+%files -n %{_cross_os}kube-proxy-1.26-bin
+%{_cross_bindir}/kube-proxy
+
+%files -n %{_cross_os}kube-proxy-1.26-fips-bin
+%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -104,6 +104,32 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.27-bin)
 %description -n %{_cross_os}kubelet-1.27-fips-bin
 %{summary}.
 
+%package -n %{_cross_os}kube-proxy-1.27
+Summary: Container cluster node proxy
+Requires: %{_cross_os}kubelet-1.27
+Requires: %{_cross_os}kube-proxy-1.27(binaries)
+
+%description -n %{_cross_os}kube-proxy-1.27
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.27-bin
+Summary: Container cluster node proxy binaries
+Provides: %{_cross_os}kube-proxy-1.27(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.27)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.27-fips-bin)
+
+%description -n %{_cross_os}kube-proxy-1.27-bin
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.27-fips-bin
+Summary: Container cluster node proxy binaries, FIPS edition
+Provides: %{_cross_os}kube-proxy-1.27(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.27)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.27-bin)
+
+%description -n %{_cross_os}kube-proxy-1.27-fips-bin
+%{summary}.
+
 %prep
 %autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
 
@@ -119,18 +145,22 @@ export FORCE_HOST_GO=1
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 
-# Build kubelet with the target toolchain.
+# Build kubelet and kube-proxy with the target toolchain.
 %set_cross_go_flags
 unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
 export GOFLAGS="${GOFLAGS} -tags=dockerless"
 export GOLDFLAGS="${GOLDFLAGS}"
+# don't build kube-proxy statically as we use linkermode=external which requires CGO
+export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 export KUBE_OUTPUT_SUBPATH="_fips_output/local"
 export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 # build the pause container
 cd build/pause/linux/
@@ -153,10 +183,12 @@ install -m 0644 %{S:101} image/manifest.json
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
 fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -229,5 +261,13 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 
 %files -n %{_cross_os}kubelet-1.27-fips-bin
 %{_cross_fips_bindir}/kubelet
+
+%files -n %{_cross_os}kube-proxy-1.27
+
+%files -n %{_cross_os}kube-proxy-1.27-bin
+%{_cross_bindir}/kube-proxy
+
+%files -n %{_cross_os}kube-proxy-1.27-fips-bin
+%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -104,6 +104,32 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.28-bin)
 %description -n %{_cross_os}kubelet-1.28-fips-bin
 %{summary}.
 
+%package -n %{_cross_os}kube-proxy-1.28
+Summary: Container cluster node proxy
+Requires: %{_cross_os}kubelet-1.28
+Requires: %{_cross_os}kube-proxy-1.28(binaries)
+
+%description -n %{_cross_os}kube-proxy-1.28
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.28-bin
+Summary: Container cluster node proxy binaries
+Provides: %{_cross_os}kube-proxy-1.28(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.28)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.28-fips-bin)
+
+%description -n %{_cross_os}kube-proxy-1.28-bin
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.28-fips-bin
+Summary: Container cluster node proxy binaries, FIPS edition
+Provides: %{_cross_os}kube-proxy-1.28(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.28)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.28-bin)
+
+%description -n %{_cross_os}kube-proxy-1.28-fips-bin
+%{summary}.
+
 %prep
 %autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
 
@@ -119,18 +145,22 @@ export FORCE_HOST_GO=1
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 
-# Build kubelet with the target toolchain.
+# Build kubelet and kube-proxy with the target toolchain.
 %set_cross_go_flags
 unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
 export GOFLAGS="${GOFLAGS} -tags=dockerless"
 export GOLDFLAGS="${GOLDFLAGS}"
+# don't build kube-proxy statically as we use linkermode=external which requires CGO
+export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 export KUBE_OUTPUT_SUBPATH="_fips_output/local"
 export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 # build the pause container
 cd build/pause/linux/
@@ -153,10 +183,12 @@ install -m 0644 %{S:101} image/manifest.json
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
 fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -229,5 +261,13 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 
 %files -n %{_cross_os}kubelet-1.28-fips-bin
 %{_cross_fips_bindir}/kubelet
+
+%files -n %{_cross_os}kube-proxy-1.28
+
+%files -n %{_cross_os}kube-proxy-1.28-bin
+%{_cross_bindir}/kube-proxy
+
+%files -n %{_cross_os}kube-proxy-1.28-fips-bin
+%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -104,6 +104,32 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.29-bin)
 %description -n %{_cross_os}kubelet-1.29-fips-bin
 %{summary}.
 
+%package -n %{_cross_os}kube-proxy-1.29
+Summary: Container cluster node proxy
+Requires: %{_cross_os}kubelet-1.29
+Requires: %{_cross_os}kube-proxy-1.29(binaries)
+
+%description -n %{_cross_os}kube-proxy-1.29
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.29-bin
+Summary: Container cluster node proxy binaries
+Provides: %{_cross_os}kube-proxy-1.29(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.29)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.29-fips-bin)
+
+%description -n %{_cross_os}kube-proxy-1.29-bin
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.29-fips-bin
+Summary: Container cluster node proxy binaries, FIPS edition
+Provides: %{_cross_os}kube-proxy-1.29(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.29)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.29-bin)
+
+%description -n %{_cross_os}kube-proxy-1.29-fips-bin
+%{summary}.
+
 %prep
 %autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
 
@@ -119,18 +145,22 @@ export FORCE_HOST_GO=1
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 
-# Build kubelet with the target toolchain.
+# Build kubelet and kube-proxy with the target toolchain.
 %set_cross_go_flags
 unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
 export GOFLAGS="${GOFLAGS} -tags=dockerless"
 export GOLDFLAGS="${GOLDFLAGS}"
+# don't build kube-proxy statically as we use linkermode=external which requires CGO
+export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 export KUBE_OUTPUT_SUBPATH="_fips_output/local"
 export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 # build the pause container
 cd build/pause/linux/
@@ -153,10 +183,12 @@ install -m 0644 %{S:101} image/manifest.json
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
 fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -229,5 +261,13 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 
 %files -n %{_cross_os}kubelet-1.29-fips-bin
 %{_cross_fips_bindir}/kubelet
+
+%files -n %{_cross_os}kube-proxy-1.29
+
+%files -n %{_cross_os}kube-proxy-1.29-bin
+%{_cross_bindir}/kube-proxy
+
+%files -n %{_cross_os}kube-proxy-1.29-fips-bin
+%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -104,6 +104,32 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.30-bin)
 %description -n %{_cross_os}kubelet-1.30-fips-bin
 %{summary}.
 
+%package -n %{_cross_os}kube-proxy-1.30
+Summary: Container cluster node proxy
+Requires: %{_cross_os}kubelet-1.30
+Requires: %{_cross_os}kube-proxy-1.30(binaries)
+
+%description -n %{_cross_os}kube-proxy-1.30
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.30-bin
+Summary: Container cluster node proxy binaries
+Provides: %{_cross_os}kube-proxy-1.30(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.30)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.30-fips-bin)
+
+%description -n %{_cross_os}kube-proxy-1.30-bin
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.30-fips-bin
+Summary: Container cluster node proxy binaries, FIPS edition
+Provides: %{_cross_os}kube-proxy-1.30(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.30)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.30-bin)
+
+%description -n %{_cross_os}kube-proxy-1.30-fips-bin
+%{summary}.
+
 %prep
 %autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
 
@@ -122,18 +148,22 @@ export GO_VERSION="1.22.2"
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 
-# Build kubelet with the target toolchain.
+# Build kubelet and kube-proxy with the target toolchain.
 %set_cross_go_flags
 unset CC
 export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
 export %{kube_cc}
 export GOFLAGS="${GOFLAGS} -tags=dockerless"
 export GOLDFLAGS="${GOLDFLAGS}"
+# don't build kube-proxy statically as we use linkermode=external which requires CGO
+export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 export KUBE_OUTPUT_SUBPATH="_fips_output/local"
 export GOEXPERIMENT="boringcrypto"
 make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
 
 # build the pause container
 cd build/pause/linux/
@@ -156,10 +186,12 @@ install -m 0644 %{S:101} image/manifest.json
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
 fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -232,5 +264,13 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 
 %files -n %{_cross_os}kubelet-1.30-fips-bin
 %{_cross_fips_bindir}/kubelet
+
+%files -n %{_cross_os}kube-proxy-1.30
+
+%files -n %{_cross_os}kube-proxy-1.30-bin
+%{_cross_bindir}/kube-proxy
+
+%files -n %{_cross_os}kube-proxy-1.30-fips-bin
+%{_cross_fips_bindir}/kube-proxy
 
 %changelog


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #16 

**Description of changes:**

Provides a kube-proxy-1.XX package that is built from the same source as kubelet.


**Testing done:**

Built & launched 1.29 and 1.30 AMIs and verified the installation:

```
bash-5.1# /usr/bin/kubelet --version
Kubernetes v1.29.1-eks-61c0bbb

bash-5.1# /usr/bin/kube-proxy --version
Kubernetes v1.29.1-eks-61c0bbb


bash-5.1# /usr/bin/kubelet --version
Kubernetes v1.30.0-eks-fff26e3

bash-5.1# /usr/bin/kube-proxy --version
Kubernetes v1.30.0-eks-fff26e3
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
