### PR TITLE
Add Changelog and update release-version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# v2.1.0 (2024-07-08)
+
+## OS Changes
+* Update kernels: 5.10.219, 5.15.160-104, and 6.1.94 ([#13], [#17])
+* Add kmod-6.1-neuron package in core kit ([#21])
+* Provide SSM agent as a system service ([#22])
+* Enable host containers and in-place updates to be optional ([#23])
+
+## Orchestrator Changes
+
+### Kubernetes
+* Move dockershim link to relative path ([#18])
+
+[#13]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/13
+[#17]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/17
+[#18]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/18
+[#21]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/21
+[#22]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/22
+[#23]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/23

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -1,7 +1,7 @@
 schema-version = 1
-release-version = "2.0.0"
+release-version = "2.1.0"
 kit = []
-digest = "0KJe+4ZRwHqxXnY1ArAm7M+VNzA52czWrv2KpjjxQ9I="
+digest = "YhIe1EIFu4Vg/KBLKKCtX4bg+gfdefpnnVTzeXewBHg="
 
 [sdk]
 name = "bottlerocket-sdk"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "2.0.0"
+release-version = "2.1.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"


### PR DESCRIPTION
**Issue number:** N/A

Closes # N/A

**Description of changes:**

- `CHANGELOG`: Creating this new file with changes for the upcoming v2.1.0 release
- `Twoliter.toml`: Bumping `release-version` from `2.0.0` to `2.1.0` + related update to `Twoliter.lock`


**Testing done:**
`make ARCH=aarch64 && make ARCH=x86_64` succeeds


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
