### PR TITLE
Re-enable `fmt` and `licenses` lints in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,9 @@ jobs:
         uses: ./.github/actions/setup-node
       - run: rustup component add rustfmt
       - run: make twoliter unit-tests
-      # TODO: fixme please!
       # Avoid running Go lint check via `cargo make check-lints` since there's a separate golangci-lint workflow
-      # - run: make twoliter check-fmt
+      - run: make twoliter check-fmt
+      # TODO: fixme please!
       # - run: make twoliter check-clippy
       - run: make twoliter check-shell
       - run: make ARCH="${{ matrix.arch }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Preflight step to set up the runner
         uses: ./.github/actions/setup-node
       - run: rustup component add rustfmt
+      - run: make twoliter check-licenses
       - run: make twoliter unit-tests
       # Avoid running Go lint check via `cargo make check-lints` since there's a separate golangci-lint workflow
       - run: make twoliter check-fmt

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -55,6 +55,8 @@ deny = [{ name = "structopt" }, { name = "clap", wrappers = ["cargo-readme"] }]
 skip = [
     # this can be removed once settings sdk is updated to base64 0.22.1
     { name = "base64", version = "=0.21.7" },
+    # this can be removed once settings sdk is updated to env_logger 0.11
+    { name = "env_logger", version = "=0.10.2" },
 ]
 
 skip-tree = [


### PR DESCRIPTION
**Description of changes:**
Re-enable `fmt` and `license` lints.

I'd like to re-enable clippy, but the `dead_code` lint is starting to detect our error enum variants if we haven't been careful about conditional compilation or in cases where modules are owned by both a `lib` and a `bin` but only a subset of the error variants are used in either. This will take some careful changes to do the right way, but we should really have the `licenses` lint enabled ASAP.

**Testing done:**
* The lints pass


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
