### PR TITLE
Update kernels

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/a76ae585dd09b2f986aa20d7b48f6a8557ac9a63265972464dcae464925ec700/kernel-5.10.219-208.866.amzn2.src.rpm"
-sha512 = "7669cab43a35f7b5a7feaf0f4e5349bbe940d7eb2a52c0c5f647e91c645ecb364c81282f17d2be47be60122f470736378fec0935c002cc30a214dd50d6c6ae29"
+url = "https://cdn.amazonlinux.com/blobstore/36b61b64a5b940e6dbe9bd7c0e63ff2a61e24901d776de27a233d38b5f52ae94/kernel-5.10.220-209.867.amzn2.src.rpm"
+sha512 = "939bc3fae149dbd22fa7b0a177c44add6b94c4b90feac2e3b4da73dba78685edf74ed705478c6e832ed1e98f186396385bbd5c1a28eef1b5b77fdc38d48a85c3"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.219
+Version: 5.10.220
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/a76ae585dd09b2f986aa20d7b48f6a8557ac9a63265972464dcae464925ec700/kernel-5.10.219-208.866.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/36b61b64a5b940e6dbe9bd7c0e63ff2a61e24901d776de27a233d38b5f52ae94/kernel-5.10.220-209.867.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/30d3a0d3adde03b0edcad16b16c89e9b3086b4d5594eb3f57e50b0d42ade76d5/kernel-5.15.160-104.158.amzn2.src.rpm"
-sha512 = "368682b26dc17636f760c3ec6f53745bd774b6a482469cd5dcfebb9f7d5418695d344ba5f9b2e3e8189987eeb901c93ac9c0885d21c6d85fb11e6beb0dfcce5f"
+url = "https://cdn.amazonlinux.com/blobstore/c86decdb8cfd1f1fe51e6d17c0dcc935d44b48480db4ea182f922934f7d0d34e/kernel-5.15.161-106.159.amzn2.src.rpm"
+sha512 = "6d7b9b5f2cb9fe8371b65772c732ab9deead6719194d849b1888c0c47f2c9b134543ee63c36333fd35c8bd2353c9865365c3c48e0b90c939a16725312d88e1f8"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.160
+Version: 5.15.161
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/30d3a0d3adde03b0edcad16b16c89e9b3086b4d5594eb3f57e50b0d42ade76d5/kernel-5.15.160-104.158.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/c86decdb8cfd1f1fe51e6d17c0dcc935d44b48480db4ea182f922934f7d0d34e/kernel-5.15.161-106.159.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/b36ee10673c56c67b1f1a12e9afe3794a81ab7ff630c09abd2295c1d46a36e40/kernel-6.1.94-99.176.amzn2023.src.rpm"
-sha512 = "d487b50ebc11b1492f5dd5e28ce1ee73d9311bc5e3fae7a4278a25096ebff821fc6b167279d9bcd5d8ea59c36f93316b1b48454465209356b7a8597e0750f0ba"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/704482a5b82230d7012a6bd9b15689a3c8c05ab85493984fbe6c4bbbb0d38e21/kernel-6.1.96-102.177.amzn2023.src.rpm"
+sha512 = "4a0c5223a4d8ee9e47440fbeb0a5b65e115421b1ed980fa603dcbd7909c74b01948a1dc853c30cc8f37ed51fe8980165b4cf69820c375a61f2e1269559514f7b"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.94
+Version: 6.1.96
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/b36ee10673c56c67b1f1a12e9afe3794a81ab7ff630c09abd2295c1d46a36e40/kernel-6.1.94-99.176.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/704482a5b82230d7012a6bd9b15689a3c8c05ab85493984fbe6c4bbbb0d38e21/kernel-6.1.96-102.177.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs
@@ -709,8 +709,6 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %endif
 %{_cross_kmoddir}/kernel/drivers/pps/clients/pps-gpio.ko.*
 %{_cross_kmoddir}/kernel/drivers/pps/clients/pps-ldisc.ko.*
-%{_cross_kmoddir}/kernel/drivers/pps/pps_core.ko.*
-%{_cross_kmoddir}/kernel/drivers/ptp/ptp.ko.*
 %{_cross_kmoddir}/kernel/drivers/ptp/ptp_kvm.ko.*
 %{_cross_kmoddir}/kernel/drivers/scsi/ch.ko.*
 %if "%{_cross_arch}" == "x86_64"


### PR DESCRIPTION
**Issue number:**

N / A

**Description of changes:**
Update kernels to the latest upstream versions:

- 5.10.220
- 5.15.161
- 6.1.96

**Patch changes**

- 5.10 changed one patch:
    - 0085-NFS-Clean-up-nfs_readdir_page_filler.patch
- 5.10 added one patch:
    - 0866-nfs-Leave-pages-in-the-pagecache-if-readpage-failed.patch
- 5.15 changed seven patches:
    - 0103-mptcp-add-new-mptcp_fill_diag-helper.patch
    - 0104-mptcp-add-MPTCP_INFO-getsockopt.patch
    - 0111-mptcp-Support-for-IP_TOS-for-MPTCP-setsockopt.patch
    - 0112-mptcp-sockopt-add-SOL_IP-freebind-transparent-option.patch
    - 0114-mptcp-add-TCP_INQ-cmsg-support.patch
    - 0118-mptcp-getsockopt-add-support-for-IP_TOS.patch
    - 0122-mptcp-support-TCP_CORK-and-TCP_NODELAY.patch
- 5.15 added one patch:
    - 0158-nfs-Leave-pages-in-the-pagecache-if-readpage-failed.patch
 - 6.1 added one patch:
     - 0176-cifs-use-origin-fullpath-for-automounts.patch

**Configuration Changes**

Summary:
```
config-aarch64-5.10-diff:	  0 removed,   0 added,   0 changed
config-aarch64-5.15-diff:	  0 removed,   0 added,   0 changed
config-aarch64-6.1-diff:	  0 removed,   0 added,   0 changed
config-x86_64-5.10-diff:	  2 removed,   2 added,   0 changed
config-x86_64-5.15-diff:	  0 removed,   0 added,   0 changed
config-x86_64-6.1-diff:	  1 removed,   5 added,   6 changed
```

Report:

```
==> /tmp/configs//config-aarch64-5.10-diff <==

==> /tmp/configs//config-aarch64-5.15-diff <==

==> /tmp/configs//config-aarch64-6.1-diff <==

==> /tmp/configs//config-x86_64-5.10-diff <==
-NFSD_V2_ACL y
-NFSD_V3 y
+NFSD_V2 n
+NFS_V4_2_SSC_HELPER y

==> /tmp/configs//config-x86_64-5.15-diff <==

==> /tmp/configs//config-x86_64-6.1-diff <==
-TICK_CPU_ACCOUNTING y
 NO_HZ_FULL n -> y
 NO_HZ_IDLE y -> n
 PPS m -> y
 PTP_1588_CLOCK m -> y
 PTP_1588_CLOCK_OPTIONAL m -> y
 VIRT_CPU_ACCOUNTING_GEN n -> y
+CONTEXT_TRACKING_USER y
+CONTEXT_TRACKING_USER_FORCE n
+RCU_NOCB_CPU y
+RCU_NOCB_CPU_DEFAULT_ALL n
+VIRT_CPU_ACCOUNTING y
```

**Testing done:**

Launched 6 instances: aws-k8s-1.23, aws-k8s-1.24, aws-k8s-1.28, for x86_64 and aarch64. All booted.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
