### PR TITLE
Add aws-otel-collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-otel-collector"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "aws-signing-helper"
 version = "0.1.0"
 dependencies = [
@@ -54,6 +61,7 @@ dependencies = [
  "acpid",
  "amazon-ssm-agent",
  "aws-iam-authenticator",
+ "aws-otel-collector",
  "aws-signing-helper",
  "bash",
  "binutils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "packages/acpid",
   "packages/amazon-ssm-agent",
   "packages/aws-iam-authenticator",
+  "packages/aws-otel-collector",
   "packages/aws-signing-helper",
   "packages/bash",
   "packages/binutils",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -15,6 +15,7 @@ path = "../kit.rs"
 acpid = { path = "../../packages/acpid" }
 amazon-ssm-agent = { path = "../../packages/amazon-ssm-agent" }
 aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+aws-otel-collector = { path = "../../packages/aws-otel-collector" }
 aws-signing-helper = { path = "../../packages/aws-signing-helper" }
 bash = { path = "../../packages/bash" }
 binutils = { path = "../../packages/binutils" }

--- a/packages/aws-otel-collector/0001-change-logger-and-extraconfig-file-paths.patch
+++ b/packages/aws-otel-collector/0001-change-logger-and-extraconfig-file-paths.patch
@@ -1,0 +1,40 @@
+From 1f1fc80e5869e125f5900aca76c3dbd3f1a24d81 Mon Sep 17 00:00:00 2001
+From: Kush Upadhyay <kushupad@amazon.com>
+Date: Thu, 15 Aug 2024 09:12:55 +0000
+Subject: [PATCH] change logger and extraconfig file paths
+
+Signed-off-by: Kush Upadhyay <kushupad@amazon.com>
+---
+ pkg/extraconfig/extraconfig.go | 2 +-
+ pkg/logger/logger.go           | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pkg/extraconfig/extraconfig.go b/pkg/extraconfig/extraconfig.go
+index 9c14d5f7..8ee7cbd9 100644
+--- a/pkg/extraconfig/extraconfig.go
++++ b/pkg/extraconfig/extraconfig.go
+@@ -23,7 +23,7 @@ import (
+ )
+ 
+ var (
+-	UnixExtraConfigPath    = "/opt/aws/aws-otel-collector/etc/extracfg.txt"
++	UnixExtraConfigPath    = "/etc/aws-otel-collector/extracfg.txt"
+ 	WindowsExtraConfigPath = "C:\\ProgramData\\Amazon\\AWSOTelCollector\\Configs\\extracfg.txt"
+ )
+ 
+diff --git a/pkg/logger/logger.go b/pkg/logger/logger.go
+index 9805eeab..7fcbab31 100644
+--- a/pkg/logger/logger.go
++++ b/pkg/logger/logger.go
+@@ -31,7 +31,7 @@ import (
+ )
+ 
+ var (
+-	UnixLogPath      = "/opt/aws/aws-otel-collector/logs/aws-otel-collector.log"
++	UnixLogPath      = "/var/log/aws/aws-otel-collector.log"
+ 	WindowsLogPath   = "C:\\ProgramData\\Amazon\\AWSOTelCollector\\Logs\\aws-otel-collector.log"
+ 	logfile          = getLogFilePath()
+ 	lumberjackLogger = tryNewLumberJackLogger()
+-- 
+2.40.1
+

--- a/packages/aws-otel-collector/Cargo.toml
+++ b/packages/aws-otel-collector/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "aws-otel-collector"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.40.0/aws-otel-collector-v0.40.0.tar.gz"
+sha512 = "4dc90d798fc818f357c93424e3111697e6830a2dc9913fb71e754959ec4f6002be8f079220208cad93b3b6850d337174fa0e52f57d517364d004dd08bae97e14"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/aws-otel-collector/aws-otel-collector-tmpfiles.conf
+++ b/packages/aws-otel-collector/aws-otel-collector-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/aws-otel-collector.yaml - - - - -

--- a/packages/aws-otel-collector/aws-otel-collector.service
+++ b/packages/aws-otel-collector/aws-otel-collector.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=AWS OTEL collector
+After=network-online.target configured.target
+Wants=network-online.target configured.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/aws-otel-collector --config /etc/aws-otel-collector.yaml
+KillMode=process
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/aws-otel-collector/aws-otel-collector.spec
+++ b/packages/aws-otel-collector/aws-otel-collector.spec
@@ -1,0 +1,77 @@
+%global goproject github.com/aws-observability
+%global gorepo aws-otel-collector
+%global goimport %{goproject}/%{gorepo}
+
+Name: %{_cross_os}aws-otel-collector
+Version: 0.40.0
+Release: 1%{?dist}
+Summary: AWS Distro for OpenTelemetry Collector
+License: Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND MIT AND MPL-2.0
+URL: https://github.com/aws-observability/aws-otel-collector
+Source0: %{gorepo}-v%{version}.tar.gz
+Source1: aws-otel-collector.service
+Source2: aws-otel-collector-tmpfiles.conf
+Source3: aws-otel-collector.yaml
+
+# Change log and extraconfig file paths from /opt to /var/log and /etc, respectively
+Patch0001: 0001-change-logger-and-extraconfig-file-paths.patch
+
+BuildRequires: %{_cross_os}glibc-devel
+Requires: %{name}(binary)
+
+%description
+%{summary}.
+
+%package bin
+Summary: Telemetry collector binary
+Provides: %{name}(binary)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: Telemetry collector binary, FIPS edition
+Provides: %{name}(binary)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
+%{summary}.
+
+%prep
+%autosetup -n %{gorepo}-%{version} -p1
+
+%build
+export GO_MAJOR="1.22"
+
+%set_cross_go_flags
+
+go build -ldflags "${GOLDFLAGS}" -o aws-otel-collector ./cmd/awscollector
+gofips build -ldflags "${GOLDFLAGS}" -o fips/aws-otel-collector ./cmd/awscollector
+
+%install
+install -D -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}/aws-otel-collector.service
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:2} %{buildroot}%{_cross_tmpfilesdir}
+
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
+install -p -m 0644 %{S:3} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
+
+install -d %{buildroot}{%{_cross_bindir},%{_cross_fips_bindir}}
+install -p -m 0755 aws-otel-collector %{buildroot}%{_cross_bindir}
+install -p -m 0755 fips/aws-otel-collector %{buildroot}%{_cross_fips_bindir}
+
+%files
+%{_cross_attribution_file}
+%{_cross_unitdir}/aws-otel-collector.service
+%{_cross_tmpfilesdir}/aws-otel-collector-tmpfiles.conf
+%{_cross_factorydir}%{_cross_sysconfdir}/aws-otel-collector.yaml
+
+%files bin
+%{_cross_bindir}/aws-otel-collector
+
+%files fips-bin
+%{_cross_fips_bindir}/aws-otel-collector

--- a/packages/aws-otel-collector/aws-otel-collector.yaml
+++ b/packages/aws-otel-collector/aws-otel-collector.yaml
@@ -1,0 +1,24 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:4317
+
+processors:
+  batch/traces:
+  batch/metrics:
+
+exporters:
+  otlp:
+    endpoint: 127.0.0.1:4318
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch/traces]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      processors: [batch/metrics]
+      exporters: [otlp]


