### PR TITLE
try a new approach to reuse cached builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Preflight step to set up the runner
         uses: ./.github/actions/setup-node
-      - run: rustup component add rustfmt
-      - run: make twoliter check-licenses
-      - run: make twoliter unit-tests
-      # Avoid running Go lint check via `cargo make check-lints` since there's a separate golangci-lint workflow
-      - run: make twoliter check-fmt
-      # TODO: fixme please!
-      # - run: make twoliter check-clippy
-      - run: make twoliter check-shell
-      - run: make ARCH="${{ matrix.arch }}"
+      - name: Install Rust nightly
+        run: rustup toolchain install nightly
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+      - name: Build modified packages
+        env:
+          MODIFIED_FILES: ${{ steps.changed-files.outputs.modified_files }}
+        run: |
+          rm -rf target/
+          rm -f tools/twoliter/twoliter
+          BUILDSYS_CICD_HACK=1 make ARCH=${{ matrix.arch }}
+          for file in ${MODIFIED_FILES} ; do
+            find "${file}" -print -exec touch {} \;
+          done
+          make ARCH=${{ matrix.arch }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "systemd"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "glibc",
  "kmod",

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ prep:
 	@mkdir -p $(TWOLITER_DIR)
 	@mkdir -p $(CARGO_HOME)
 	@$(TOOLS_DIR)/install-twoliter.sh \
-		--repo "https://github.com/bottlerocket-os/twoliter" \
-		--version v$(TWOLITER_VERSION) \
+		--repo "https://github.com/bcressey/twoliter/" \
+		--version 196f8c8 \
 		--directory $(TWOLITER_DIR) \
+		--skip-version-check \
 		--reuse-existing-install \
-		--allow-binary-install \
 		--allow-from-source
 
 update: prep

--- a/packages/systemd/Cargo.toml
+++ b/packages/systemd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systemd"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 build = "../build.rs"


### PR DESCRIPTION
**Issue number:**
Follow-up on #65

**Description of changes:**
Try a new strategy to force use of cache:

1. Rebuild everything with a new buildsys flag that skips actual builds
2. Obtain a list of modified files
3. Touch all modified files so the corresponding crates will rebuild
4. Launch a build without the special buildsys flag


**Testing done:**
😬 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
