### PR TITLE
support hostname-override-source

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3148,6 +3148,7 @@ dependencies = [
  "generate-readme",
  "headers",
  "http 0.2.12",
+ "httptest",
  "hyper",
  "hyper-rustls",
  "imdsclient",

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -40,3 +40,6 @@ version = "0.2.0"
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }
+
+[dev-dependencies]
+httptest = "0.15"

--- a/sources/api/pluto/src/aws.rs
+++ b/sources/api/pluto/src/aws.rs
@@ -25,7 +25,7 @@ pub(crate) async fn sdk_config(region: &str) -> SdkConfig {
         .imds_client(sdk_imds_client())
         .build()
         .await;
-    aws_config::defaults(BehaviorVersion::v2023_11_09())
+    aws_config::defaults(BehaviorVersion::v2024_03_28())
         .region(Region::new(region.to_owned()))
         .credentials_provider(provider)
         .retry_config(sdk_retry_config())

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -60,7 +60,8 @@ impl ImdsClient {
         Self::new_impl(BASE_URI.to_string())
     }
 
-    fn new_impl(imds_base_uri: String) -> Self {
+    /// Exposed solely to allow unit testing.
+    pub fn new_impl(imds_base_uri: String) -> Self {
         Self {
             client: Client::new(),
             retry_timeout: Duration::from_secs(RETRY_TIMEOUT_SECS),


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

Supports the new hostname-override-source setting to we can use the instance-id as the node name with K8s.


**Testing done:**

Built & verified that the following AMIs launched and joined the cluster with the correct node name for the following scenarios:
1.23 - No userdata
1.29 - No userdata
1.29 - hostname-override-source = private-dns-name
1.29 - hostname-override-source = instance-id


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
