### PR TITLE
changelog: correct links in 2.3.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@
 
 * Update Twoliter to 0.4.3 ([#39])
     
-[#39] https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/39
-[#40] https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/40
-[#42] https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/42
-[#43] https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/43
-[#46] https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/46
+[#39]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/39
+[#40]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/40
+[#42]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/42
+[#43]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/43
+[#46]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/46
 
 # v2.2.0 (2024-07-18)
 


### PR DESCRIPTION


**Description of changes:**

Correct links in 2.3.0 changelog notes. We were missing `:` before URLs

**Testing done:**

n/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
