### PR TITLE
Add support for ap-southeast-5

### DIFF
--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -37,6 +37,7 @@ lazy_static! {
         m.insert("ap-southeast-2", "328549459982");
         m.insert("ap-southeast-3", "386774335080");
         m.insert("ap-southeast-4", "731751899352");
+        m.insert("ap-southeast-5", "851725293737");
         m.insert("ca-central-1", "328549459982");
         m.insert("ca-west-1", "253897149516");
         m.insert("cn-north-1", "183470599484");
@@ -84,6 +85,7 @@ lazy_static! {
         m.insert("ap-southeast-2", "602401143452");
         m.insert("ap-southeast-3", "296578399912");
         m.insert("ap-southeast-4", "491585149902");
+        m.insert("ap-southeast-5", "151610086707");
         m.insert("ca-central-1", "602401143452");
         m.insert("ca-west-1", "761377655185");
         m.insert("cn-north-1", "918309763551");

--- a/sources/api/schnauzer/src/helpers.rs
+++ b/sources/api/schnauzer/src/helpers.rs
@@ -71,53 +71,6 @@ const ECR_FALLBACK_REGION: &str = "us-east-1";
 const ECR_FALLBACK_REGISTRY: &str = "328549459982";
 
 lazy_static! {
-    /// A map to tell us which registry to pull pause container images from for a given region.
-    static ref PAUSE_CONTAINER_MAP: HashMap<&'static str, &'static str> = {
-        let mut m = HashMap::new();
-        m.insert("af-south-1", "877085696533");
-        m.insert("ap-east-1", "800184023465");
-        m.insert("ap-northeast-1", "602401143452");
-        m.insert("ap-northeast-2", "602401143452");
-        m.insert("ap-northeast-3", "602401143452");
-        m.insert("ap-south-1", "602401143452");
-        m.insert("ap-south-2", "900889452093");
-        m.insert("ap-southeast-1", "602401143452");
-        m.insert("ap-southeast-2", "602401143452");
-        m.insert("ap-southeast-3", "296578399912");
-        m.insert("ap-southeast-4", "491585149902");
-        m.insert("ap-southeast-5", "151610086707");
-        m.insert("ca-central-1", "602401143452");
-        m.insert("ca-west-1", "761377655185");
-        m.insert("cn-north-1", "918309763551");
-        m.insert("cn-northwest-1", "961992271922");
-        m.insert("eu-central-1", "602401143452");
-        m.insert("eu-central-2", "900612956339");
-        m.insert("eu-north-1", "602401143452");
-        m.insert("eu-south-1", "590381155156");
-        m.insert("eu-south-2", "455263428931");
-        m.insert("eu-west-1", "602401143452");
-        m.insert("eu-west-2", "602401143452");
-        m.insert("eu-west-3", "602401143452");
-        m.insert("il-central-1", "066635153087");
-        m.insert("me-central-1", "759879836304");
-        m.insert("me-south-1", "558608220178");
-        m.insert("sa-east-1", "602401143452");
-        m.insert("us-east-1", "602401143452");
-        m.insert("us-east-2", "602401143452");
-        m.insert("us-gov-east-1", "151742754352");
-        m.insert("us-gov-west-1", "013241004608");
-        m.insert("us-west-1", "602401143452");
-        m.insert("us-west-2", "602401143452");
-        m
-    };
-}
-
-/// But if there is a region that does not exist in our map (for example a new
-/// region is created or being tested), then we will fall back to this.
-const PAUSE_FALLBACK_REGISTRY: &str = "602401143452";
-const PAUSE_FALLBACK_REGION: &str = "us-east-1";
-
-lazy_static! {
     /// A map to tell us which endpoint to pull updates from for a given region.
     static ref TUF_ENDPOINT_MAP: HashMap<&'static str, &'static str> = {
         let mut m = HashMap::new();
@@ -176,12 +129,6 @@ mod error {
             value: handlebars::JsonValue,
             template: String,
         },
-
-        #[snafu(display(
-            "Expected ecr helper to be called with either 'registry' or 'region', got '{}'",
-            value,
-        ))]
-        EcrParam { value: String },
 
         #[snafu(display(
             "Incorrect number of params provided to helper '{}' in template '{}' - {} expected, {} received",
@@ -777,59 +724,6 @@ pub fn ecr_prefix(
 
     // write it to the template
     out.write(&ecr_registry)
-        .with_context(|_| error::TemplateWriteSnafu {
-            template: template_name.to_owned(),
-        })?;
-
-    Ok(())
-}
-
-/// The `pause-prefix` helper is used to map an AWS region to the correct pause
-/// container registry.
-///
-/// Because the repo URL includes the the registry number, we created this helper
-/// to lookup the correct registry number for a given region.
-///
-/// This helper takes the AWS region as its only parameter, and returns the
-/// fully qualified domain name to the correct registry.
-///
-/// # Fallback
-///
-/// If we do not have the region in our map, a fallback region and registry number
-/// are returned.  This would allow a version of Bottlerocket to run in a new region
-/// before this map has been updated.
-///
-/// # Example
-///
-/// In this example the registry number for the region will be returned.
-/// `{{ pause-prefix settings.aws.region }}`
-///
-/// This would result in something like:
-/// `602401143452.dkr.ecr.eu-central-1.amazonaws.com`
-pub fn pause_prefix(
-    helper: &Helper<'_, '_>,
-    _: &Handlebars,
-    _: &Context,
-    renderctx: &mut RenderContext<'_, '_>,
-    out: &mut dyn Output,
-) -> Result<(), RenderError> {
-    trace!("Starting pause prefix helper");
-    let template_name = template_name(renderctx);
-    check_param_count(helper, template_name, 1)?;
-
-    // get the region parameter, which is probably given by the template value
-    // settings.aws.region. regardless, we expect it to be a string.
-    let aws_region = get_param(helper, 0)?;
-    let aws_region = aws_region.as_str().with_context(|| error::AwsRegionSnafu {
-        value: aws_region.to_owned(),
-        template: template_name,
-    })?;
-
-    // construct the registry fqdn
-    let pause_registry = pause_registry(aws_region);
-
-    // write it to the template
-    out.write(&pause_registry)
         .with_context(|_| error::TemplateWriteSnafu {
             template: template_name.to_owned(),
         })?;
@@ -1865,24 +1759,6 @@ fn ecr_registry<S: AsRef<str>>(region: S) -> String {
     }
 }
 
-/// Constructs the fully qualified domain name for the pause container (pod infra
-/// container) for the given region. Returns a default if the region is not mapped.
-fn pause_registry<S: AsRef<str>>(region: S) -> String {
-    // lookup the registry ID or fallback to the default region and id
-    let (region, registry_id) = match PAUSE_CONTAINER_MAP.borrow().get(region.as_ref()) {
-        None => (PAUSE_FALLBACK_REGION, PAUSE_FALLBACK_REGISTRY),
-        Some(registry_id) => (region.as_ref(), *registry_id),
-    };
-    let partition = match ALT_PARTITION_MAP.borrow().get(region) {
-        None => STANDARD_PARTITION,
-        Some(partition) => *partition,
-    };
-    match partition {
-        "aws-cn" => format!("{}.dkr.ecr.{}.amazonaws.com.cn", registry_id, region),
-        _ => format!("{}.dkr.ecr.{}.amazonaws.com", registry_id, region),
-    }
-}
-
 /// Constructs the fully qualified domain name for the TUF repository for the
 /// given region. Returns a default if the region is not mapped.
 fn tuf_repository<S: AsRef<str>>(region: S) -> String {
@@ -2411,63 +2287,6 @@ mod test_ecr_registry {
             )
             .unwrap();
             assert_eq!(result, *expected_url);
-        }
-    }
-}
-
-#[cfg(test)]
-mod test_pause_registry {
-    use super::*;
-    use handlebars::RenderError;
-    use serde::Serialize;
-    use serde_json::json;
-
-    // A thin wrapper around the handlebars render_template method that includes
-    // setup and registration of helpers
-    fn setup_and_render_template<T>(tmpl: &str, data: &T) -> Result<String, RenderError>
-    where
-        T: Serialize,
-    {
-        let mut registry = Handlebars::new();
-        registry.register_helper("pause-prefix", Box::new(pause_prefix));
-
-        registry.render_template(tmpl, data)
-    }
-
-    const CONTAINER_TEMPLATE: &str = "{{ pause-prefix settings.aws.region }}/container:tag";
-
-    const PAUSE_REGISTRY_TESTS: &[(&str, &str)] = &[
-        (
-            "eu-central-1",
-            "602401143452.dkr.ecr.eu-central-1.amazonaws.com/container:tag",
-        ),
-        (
-            "af-south-1",
-            "877085696533.dkr.ecr.af-south-1.amazonaws.com/container:tag",
-        ),
-        (
-            "xy-ztown-1",
-            "602401143452.dkr.ecr.us-east-1.amazonaws.com/container:tag",
-        ),
-        (
-            "cn-north-1",
-            "918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/container:tag",
-        ),
-        (
-            "ap-southeast-4",
-            "491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/container:tag",
-        ),
-    ];
-
-    #[test]
-    fn pause_container_registry() {
-        for (region, expected) in PAUSE_REGISTRY_TESTS {
-            let result = setup_and_render_template(
-                CONTAINER_TEMPLATE,
-                &json!({"settings": {"aws": {"region": *region}}}),
-            )
-            .unwrap();
-            assert_eq!(result, *expected);
         }
     }
 }

