### PR TITLE
Update kubernetes sources for 1.23, 1.24, 1.25 and 1.26

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -1,7 +1,7 @@
 schema-version = 1
-release-version = "2.1.0"
+release-version = "2.1.1"
 kit = []
-digest = "YhIe1EIFu4Vg/KBLKKCtX4bg+gfdefpnnVTzeXewBHg="
+digest = "8NVY4kTJODINxCvkP7u+ELgFqqyxjuRLCcVacJ6xhgs="
 
 [sdk]
 name = "bottlerocket-sdk"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "2.1.0"
+release-version = "2.1.1"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -14,28 +14,232 @@ path = "../packages.rs"
 package-name = "kubernetes-1.23"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-23/releases/33/artifacts/kubernetes/v1.23.17/kubernetes-src.tar.gz"
-sha512 = "a11b1869c4f201e515b62fd83cf8a984ff83a5238f4447ef62426b933ade0132cdebeb9cd501ddae4b2b6dc6fad4fcea10a94673c36c0b77200602e2789640d5"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.23.17/kubernetes-1.23.17.tar.gz"
+sha512 = "8cbe20601966faf2830dbe66548b95654651e3501c474be5351dbf64dabd1763f75e0afaa99ee31dabd8ea02ba1b16df6ba2a789aaddcad776ca0690637d05ff"
 
 [[package.metadata.build-package.external-files]]
-url = "https://raw.githubusercontent.com/aws/eks-distro/168d252ab1f465d3621a6e9b2251fb72b250c49f/projects/kubernetes/kubernetes/1-23/patches/0026-EKS-PATCH-Cherry-pick-119832-Fix-the-problem-Pod-ter.patch"
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0001-EKS-PATCH-Pass-region-to-sts-client.patch"
+sha512 = "4e4317b6914feb97f9607f14e93e9c3bc355a686425985397fd89ac65e171093f5fc5f1d3096e3651a6fced1e3e6409f5a88620bf1abdfa6a8baad35a4e1cd97"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0002-EKS-PATCH-admission-webhook-exclusion-from-file.patch"
+sha512 = "c22bfec0cf4efd5367485774941b6acaeda1e1d9c8199a50a29fe7d5695a7ba4a253316fd259560f37931085d55d248bdb2751a929653501e7e0c3be6b8d8e67"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0003-EKS-PATCH-Use-GNU-date.patch"
+sha512 = "eef333846dc9d10b15657552f6fed384db4c646995ad4dbbbcce362bb07eded220734f3f33c71b4a8778fb34000cbfa187cf0890c5f8799ea25c201cbc242c24"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0004-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch"
+sha512 = "12c6a8ab29d4f0942c05547669e2f90338ee74b5b7db75c8c79d059dcff6a9829dd69cdb277585e15d4fb37557e1264425cb6462ab46de9b56fba7d9c7ab7970"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0005-EKS-PATCH-extend-sa-token-if-audience-is-apiserver-1.patch"
+sha512 = "6bde6972103805d7f07c925a84aa58ca856ca648354cb8c49efdd94b7827944219f220be0cc60aebac551141cbfde6c99a6113fe930335f43a509f3204ab710b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0006-EKS-PATCH-Parse-ipv6-address-before-comparison-10773.patch"
+sha512 = "71271b20acc47a7bef5cab975eeee29a9be5a054565b7907cf4a64cbc4c95db1e1aff604ea429178cb0684d8612763f2c8750b68dfcadc5ec03d3fe3093d3e3f"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0007-EKS-PATCH-AWS-Include-IPv6-addresses-in-NodeAddresse.patch"
+sha512 = "cacab0ac2ced0646b64ba2fd0444cc62d9f337be58fd1389a6d61dc90a1a2e9ec151b5d40d4842074dbc0f815b669dab1c8ba1a1f98509f11022ae84b45e2316"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0009-EKS-PATCH-Make-kubelet-set-alpha.kubernetes.io-provi.patch"
+sha512 = "14475ad38383962c00b428d0d8f56205c88a8e28c5880d599bde49705fbfa8fd66cbb8a20097d7c684d8b55f33bf6ca8044d4d785c149f75bc2e2f86319c07bb"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0010-EKS-PATCH-Skip-mount-point-checks-when-possible-duri.patch"
+sha512 = "e9a724bc8a89ba4ca35b957552190b224492a74db534d027c73c1fd7b433a794a0cee47511cf642b298d0deec7b41b9b691c97c43d70582fb29c7b12ce814fdd"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0017-EKS-PATCH-Update-aws-sdk-go-to-include-new-regions.patch"
+sha512 = "2ba3eca3eb6cdbf8a95a77f64b9bd51628ecf6358f47865a215d397deb07c170dec265018eddfca8ed6329aa51853094128069c106e0dc4b1c5e3f7f7b676888"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0018-EKS-PATCH-Prevent-watch-requests-on-resources-with-a.patch"
+sha512 = "fb7c266f533e720890e24ffcd7b53b9c8933f8e1f44276a459a6c08578d810c10e91dbf4b3583794eeaf11d80f68248ff5e9453605ced1270e18ca176c5e98e7"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0019-EKS-PATCH-add-Authentication-tracking-request-error-.patch"
+sha512 = "72c8a758dac09be941613e983f439efb3c08a5e797fca6d34e347e6f825d1f5ca1fc6207cbab518e3b0c43350ca631c031397e8f08e3f40e6b59ed5caeb53a2e"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0020-EKS-PATCH-Added-serialization-from-etcd-error-metric.patch"
+sha512 = "66c36a269b0ab95cc8407f010d758faf71694cc7cc78eaf04f2e697da300df60d1d8d52738be99cf01bafb5779df1585972eeaa029315ddfbfdd1a7e2a521583"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0021-EKS-PATCH-Bump-1.23-runc-version-to-1.1.6.patch"
+sha512 = "45365e7365e9242a02ac777ae0eb8cce39545826de71394534c871eb1ddc0ab6c8b712e161b004125aefbb63ccc4e5d8c8e7c810b178178503d46bb1e86cb69b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0022-EKS-PATCH-Handle-eventually-consistent-EC2-PrivateDn.patch"
+sha512 = "83a66b0fbc78f4546cdc69e29fc770330cb7ab2528ff0a7343e3e10e69276a341f6d86a14221d674b4cde28c49f42302d0bad3c6aac3f799ec92bcac29b9d736"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0023-EKS-PATCH-Remove-check-for-CSI-driver-running-on-nod.patch"
+sha512 = "2cf21d20fbc5c3ab205b6616e59737d486d5f2cfd92e919d20272ba836779be3e7aa04b6d4871d560ff71783b583670c24d47e398016e6567a70d6563f66eccd"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0024-EKS-PATCH-Update-managedFields-time-when-value-is-mo.patch"
+sha512 = "59883c37789b6912f04a4d72406093178e71ad303c3e56dc764b3c3c6fadf45ab8499f21822ee1f99910ca9fff1a7150734b45737f5a53207795d96c53b9e901"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0025-EKS-PATCH-Return-error-for-localhost-seccomp-type-wi.patch"
+sha512 = "3f292964195d6483c2d9f62f978b83f3edae25cd73bedd74e579f7fb192390ae34d0b9e9a44b32f8788d5f45680624171a1c10bb3ccf5335089ad40248ab9f89"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0026-EKS-PATCH-Cherry-pick-119832-Fix-the-problem-Pod-ter.patch"
 sha512 = "0406fad037a41750310bcc7e75dceaa65cb6d9ffd8e324541068d25074386ff5fbfdb3e6b4d429704e692a39624377483ecd8ed7fcc16d54ba68d81c97d5d270"
 
 [[package.metadata.build-package.external-files]]
