### PR TITLE
Update kernels: 5.10.220, 5.15.162, 6.1.97

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/36b61b64a5b940e6dbe9bd7c0e63ff2a61e24901d776de27a233d38b5f52ae94/kernel-5.10.220-209.867.amzn2.src.rpm"
-sha512 = "939bc3fae149dbd22fa7b0a177c44add6b94c4b90feac2e3b4da73dba78685edf74ed705478c6e832ed1e98f186396385bbd5c1a28eef1b5b77fdc38d48a85c3"
+url = "https://cdn.amazonlinux.com/blobstore/8ec5b8c87de6871a92e268fc5b3e79c230b45a1629f503584407a91d94c424be/kernel-5.10.220-209.869.amzn2.src.rpm"
+sha512 = "46140306a2eb9dbcbf80ec3fd9a96b62490c945b76c02a792cfa20ac6b012d066fcd554697d2d553712ebe23fb450311ab8671b212c71d45f3ba0f9f5fc6d46d"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/36b61b64a5b940e6dbe9bd7c0e63ff2a61e24901d776de27a233d38b5f52ae94/kernel-5.10.220-209.867.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/8ec5b8c87de6871a92e268fc5b3e79c230b45a1629f503584407a91d94c424be/kernel-5.10.220-209.869.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/c86decdb8cfd1f1fe51e6d17c0dcc935d44b48480db4ea182f922934f7d0d34e/kernel-5.15.161-106.159.amzn2.src.rpm"
-sha512 = "6d7b9b5f2cb9fe8371b65772c732ab9deead6719194d849b1888c0c47f2c9b134543ee63c36333fd35c8bd2353c9865365c3c48e0b90c939a16725312d88e1f8"
+url = "https://cdn.amazonlinux.com/blobstore/f66f6724d9537ad1beb2068370c8d59d77d54b669036be14278bb92e8656def6/kernel-5.15.162-107.160.amzn2.src.rpm"
+sha512 = "aa24e68ddeb428e2364b7baca15736d1e97381871dd037d3143313ddd578de992ec61b67772c360caaed816afdbd0d3ca70c0c43d1277714803aa88a9d92a6e0"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.161
+Version: 5.15.162
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/c86decdb8cfd1f1fe51e6d17c0dcc935d44b48480db4ea182f922934f7d0d34e/kernel-5.15.161-106.159.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/f66f6724d9537ad1beb2068370c8d59d77d54b669036be14278bb92e8656def6/kernel-5.15.162-107.160.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/704482a5b82230d7012a6bd9b15689a3c8c05ab85493984fbe6c4bbbb0d38e21/kernel-6.1.96-102.177.amzn2023.src.rpm"
-sha512 = "4a0c5223a4d8ee9e47440fbeb0a5b65e115421b1ed980fa603dcbd7909c74b01948a1dc853c30cc8f37ed51fe8980165b4cf69820c375a61f2e1269559514f7b"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/d99ee343f454259e069b83f9c5b6c672d3e166a424243a4ae9fc2634a8d7d4d4/kernel-6.1.97-104.177.amzn2023.src.rpm"
+sha512 = "c368f7e9f999e6b95d0ca12a32af5944fe91e2ac410d06b289f2ef9b0722fe97e2ae8abab8859dba26ab18fcd85e17f9065a864e13be7aff1f4015bf5e670b12"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.96
+Version: 6.1.97
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/704482a5b82230d7012a6bd9b15689a3c8c05ab85493984fbe6c4bbbb0d38e21/kernel-6.1.96-102.177.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/d99ee343f454259e069b83f9c5b6c672d3e166a424243a4ae9fc2634a8d7d4d4/kernel-6.1.97-104.177.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3205,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4091e032efecb09d7b1f711f487b85ab925632a842627e3200fb088382cde32c"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
  "serde",

--- a/sources/netdog/Cargo.toml
+++ b/sources/netdog/Cargo.toml
@@ -20,7 +20,7 @@ indexmap = { version = "1", features = ["serde"] }
 envy = "0.4"
 lazy_static = "1"
 systemd-derive = { path = "systemd-derive", version = "0.1" }
-quick-xml = { version = "0.36", features = ["serialize"] }
+quick-xml = { version = "0.26", features = ["serialize"] }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/tools/diff-kernel-config
+++ b/tools/diff-kernel-config
@@ -160,7 +160,7 @@ for state in after before; do
             # Run build
             #
 
-            ARCH="${arch}" PACKAGE="kernel-${kver/./_}" make twoliter build-package \
+            BUILDSYS_ARCH="${arch}" PACKAGE="kernel-${kver/./_}" make twoliter build-package \
                 || bail "Build failed for ${debug_id}"
 
             #


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

Update kernels to the latest upstream versions:

* 5.10.220-209.869
* 5.15.162-107.160
* 6.1.97-104.177

Fix `ARCH` -> `BUILDSYS_ARCH` in `tools/diff-kernel-config`

Additionally, revert changes to update `quick-xml` dependency of `netdog`; see #47 


**Patch Changes**

Kernel-5.10 patches summary:
```
Patches that changed:
Patches that were dropped:
Patches that were added:
0867-arm64-bpf-Remove-128MB-limit-for-BPF-JIT-programs.patch
0868-iommu-Optimise-PCI-SAC-address-trick.patch
```

Kernel-5.15 patches summary:

```
Patches that changed:
Patches that were dropped:
0158-nfs-Leave-pages-in-the-pagecache-if-readpage-failed.patch
Patches that were added:
0158-Revert-kheaders-explicitly-define-file-modes-for-arc.patch
0159-Revert-Revert-kheaders-substituting-sort-in-archive-.patch
```

The patch `0159-Revert-Revert-kheaders-substituting-sort-in-archive-.patch` looks suspicious, with the trailing `-`, but this is due to patch filename length restrictions.

Kernel-6.1 patches summary:

```
Patches that changed:
0090-crypto-ecdh-zeroize-crpytographic-keys-after-use.patch -> 0090-crypto-ecdh-zeroize-crpytographic-keys-after-use.patch
Patches that were dropped:
Patches that were added:
```

**Configuration Changes**

None.

```
...
config-aarch64-5.10-diff:         0 removed,   0 added,   0 changed
config-aarch64-5.15-diff:         0 removed,   0 added,   0 changed
config-aarch64-6.1-diff:          0 removed,   0 added,   0 changed
config-x86_64-5.10-diff:          0 removed,   0 added,   0 changed
config-x86_64-5.15-diff:          0 removed,   0 added,   0 changed
config-x86_64-6.1-diff:   0 removed,   0 added,   0 changed
```

Diff report:

```
==> configs/config-aarch64-5.10-diff <==

==> configs/config-aarch64-5.15-diff <==

==> configs/config-aarch64-6.1-diff <==

==> configs/config-x86_64-5.10-diff <==

==> configs/config-x86_64-5.15-diff <==

==> configs/config-x86_64-6.1-diff <==
```

**Testing done:**

Launched 6 instances, all booted: 
- [x] aws-k8s-1.23, x86_64
- [x] aws-k8s-1.23, aarch64
- [x] aws-k8s-1.24, x86_64
- [x] aws-k8s-1.24, aarch64
- [x] aws-k8s-1.28, x86_64
- [x] aws-k8s-1.28, aarch64

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
