### PR TITLE
nvidia-k8s-device-plugin: add time-slicing support

### DIFF
--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -11,3 +11,13 @@ flags:
     passDeviceSpecs: {{default true settings.kubernetes.device-plugins.nvidia.pass-device-specs}}
     deviceListStrategy: {{default "volume-mounts" settings.kubernetes.device-plugins.nvidia.device-list-strategy}}
     deviceIDStrategy: {{default "index" settings.kubernetes.device-plugins.nvidia.device-id-strategy}}
+{{#if settings.kubernetes.device-plugins.nvidia.max-sharing-per-gpu}}
+{{#if (gt settings.kubernetes.device-plugins.nvidia.max-sharing-per-gpu 1)}}
+sharing:
+  timeSlicing:
+    renameByDefault: {{default false settings.kubernetes.device-plugins.nvidia.rename-shared-gpu}}
+    resources:
+    - name: "nvidia.com/gpu"
+      replicas: {{settings.kubernetes.device-plugins.nvidia.max-sharing-per-gpu}}
+{{/if}}
+{{/if}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
Update the device plugin template to support time-slicing settings.

By contributing this pull request, I grant permission to use, modify, replicate, and distribute my submission, in accordance with your preferred terms.


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