-url = "https://raw.githubusercontent.com/aws/eks-distro/168d252ab1f465d3621a6e9b2251fb72b250c49f/projects/kubernetes/kubernetes/1-23/patches/0027-EKS-PATCH-Prevent-rapid-reset-http2-DOS-on-API-serve.patch"
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0027-EKS-PATCH-Prevent-rapid-reset-http2-DOS-on-API-serve.patch"
 sha512 = "d36a581ec2b4622da52d25e942fc063c7fcccbba08ee3c9d0dd52366ca6cd80300ced9c807ef786544b83e7d1dddcf88e24b478a4a4f32e864e9e8edaea8940d"
 
 [[package.metadata.build-package.external-files]]
-url = "https://raw.githubusercontent.com/aws/eks-distro/168d252ab1f465d3621a6e9b2251fb72b250c49f/projects/kubernetes/kubernetes/1-23/patches/0028-EKS-PATCH-bump-golang.org-x-net-to-v0.17.patch"
-sha512 = "b9a87cc4d8d37af308ef0d65cf270b120da6b75aeeed4011f14a2a62e194b0ef509df687d1f7c75e4656606b7e9d7fff4162d3277d1150e3df27d8fca14c83fe"
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0028-EKS-PATCH-bump-golang.org-x-net-to-v0.17.patch"
+sha512 = "11a7d705a9cfbc06cd18262222c635567aa702311b7db2bdc1ce2697f67e1d07216559f8d7c5f17ad6026ea22eb433fe480048a22e32680469ded93b8bfd2baa"
 
 [[package.metadata.build-package.external-files]]
-url = "https://raw.githubusercontent.com/aws/eks-distro/168d252ab1f465d3621a6e9b2251fb72b250c49f/projects/kubernetes/kubernetes/1-23/patches/0029-EKS-PATCH-Add-ephemeralcontainer-to-imagepolicy-secu.patch"
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0029-EKS-PATCH-Add-ephemeralcontainer-to-imagepolicy-secu.patch"
 sha512 = "3b68bc637648a1fff3f2acdbe370689f09c74b465ac1124d62bb99deefb691eb15f88fae4cf4da66c67fca6888513134b5012e5f48cd58f6632360465d8e38cb"
 
 [[package.metadata.build-package.external-files]]
-url = "https://raw.githubusercontent.com/aws/eks-distro/168d252ab1f465d3621a6e9b2251fb72b250c49f/projects/kubernetes/kubernetes/1-23/patches/0030-EKS-PATCH-go-Bump-images-dependencies-and-versions-t.patch"
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0030-EKS-PATCH-go-Bump-images-dependencies-and-versions-t.patch"
 sha512 = "66bcd6602e974e237c083fafc24e68b88a0010db1e2fe30c1ea41ef3c112d94c639ae87c3f7cc9a0142d823ea44cce2aa71476ca01bf2efc1ad3f00454df627f"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0031-EKS-PATCH-Fix-CVE-2023-5528.patch"
