### PR TITLE
pluto: move hostname variant prevention to the correct place

### DIFF
--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -324,9 +324,7 @@ async fn generate_provider_id(
     client: &mut ImdsClient,
     aws_k8s_info: &mut AwsK8sInfo,
 ) -> Result<()> {
-    if aws_k8s_info.provider_id.is_some()
-        || NO_HOSTNAME_VARIANTS.contains(&aws_k8s_info.variant_id.as_str())
-    {
+    if aws_k8s_info.provider_id.is_some() {
         return Ok(());
     }
 
@@ -352,7 +350,7 @@ async fn generate_private_dns_name(
     client: &mut ImdsClient,
     aws_k8s_info: &mut AwsK8sInfo,
 ) -> Result<()> {
-    if aws_k8s_info.hostname_override.is_some() {
+    if aws_k8s_info.hostname_override.is_some() || NO_HOSTNAME_VARIANTS.contains(&aws_k8s_info.variant_id.as_str()) {
         return Ok(());
     }
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

* The NO_HOSTNAME_VARIANTS check was supposed to be in the generate_private_dns_name not the provider_id method. This will make it so `hostname-override` is only generated/set 



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
