### PR TITLE
Add advisories for 2.2.0 core-kit third party packages

### DIFF
--- a/advisories/2.2.0/BRSA-tjnwgl2a.toml
+++ b/advisories/2.2.0/BRSA-tjnwgl2a.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-tjnwgl2a"
+title = "docker-engine CVE-2024-29018"
+cve = "CVE-2024-29018"
+severity = "high"
+description = "A flaw in the `dockerd` design allowed for a potential data exfiltration from 'internal' networks via authoritative DNS servers. This is because `dockerd` will forward DNS requests to the host loopback device, bypassing the container network namespace's normal routing semantics entirely."
+
+[[advisory.products]]
+package-name = "docker-engine"
+patched-version = "25.0.5"
+
+[updateinfo]
+author = "vighmah"
+issue-date = 2024-07-18T20:54:34Z 
+arches = ["aarch64", "x86_64"]
+version = "2.2.0"

--- a/advisories/2.2.0/BRSA-wyuvthdr.toml
+++ b/advisories/2.2.0/BRSA-wyuvthdr.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-wyuvthdr"
+title = "soci-snapshotter CVE-2024-24788"
+cve = "CVE-2024-24788"
+severity = "high"
+description = "A malformed DNS message in response to a query can cause the Lookup functions to get stuck in an infinite loop."
+
+[[advisory.products]]
+package-name = "soci-snapshotter"
+patched-version = "0.6.1"
+
+[updateinfo]
+author = "vighmah"
+issue-date = 2024-07-18T20:54:34Z 
+arches = ["x86_64", "aarch64"]
+version = "2.2.0"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Add Bottlerocket Security Advisories for the `2.2.0` release of the bottlerocket-core-kit. 

This PR is just for the third-party package CVEs fixed in 2.2.0. Kernel advisories in #37

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