--- a/sources/api/schnauzer/src/v1.rs
+++ b/sources/api/schnauzer/src/v1.rs
@@ -120,7 +120,6 @@ pub fn build_template_registry() -> Result<handlebars::Handlebars<'static>> {
     template_registry.register_helper("join_node_taints", Box::new(helpers::join_node_taints));
     template_registry.register_helper("default", Box::new(helpers::default));
     template_registry.register_helper("ecr-prefix", Box::new(helpers::ecr_prefix));
-    template_registry.register_helper("pause-prefix", Box::new(helpers::pause_prefix));
     template_registry.register_helper("tuf-prefix", Box::new(helpers::tuf_prefix));
     template_registry.register_helper("metadata-prefix", Box::new(helpers::metadata_prefix));
     template_registry.register_helper("host", Box::new(helpers::host));

--- a/sources/api/schnauzer/src/v2/import/helpers.rs
+++ b/sources/api/schnauzer/src/v2/import/helpers.rs
@@ -45,7 +45,6 @@ fn all_helpers() -> HashMap<ExtensionName, HashMap<HelperName, Box<dyn HelperDef
             "join_node_taints" => helper!(handlebars_helpers::join_node_taints),
             "kube_reserve_cpu" => helper!(handlebars_helpers::kube_reserve_cpu),
             "kube_reserve_memory" => helper!(handlebars_helpers::kube_reserve_memory),