+sha512 = "40f2db8b26be9ba4e946e7695ca886b4f57340cc7455ec2996ac5e4e9c3aed84b4df0aa0b42ee97b2041937c70a725a15cabf85cc46c027247f347a190574e84"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0032-EKS-PATCH-bump-google.golang.org-grpc-to-v1.56.3.patch"
+sha512 = "9ecd474bb02076249c917dbfd70f350a260f765a4268aeace4ef94af1031f7b1580816d794f411922dca6c6f13c0dd6ca38a6254ed06750060e3f912d221a47b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0033-EKS-PATCH-Fix-multiple-CVEs-in-windows-Kubelet.patch"
+sha512 = "e3af8eee63d6041d2f5272617f0f4ee667d60532170a2d570c5f5a991b814033f8a23d7de205ea7bf0b1b757ffabaf9fdc5df2a0914cfbbba6f11e18ebaedbef"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0034-EKS-PATCH-Support-tracking-executing-requests.patch"
+sha512 = "00d2d6f102f41e5499bc57722cc64b41a0b24d135dd9414a26113f06138c36c044bc06f978efc4209515e7266fe26cc65c5d5ac1a6499152fb4936e5ed68c979"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0035-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.23.17.patch"
+sha512 = "56536ac2e8e69b549ae3b32a47a5a012a911a0a86bee8f20cb495684d3d22073923b9d5884b2f440eb897f164d5044a6262c103f6a08745da65bba8cfa6eb335"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0036-EKS-PATCH-kubelet-expose-OOM-metrics.patch"
+sha512 = "acb930741b427e5ed310aae6e7e8ac34bbc86e83a9b8604fdfb7921abe2b4cdb48778d3df0a99ce96155c975aef58342c837e864b300bc6b119beea03b292c13"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0037-EKS-PATCH-GO-UPDATE-Explicitly-call-rand.Seed-method.patch"
+sha512 = "38308652a1d54c0d9e21b1d2a5f544a38fc0e51f11aba280852ea0a500f5c655e24926937d0ce919177a8316110adfc0255fc984160602630d86c1dd26889316"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0038-EKS-PATCH-GO-UPDATE-Fixes-the-issue-114145.patch"
+sha512 = "0b8f9cb2877f7bff1cf974e063b7696cd84ca999f5fa473387dd531a27a3d870f80cf19c2afcd74ff582455c15d788ed91eedc2caeeff768c80298b3d00649e4"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0039-EKS-PATCH-GO-UPDATE-bump-honnef.co-go-tools-to-suppo.patch"
+sha512 = "894b378b2548481f4e1666602bee135aeaabbd1bef9cbc57ebefd83c3e55def63e6f7fac7191873a4c3fb04412c50166e7567a2260bc20116b69fa48e7ba2d32"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0040-EKS-PATCH-GO-UPDATE-Avoid-typechecking-stdlib.patch"
+sha512 = "d1cee2a851afc505bac085818ed99c5be908f9ba282826c70751cf6fded930147be7fb58feb8cf5a674e44e06086529abc0ec33123d236f247aed908355e9431"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0041-EKS-PATCH-GO-UPDATE-hack-tools-Bump-golangci-lint-ve.patch"
+sha512 = "ee2aa319406b5c1991a98f8d5660cb3f89e9b1277e1e76027967b9efdf6f8d7d15013767793826d8897d413cb9b93787cc4155838450757aa6c03480d19626ac"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0042-EKS-PATCH-GO-UPDATE-Fix-linter-warnings.patch"
+sha512 = "703c28a232133c8c318d34d74bd0eeb363f738ca0b177a8c04d017e3e75d9da804e06c6f4f5090f1e13e341371f35c148f7fce5d6eca7914ce40619e8195e82c"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0043-EKS-PATCH-GO-UPDATE-Bump-version-of-vmware-govmomi.patch"
+sha512 = "b586b46fad20104bb5a77d2f9f8a18bbcdd2ebbca1b944c114726120b57d1eaa024bd978d36bd0e6e2f72e4a2810505362203a148a3db67dac2036b1813c69e0"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0044-EKS-PATCH-GO-UPDATE-vsphere-Adapt-to-govmomi-version.patch"
+sha512 = "d260917508a7ba6107de18a3d4a8240c02215d18abc96d29d31059e598b4b81b04d5c152281efb348d006b829dd8614d6c0118d3156fe9c1ca0d8b576c919586"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0045-EKS-PATCH-GO-UPDATE-vclib-Modify-x509.UnknownAuthori.patch"
+sha512 = "23f67db085ed5949349c3ba3470cbefa70ee572a951357be4b606ce777472a95608e320aa8ddc3d18cb3e4b0c652c0aacf30d47bff462bde0ea7e0cfac82ae1e"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0046-EKS-PATCH-GO-UPDATE-Switch-to-assert.ErrorEquals-fro.patch"
+sha512 = "b85a3b0354030cb5af83588700dd21972a545fc8cad918f397a9dd0e5c4d4a9ff2d743e7aa20a7dffe524a330edf73f7db097a68c06255c0511aaf772569a046"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0047-EKS-PATCH-GO-UPDATE-.-bump-govmomi-to-v0.30.6.patch"
+sha512 = "432567987497e293c02bc44f14f61f1b1966c37132c73db65d19b39dd159a6e406b2eedb76b69a295e9a43f344072e249b8799e707d1238d7522e112d5cc970f"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0048-EKS-PATCH-GO-UPDATE-vsphere-adapt-to-govmomi-bump.patch"
+sha512 = "be3248779f21ce43b908a34989c830a0dd87ab7eaad244f7b13e8ab80535065630d2cd5e9fc9231e44ea9c1f195287773684cd56301e3cafcffc4345c391a188"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0049-EKS-PATCH-GO-UPDATE-release-1.23-releng-go-Update-im.patch"
+sha512 = "ee9870c6654dde40662214a150f24ab7ef9f9675bf09f6c76b03a13d32d6a8c4e47a9f3856e73d41bc9c2ce434b276e18694521a41f867027c2880d97fa18d8c"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0050-EKS-PATCH-GO-UPDATE-Defer-builds-to-test-cmd-and-tes.patch"
+sha512 = "dc7a4133eb5886af1637176ab746a753c9b107f8657c89332430a7e742331141cfb39faec30dc42959502866d52854c5a5fbb3328fc8b8547ad79252e9f94567"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0051-EKS-PATCH-GO-UPDATE-Add-gimme.patch"
+sha512 = "c4c2291ce3ece8646745ca06ae7be6f4c773f8ccf2f3e8492f1e4d080c9c8eccc0d02c74f170595c12a53fd3ce0806184be9e0747a08980d01cbfaf3e1be8e47"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0052-EKS-PATCH-GO-UPDATE-Invoke-gimme-from-kube-golang-ve.patch"
+sha512 = "be3f0c6a51cb1eca9694cdb5bc4d2dbb96fb15357355c2bd457e86e36e9db2b3d631385a24bf11dcc2ec237bdbdd61fa4cc7d694fe53c5f4eedadbff58ad5adc"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0053-EKS-PATCH-CVE-2024-24786-Bump-github.com-golang-prot.patch"
+sha512 = "aff218fe4b16672de701c7a0a76889f6fdac065cab7ca1cf2904a79be118214145efd5500ff5ba215de05b79978aa82d6b283cc47602e7a2ea0b46a3ebda5b97"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0054-EKS-PATCH-GO-UPDATE-kubeadm-remove-function-pointer-.patch"
+sha512 = "5bea80b8a06326c9e9476c77c6876562eef4821a2aaa771b0b70550ea1a0b6333875ebf84e578eb8400f9c5771531cfad63cd4615101d34f0e5eecd6888b5b6f"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0055-EKS-PATCH-GO-UPDATE-update-webhook-test-to-go-1.21.patch"
+sha512 = "7ba247d9d514f3428d3e0f92e7f97d33da4e40040f88b01650fbc1bbc33176e34e160eb2b7cd2eb0d127b4051006e687fe14d085cdaf1798b7a515b5141123ff"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0056-EKS-PATCH-GO-UPDATE-Fix-the-git-repo-test-error-caus.patch"
+sha512 = "ce3f479068d05f2af0ca55439ffb1b6e335b188d05cbe5882193d8cdd186d1899212e102314d7a5cf9e7d3953d9004247a7e0259bbb897fce8cba6c77363228b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0057-EKS-PATCH-GO-UPDATE-prep-for-go1.21-use-e-in-go-list.patch"
+sha512 = "3d72c59900a2c7478398568ead6f075c215ff07bb779137267cf1a513bf77b032cb0d2132438fbf6e2ddc560d3db1e9836f404d7d403e4cc32565f2d30bb4321"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0058-EKS-PATCH-GO-UPDATE-Merge-pull-request-122077-from-B.patch"
+sha512 = "c66d654f92b9a2a083412aab3d7630911d27956fda4c2c160f32591247831289949194248de85e4cfb2de2a1094747bcdb9f28541b17e059aa69169836a7466f"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0059-EKS-PATCH-GO-UPDATE-update-to-golangci-lint-v1.54.1-.patch"
+sha512 = "bcbad85b841eddf765752e9eb6d4e63d356a6c2c43691313d0f62ffc5ff1025841c0b757ca81b18b3c991e233c5547de14bf26c4ddeb4f68ec884cd603cd8b28"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0060-EKS-PATCH-GO-UPDATE-feat-use-clock-instead.patch"
+sha512 = "f9a878742c51614a955fd5ee661d6d640f5590396b8117ccef5e8c6dfc54b5c0904dcade8326a01846c346b4c4c3024f007821dc51395687fec60328a9f193c0"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0061-EKS-PATCH-GO-UPDATE-go-Bump-images-dependencies-and-.patch"
+sha512 = "816d4a17f375eafed4a4a9f5b7ad711ee56eb613991e37546832bcb02212e8974876023862004fe53be7fb42dfe883d03cd9c0153950cfa24ddc9349ab4387d6"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0062-EKS-PATCH-CVE-2023-45288-Bump-dependecy-for-1.23.patch"
+sha512 = "775b7861f460e670fa44b71db257e7b895010d5f6380e34e471e4235719551fb9d85260c949807d8e9c4ea2aa68b83a04d0479a02579f892ce70a19d93ebc2bc"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0063-EKS-PATCH-Update-aws-sdk-go-to-include-NCL-region.patch"
+sha512 = "aff32046ed5644ef9c50a491534bbc1be19d5d255adb147a9bf90a142267be631caac23de3b3eb6a899a05e7ee43359dfccbecc3db4c84675e8627fbb5a5b63a"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -29,7 +29,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-23/releases/33/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://github.com/kubernetes/kubernetes/archive/v%{gover}/kubernetes-%{gover}.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config
@@ -59,11 +59,63 @@ Source102: pod-infra-container-image
 Source1000: clarify.toml
 
 # Additional patches on top of last 1.23 point release
