### PR TITLE
Kit changes for Bootstrap Commands

### DIFF
--- a/packages/os/bootstrap-commands-tmpfiles.conf
+++ b/packages/os/bootstrap-commands-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /etc/bootstrap-commands 0750 root root -

--- a/packages/os/bootstrap-commands-toml
+++ b/packages/os/bootstrap-commands-toml
@@ -1,0 +1,18 @@
+[required-extensions]
+bootstrap-commands= "v1"
+std = { version = "v1", helpers = ["if_not_null", "toml_encode"]}
++++
+{{#if_not_null settings.bootstrap-commands}}
+{{#each settings.bootstrap-commands}}
+[bootstrap-commands."{{@key}}"]
+{{#if_not_null this.commands}}
+commands = {{ toml_encode this.commands }}
+{{/if_not_null}}
+{{#if_not_null this.mode}}
+mode = "{{{this.mode}}}"
+{{/if_not_null}}
+{{#if_not_null this.essential}}
+essential = {{this.essential}}
+{{/if_not_null}}
+{{/each}}
+{{/if_not_null}}

--- a/packages/os/bootstrap-commands.service
+++ b/packages/os/bootstrap-commands.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Bootstrap Commands
+# We depend on systemd-logind.service for running systemd-inhibit.
+After=systemd-logind.service settings-applier.service apiserver.service
+Requires=systemd-logind.service settings-applier.service apiserver.service
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemd-inhibit --what=shutdown --why="Running bootstrap commands" --mode=delay /usr/bin/bootstrap-commands
+RemainAfterExit=true
+StandardError=journal+console
+SyslogIdentifier=bootstrap-commands
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -32,6 +32,7 @@ Source17: corndog-toml
 Source18: bootstrap-containers-toml
 Source19: host-containers-toml
 Source20: bottlerocket-fips-checks-metadata-json
+Source21: bootstrap-commands-toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -52,6 +53,7 @@ Source119: reboot-if-required.service
 Source120: warm-pool-wait.service
 Source122: has-boot-ever-succeeded.service
 Source123: pluto.service
+Source124: bootstrap-commands.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -59,6 +61,7 @@ Source201: host-containers-tmpfiles.conf
 Source202: thar-be-updates-tmpfiles.conf
 Source203: bootstrap-containers-tmpfiles.conf
 Source204: storewolf-tmpfiles.conf
+Source205: bootstrap-commands-tmpfiles.conf
 
 # 3xx sources: udev rules
 Source300: ephemeral-storage.rules
@@ -74,6 +77,7 @@ BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}apiclient
 Requires: %{_cross_os}apiserver
 Requires: %{_cross_os}bloodhound
+Requires: %{_cross_os}bootstrap-commands
 Requires: %{_cross_os}corndog
 Requires: %{_cross_os}certdog
 Requires: %{_cross_os}ghostdog
@@ -246,6 +250,11 @@ Requires: %{_cross_os}binutils
 %description -n %{_cross_os}driverdog
 %{summary}.
 
+%package -n %{_cross_os}bootstrap-commands
+Summary: Manages bootstrap-commands
+%description -n %{_cross_os}bootstrap-commands
+%{summary}.
+
 %package -n %{_cross_os}bootstrap-containers
 Summary: Manages bootstrap-containers
 Requires: %{_cross_os}host-ctr
@@ -350,6 +359,7 @@ echo "** Output from non-static builds:"
     -p metricdog \
     -p ghostdog \
     -p corndog \
+    -p bootstrap-commands \
     -p bootstrap-containers \
     -p prairiedog \
     -p certdog \
@@ -385,7 +395,7 @@ for p in \
   storewolf settings-committer \
   migrator prairiedog certdog \
   signpost updog metricdog logdog \
-  ghostdog bootstrap-containers \
+  ghostdog bootstrap-commands bootstrap-containers \
   shimpei bloodhound \
   bottlerocket-cis-checks \
   bottlerocket-fips-checks \
@@ -473,14 +483,14 @@ if [ -s "%{_cross_repo_root_json}" ] ; then
 fi
 
 install -d %{buildroot}%{_cross_templatedir}
-install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{S:15} %{S:16} %{S:17} %{S:18} %{S:19} \
+install -p -m 0644 %{S:5} %{S:6} %{S:7} %{S:8} %{S:14} %{S:15} %{S:16} %{S:17} %{S:18} %{S:19} %{S:21} \
   %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:100} %{S:102} %{S:103} %{S:105} \
   %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
-  %{S:113} %{S:114} %{S:119} %{S:122} %{S:123} \
+  %{S:113} %{S:114} %{S:119} %{S:122} %{S:123} %{S:124} \
   %{buildroot}%{_cross_unitdir}
 
 sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:115} > link-kernel-modules.service
@@ -502,6 +512,7 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_tmpfilesdir}/host-containers.co
 install -p -m 0644 %{S:202} %{buildroot}%{_cross_tmpfilesdir}/thar-be-updates.conf
 install -p -m 0644 %{S:203} %{buildroot}%{_cross_tmpfilesdir}/bootstrap-containers.conf
 install -p -m 0644 %{S:204} %{buildroot}%{_cross_tmpfilesdir}/storewolf.conf
+install -p -m 0644 %{S:205} %{buildroot}%{_cross_tmpfilesdir}/bootstrap-commands.conf
 
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-storage.rules
@@ -639,6 +650,12 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %files -n %{_cross_os}certdog
 %{_cross_bindir}/certdog
 %{_cross_templatedir}/certdog-toml
+
+%files -n %{_cross_os}bootstrap-commands
+%{_cross_bindir}/bootstrap-commands
+%{_cross_unitdir}/bootstrap-commands.service
+%{_cross_tmpfilesdir}/bootstrap-commands.conf
+%{_cross_templatedir}/bootstrap-commands-toml
 
 %files -n %{_cross_os}bootstrap-containers
 %{_cross_bindir}/bootstrap-containers

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -85,6 +85,7 @@ Source1085: usr-libexec.mount.in
 Source1100: systemd-tmpfiles-setup-service-debug.conf
 Source1101: systemd-resolved-service-env.conf
 Source1102: systemd-networkd-service-env.conf
+Source1103: systemd-logind-inhibit-maxdelay.conf
 
 # network link rules
 Source1200: 80-release.link
@@ -171,6 +172,9 @@ install -p -m 0644 %{S:98} %{buildroot}%{_cross_libdir}/systemd/system.conf.d/80
 
 install -d %{buildroot}%{_cross_libdir}/systemd/network
 install -p -m 0644 %{S:1200} %{buildroot}%{_cross_libdir}/systemd/network/80-release.link
+
+install -d %{buildroot}%{_cross_libdir}/systemd/logind.conf.d
+install -p -m 0644 %{S:1103} %{buildroot}%{_cross_libdir}/systemd/logind.conf.d/systemd-logind.conf
 
 cat >%{buildroot}%{_cross_libdir}/os-release <<EOF
 NAME=Bottlerocket
@@ -265,6 +269,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_libdir}/os-release
 %dir %{_cross_libdir}/repart.d
 %{_cross_libdir}/repart.d/80-local.conf
+%{_cross_libdir}/systemd/logind.conf.d/systemd-logind.conf
 %{_cross_libdir}/systemd/network/80-release.link
 %{_cross_libdir}/systemd/networkd.conf.d/80-release.conf
 %{_cross_libdir}/systemd/system.conf.d/80-release.conf

--- a/packages/release/systemd-logind-inhibit-maxdelay.conf
+++ b/packages/release/systemd-logind-inhibit-maxdelay.conf
@@ -1,0 +1,4 @@
+[Login]
+# Maximum time a system shutdown or sleep request is delayed due to to an inhibitor lock.
+# We set it to 5 minutes to let configurations in bootstrap commands to finish before a restart.
+InhibitDelayMaxSec=300

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1041,6 +1041,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bootstrap-commands"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-models",
+ "constants",
+ "generate-readme",
+ "itertools",
+ "log",
+ "serde",
+ "serde_json",
+ "simplelog",
+ "snafu",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "bootstrap-containers"
 version = "0.1.0"
 dependencies = [
@@ -1067,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1076,8 +1095,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+version = "0.4.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -1111,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1120,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1144,8 +1163,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+version = "0.4.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1157,6 +1176,7 @@ dependencies = [
  "serde_json",
  "settings-extension-autoscaling",
  "settings-extension-aws",
+ "settings-extension-bootstrap-commands",
  "settings-extension-bootstrap-containers",
  "settings-extension-cloudformation",
  "settings-extension-container-registry",
@@ -1193,7 +1213,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1206,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "serde",
 ]
@@ -1214,7 +1234,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -3659,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3672,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3683,9 +3703,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-bootstrap-commands"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "serde",
+ "serde_json",
+ "snafu",
+]
+
+[[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3698,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3711,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3724,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3737,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3750,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3763,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3776,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3789,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3803,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3816,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -3828,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3841,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3854,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3867,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3881,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3894,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3907,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -23,6 +23,8 @@ members = [
 
     "bloodhound",
 
+    "bootstrap-commands",
+
     "bottlerocket-release",
 
     "bottlerocket-variant",
@@ -191,13 +193,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.3.0"
-version = "0.3.0"
+tag = "bottlerocket-settings-models-v0.4.0"
+version = "0.4.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.3.0"
-version = "0.3.0"
+tag = "bottlerocket-settings-models-v0.4.0"
+version = "0.4.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -206,7 +208,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.3.0"
+tag = "bottlerocket-settings-models-v0.4.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -557,9 +557,9 @@ async fn deactivate_update() -> Result<HttpResponse> {
 /// Reboots the machine
 async fn reboot() -> Result<HttpResponse> {
     debug!("Rebooting now");
-    let output = Command::new("/sbin/shutdown")
-        .arg("-r")
-        .arg("now")
+    let output = Command::new("/usr/bin/systemctl")
+        .arg("reboot")
+        .arg("--check-inhibitors=yes")
         .output()
         .context(error::ShutdownSnafu)?;
     ensure!(

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -87,7 +87,7 @@ use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 use std::str::FromStr;
 
-use bottlerocket_modeled_types::{BootstrapContainerMode, Identifier, Url, ValidBase64};
+use bottlerocket_modeled_types::{BootstrapMode, Identifier, Url, ValidBase64};
 
 const ENV_FILE_DIR: &str = "/etc/bootstrap-containers";
 const DROPIN_FILE_DIR: &str = "/etc/systemd/system";
@@ -101,7 +101,7 @@ struct BootstrapContainer {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     source: Option<Url>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    mode: Option<BootstrapContainerMode>,
+    mode: Option<BootstrapMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     user_data: Option<ValidBase64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -134,7 +134,7 @@ enum Subcommand {
 #[derive(Debug)]
 struct MarkBootstrapArgs {
     container_id: String,
-    mode: BootstrapContainerMode,
+    mode: BootstrapMode,
 }
 
 /// Print a usage message in the event a bad arg is passed
@@ -251,7 +251,7 @@ fn parse_mark_bootstrap_args(args: Vec<String>) -> Result<Subcommand> {
     Ok(Subcommand::MarkBootstrap(MarkBootstrapArgs {
         container_id,
         // Fail if 'mode' is invalid
-        mode: BootstrapContainerMode::try_from(mode).context(error::BootstrapContainerModeSnafu)?,
+        mode: BootstrapMode::try_from(mode).context(error::BootstrapModeSnafu)?,
     }))
 }
 
@@ -605,9 +605,9 @@ mod error {
             source: base64::DecodeError,
         },
 
-        // `try_from` in `BootstrapContainerMode` already returns a useful error message
+        // `try_from` in `BootstrapMode` already returns a useful error message
         #[snafu(display("Failed to parse mode: {}", source))]
-        BootstrapContainerMode {
+        BootstrapMode {
             source: bottlerocket_modeled_types::error::Error,
         },
 

--- a/sources/api/schnauzer/src/helpers/mod.rs
+++ b/sources/api/schnauzer/src/helpers/mod.rs
@@ -22,7 +22,7 @@ use url::Url;
 pub mod stdlib;
 
 pub use stdlib::{
-    any_enabled, base64_decode, default, goarch, join_array, join_map, negate_or_else,
+    any_enabled, base64_decode, default, goarch, join_array, join_map, negate_or_else, toml_encode,
     IfNotNullHelper, IsArray, IsBool, IsNull, IsNumber, IsObject, IsString,
 };
 
@@ -281,6 +281,18 @@ mod error {
         InvalidMetadataServiceLimits {
             rps: handlebars::JsonValue,
             burst: handlebars::JsonValue,
+        },
+
+        #[snafu(display(
+            "Unable to encode input '{}' from template '{}' as toml: {}",
+            value,
+            source,
+            template
+        ))]
+        TomlEncode {
+            value: serde_json::Value,
+            source: serde_json::Error,
+            template: String,
         },
     }
 

--- a/sources/api/schnauzer/src/v1.rs
+++ b/sources/api/schnauzer/src/v1.rs
@@ -125,6 +125,7 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     template_registry.register_helper("host", Box::new(helpers::host));
     template_registry.register_helper("goarch", Box::new(helpers::goarch));
     template_registry.register_helper("join_array", Box::new(helpers::join_array));
+    template_registry.register_helper("toml_encode", Box::new(helpers::toml_encode));
     template_registry.register_helper("kube_reserve_cpu", Box::new(helpers::kube_reserve_cpu));
     template_registry.register_helper(
         "kube_reserve_memory",

--- a/sources/api/schnauzer/src/v2/import/helpers.rs
+++ b/sources/api/schnauzer/src/v2/import/helpers.rs
@@ -68,6 +68,7 @@ fn all_helpers() -> HashMap<ExtensionName, HashMap<HelperName, Box<dyn HelperDef
             "any_enabled" => helper!(handlebars_helpers::any_enabled),
             "base64_decode" => helper!(handlebars_helpers::base64_decode),
             "default" => helper!(handlebars_helpers::default),
+            "toml_encode" => helper!(handlebars_helpers::toml_encode),
             "join_array" => helper!(handlebars_helpers::join_array),
             "join_map" => helper!(handlebars_helpers::join_map),
             "if_not_null" => Box::new(handlebars_helpers::IfNotNullHelper),

--- a/sources/bootstrap-commands/Cargo.toml
+++ b/sources/bootstrap-commands/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "bootstrap-commands"
+version = "0.1.0"
+authors = ["Piyush Jena <jepiyush@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+base64.workspace = true
+constants.workspace = true
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+toml.workspace = true
+itertools.workspace = true
+bottlerocket-modeled-types.workspace = true
+bottlerocket-settings-models.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[build-dependencies]
+generate-readme.workspace = true

--- a/sources/bootstrap-commands/README.md
+++ b/sources/bootstrap-commands/README.md
@@ -1,0 +1,43 @@
+# bootstrap-commands
+
+Current version: 0.1.0
+
+## Bootstrap commands
+
+`bootstrap-commands` ensures that bootstrap commands are executed as defined in the system
+settings. It is called by `bootstrap-commands.service` which runs prior to the execution of
+`bootstrap-containers`.
+
+Each bootstrap command is a set of Bottlerocket API commands. The settings are first rendered
+into a config file. Then, the system is configured by going through all the bootstrap commands
+in lexicographical order and running all the commands inside it.
+
+### Example:
+Given a bootstrap command called `001-test-bootstrap-commands` with the following configuration:
+
+```toml
+[settings.bootstrap-commands.001-test-bootstrap-commands]
+commands = [[ "apiclient", "set", "motd=helloworld"]]
+essential = true
+mode = "always"
+```
+This would set `/etc/motd` to "helloworld".
+
+## Additional Information:
+Certain valid `apiclient` commands that work in a session may fail in `bootstrap-commands`
+due to relevant services not running at the time of the launch of the systemd service.
+
+### Example:
+```toml
+[settings.bootstrap-commands.001-test-bootstrap-commands]
+commands = [[ "apiclient", "exec", "admin", "ls"]]
+essential = true
+mode = "always"
+```
+This command fails because `bootstrap-commands.service` which calls this binary is launched
+prior to `preconfigured.target` while `host-containers@.service` which is a requirement for
+running "exec" commands are launched after preconfigured.target.
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/bootstrap-commands/README.tpl
+++ b/sources/bootstrap-commands/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/bootstrap-commands/build.rs
+++ b/sources/bootstrap-commands/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    generate_readme::from_main().unwrap();
+}

--- a/sources/bootstrap-commands/src/main.rs
+++ b/sources/bootstrap-commands/src/main.rs
@@ -1,0 +1,370 @@
+/*!
+# Bootstrap commands
+
+`bootstrap-commands` ensures that bootstrap commands are executed as defined in the system
+settings. It is called by `bootstrap-commands.service` which runs prior to the execution of
+`bootstrap-containers`.
+
+Each bootstrap command is a set of Bottlerocket API commands. The settings are first rendered
+into a config file. Then, the system is configured by going through all the bootstrap commands
+in lexicographical order and running all the commands inside it.
+
+## Example:
+Given a bootstrap command called `001-test-bootstrap-commands` with the following configuration:
+
+```toml
+[settings.bootstrap-commands.001-test-bootstrap-commands]
+commands = [[ "apiclient", "set", "motd=helloworld"]]
+essential = true
+mode = "always"
+```
+This would set `/etc/motd` to "helloworld".
+
+# Additional Information:
+Certain valid `apiclient` commands that work in a session may fail in `bootstrap-commands`
+due to relevant services not running at the time of the launch of the systemd service.
+
+## Example:
+```toml
+[settings.bootstrap-commands.001-test-bootstrap-commands]
+commands = [[ "apiclient", "exec", "admin", "ls"]]
+essential = true
+mode = "always"
+```
+This command fails because `bootstrap-commands.service` which calls this binary is launched
+prior to `preconfigured.target` while `host-containers@.service` which is a requirement for
+running "exec" commands are launched after preconfigured.target.
+*/
+
+use log::info;
+use serde::Deserialize;
+use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::collections::BTreeMap;
+use std::env;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{self, Command};
+use std::str::FromStr;
+
+use bottlerocket_modeled_types::{ApiclientCommand, BootstrapMode, Identifier};
+
+const DEFAULT_CONFIG_PATH: &str = "/etc/bootstrap-commands/bootstrap-commands.toml";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct BootstrapCommandConfig {
+    #[serde(default)]
+    bootstrap_commands: BTreeMap<Identifier, BootstrapCommand>,
+}
+
+impl BootstrapCommandConfig {
+    // Gets an iterator for bootstrap_commands, sorted in lexicographical order of their names.
+    fn iter(self) -> impl Iterator<Item = (Identifier, BootstrapCommand)> {
+        self.bootstrap_commands.into_iter()
+    }
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct BootstrapCommand {
+    #[serde(default)]
+    commands: Vec<ApiclientCommand>,
+    #[serde(default)]
+    mode: BootstrapMode,
+    #[serde(default)]
+    essential: bool,
+}
+
+/// Stores user-supplied global arguments
+struct Args {
+    log_level: LevelFilter,
+    config_path: PathBuf,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            log_level: LevelFilter::Info,
+            config_path: PathBuf::from_str(DEFAULT_CONFIG_PATH).unwrap(),
+        }
+    }
+}
+
+/// Wrapper around process::Command that adds error checking.
+fn run_command<I, S>(bin_path: &str, args: I) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new(bin_path);
+
+    command
+        .args(args)
+        .status()
+        .context(error::ExecutionFailureSnafu { command })?;
+
+    Ok(())
+}
+
+fn handle_bootstrap_command<S>(name: S, bootstrap_command: BootstrapCommand) -> Result<()>
+where
+    S: AsRef<str>,
+{
+    let name = name.as_ref();
+    let mode = bootstrap_command.mode.as_ref();
+    let commands = &bootstrap_command.commands;
+
+    if mode == "off" {
+        // If mode is 'off', just log this information.
+        info!("Bootstrap command mode for '{}' is 'off'", name);
+        return Ok(());
+    }
+
+    info!("Processing bootstrap command '{}' ... ", name);
+
+    for command in commands.iter() {
+        let (cmd, args) = command.get_command_and_args();
+        run_command(cmd, args)?;
+    }
+
+    if mode == "once" {
+        let formatted = format!("settings.bootstrap-commands.{}.mode=off", name);
+        info!("Turning off bootstrap command '{}'", name);
+        run_command("apiclient", ["set", formatted.as_str()])?;
+    }
+
+    info!("Successfully ran bootstrap command '{}'", name);
+
+    Ok(())
+}
+
+/// Read our config file for the set of defined bootstrap commands
+fn get_bootstrap_commands<P>(config_path: P) -> Result<BootstrapCommandConfig>
+where
+    P: AsRef<Path>,
+{
+    let config_str = fs::read_to_string(config_path.as_ref()).context(error::ReadConfigSnafu {
+        config_path: config_path.as_ref(),
+    })?;
+
+    let config: BootstrapCommandConfig =
+        toml::from_str(&config_str).context(error::DeserializationSnafu {
+            config_path: config_path.as_ref(),
+        })?;
+
+    Ok(config)
+}
+
+/// Parse the args to the program and return an Args struct
+fn parse_args(args: env::Args) -> Result<Args> {
+    let mut global_args = Args::default();
+
+    let mut iter = args.skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_ref() {
+            // Global args
+            "--log-level" => {
+                let log_level = iter.next().context(error::UsageSnafu {
+                    message: "Did not give argument to --log-level",
+                })?;
+                global_args.log_level = LevelFilter::from_str(&log_level)
+                    .context(error::LogLevelSnafu { log_level })?;
+            }
+
+            "-c" | "--config-path" => {
+                let config_str = iter.next().context(error::UsageSnafu {
+                    message: "Did not give argument to --config-path",
+                })?;
+                global_args.config_path = PathBuf::from(config_str.as_str());
+            }
+
+            _ => (),
+        }
+    }
+
+    Ok(global_args)
+}
+
+fn run() -> Result<()> {
+    let args = parse_args(env::args())?;
+
+    // SimpleLogger will send errors to stderr and anything less to stdout.
+    SimpleLogger::init(args.log_level, LogConfig::default()).context(error::LoggerSnafu)?;
+
+    let bootstrap_commands = get_bootstrap_commands(args.config_path)?;
+
+    for (bootstrap_command_name, bootstrap_command) in bootstrap_commands.iter() {
+        let name = bootstrap_command_name.as_ref();
+        let essential = bootstrap_command.essential;
+        let status = handle_bootstrap_command(name, bootstrap_command);
+
+        ensure!(
+            !essential || status.is_ok(),
+            error::BootstrapCommandExecutionSnafu { name }
+        )
+    }
+
+    Ok(())
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+mod error {
+    use snafu::Snafu;
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub(super) enum Error {
+        #[snafu(display("Failed to read settings from config at {}: {}", config_path.display(), source))]
+        ReadConfig {
+            config_path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to deserialize settings from config at {}: {}", config_path.display(), source))]
+        Deserialization {
+            config_path: PathBuf,
+            source: toml::de::Error,
+        },
+
+        #[snafu(display("Bootstrap command '{}' failed.", name))]
+        BootstrapCommandExecution { name: String },
+
+        #[snafu(display("Failed to execute '{:?}': {}", command, source))]
+        ExecutionFailure {
+            command: Command,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Logger setup error: {}", source))]
+        Logger { source: log::SetLoggerError },
+
+        #[snafu(display("Invalid log level '{}'", log_level))]
+        LogLevel {
+            log_level: String,
+            source: log::ParseLevelError,
+        },
+
+        #[snafu(display("{}", message))]
+        Usage { message: String },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get_bootstrap_commands() {
+        let config_toml = r#"[bootstrap-commands."002-test-bootstrap-commands"]
+        commands = [["apiclient", "set", "motd=helloworld2"], ["apiclient", "set", "motd=helloworld3"]]
+        mode = "once"
+        essential = true
+
+        [bootstrap-commands."001-test-bootstrap-commands"]
+        commands = [["apiclient", "set", "motd=helloworld1"]]
+        mode = "always"
+        essential = true
+        "#;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_config = Path::join(temp_dir.path(), "bootstrap-commands.toml");
+        let _ = std::fs::write(&temp_config, config_toml).unwrap();
+
+        let bootstrap_command_config = get_bootstrap_commands(&temp_config).unwrap();
+        let bootstrap_commands = bootstrap_command_config.bootstrap_commands;
+
+        let mut expected_bootstrap_commands = BTreeMap::new();
+        let testcmd_1 = ApiclientCommand::try_from(vec![
+            "apiclient".to_string(),
+            "set".to_string(),
+            "motd=helloworld1".to_string(),
+        ])
+        .unwrap();
+        let testcmd_2 = ApiclientCommand::try_from(vec![
+            "apiclient".to_string(),
+            "set".to_string(),
+            "motd=helloworld2".to_string(),
+        ])
+        .unwrap();
+        let testcmd_3 = ApiclientCommand::try_from(vec![
+            "apiclient".to_string(),
+            "set".to_string(),
+            "motd=helloworld3".to_string(),
+        ])
+        .unwrap();
+        expected_bootstrap_commands.insert(
+            Identifier::try_from("001-test-bootstrap-commands").unwrap(),
+            BootstrapCommand {
+                commands: vec![testcmd_1],
+                mode: BootstrapMode::try_from("always").unwrap(),
+                essential: true,
+            },
+        );
+        expected_bootstrap_commands.insert(
+            Identifier::try_from("002-test-bootstrap-commands").unwrap(),
+            BootstrapCommand {
+                commands: vec![testcmd_2, testcmd_3],
+                mode: BootstrapMode::try_from("once").unwrap(),
+                essential: true,
+            },
+        );
+
+        assert_eq!(bootstrap_commands, expected_bootstrap_commands)
+    }
+
+    #[test]
+    fn test_get_bootstrap_commands_defaults() {
+        let config_toml = r#"[bootstrap-commands."001-test-bootstrap-commands"]
+        commands = []
+        "#;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_config = Path::join(temp_dir.path(), "bootstrap-commands.toml");
+        let _ = std::fs::write(&temp_config, config_toml).unwrap();
+
+        let bootstrap_command_config = get_bootstrap_commands(&temp_config).unwrap();
+        let bootstrap_commands = bootstrap_command_config.bootstrap_commands;
+
+        let mut expected_bootstrap_commands = BTreeMap::new();
+        expected_bootstrap_commands.insert(
+            Identifier::try_from("001-test-bootstrap-commands").unwrap(),
+            BootstrapCommand {
+                commands: vec![],
+                mode: BootstrapMode::try_from("off").unwrap(),
+                essential: false,
+            },
+        );
+
+        assert_eq!(bootstrap_commands, expected_bootstrap_commands)
+    }
+
+    #[test]
+    fn test_get_bootstrap_commands_invalid() {
+        let config_toml = r#"[bootstrap-commands."001-test-bootstrap-commands"]
+        commands = [["/usr/bin/touch", "helloworld.txt"], ["apiclient", "set", "motd=helloworld3"]]
+        mode = "once"
+        essential = true
+        "#;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_config = Path::join(temp_dir.path(), "bootstrap-commands.toml");
+        let _ = std::fs::write(&temp_config, config_toml).unwrap();
+
+        // It should fail because one of the commands is not valid.
+        assert!(get_bootstrap_commands(&temp_config).is_err());
+    }
+}
+
+type Result<T> = std::result::Result<T, error::Error>;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
This PR contains core-kit changes to add `bootstrap-commands`. The relevant settings-sdk changes are in [PR 46](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/46)



**Testing done:**
Test case 1: 2 bootstrap commands
```
[settings.bootstrap-commands."002-test-bootstrap-commands"]
commands = [["apiclient", "set", "motd=helloworld2"], ["apiclient", "set", "motd=helloworld3"]]
mode = "once"
essential = true

[settings.bootstrap-commands."001-test-bootstrap-commands"]
commands = [["apiclient", "set", "motd=helloworld1"]]
mode = "always"
essential = true
```
first boot sets `motd` to `helloworld3`
second boot sets `motd` to `helloworld1`

Test case 2: No bootstrap commands
No boot issues.

Note:
3 files have been modified to build successfully. "sources/api/Cargo.toml", "sources/deny.toml", "sources/Cargo.lock". These are dependent on the settings-sdk changes in [PR 46](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/46). They will be reverted back at the end of code review.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