-            "pause-prefix" => helper!(handlebars_helpers::pause_prefix),
         },
 
         "network" => hashmap! {
@@ -280,7 +279,7 @@ mod test {
         let success_cases = &[
             ("network", "v1", vec!["host"]),
             ("empty-helpers-succeeds", "v1", vec![]),
-            ("kubernetes", "v1", vec!["pause-prefix"]),
+            ("kubernetes", "v1", vec!["join_node_taints"]),
         ];
 
         for (setting_name, version, helpers) in fail_cases.into_iter() {
@@ -332,7 +331,6 @@ mod test {
                     "join_node_taints",
                     "kube_reserve_cpu",
                     "kube_reserve_memory",
-                    "pause-prefix",
                 ],
             ),
         ];

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -21,12 +21,12 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/contrib/seccomp"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -1048,6 +1048,7 @@ func pullImage(ctx context.Context, source string, client *containerd.Client, re
 	for {
 		var err error
 
+		//nolint:staticcheck // We will re-evaluate the deprecated WithSchema1Conversion
 		pullOpts := []containerd.RemoteOpt{
 			withDynamicResolver(ctx, source, registryConfig),
 			containerd.WithSchema1Conversion,

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -597,7 +597,6 @@ func cleanUp(containerdSocket string, namespace string, containerID string) erro
 // Referenced source: https://github.com/awslabs/amazon-ecr-containerd-resolver/blob/a5058cf091f4fc573813a032db37a9820952f1f9/ecr/ref.go#L70-L71
 func parseImageURISpecialRegions(input string) (ecr.ECRSpec, error) {
 	ecrRefPrefixMapping := map[string]string{
-		"ca-west-1": "ecr.aws/arn:aws:ecr:ca-west-1:",
 		"ap-southeast-5": "ecr.aws/arn:aws:ecr:ap-southeast-5:",
 	}
 	// Matching on account, region

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -598,6 +598,7 @@ func cleanUp(containerdSocket string, namespace string, containerID string) erro
 func parseImageURISpecialRegions(input string) (ecr.ECRSpec, error) {
 	ecrRefPrefixMapping := map[string]string{
 		"ca-west-1": "ecr.aws/arn:aws:ecr:ca-west-1:",
+		"ap-southeast-5": "ecr.aws/arn:aws:ecr:ap-southeast-5:",
 	}
 	// Matching on account, region
 	matches := ecrRegex.FindStringSubmatch(input)

--- a/sources/host-ctr/go.mod
+++ b/sources/host-ctr/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/aws/aws-sdk-go v1.54.20
 	github.com/awslabs/amazon-ecr-containerd-resolver v0.0.0-20240521172427-b580afd02343
 	github.com/containerd/containerd v1.7.20
+	github.com/containerd/errdefs v0.1.0
+	github.com/containerd/log v0.1.0
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
@@ -36,11 +38,9 @@ require (
 	github.com/containerd/cgroups/v3 v3.0.2 // indirect
 	github.com/containerd/containerd/api v1.7.19 // indirect
 	github.com/containerd/continuity v0.4.3 // indirect
-	github.com/containerd/errdefs v0.1.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/go-cni v1.1.9 // indirect
 	github.com/containerd/imgcrypt v1.1.11 // indirect
-	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/nri v0.6.1 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/containerd/ttrpc v1.2.5 // indirect


### PR DESCRIPTION
**Description of changes:**

Adds support for upcoming region. Also removes unneeded code from `schnauzer` and `host-ctr`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
