### PR TITLE
Add missing libz dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ version = "0.1.0"
 dependencies = [
  "glibc",
  "libelf",
+ "libz",
 ]
 
 [[package]]


### PR DESCRIPTION
**Issue number:**

N / A

**Description of changes:**

In 2294a335, libz was added to libbpf but the Cargo.lock file wasn't updated with it

**Testing done:**

`make ARCH=x86_64` doesn't re-generate `Cargo.lock`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