-Patch0001: 0026-EKS-PATCH-Cherry-pick-119832-Fix-the-problem-Pod-ter.patch
-Patch0002: 0027-EKS-PATCH-Prevent-rapid-reset-http2-DOS-on-API-serve.patch
-Patch0003: 0028-EKS-PATCH-bump-golang.org-x-net-to-v0.17.patch
-Patch0004: 0029-EKS-PATCH-Add-ephemeralcontainer-to-imagepolicy-secu.patch
-Patch0005: 0030-EKS-PATCH-go-Bump-images-dependencies-and-versions-t.patch
+
+Patch0001: 0001-EKS-PATCH-Pass-region-to-sts-client.patch
+Patch0002: 0002-EKS-PATCH-admission-webhook-exclusion-from-file.patch
+Patch0003: 0003-EKS-PATCH-Use-GNU-date.patch
+Patch0004: 0004-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch
+Patch0005: 0005-EKS-PATCH-extend-sa-token-if-audience-is-apiserver-1.patch
+Patch0006: 0006-EKS-PATCH-Parse-ipv6-address-before-comparison-10773.patch
+Patch0007: 0007-EKS-PATCH-AWS-Include-IPv6-addresses-in-NodeAddresse.patch
+Patch0009: 0009-EKS-PATCH-Make-kubelet-set-alpha.kubernetes.io-provi.patch
+Patch0010: 0010-EKS-PATCH-Skip-mount-point-checks-when-possible-duri.patch
+Patch0017: 0017-EKS-PATCH-Update-aws-sdk-go-to-include-new-regions.patch
+Patch0018: 0018-EKS-PATCH-Prevent-watch-requests-on-resources-with-a.patch
+Patch0019: 0019-EKS-PATCH-add-Authentication-tracking-request-error-.patch
+Patch0020: 0020-EKS-PATCH-Added-serialization-from-etcd-error-metric.patch
+Patch0021: 0021-EKS-PATCH-Bump-1.23-runc-version-to-1.1.6.patch
+Patch0022: 0022-EKS-PATCH-Handle-eventually-consistent-EC2-PrivateDn.patch
+Patch0023: 0023-EKS-PATCH-Remove-check-for-CSI-driver-running-on-nod.patch
+Patch0024: 0024-EKS-PATCH-Update-managedFields-time-when-value-is-mo.patch
+Patch0025: 0025-EKS-PATCH-Return-error-for-localhost-seccomp-type-wi.patch
+Patch0026: 0026-EKS-PATCH-Cherry-pick-119832-Fix-the-problem-Pod-ter.patch
+Patch0027: 0027-EKS-PATCH-Prevent-rapid-reset-http2-DOS-on-API-serve.patch
+Patch0028: 0028-EKS-PATCH-bump-golang.org-x-net-to-v0.17.patch
+Patch0029: 0029-EKS-PATCH-Add-ephemeralcontainer-to-imagepolicy-secu.patch
+Patch0030: 0030-EKS-PATCH-go-Bump-images-dependencies-and-versions-t.patch
+Patch0031: 0031-EKS-PATCH-Fix-CVE-2023-5528.patch
+Patch0032: 0032-EKS-PATCH-bump-google.golang.org-grpc-to-v1.56.3.patch
+Patch0033: 0033-EKS-PATCH-Fix-multiple-CVEs-in-windows-Kubelet.patch
+Patch0034: 0034-EKS-PATCH-Support-tracking-executing-requests.patch
+Patch0035: 0035-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.23.17.patch
+Patch0036: 0036-EKS-PATCH-kubelet-expose-OOM-metrics.patch
+Patch0037: 0037-EKS-PATCH-GO-UPDATE-Explicitly-call-rand.Seed-method.patch
+Patch0038: 0038-EKS-PATCH-GO-UPDATE-Fixes-the-issue-114145.patch
+Patch0039: 0039-EKS-PATCH-GO-UPDATE-bump-honnef.co-go-tools-to-suppo.patch
+Patch0040: 0040-EKS-PATCH-GO-UPDATE-Avoid-typechecking-stdlib.patch
+Patch0041: 0041-EKS-PATCH-GO-UPDATE-hack-tools-Bump-golangci-lint-ve.patch
+Patch0042: 0042-EKS-PATCH-GO-UPDATE-Fix-linter-warnings.patch
+Patch0043: 0043-EKS-PATCH-GO-UPDATE-Bump-version-of-vmware-govmomi.patch
+Patch0044: 0044-EKS-PATCH-GO-UPDATE-vsphere-Adapt-to-govmomi-version.patch
+Patch0045: 0045-EKS-PATCH-GO-UPDATE-vclib-Modify-x509.UnknownAuthori.patch
+Patch0046: 0046-EKS-PATCH-GO-UPDATE-Switch-to-assert.ErrorEquals-fro.patch
+Patch0047: 0047-EKS-PATCH-GO-UPDATE-.-bump-govmomi-to-v0.30.6.patch
+Patch0048: 0048-EKS-PATCH-GO-UPDATE-vsphere-adapt-to-govmomi-bump.patch
+Patch0049: 0049-EKS-PATCH-GO-UPDATE-release-1.23-releng-go-Update-im.patch
+Patch0050: 0050-EKS-PATCH-GO-UPDATE-Defer-builds-to-test-cmd-and-tes.patch
+Patch0051: 0051-EKS-PATCH-GO-UPDATE-Add-gimme.patch
+Patch0052: 0052-EKS-PATCH-GO-UPDATE-Invoke-gimme-from-kube-golang-ve.patch
+Patch0053: 0053-EKS-PATCH-CVE-2024-24786-Bump-github.com-golang-prot.patch
+Patch0054: 0054-EKS-PATCH-GO-UPDATE-kubeadm-remove-function-pointer-.patch
+Patch0055: 0055-EKS-PATCH-GO-UPDATE-update-webhook-test-to-go-1.21.patch
+Patch0056: 0056-EKS-PATCH-GO-UPDATE-Fix-the-git-repo-test-error-caus.patch
+Patch0057: 0057-EKS-PATCH-GO-UPDATE-prep-for-go1.21-use-e-in-go-list.patch
+Patch0058: 0058-EKS-PATCH-GO-UPDATE-Merge-pull-request-122077-from-B.patch
+Patch0059: 0059-EKS-PATCH-GO-UPDATE-update-to-golangci-lint-v1.54.1-.patch
+Patch0060: 0060-EKS-PATCH-GO-UPDATE-feat-use-clock-instead.patch
+Patch0061: 0061-EKS-PATCH-GO-UPDATE-go-Bump-images-dependencies-and-.patch
+Patch0062: 0062-EKS-PATCH-CVE-2023-45288-Bump-dependecy-for-1.23.patch
+Patch0063: 0063-EKS-PATCH-Update-aws-sdk-go-to-include-NCL-region.patch
 
 BuildRequires: git
 BuildRequires: rsync
@@ -104,7 +156,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.23-bin)
 %{summary}.
 
 %prep
-%autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 
 # third_party licenses
 # multiarch/qemu-user-static ignored, we're not using it

