### PR TITLE
Update five third-party packages.

### DIFF
--- a/packages/ecr-credential-provider-1.27/Cargo.toml
+++ b/packages/ecr-credential-provider-1.27/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.27"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.27.1"
-path = "cloud-provider-aws-1.27.1.tar.gz"
-sha512 = "d7a28f4fb3cb2a1e7ee8d94405e3268608562af0ac509b51c32fcca19353eb68c87b023bd7dae1e84a76d9e856e4951cbc8a2260bab358d1eb492e47caedd29d"
+url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.27.8"
+path = "cloud-provider-aws-1.27.8.tar.gz"
+sha512 = "31a4627760cfc173a216e902d403e0dd47bbdf69437f3b64545b303bd66e6b7025db5e312d96432a2002bc70921cd1394d6923e2e1ac36f8adb610664d65a29f"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.27/ecr-credential-provider-1.27.spec
+++ b/packages/ecr-credential-provider-1.27/ecr-credential-provider-1.27.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.27.1
+%global gover 1.27.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.29/Cargo.toml
+++ b/packages/ecr-credential-provider-1.29/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.29"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.29.0"
-path = "cloud-provider-aws-1.29.0.tar.gz"
-sha512 = "30b08ca55d182de4b2289f58acf0af4476cbeff74ea2668d7e9d4c53e2fdbb38016d7cf434a55bba895230255a699233d4484333b5b516c16acb0515df514876"
+url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.29.6"
+path = "cloud-provider-aws-1.29.6.tar.gz"
+sha512 = "de484b7cc87f3cef5bcc1d9d03ea2f81b25f83f52427a4006ebb07768495cb42281063c3ddd43ab1f92c1e4f82659823012dcd58db1226e15cdf61c3a9d0af01"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.29/ecr-credential-provider-1.29.spec
+++ b/packages/ecr-credential-provider-1.29/ecr-credential-provider-1.29.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.29.0
+%global gover 1.29.6
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.30/Cargo.toml
+++ b/packages/ecr-credential-provider-1.30/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.30"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.30.0"
-path = "cloud-provider-aws-1.30.0.tar.gz"
-sha512 = "d9b9c63f2f2b6d9e910650464acc5000ba0cc2e35d0f5f27c4121c5e3cd539682a4b89f80358a5fb2a4c8409e2d82a66c5409e9895c58546c78bbb78b39d96be"
+url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.30.3"
+path = "cloud-provider-aws-1.30.3.tar.gz"
+sha512 = "aa351cd531e452dd4ccead4a591a9161a25737ada93a7317c5c181c3d4fe55b279e94b686d8c03665ebee01191129a52b01c9dabfba7075c5e9bde52e6a341c8"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
+++ b/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.30.0
+%global gover 1.30.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider/Cargo.toml
+++ b/packages/ecr-credential-provider/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.25.3/cloud-provider-aws-1.25.3.tar.gz"
-sha512 = "d727c01ea98608b0b51edc2bfe892218b55eee7148e358e18387f3f4a52ad765f8d0ee372884e36f95f1303c13dbeba81926f7560c325a8d3c258da11cdfc24b"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.25.15/cloud-provider-aws-1.25.15.tar.gz"
+sha512 = "1e4ee33900d3ec655ce9f5788bb8f173621f187b130464bef196ef6e18a61a49d9501f5492909922a34b086fcffbb0cb369cfa8b941efbb0c38ffb0abe6c17dc"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider/ecr-credential-provider.spec
+++ b/packages/ecr-credential-provider/ecr-credential-provider.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.25.3
+%global gover 1.25.15
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/soci-snapshotter/Cargo.toml
+++ b/packages/soci-snapshotter/Cargo.toml
@@ -12,15 +12,15 @@ path = "../packages.rs"
 releases-url = "https://github.com/awslabs/soci-snapshotter/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.6.1.tar.gz"
-sha512 = "5d789e79be7157aed7a6af0bdde622d0d60bef3c268971d4eb980d4f32dbcad651c99912d94165f500fdf63498cc4e782083f046412b941ced7522e3ee32588d"
-bundle-root-path = "soci-snapshotter-0.6.1/cmd"
+url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.7.0.tar.gz"
+sha512 = "91c07db47a971b0e32554457036ae4eb90850c076e6e7c3c99d590332dd24a805ca977a8092bf60cf72fb82b42e2fb22c29fdf96de801625e1d44a4c9431b9b9"
+bundle-root-path = "soci-snapshotter-0.7.0/cmd"
 bundle-output-path = "bundled-cmd.tar.gz"
 bundle-modules = [ "go" ]
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.6.1.tar.gz"
-sha512 = "5d789e79be7157aed7a6af0bdde622d0d60bef3c268971d4eb980d4f32dbcad651c99912d94165f500fdf63498cc4e782083f046412b941ced7522e3ee32588d"
+url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.7.0.tar.gz"
+sha512 = "91c07db47a971b0e32554457036ae4eb90850c076e6e7c3c99d590332dd24a805ca977a8092bf60cf72fb82b42e2fb22c29fdf96de801625e1d44a4c9431b9b9"
 bundle-modules = [ "go" ]
 
 # RPM BuildRequires

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -1,5 +1,5 @@
 %global gorepo soci-snapshotter
-%global gover 0.6.1
+%global gover 0.7.0
 %global rpmver %{gover}
 
 Name: %{_cross_os}soci-snapshotter


### PR DESCRIPTION
Update the ecr-credential-provider* packages and soci-snapshotter, to pick up bug fixes and dependency updates.

**Description of changes:**

Update these five packages to the current upstream releases:
* ecr-credential-provider: update from 1.25.3 to 1.25.15
* ecr-credential-provider-1.27: update from 1.27.1 to 1.27.8
* ecr-credential-provider-1.29: update from 1.29.0 to 1.29.6
* ecr-credential-provider-1.30: update from 1.30.0 to 1.30.3
* soci-snapshotter: update from 0.6.1 to 0.7.0

**Testing done:**

Built EKS nodegroups for each ecr-credential-provider version, verified that they boot, include the kubelet plugin, and the plugin functions. Built aws-dev, verified that soci snapshotter runs.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
