### PR TITLE
Prepare for v2.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# v2.3.1 (2024-08-01)
+
+## OS Changes
+
+* Update docker-engine to v25.0.6 ([#55])
+
+## Orchestrator Changes
+
+### Kubernetes
+
+* nvidia-container-runtime, nvidia-k8s-device-plugin: support Nvidia settings APIs [#48]
+* Support hostname-override-source ([#59])
+
+## Build Changes
+
+* Update bottlerocket-settings-models to v0.2.0 ([#58])
+* Update bottlerocket-sdk to v0.43.0 ([#60])
+
+[#48]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/48
+[#55]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/55
+[#58]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/58
+[#59]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/59
+[#60]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/60
+
 # v2.3.0 (2024-07-24)
 
 ## OS Changes

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -1,7 +1,7 @@
 schema-version = 1
-release-version = "2.3.0"
+release-version = "2.3.1"
 kit = []
-digest = "mVTPtGJs7HIhZyNfCyIo7znO4ZHU3IxQFcXLsObga14="
+digest = "4Dw94LDRm25CS2JzxmchQHxaXcuM8n56fymXwD7UQG4="
 
 [sdk]
 name = "bottlerocket-sdk"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "2.3.0"
+release-version = "2.3.1"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/advisories/2.3.1/BRSA-eve2oc0u.toml
+++ b/advisories/2.3.1/BRSA-eve2oc0u.toml
@@ -11,6 +11,6 @@ patched-version = "25.0.6"
 
 [updateinfo]
 author = "giinglis"
-issue-date = 2024-07-29T17:13:52Z
+issue-date = 2024-08-01T20:00:00Z
 arches = ["aarch64", "x86_64"]
-version = "staging"
+version = "2.3.1"


### PR DESCRIPTION
**Issue number:** N/a

**Description of changes:**

This includes the following changes:
- `CHANGELOG` update for upcoming 2.3.1 release
- Bumping `release-version` to `2.3.1` in Twoliter
- Creating advisory directory for 2.3.1 with relevant files


**Testing done:** N/a



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