--- a/packages/kubernetes-1.24/.gitignore
+++ b/packages/kubernetes-1.24/.gitignore
@@ -1,0 +1,1 @@
+/*-EKS-PATCH-*.patch

--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -14,8 +14,125 @@ path = "../packages.rs"
 package-name = "kubernetes-1.24"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-24/releases/36/artifacts/kubernetes/v1.24.17/kubernetes-src.tar.gz"
-sha512 = "ac71b53a37c2875a2f0ecf816aba3d3bb6da555976496f43f18e3fedfc8c60903b372a11c7f5b1114561e8d8baecb028ed92c34d8adeafe495e5b9dc7d32a4ab"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.24.17/kubernetes-1.24.17.tar.gz"
+sha512 = "d5a1356d5937afcede59a54835456db7883f193ba46711a8c6a87636a7f79995458245cbe5b3b89a6c5f668febaf17ba82a21f80e49e68c86e8b87ffe4138b54"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0001-EKS-PATCH-Pass-region-to-sts-client.patch"
+sha512 = "4e4317b6914feb97f9607f14e93e9c3bc355a686425985397fd89ac65e171093f5fc5f1d3096e3651a6fced1e3e6409f5a88620bf1abdfa6a8baad35a4e1cd97"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0002-EKS-PATCH-admission-webhook-exclusion-from-file.patch"
+sha512 = "5da4e6b3541416f970d34392afc00aa96e516fce671b1be4b0f49c44e40f004e9061bfa861325e32a142bc35b5f4b9c5ad482935e18a5221127005e6231c7730"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0003-EKS-PATCH-Use-GNU-date.patch"
+sha512 = "eef333846dc9d10b15657552f6fed384db4c646995ad4dbbbcce362bb07eded220734f3f33c71b4a8778fb34000cbfa187cf0890c5f8799ea25c201cbc242c24"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0004-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch"
+sha512 = "12c6a8ab29d4f0942c05547669e2f90338ee74b5b7db75c8c79d059dcff6a9829dd69cdb277585e15d4fb37557e1264425cb6462ab46de9b56fba7d9c7ab7970"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0005-EKS-PATCH-AWS-Include-IPv6-addresses-in-NodeAddresse.patch"
+sha512 = "2fbea2f2c7e37b90886a6dd43a89dc309a91b5a64681483f3783aa72774f7beb2ca37c2f450ee2635ce70e8fd1ec9a8fb927bdd57d0777c6e10b0a1b1cab5cc8"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0007-EKS-PATCH-Make-kubelet-set-alpha.kubernetes.io-provi.patch"
+sha512 = "68bb9c66f18dbf724513b1db2b5cfbd865a4a810172b9518c834a72e8525877d0b3466285a64758ac7fbf53ec7e05ece64619a4a1303aefdd558cd6e70df9dca"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0008-EKS-PATCH-Update-aws-sdk-go-for-new-regions.patch"
+sha512 = "6389005009020909ccb19c453ff24e013b5767dccdcbda7886256f314b702d1d6792fa23ceb17a985bc64caabec67bba4f6b43bb5e27a5125cd12be05ab6974c"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0013-EKS-PATCH-Patch-kubelet-Keep-trying-fast-status-upda.patch"
+sha512 = "6221d5ed4edabb70a1a6c843a5091aaf33ae4bc0cd86cc97391c101b99e1f21cdaf9dbfaa0b90a590f4adc101a0d2833ae30ae18b610873efb3f41c96cb3089d"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0014-EKS-PATCH-add-Authentication-tracking-request-error-.patch"
+sha512 = "d092f38d2c35842dc5cf160c45f353867e1b9f3470a7dd0065eb9ffb793a4ab4b9929f9c3f414598bf81c05b5e9629bfbaf79d80fd1f28d965910800e21d324f"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0015-EKS-PATCH-Added-serialization-from-etcd-error-metric.patch"
+sha512 = "98f27b2f9e831ba4f75a6a70d2b4a94b14456f8a99773cbd7a0173075fa4f86e0ed2526c7b928743ca8e8c1bec67cdf6a285e3d68f937b47ec1d76ebc5bae3d4"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0016-EKS-PATCH-Handle-eventually-consistent-EC2-PrivateDn.patch"
+sha512 = "5dfc42da456d6a5e60e730d598f07dc9a61dd27a0d5105ad1dc40170805707f200c50ac7104bb2791c520639976509b4b08305e00f1257978c54c11df22f383e"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0017-EKS-PATCH-Incorporating-feedback-on-119341.patch"
+sha512 = "fe93af403013bc3719b4cf176dde294ccea9502a6b4504426e59d056c7f81c9b05c2f04e302d531d1e010856385657c0dcc51f9718e4c209dc313349f1f0bb86"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0018-EKS-PATCH-Update-managedFields-time-when-value-is-mo.patch"
+sha512 = "59883c37789b6912f04a4d72406093178e71ad303c3e56dc764b3c3c6fadf45ab8499f21822ee1f99910ca9fff1a7150734b45737f5a53207795d96c53b9e901"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0019-EKS-PATCH-Cherry-pick-119832-Fix-the-problem-Pod-ter.patch"
+sha512 = "b42c8804c92adacc6c67cdae6225bb5354211ecaa72aaeec964f95f90096e5b15a01ccdbce6fdc5a55c2782a5d2978266b75f62f02c69e4a4aa007f400e0e330"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0020-EKS-PATCH-Prevent-rapid-reset-http2-DOS-on-API-serve.patch"
+sha512 = "c3b67f16970a7032a75d580b10c8c694e70be80008b8021ad9c9d1645a022ca700ffa9944260aa7367e99bda10d805272f759042f1194ad0b853f6542782eeab"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0021-EKS-PATCH-bump-golang.org-x-net-to-v0.17.patch"
+sha512 = "4f4d53510f24024b9f1eea5556324ec17d3cb9ac24f670fa2af8805527c3081fe000107014f4399d1eb3235c1e65e9784d696fa8d6b006da0129ba18f5c71163"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0022-EKS-PATCH-go-Bump-images-dependencies-and-versions-t.patch"
+sha512 = "8d77d2f5c9808c6b22583c60a965b2d52725e45caee109c8c1ae06b6a0d5870090fc42c697a1de264eba012a3d9d0206ab7b00ab5484b8435e7b4ab2bb2c0665"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0023-EKS-PATCH-Fix-CVE-2023-5528.patch"
+sha512 = "0eab28663c72e03fdcbc087abe2f7f6a2ddbab53765a399d5e6cb8c14ddb8b35bb46a61d5c27929d40848b0893504091e70e53204148243fcadfa442ddf3404f"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0024-EKS-PATCH-bump-google.golang.org-grpc-to-v1.56.3.patch"
+sha512 = "c99169ce1a668628916a1e186d9505178f74e1e51c68b212118c95a9a5d3dff32be8c18c76f1c2854f580cc45a879d125e3bec720ec10e17d198d9ee73db10ca"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0025-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.24.15.patch"
+sha512 = "ef13eb6e65dad30626dec82b1e283447792f2a8acb0a65be63d7c6f238ec53ad6f3d7198598f8d84d2b4c5480ee5e530a1755005391be36324abf6ef319aac71"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0026-EKS-PATCH-Support-tracking-executing-requests.patch"
+sha512 = "3959156d30a72da4aee0cb0328ce41e2cde197a591556f26621d6f58c5b58efa0761cdc43da0c56cc7d1d8026784a55205d15e8c866b7c162ae9152bf32d949f"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0027-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.24.17.patch"
+sha512 = "755f5a8d9e8529005e8b4f5d9bd3f8409574a86d305f20028016f6ca947c9ec60bfeb395364bb5fc3b965c7be5024a439ea8e105f1125b0ec17ce647acb7233b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0028-EKS-PATCH-Update-log-verbosity-for-node-health-and-t.patch"
+sha512 = "2ee87971165a0de30e0ec30febbd0c293095bfa93b6d0e39d0ccdf7ecb51a0e386be4ee776ab4352843f95b86068aaa489a29ba0a0e480f134d2ab26d0ddf75b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0029-EKS-PATCH-CVE-2024-24786-Bump-github.com-golang-prot.patch"
+sha512 = "61202c24aa47ffc860e53b56e2e3cae85fe651e78b7670e2e1ab167bbcb5696a809a5a9b77c3d7e95f1b3f605e718831ab71f863404fd02169207843a3fe088f"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0030-EKS-PATCH-GO-UPDATE-prep-for-go1.21-use-e-in-go-list.patch"
+sha512 = "3d72c59900a2c7478398568ead6f075c215ff07bb779137267cf1a513bf77b032cb0d2132438fbf6e2ddc560d3db1e9836f404d7d403e4cc32565f2d30bb4321"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0031-EKS-PATCH-GO-UPDATE-update-to-golangci-lint-v1.54.1-.patch"
+sha512 = "dd50b81e617cde8089859092a93439e9da603701e4589e7ae8fb214593ad47b04b3f74c57ba64c6ff68adac1b253baef2e51b08bc90a2926e1eeee0d8b47d439"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0032-EKS-PATCH-GO-UPDATE-Merge-pull-request-122077-from-B.patch"
+sha512 = "06aa5ed235a79e9232cf095113be744e323350062b046f9db2b365210c4abf8f8f1857b4d638478ec074f57e38dbebb6537fdffcccc3a4b71691e784e5b7a6ff"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0033-EKS-PATCH-GO-UPDATE-go-Bump-images-dependencies-and-.patch"
+sha512 = "f7a486404dc156145b3114e430f3e2c4f34f1cc51f5c98d2b2364064588b2432fb161de09495c740267d289a91e686488df9e403d3704c3684f4515c91606352"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0034-EKS-PATCH-CVE-2023-45288-Bumps-1.24-dependency-for-C.patch"
+sha512 = "c34ca3f3585137c7ec40be543da2b6f39f6751e89e2cf1bc4f16c5f98d8bcedb1cc8f05a39aabe363745cdfe78c0e4acfc72e9b5b3fc29b22b0b3cb56b9bb30c"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -37,7 +37,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-24/releases/36/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://github.com/kubernetes/kubernetes/archive/v%{gover}/kubernetes-%{gover}.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config
@@ -65,6 +65,36 @@ Source101: pause-manifest.json
 Source102: pod-infra-container-image
 
 Source1000: clarify.toml
+
+Patch0001: 0001-EKS-PATCH-Pass-region-to-sts-client.patch
+Patch0002: 0002-EKS-PATCH-admission-webhook-exclusion-from-file.patch
+Patch0003: 0003-EKS-PATCH-Use-GNU-date.patch
+Patch0004: 0004-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch
+Patch0005: 0005-EKS-PATCH-AWS-Include-IPv6-addresses-in-NodeAddresse.patch
+Patch0007: 0007-EKS-PATCH-Make-kubelet-set-alpha.kubernetes.io-provi.patch
+Patch0008: 0008-EKS-PATCH-Update-aws-sdk-go-for-new-regions.patch
+Patch0013: 0013-EKS-PATCH-Patch-kubelet-Keep-trying-fast-status-upda.patch
+Patch0014: 0014-EKS-PATCH-add-Authentication-tracking-request-error-.patch
+Patch0015: 0015-EKS-PATCH-Added-serialization-from-etcd-error-metric.patch
+Patch0016: 0016-EKS-PATCH-Handle-eventually-consistent-EC2-PrivateDn.patch
+Patch0017: 0017-EKS-PATCH-Incorporating-feedback-on-119341.patch
+Patch0018: 0018-EKS-PATCH-Update-managedFields-time-when-value-is-mo.patch
+Patch0019: 0019-EKS-PATCH-Cherry-pick-119832-Fix-the-problem-Pod-ter.patch
+Patch0020: 0020-EKS-PATCH-Prevent-rapid-reset-http2-DOS-on-API-serve.patch
+Patch0021: 0021-EKS-PATCH-bump-golang.org-x-net-to-v0.17.patch
+Patch0022: 0022-EKS-PATCH-go-Bump-images-dependencies-and-versions-t.patch
+Patch0023: 0023-EKS-PATCH-Fix-CVE-2023-5528.patch
+Patch0024: 0024-EKS-PATCH-bump-google.golang.org-grpc-to-v1.56.3.patch
+Patch0025: 0025-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.24.15.patch
+Patch0026: 0026-EKS-PATCH-Support-tracking-executing-requests.patch
+Patch0027: 0027-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.24.17.patch
+Patch0028: 0028-EKS-PATCH-Update-log-verbosity-for-node-health-and-t.patch
+Patch0029: 0029-EKS-PATCH-CVE-2024-24786-Bump-github.com-golang-prot.patch
+Patch0030: 0030-EKS-PATCH-GO-UPDATE-prep-for-go1.21-use-e-in-go-list.patch
+Patch0031: 0031-EKS-PATCH-GO-UPDATE-update-to-golangci-lint-v1.54.1-.patch
+Patch0032: 0032-EKS-PATCH-GO-UPDATE-Merge-pull-request-122077-from-B.patch
+Patch0033: 0033-EKS-PATCH-GO-UPDATE-go-Bump-images-dependencies-and-.patch
+Patch0034: 0034-EKS-PATCH-CVE-2023-45288-Bumps-1.24-dependency-for-C.patch
 
 BuildRequires: git
 BuildRequires: rsync
@@ -105,7 +135,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.24-bin)
 %{summary}.
 
 %prep
-%autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 
 # third_party licenses
 # multiarch/qemu-user-static ignored, we're not using it

--- a/packages/kubernetes-1.25/.gitignore
+++ b/packages/kubernetes-1.25/.gitignore
@@ -1,0 +1,1 @@
+/*-EKS-PATCH-*.patch

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -14,8 +14,94 @@ path = "../packages.rs"
 package-name = "kubernetes-1.25"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-25/releases/35/artifacts/kubernetes/v1.25.16/kubernetes-src.tar.gz"
-sha512 = "e3672cc93d74f1ffbdbf446b84693fa8e03d989f6c9174adc60b4ea8f53ac0e5bc660d06377f99bc7cc11f40c2c611e8641f6b9c1d6d2c658b1b0ece79909b1b"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.25.16/kubernetes-1.25.16.tar.gz"
+sha512 = "58bafc4ff4c6152e90f68b78255d625716e4b075488dfd48d938cf6b38a5d806defeee9e46f5c0c692b4e36da6309d572e0af498983bad659b6b0c27e63a9885"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0001-EKS-PATCH-Pass-region-to-sts-client.patch"
+sha512 = "4e4317b6914feb97f9607f14e93e9c3bc355a686425985397fd89ac65e171093f5fc5f1d3096e3651a6fced1e3e6409f5a88620bf1abdfa6a8baad35a4e1cd97"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0002-EKS-PATCH-admission-webhook-exclusion-from-file.patch"
+sha512 = "2699953c6fcd80ddab10013dfe22d0d7956bd9e62399a3d7ed11ed5e0a70f3e622366d26c89a922d9d6f7f401c00f8342f376b5555e09c0d769d57ddead9c046"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0003-EKS-PATCH-Use-GNU-date.patch"
+sha512 = "dbf7e716f45aeb3c7e5c642f55101d668dd68f8b5fbd648b4a53c94e38b284eb09259cbcee9daae2d9456cdae234dc9830837f532604a491acaa21e8446878e1"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0004-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch"
+sha512 = "89ca5563f36b55c4c6637949a5771b1431ce00bab86facb72ba051a4e9625cdc06e7a01f50b37a8facd085062af4c690c35eaaad994e4cea38b59a1849417253"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0005-EKS-PATCH-AWS-Include-IPv6-addresses-in-NodeAddresse.patch"
+sha512 = "2fbea2f2c7e37b90886a6dd43a89dc309a91b5a64681483f3783aa72774f7beb2ca37c2f450ee2635ce70e8fd1ec9a8fb927bdd57d0777c6e10b0a1b1cab5cc8"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0007-EKS-PATCH-kubelet-Keep-trying-fast-status-update-at-.patch"
+sha512 = "2b1936d4d960772b4b8ce7b676a4e435fcdc0062f9bd0414580ad4d1193da2d2ab9db50dcf6246502a978709dd915bd997237ad26abdfd3842522907a705216e"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0008-EKS-PATCH-add-Authentication-tracking-request-error-.patch"
+sha512 = "f98974e3a8ac955136f72901cae0ce43bc5215e8b26e37697db3342738eb13732825300888cce84e65de00e61b63fe874474ee1b75f89e0ea2802c0ff049fea4"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0009-EKS-PATCH-Added-serialization-from-etcd-error-metric.patch"
+sha512 = "d7a9e69605bab7d10cfbe1821dd85e186eaaaed728954fc450dc0d070c0a2d3596ffcec51f3b055dcc915013d005b38ff03fe65fe6bfd119478096651419fc34"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0010-EKS-PATCH-Handle-eventually-consistent-EC2-PrivateDn.patch"
+sha512 = "94e70c49ba971bcf9f3ab5955e57e388277714813e791b38954e4225a5d7b704ef3550ba5ff6d2774e5a72de4855bd5e2e671e85a898ed02386a4886f63987a1"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0011-EKS-PATCH-Fix-controllers-scheduling-and-logging-bug.patch"
+sha512 = "194e3b926994bbd924867978eccdc1e17d92ec73610042f909523f29e71c12ead860373cf9a8a8a223527b3137034cf64f3101d22b979c70587b2ecbc5b6ff13"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0012-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.25.11.patch"
+sha512 = "e3eb50a95032001b14ec7c5ce2eecddfa8a3ee1dcc334e9ddde66c0c415e9ae8bc2df76c564b50fe581b0bb218b5b042393d76c5e86f5f906e36273b08c4db71"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0013-EKS-PATCH-Support-tracking-executing-requests.patch"
+sha512 = "391fb3e18d58f2a7051fd2a7cae3037b736188f25e99a2b5f60512d6509d3d05905f605d565055cbb194d24c270b97882df48365e6fe5ddd1c5ff33bd15dffbd"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0014-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.25.14.patch"
+sha512 = "892b8adc55676ca931507e9c3236daaa1c7e09cfbba542f490b1edab09db9ce6ce94455421a99b34bf93fa5d73f9c3293de6dd0779b296bf1f1bdb5fe172c34b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0015-EKS-PATCH-bump-google.golang.org-grpc-to-v1.56.3.patch"
+sha512 = "b3805e8b25484483d7c2cc776c46c8388b26733548a9637433c770769f44a7a258ac23616088ecafca8e2e11cf44c7c760ea07d2c57b9ff1e473c0c1d3af5095"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0016-EKS-PATCH-kms-fix-go-routine-leak-in-gRPC-connection.patch"
+sha512 = "8e876c263dfaacaf3f5e293bf4a709c4a329391282505e2e2d2db34fcd04431420054b9a5b5531edcd897d1ed453318e97de07d50f3ae207e29916455146b656"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0017-EKS-PATCH-Update-log-verbosity-for-node-health-and-t.patch"
+sha512 = "2ee87971165a0de30e0ec30febbd0c293095bfa93b6d0e39d0ccdf7ecb51a0e386be4ee776ab4352843f95b86068aaa489a29ba0a0e480f134d2ab26d0ddf75b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0018-EKS-PATCH-CVE-2024-24786-Bump-github.com-golang-prot.patch"
+sha512 = "b3a00a8339a0115188ac056d12f45f8c5fb93e659d7a4276c06dc60e4a347aa9d64146908280a25e4de6b0bbb7dd1e7afb9adbabb5e19a95095695f356da8286"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0019-EKS-PATCH-GO-UPDATE-handle-GOTOOLCHAIN-in-kube-golan.patch"
+sha512 = "8fd6c7d28b2a2c95f7e388f35c20ea22fa4d225e8c7f247e669fb6ca2e776001dc237ea20e5609a63af707f1cb3e3b6d0e88ff14503d49e49cbfa88c7f7e059b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0020-EKS-PATCH-GO-UPDATE-Bump-images-dependencies-and-ver.patch"
+sha512 = "fe816af80574b5858bf85885870a0ac5a206cd3aff16cf47ed8145063e593b49a33c5c1acf1f5f0ff65a139f469cb2465be2e5d43767f44923509217acb15c7a"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0021-EKS-PATCH-Bumps-dependencies-for-fixing-CVE-2023-452.patch"
+sha512 = "ceb1a7844e4e2ed5fa3a838949086ebf86114bba8007a3125ea4ebd6aba7e790eb19b1e8cdd9f767aad1ffa4333ceee7156aa1cddf8ceaa4114a3e90e3d052dc"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0022-EKS-PATCH-Update-aws-sdk-go-to-include-new-regions.patch"
+sha512 = "e226f5a70aeafa25ff010c607b1e7913b562f37674062a0aadbe77fd62532dd5bab10c3bfc38af455a00232da0548f82cd77a86d124b17149d5f9e4bcc96fa30"
+
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -37,7 +37,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-25/releases/35/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://github.com/kubernetes/kubernetes/archive/v%{gover}/kubernetes-%{gover}.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config
@@ -65,6 +65,28 @@ Source101: pause-manifest.json
 Source102: pod-infra-container-image
 
 Source1000: clarify.toml
+
+Patch0001: 0001-EKS-PATCH-Pass-region-to-sts-client.patch
+Patch0002: 0002-EKS-PATCH-admission-webhook-exclusion-from-file.patch
+Patch0003: 0003-EKS-PATCH-Use-GNU-date.patch
+Patch0004: 0004-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch
+Patch0005: 0005-EKS-PATCH-AWS-Include-IPv6-addresses-in-NodeAddresse.patch
+Patch0007: 0007-EKS-PATCH-kubelet-Keep-trying-fast-status-update-at-.patch
+Patch0008: 0008-EKS-PATCH-add-Authentication-tracking-request-error-.patch
+Patch0009: 0009-EKS-PATCH-Added-serialization-from-etcd-error-metric.patch
+Patch0010: 0010-EKS-PATCH-Handle-eventually-consistent-EC2-PrivateDn.patch
+Patch0011: 0011-EKS-PATCH-Fix-controllers-scheduling-and-logging-bug.patch
+Patch0012: 0012-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.25.11.patch
+Patch0013: 0013-EKS-PATCH-Support-tracking-executing-requests.patch
+Patch0014: 0014-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.25.14.patch
+Patch0015: 0015-EKS-PATCH-bump-google.golang.org-grpc-to-v1.56.3.patch
+Patch0016: 0016-EKS-PATCH-kms-fix-go-routine-leak-in-gRPC-connection.patch
+Patch0017: 0017-EKS-PATCH-Update-log-verbosity-for-node-health-and-t.patch
+Patch0018: 0018-EKS-PATCH-CVE-2024-24786-Bump-github.com-golang-prot.patch
+Patch0019: 0019-EKS-PATCH-GO-UPDATE-handle-GOTOOLCHAIN-in-kube-golan.patch
+Patch0020: 0020-EKS-PATCH-GO-UPDATE-Bump-images-dependencies-and-ver.patch
+Patch0021: 0021-EKS-PATCH-Bumps-dependencies-for-fixing-CVE-2023-452.patch
+Patch0022: 0022-EKS-PATCH-Update-aws-sdk-go-to-include-new-regions.patch
 
 BuildRequires: git
 BuildRequires: rsync
@@ -105,7 +127,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.25-bin)
 %{summary}.
 
 %prep
-%autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 
 # third_party licenses
 # multiarch/qemu-user-static ignored, we're not using it

--- a/packages/kubernetes-1.26/.gitignore
+++ b/packages/kubernetes-1.26/.gitignore
@@ -1,0 +1,1 @@
+/*-EKS-PATCH-*.patch

--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -14,8 +14,53 @@ path = "../packages.rs"
 package-name = "kubernetes-1.26"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-26/releases/31/artifacts/kubernetes/v1.26.14/kubernetes-src.tar.gz"
-sha512 = "6e4df683493b055e0445be2389f7c31b48da5a26f82f833df9ab9d0ae17e769cda65d58e0af2bbd4472a30b6f8ec4bd144af00b35a8ecd2b7afd9c62c2fcc7dc"
+url = "https://github.com/kubernetes/kubernetes/archive/v1.26.15/kubernetes-1.26.15.tar.gz"
+sha512 = "0212885b7ab842e487de538f490b9050739dabedbf6f19bd365478144af2de665d98a3948e69b63a87826ba66bc3d1cc25031837af6da0c82513587d0dce823a"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0001-EKS-PATCH-admission-webhook-exclusion-from-file.patch"
+sha512 = "bbea4d4dc2080192f191913787981d143b0fa085a3088fa7b2c5fbfb592fe333c368c36cf49bc57ef7d745783e5ca55ce1126ada468d58b3556634fdc8f49f1a"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0002-EKS-PATCH-AWS-Include-IPv6-addresses-in-NodeAddresse.patch"
+sha512 = "2fbea2f2c7e37b90886a6dd43a89dc309a91b5a64681483f3783aa72774f7beb2ca37c2f450ee2635ce70e8fd1ec9a8fb927bdd57d0777c6e10b0a1b1cab5cc8"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0004-EKS-PATCH-Add-ConcurrentNodeSyncs-option-to-node-con.patch"
+sha512 = "5d4014ba85cdf866796ee27fe987ba616a763db278cc0024cc2e42b32dbb203372f254d1a1564ef4aced552bbb1ca102c476791a0228b4329b7d06d2b69ad507"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0005-EKS-PATCH-Added-serialization-from-etcd-error-metric.patch"
+sha512 = "fe1f9484c8a20aa560251a718e9b2306ac51d2742f5feaf5b8e3011743fe4829f7679dbc1a813dd5fabccef64e346ebd81c322ca7c4dd368c383890c3b258ad9"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0006-EKS-PATCH-add-Authentication-tracking-request-error-.patch"
+sha512 = "f98974e3a8ac955136f72901cae0ce43bc5215e8b26e37697db3342738eb13732825300888cce84e65de00e61b63fe874474ee1b75f89e0ea2802c0ff049fea4"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0008-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.26.6.patch"
+sha512 = "3ab718d86ee0f33b76b9040acc63a6c45efa2f5f425291e087a5a514fa35c4c58e967976e326b915f72e7a9cfb68089d8e310add79222129ea647a090ce09e45"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0009-EKS-PATCH-Support-tracking-executing-requests.patch"
+sha512 = "eb22f01087c8c2b41952b3faad7052483d910f2719778073b553b2d701b2f988e34265abf32ad59fabd898d48158381d2d20e70629af495b810e4871f964adbf"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0010-EKS-PATCH-Update-log-verbosity-for-node-health-and-t.patch"
+sha512 = "6e7ffb413f4ccec69c8f971b6c9922dd3566bc86401628d7c6590e1791da9f85193df15b3f1db9a080da547581119b7212ce8c440d10ec9cfe90cb86ecdad5d2"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0011-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch"
+sha512 = "f04a1394e74afe4fa20017d4b35f23d63abc303a9888da043966aa69f4b3d0080a5a71ef421a5e6cb87a6b499caf19d0a92b1fc2db62643ba1b17f270a400b7e"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0012-EKS-PATCH-Bumps-dependency-for-CVE-2023-45288.patch"
+sha512 = "9328a84b0dbd3948f2a1ff87c4c2afe11d07f29f376cb845a115ba844e9f92a20438e6477fe31c1aeb64ea80b232de3569e9fd833ac05d1baf27600c473388a2"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0013-EKS-PATCH-Update-aws-sdk-go-for-new-regions.patch"
+sha512 = "edb501bdc01863a7abe28a19369230ef94841630866644c3abdf42041d3876023ae359fea679133d403c517f6b43c9b0c24c5b59a28d9b6508c6f2d87a99f37f"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.26.14
+%global gover 1.26.15
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -37,7 +37,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-26/releases/31/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://github.com/kubernetes/kubernetes/archive/v%{gover}/kubernetes-%{gover}.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config
@@ -65,6 +65,18 @@ Source101: pause-manifest.json
 Source102: pod-infra-container-image
 
 Source1000: clarify.toml
+
+Patch0001: 0001-EKS-PATCH-admission-webhook-exclusion-from-file.patch
+Patch0002: 0002-EKS-PATCH-AWS-Include-IPv6-addresses-in-NodeAddresse.patch
+Patch0004: 0004-EKS-PATCH-Add-ConcurrentNodeSyncs-option-to-node-con.patch
+Patch0005: 0005-EKS-PATCH-Added-serialization-from-etcd-error-metric.patch
+Patch0006: 0006-EKS-PATCH-add-Authentication-tracking-request-error-.patch
+Patch0008: 0008-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.26.6.patch
+Patch0009: 0009-EKS-PATCH-Support-tracking-executing-requests.patch
+Patch0010: 0010-EKS-PATCH-Update-log-verbosity-for-node-health-and-t.patch
+Patch0011: 0011-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch
+Patch0012: 0012-EKS-PATCH-Bumps-dependency-for-CVE-2023-45288.patch
+Patch0013: 0013-EKS-PATCH-Update-aws-sdk-go-for-new-regions.patch
 
 BuildRequires: git
 BuildRequires: rsync
@@ -105,7 +117,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.26-bin)
 %{summary}.
 
 %prep
-%autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 
 # third_party licenses
 # multiarch/qemu-user-static ignored, we're not using it


### PR DESCRIPTION
**Issue number:**

N / A

**Description of changes:**

This updates the kubernetes sources of the versions that reached their EOL in upstream kubernetes but are in extended support in EKS Distro.

As part of this change, we migrated back to upstream kubernetes for 1.23, 1.24, 1.25 and 1.26 and applied all the patches provided by EKS Distro. With the previous sources, the patches failed to be applied. 


**Testing done:**

Launched 4 nodes, one of each kubernetes version. All joined the cluster and pods are running. I confirmed the versions reported match the new versions

```
kubernetes-updates on Fedora ❯ k get nodes
NAME                                           STATUS   ROLES    AGE   VERSION
ip-xxxx.us-west-2.compute.internal             Ready    <none>   15m   v1.23.17
ip-xxxx.us-west-2.compute.internal             Ready    <none>   15m   v1.24.17
ip-xxxx.us-west-2.compute.internal             Ready    <none>   15m   v1.25.16
ip-xxxx.us-west-2.compute.internal             Ready    <none>   15m   v1.26.15
kubernetes-updates on Fedora ❯ k get pods
NAME           READY   STATUS    RESTARTS   AGE
fedora-8tx8k   1/1     Running   0          24s
fedora-bggg4   1/1     Running   0          24s
fedora-p29c7   1/1     Running   0          24s
fedora-xggnk   1/1     Running   0          24s
kubernetes-updates on Fedora ❯
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