### PR DESCRIPTION
**Issue number:** #52 

Closes #52 

**Description of changes:**

This change adds the `aws-otel-collector` package to the core-kit to be used by our downstream customers. Specifically, it includes the following:

- `aws-otel-collector.spec` which provides non-FIPS and FIPS versions of the collector binary
- `Cargo.toml` for the new package
- `aws-otel-collector.service` which is the systemd service for the collector. This is similar to [the default service](https://github.com/aws-observability/aws-otel-collector/blob/main/tools/packaging/linux/aws-otel-collector.service) with the following changes:
    - Removing the `EnvironmentFile` field and providing the config path directly in `ExecStart`. This way if downstream customers want to provide their own config, they just have to add a drop-in unit updating the `ExecStart` field.
    - Changing `Restart` from `on-failure` to `always` just for safety
    - Reducing the `RestartSec` from 60s to 5s
    - Removing the `User` and `Group` fields since they are unnecessary
    - Changing `network.target` to `network-online.target configured.target` in relevant settings
- `aws-otel-collector.yaml` which is a minimal config needed for the collector to run
- `aws-otel-collector-tmpfiles.conf` to install above config in `/etc` rather than the default `/opt`
- `0001-change-logger-and-extraconfig-file-paths.patch` to change the log and extraconfig file paths from `/opt` to `/var/log` and `/etc`, respectively
-  Updates to the `bottlerocket-core-kit/Cargo.toml` and root `Cargo.toml` and `Cargo.lock` to add the aws-otel-collector to the kit

**Testing done:**

Launched an `aws-dev` variant instance with the `aws-otel-collector` package added and verified the following:

- Collector service is running successfully:
```bash
bash-5.2# systemctl status aws-otel-collector
● aws-otel-collector.service - AWS OTEL collector
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/aws-otel-collector.service; enabled; preset: enabled)
     Active: active (running) since Wed 2024-07-24 07:24:58 UTC; 14h ago
   Main PID: 1346 (aws-otel-collec)
      Tasks: 9 (limit: 18599)
     Memory: 134.7M
        CPU: 13.451s
     CGroup: /system.slice/aws-otel-collector.service
             └─1346 /usr/bin/aws-otel-collector --config /etc/aws-otel-collector-default-config.yaml
```

- Config file is installed correctly in `/etc`:
```
bash-5.2# ls /etc/ | grep otel
aws-otel-collector-default-config.yaml
```

- Log file is installed in correct location in `/var/log`:
```
bash-5.2# ls /var/log/aws/
aws-otel-collector.log
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
