### PR TITLE
Use workspace dependencies for all dependencies

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1349,7 +1349,7 @@ name = "certdog"
 version = "0.1.0"
 dependencies = [
  "argh",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bottlerocket-modeled-types",
  "constants",
  "generate-readme",
@@ -2246,7 +2246,7 @@ dependencies = [
 name = "host-containers"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bottlerocket-modeled-types",
  "constants",
  "generate-readme",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -76,5 +76,142 @@ members = [
     "xfscli",
 ]
 
+[workspace.dependencies]
+apiclient = { version = "0.1", path = "api/apiclient" }
+block-party = { version = "0.1", path = "updater/block-party" }
+bottlerocket-release = { version = "0.1", path = "bottlerocket-release" }
+constants = { version = "0.1", path = "constants" }
+datastore = { version = "0.1", path = "api/datastore" }
+dogtag = { version = "0.1", path = "dogtag" }
+early-boot-config-provider = { version = "0.1", path = "early-boot-config/early-boot-config-provider" }
+generate-readme = { version = "0.1", path = "generate-readme" }
+imdsclient = { version = "0.1", path = "imdsclient" }
+models = { version = "0.1", path = "models" }
+parse-datetime = { version = "0.1", path = "parse-datetime" }
+retry-read = { version = "0.1", path = "retry-read" }
+signpost = { version = "0.1", path = "updater/signpost" }
+storewolf = { version = "0.1", path = "api/storewolf" }
+simple-settings-plugin = { version = "0.1", path = "api/simple-settings-plugin" }
+systemd-derive = { version = "0.1", path = "netdog/systemd-derive" }
+thar-be-updates = { version = "0.1", path = "api/thar-be-updates" }
+update_metadata = { version = "0.1", path = "updater/update_metadata" }
+schnauzer = { version = "0.1", path = "api/schnauzer" }
+
+abi_stable = "0.11.3"
+actix = { version = "0.13", default-features = false }
+actix-rt = "2"
+actix-web = { version = "4", default-features = false }
+actix-web-actors = { version = "4", default-features = false }
+argh = "0.1"
+async-trait = "0.1"
+aws-config = "1"
+aws-sdk-cloudformation = "1"
+aws-sdk-ec2 = "1"
+aws-sdk-eks = "1"
+aws-smithy-runtime = "1"
+aws-smithy-types = "1"
+aws-types = "1"
+bit_field = "0.10"
+bytes = "1"
+cached = "0.49"
+cargo-readme = "3"
+chrono = { version = "0.4", default-features = false }
+darling = { version = "0.20", default-features = false }
+dns-lookup = "2"
+env_logger = "0.11"
+envy = "0.4"
+flate2 = { version = "1", default-features = false }
+fs2 = "0.4"
+futures = { version = "0.3", default-features = false }
+futures-channel = { version = "0.3", default-features = false }
+futures-core = "0.3"
+futures-util = { version = "0.3", default-features = false }
+glob = "0.3"
+gptman = { version = "1", default-features = false }
+handlebars = "4"
+headers = "0.3"
+hex-literal = "0.4"
+http = "0.2"
+httparse = "1"
+httptest = "0.15"
+hyper = { version = "0.14", default-features = false }
+hyper-rustls = { version = "0.24", default-features = false }
+hyper-unix-connector = "0.2"
+indexmap = "1"
+ipnet = "2"
+itertools = "0.13"
+lazy_static = "1"
+libc = "0.2"
+log = "0.4.21"
+lz4 = "1"
+maplit = "1.0"
+nix = "0.26"
+num = "0.4"
+num-derive = "0.4"
+num-traits = "0.2"
+num_cpus = "1"
+pentacle = "1"
+percent-encoding = "2"
+pest = "2.5"
+pest_derive = "2.5"
+proc-macro2 = "1"
+quick-xml = "0.26"
+quote = "1"
+rand = { version = "0.8", default-features = false }
+regex = "1"
+reqwest = { version = "0.11", default-features = false }
+semver = "1"
+serde = "1"
+serde-xml-rs = "0.6"
+serde_json = "1"
+serde_plain = "1"
+serde_yaml = "0.9"
+shell-words = "1"
+shlex = "1"
+signal-hook = "0.3"
+simplelog = "0.12"
+snafu = "0.8"
+syn = { version = "2", default-features = false }
+tar = { version = "0.4", default-features = false }
+tempfile = "3"
+tokio = { version = "~1.32", default-features = false }  # LTS
+tokio-retry = "0.3"
+tokio-rustls = "0.24"
+tokio-test = "0.4"
+tokio-tungstenite = { version = "0.20", default-features = false }
+tokio-util = "0.7"
+toml = "0.8"
+tough = "0.17"
+unindent = "0.2"
+url = "2"
+walkdir = "2.4"
+x509-parser = "0.16"
+base64 = "0.22"
+
+[workspace.dependencies.bottlerocket-modeled-types]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-models-v0.2.0"
+version = "0.2.0"
+
+[workspace.dependencies.bottlerocket-settings-models]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-models-v0.2.0"
+version = "0.2.0"
+
+[workspace.dependencies.bottlerocket-settings-plugin]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-plugin-v0.1.0"
+version = "0.1.0"
+
+[workspace.dependencies.settings-extension-oci-defaults]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-models-v0.2.0"
+version = "0.1.0"
+
+[workspace.dependencies.settings-extension-updates]
+git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
+tag = "bottlerocket-settings-models-v0.2.0"
+version = "0.1.0"
+
 [profile.release]
 debug = true

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -10,32 +10,32 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-base64 = "0.22"
-constants = { path = "../../constants", version = "0.1" }
-datastore = { path = "../datastore", version = "0.1" }
-futures = { version = "0.3", default-features = false }
-futures-channel = { version = "0.3", default-features = false }
-http = "0.2"
-httparse = "1"
-hyper = { version = "0.14", default-features = false, features = ["client", "http1", "http2"] }
-hyper-unix-connector = "0.2"
-libc = "0.2"
-log = "0.4"
-models = { path = "../../models", version = "0.1" }
-nix = "0.26"
-rand = "0.8"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-native-roots"] }
-retry-read = { path = "../../retry-read", version = "0.1" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-signal-hook = "0.3"
-simplelog = "0.12"
-snafu = { version = "0.8", features = ["futures"] }
-tokio = { version = "~1.32", default-features = false, features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "time"] }  # LTS
-tokio-tungstenite = { version = "0.20", default-features = false, features = ["connect"] }
-toml = "0.8"
-unindent = "0.2"
-url = "2"
+base64.workspace = true
+constants.workspace = true
+datastore.workspace = true
+futures.workspace = true
+futures-channel.workspace = true
+http.workspace = true
+httparse.workspace = true
+hyper = { workspace = true, features = ["client", "http1", "http2"] }
+hyper-unix-connector.workspace = true
+libc.workspace = true
+log.workspace = true
+models.workspace = true
+nix.workspace = true
+rand = { workspace = true, features = ["default"] }
+reqwest = { workspace = true, features = ["rustls-tls-native-roots"] }
+retry-read.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+signal-hook.workspace = true
+simplelog.workspace = true
+snafu = { workspace = true, features = ["futures"] }
+tokio = { workspace = true, features = ["fs", "io-std", "io-util", "macros", "rt-multi-thread", "time"] }
+tokio-tungstenite = { workspace = true, features = ["connect"] }
+toml.workspace = true
+unindent.workspace = true
+url.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -10,32 +10,32 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-actix = { version = "0.13", default-features = false, features = ["macros"] }
-actix-rt = "2"
-actix-web = { version = "4", default-features = false }
-actix-web-actors = { version = "4", default-features = false }
-bytes = "1"
-bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1" }
-datastore = { path = "../datastore", version = "0.1" }
-fs2 = "0.4"
-http = "0.2"
-libc = "0.2"
-log = "0.4"
-models = { path = "../../models", version = "0.1" }
-nix = "0.26"
-num = "0.4"
-rand = "0.8"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-simplelog = "0.12"
-snafu = "0.8"
-thar-be-updates = { path = "../thar-be-updates", version = "0.1" }
-tokio = { version = "~1.32", default-features = false, features = ["process"] }
+actix = { workspace = true, features = ["macros"] }
+actix-rt.workspace = true
+actix-web.workspace = true
+actix-web-actors.workspace = true
+bytes.workspace = true
+bottlerocket-release.workspace = true
+datastore.workspace = true
+fs2.workspace = true
+http.workspace = true
+libc.workspace = true
+log.workspace = true
+models.workspace = true
+nix.workspace = true
+num.workspace = true
+rand = { workspace = true, features = ["default"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+thar-be-updates.workspace = true
+tokio = { workspace = true, features = ["process"] }
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true
 
 [dev-dependencies]
-maplit = "1"
-toml = "0.8"
-simple-settings-plugin = { path = "../simple-settings-plugin", version = "0.1" }
+maplit.workspace = true
+toml.workspace = true
+simple-settings-plugin.workspace = true

--- a/sources/api/bootstrap-containers/Cargo.toml
+++ b/sources/api/bootstrap-containers/Cargo.toml
@@ -10,19 +10,15 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-base64 = "0.22"
-constants = { path = "../../constants", version = "0.1" }
-log = "0.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
-simplelog = "0.12"
-snafu = "0.8"
-toml = "0.8"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+base64.workspace = true
+constants.workspace = true
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+toml.workspace = true
+bottlerocket-modeled-types.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/api/bork/Cargo.toml
+++ b/sources/api/bork/Cargo.toml
@@ -9,10 +9,6 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-rand = "0.8"
-serde_json = "1"
-
-[dependencies.settings-extension-updates]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.1.0"
+rand = { workspace = true, features = ["default"] }
+serde_json.workspace = true
+settings-extension-updates.workspace = true

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["README.md"]
 
 [dependencies]
 argh = "0.1"
-base64 = "0.21"
+base64 = "0.22"
 constants = { path = "../../constants", version = "0.1" }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/sources/api/certdog/Cargo.toml
+++ b/sources/api/certdog/Cargo.toml
@@ -10,23 +10,19 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-argh = "0.1"
-base64 = "0.22"
-constants = { path = "../../constants", version = "0.1" }
-log = "0.4"
-serde = { version = "1.0", features = ["derive"] }
-simplelog = "0.12"
-snafu = "0.8"
-toml = "0.8"
-x509-parser = "0.16"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+argh.workspace = true
+base64.workspace = true
+constants.workspace = true
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+simplelog.workspace = true
+snafu.workspace = true
+toml.workspace = true
+x509-parser.workspace = true
+bottlerocket-modeled-types.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/api/corndog/Cargo.toml
+++ b/sources/api/corndog/Cargo.toml
@@ -10,17 +10,13 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-log = "0.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
-simplelog = "0.12"
-snafu = "0.8"
-toml = "0.8"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+toml.workspace = true
+bottlerocket-modeled-types.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/api/datastore/Cargo.toml
+++ b/sources/api/datastore/Cargo.toml
@@ -10,16 +10,16 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-log = "0.4"
-percent-encoding = "2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-snafu = "0.8"
-walkdir = "2"
+log.workspace = true
+percent-encoding.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+walkdir.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true
 
 [dev-dependencies]
-maplit = "1"
-toml = "0.8"
+maplit.workspace = true
+toml.workspace = true

--- a/sources/api/ecs-settings-applier/Cargo.toml
+++ b/sources/api/ecs-settings-applier/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 models = { path = "../../models", version = "0.1" }
 simplelog = "0.12"
 snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 bottlerocket-variant = { version = "0.1", path = "../../bottlerocket-variant" }

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-base64 = "0.21"
+base64 = "0.22"
 constants = { path = "../../constants", version = "0.1" }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -10,21 +10,17 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-base64 = "0.22"
-constants = { path = "../../constants", version = "0.1" }
-log = "0.4"
-serde = { version = "1", features = ["derive"] }
-simplelog = "0.12"
-snafu = "0.8"
-toml = "0.8"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+base64.workspace = true
+constants.workspace = true
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+simplelog.workspace = true
+snafu.workspace = true
+toml.workspace = true
+bottlerocket-modeled-types.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -10,31 +10,31 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-bottlerocket-release = { path = "../../../bottlerocket-release", version = "0.1" }
-bytes = "1"
-futures = "0.3"
-futures-core = "0.3"
-log = "0.4"
-lz4 = "1"
-nix = "0.26"
-pentacle = "1"
-rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
-semver = "1"
-simplelog = "0.12"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["fs", "macros", "rt-multi-thread"] }  # LTS
-tokio-util = { version = "0.7", features = ["compat", "io-util"] }
-tough = { version = "0.17", features = ["http"] }
-update_metadata = { path = "../../../updater/update_metadata", version = "0.1" }
-url = "2"
+bottlerocket-release.workspace = true
+bytes.workspace = true
+futures = { workspace = true, features = ["default"] }
+futures-core.workspace = true
+log.workspace = true
+lz4.workspace = true
+nix.workspace = true
+pentacle.workspace = true
+rand = { workspace = true, features = ["std", "std_rng"] }
+semver.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["compat", "io-util"] }
+tough = { workspace = true, features = ["http"] }
+update_metadata.workspace = true
+url.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../../generate-readme" }
+generate-readme.workspace = true
 
 [dev-dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-storewolf = { path = "../../storewolf", version = "0.1" }
-tempfile = "3"
+chrono = { workspace = true, features = ["clock", "std"] }
+storewolf.workspace = true
+tempfile.workspace = true
 
 [[bin]]
 name = "migrator"

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -10,36 +10,32 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-bytes = "1"
-constants = { path = "../../constants", version = "0.1" }
-futures-util = { version = "0.3", default-features = false }
-headers = "0.3"
-http = "0.2"
-hyper = "0.14"
-hyper-rustls = { version = "0.24", default-features = false, features = ["http2", "native-tokio", "tls12", "logging"] }
-imdsclient = { path = "../../imdsclient", version = "0.1" }
-aws-config = "1"
-aws-sdk-eks = "1"
-aws-sdk-ec2 = "1"
-aws-types = "1"
-aws-smithy-types = "1"
-aws-smithy-runtime = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
-tokio-retry = "0.3"
-tokio-rustls = "0.24"
-url = "2"
-log = "0.4.21"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+bytes.workspace = true
+constants.workspace = true
+futures-util.workspace = true
+headers.workspace = true
+http.workspace = true
+hyper = { workspace = true, features = ["default"] }
+hyper-rustls = { workspace = true, features = ["http2", "logging", "native-tokio", "tls12"] }
+imdsclient.workspace = true
+aws-config.workspace = true
+aws-sdk-eks.workspace = true
+aws-sdk-ec2.workspace = true
+aws-types.workspace = true
+aws-smithy-types.workspace = true
+aws-smithy-runtime.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-retry.workspace = true
+tokio-rustls.workspace = true
+url.workspace = true
+log.workspace = true
+bottlerocket-modeled-types.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true
 
 [dev-dependencies]
-httptest = "0.15"
+httptest.workspace = true

--- a/sources/api/prairiedog/Cargo.toml
+++ b/sources/api/prairiedog/Cargo.toml
@@ -9,26 +9,22 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-argh = "0.1"
-bytes = "1"
-constants = { path = "../../constants", version = "0.1" }
-log = "0.4"
-nix = "0.26"
-schnauzer = { path = "../schnauzer", version = "0.1" }
-signpost = { path = "../../updater/signpost", version = "0.1" }
-simplelog = "0.12"
-snafu = "0.8"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-toml = "0.8"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+argh.workspace = true
+bytes.workspace = true
+constants.workspace = true
+log.workspace = true
+nix.workspace = true
+schnauzer.workspace = true
+signpost.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+toml.workspace = true
+bottlerocket-modeled-types.workspace = true
 
 [dev-dependencies]
-maplit = "1"
+maplit.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -14,47 +14,39 @@ default = []
 testfakes = []
 
 [dependencies]
-apiclient = { path = "../apiclient", version = "0.1" }
-argh = "0.1"
-async-trait = "0.1"
-base64 = "0.22"
-cached = { version = "0.49", features = ["async"] }
-constants = { path = "../../constants", version = "0.1" }
-bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1" }
-dns-lookup = "2"
-handlebars = "4"
-http = "0.2"
-lazy_static = "1"
-log = "0.4"
-maplit = "1.0"
-models = { path = "../../models", version = "0.1" }
-num_cpus = "1"
-percent-encoding = "2"
-pest = "2.5"
-pest_derive = "2.5"
-regex = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_plain = "1"
-simplelog = "0.12"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] } # LTS
-toml = "0.8"
-url = "2"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
-
-[dependencies.settings-extension-oci-defaults]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.1.0"
+apiclient.workspace = true
+argh.workspace = true
+async-trait.workspace = true
+base64.workspace = true
+cached = { workspace = true, features = ["async"] }
+constants.workspace = true
+bottlerocket-release.workspace = true
+dns-lookup.workspace = true
+handlebars.workspace = true
+http.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+maplit.workspace = true
+models.workspace = true
+num_cpus.workspace = true
+percent-encoding.workspace = true
+pest.workspace = true
+pest_derive.workspace = true
+regex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_plain.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+toml.workspace = true
+url.workspace = true
+bottlerocket-modeled-types.workspace = true
+settings-extension-oci-defaults.workspace = true
 
 [dev-dependencies]
 # Workaround to enable a feature during integration tests.
-schnauzer = { path = ".", version = "0.1", features = ["testfakes"] }
+schnauzer = { workspace = true, features = ["testfakes"] }
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -54,7 +54,7 @@ version = "0.1.0"
 
 [dev-dependencies]
 # Workaround to enable a feature during integration tests.
-schnauzer = { path = ".", version = "0.1.0", features = ["testfakes"] }
+schnauzer = { path = ".", version = "0.1", features = ["testfakes"] }
 
 [build-dependencies]
 generate-readme = { version = "0.1", path = "../../generate-readme" }

--- a/sources/api/settings-committer/Cargo.toml
+++ b/sources/api/settings-committer/Cargo.toml
@@ -10,14 +10,14 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient", version = "0.1" }
-constants = { path = "../../constants", version = "0.1" }
-snafu = "0.8"
-http = "0.2"
-log = "0.4"
-serde_json = "1"
-simplelog = "0.12"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+apiclient.workspace = true
+constants.workspace = true
+snafu.workspace = true
+http.workspace = true
+log.workspace = true
+serde_json.workspace = true
+simplelog.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -25,4 +25,4 @@ toml = "0.8"
 generate-readme = { version = "0.1", path = "../../generate-readme" }
 
 [dev-dependencies]
-tempfile = { version = "3", default-features = false }
+tempfile = { version = "3" }

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -10,19 +10,19 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-argh = "0.1"
-base64 = "0.22"
-imdsclient = { path = "../../imdsclient", version = "0.1" }
-log = "0.4"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-simplelog = "0.12"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
-toml = "0.8"
+argh.workspace = true
+base64.workspace = true
+imdsclient.workspace = true
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+toml.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true
 
 [dev-dependencies]
-tempfile = { version = "3" }
+tempfile.workspace = true

--- a/sources/api/simple-settings-plugin/Cargo.toml
+++ b/sources/api/simple-settings-plugin/Cargo.toml
@@ -11,20 +11,11 @@ name = "settings"
 path = "src/lib.rs"
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true
 
 [dependencies]
-abi_stable = "0.11.3"
-serde = "1.0.198"
-serde_json = "1.0.116"
-
-# settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+abi_stable.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+bottlerocket-settings-plugin.workspace = true
+bottlerocket-settings-models.workspace = true

--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -10,24 +10,20 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-constants = { path = "../../constants", version = "0.1" }
-bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1" }
-datastore = { path = "../datastore", version = "0.1" }
-log = "0.4"
-models = { path = "../../models", version = "0.1" }
-rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
-semver = "1"
-simplelog = "0.12"
-snafu = "0.8"
-toml = "0.8"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+constants.workspace = true
+bottlerocket-release.workspace = true
+datastore.workspace = true
+log.workspace = true
+models.workspace = true
+rand = { workspace = true, features = ["std", "std_rng"] }
+semver.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+toml.workspace = true
+bottlerocket-modeled-types.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true
 
 [[bin]]
 name = "storewolf"

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -10,17 +10,17 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient", version = "0.1" }
-constants = { path = "../../constants", version = "0.1" }
-datastore = { path = "../datastore", version = "0.1" }
-http = "0.2"
-log = "0.4"
-models = { path = "../../models", version = "0.1" }
-serde_json = "1"
-simplelog = "0.12"
-shlex = "1"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["process", "macros", "rt-multi-thread"] }  # LTS
+apiclient.workspace = true
+constants.workspace = true
+datastore.workspace = true
+http.workspace = true
+log.workspace = true
+models.workspace = true
+serde_json.workspace = true
+simplelog.workspace = true
+shlex.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread"] }
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -10,22 +10,22 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../apiclient", version = "0.1" }
-constants = { path = "../../constants", version = "0.1" }
-handlebars = "4"
-http = "0.2"
-itertools = "0.13"
-log = "0.4"
-models = { path = "../../models", version = "0.1" }
-nix = "0.26"
-schnauzer = { path = "../schnauzer", version = "0.1" }
-serde_json = "1"
-simplelog = "0.12"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
+apiclient.workspace = true
+constants.workspace = true
+handlebars.workspace = true
+http.workspace = true
+itertools.workspace = true
+log.workspace = true
+models.workspace = true
+nix.workspace = true
+schnauzer.workspace = true
+serde_json.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true
 
 [dev-dependencies]
-maplit = "1"
+maplit.workspace = true

--- a/sources/api/thar-be-updates/Cargo.toml
+++ b/sources/api/thar-be-updates/Cargo.toml
@@ -10,28 +10,24 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1" }
-chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
-fs2 = "0.4"
-log = "0.4"
-nix = "0.26"
-num-derive = "0.4"
-num-traits = "0.2"
-semver = { version = "1", features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_plain = "1"
-signpost = { path = "../../updater/signpost", version = "0.1" }
-simplelog = "0.12"
-snafu = "0.8"
-tempfile = "3"
-toml = "0.8"
-update_metadata = { path = "../../updater/update_metadata", version = "0.1" }
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+bottlerocket-release.workspace = true
+chrono = { workspace = true, features = ["clock", "serde", "std"] }
+fs2.workspace = true
+log.workspace = true
+nix.workspace = true
+num-derive.workspace = true
+num-traits.workspace = true
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_plain.workspace = true
+signpost.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+tempfile.workspace = true
+toml.workspace = true
+update_metadata.workspace = true
+bottlerocket-modeled-types.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/bloodhound/Cargo.toml
+++ b/sources/bloodhound/Cargo.toml
@@ -9,16 +9,16 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-argh = "0.1"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
-libc = { version = "0.2" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_yaml = "0.9"
-walkdir = "2"
+argh.workspace = true
+chrono = { workspace = true, features = ["clock"] }
+libc.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_yaml.workspace = true
+walkdir.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/bottlerocket-release/Cargo.toml
+++ b/sources/bottlerocket-release/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-envy = "0.4"
-log = "0.4"
-semver = { version = "1", features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
-snafu = "0.8"
+envy.workspace = true
+log.workspace = true
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+snafu.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/bottlerocket-variant/Cargo.toml
+++ b/sources/bottlerocket-variant/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-serde = "1"
-snafu = "0.8"
+serde.workspace = true
+snafu.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/cfsignal/Cargo.toml
+++ b/sources/cfsignal/Cargo.toml
@@ -8,16 +8,16 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-log = "0.4"
-serde = { version = "1", features = ["derive"] }
-simplelog = "0.12"
-snafu = { version = "0.8" }
-toml = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }
-aws-config = "1"
-aws-sdk-cloudformation = "1"
-aws-types = "1"
-imdsclient = { path = "../imdsclient", version = "0.1" }
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+simplelog.workspace = true
+snafu.workspace = true
+toml.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+aws-config.workspace = true
+aws-sdk-cloudformation.workspace = true
+aws-types.workspace = true
+imdsclient.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/constants/Cargo.toml
+++ b/sources/constants/Cargo.toml
@@ -11,4 +11,4 @@ exclude = ["README.md"]
 [dependencies]
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/dogtag/Cargo.toml
+++ b/sources/dogtag/Cargo.toml
@@ -18,14 +18,14 @@ path = "bin/reverse.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-argh = "0.1"
-dns-lookup = "2"
-imdsclient = { version = "0.1", path = "../imdsclient" }
-log = "0.4"
-snafu = "0.8"
-tokio = { version = "~1.32", features = ["macros"]}  # LTS
-tokio-retry = "0.3"
-walkdir = "2"
+argh.workspace = true
+dns-lookup.workspace = true
+imdsclient.workspace = true
+log.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["default", "macros"] }
+tokio-retry.workspace = true
+walkdir.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/driverdog/Cargo.toml
+++ b/sources/driverdog/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-argh = "0.1"
-log = "0.4"
-simplelog = "0.12"
-snafu = "0.8"
-serde = { version = "1", features = ["derive"] }
-tempfile = "3"
-toml = "0.8"
+argh.workspace = true
+log.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+serde = { workspace = true, features = ["derive"] }
+tempfile.workspace = true
+toml.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/early-boot-config/early-boot-config-provider/Cargo.toml
+++ b/sources/early-boot-config/early-boot-config-provider/Cargo.toml
@@ -10,19 +10,19 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-async-trait = "0.1"
-env_logger = "0.11"
-flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
-log = "0.4"
-retry-read = { path = "../../retry-read", version = "0.1" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-snafu = "0.8"
-toml = "0.8"
+async-trait.workspace = true
+env_logger.workspace = true
+flate2 = { workspace = true, features = ["rust_backend"] }
+log.workspace = true
+retry-read.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+toml.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true
 
 [dev-dependencies]
-hex-literal = "0.4"
-lazy_static = "1"
+hex-literal.workspace = true
+lazy_static.workspace = true

--- a/sources/early-boot-config/early-boot-config/Cargo.toml
+++ b/sources/early-boot-config/early-boot-config/Cargo.toml
@@ -10,22 +10,22 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-apiclient = { path = "../../api/apiclient", version = "0.1" }
-async-trait = "0.1"
-base64 = "0.22"
-constants = { path = "../../constants", version = "0.1" }
-early-boot-config-provider = { path = "../early-boot-config-provider", version = "0.1" }
-env_logger = "0.11"
-http = "0.2"
-log = "0.4"
-serde_json = "1"
-serde_plain = "1"
-serde-xml-rs = "0.6"
-simplelog = "0.12"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["process", "macros", "rt-multi-thread"] }  # LTS
-toml = "0.8"
-walkdir = "2.4"
+apiclient.workspace = true
+async-trait.workspace = true
+base64.workspace = true
+constants.workspace = true
+early-boot-config-provider.workspace = true
+env_logger.workspace = true
+http.workspace = true
+log.workspace = true
+serde_json.workspace = true
+serde_plain.workspace = true
+serde-xml-rs.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread"] }
+toml.workspace = true
+walkdir.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/early-boot-config/user-data-providers/ec2-identity-doc/Cargo.toml
+++ b/sources/early-boot-config/user-data-providers/ec2-identity-doc/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-async-trait = "0.1"
-imdsclient = { path = "../../../imdsclient", version = "0.1" }
-log = "0.4"
-serde_json = "1"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["process", "macros", "rt-multi-thread"] }  # LTS
-early-boot-config-provider = { path = "../../early-boot-config-provider", version = "0.1" }
+async-trait.workspace = true
+imdsclient.workspace = true
+log.workspace = true
+serde_json.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread"] }
+early-boot-config-provider.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/early-boot-config/user-data-providers/ec2-imds/Cargo.toml
+++ b/sources/early-boot-config/user-data-providers/ec2-imds/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-async-trait = "0.1"
-imdsclient = { path = "../../../imdsclient", version = "0.1" }
-log = "0.4"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["process", "macros", "rt-multi-thread"] }  # LTS
-early-boot-config-provider = { path = "../../early-boot-config-provider", version = "0.1" }
+async-trait.workspace = true
+imdsclient.workspace = true
+log.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread"] }
+early-boot-config-provider.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/early-boot-config/user-data-providers/local-defaults/Cargo.toml
+++ b/sources/early-boot-config/user-data-providers/local-defaults/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-early-boot-config-provider = { path = "../../early-boot-config-provider", version = "0.1" }
+early-boot-config-provider.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/early-boot-config/user-data-providers/local-file/Cargo.toml
+++ b/sources/early-boot-config/user-data-providers/local-file/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-early-boot-config-provider = { path = "../../early-boot-config-provider", version = "0.1" }
+early-boot-config-provider.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/early-boot-config/user-data-providers/local-overrides/Cargo.toml
+++ b/sources/early-boot-config/user-data-providers/local-overrides/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-early-boot-config-provider = { path = "../../early-boot-config-provider", version = "0.1" }
+early-boot-config-provider.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/early-boot-config/user-data-providers/vmware-cd-rom/Cargo.toml
+++ b/sources/early-boot-config/user-data-providers/vmware-cd-rom/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-base64 = "0.22"
-log = "0.4"
-serde = { version = "1", features = ["derive"] }
-serde-xml-rs = "0.6"
-snafu = "0.8"
-early-boot-config-provider = { path = "../../early-boot-config-provider", version = "0.1" }
+base64.workspace = true
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde-xml-rs.workspace = true
+snafu.workspace = true
+early-boot-config-provider.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/early-boot-config/user-data-providers/vmware-guestinfo/Cargo.toml
+++ b/sources/early-boot-config/user-data-providers/vmware-guestinfo/Cargo.toml
@@ -9,16 +9,16 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-base64 = "0.22"
-log = "0.4"
-serde = { version = "1", features = ["derive"] }
-serde_plain = "1"
-snafu = "0.8"
-early-boot-config-provider = { path = "../../early-boot-config-provider", version = "0.1" }
+base64.workspace = true
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_plain.workspace = true
+snafu.workspace = true
+early-boot-config-provider.workspace = true
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 # vmw_backdoor includes x86_64 assembly, prevent it from building for ARM
 vmw_backdoor = "0.2"
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../../../generate-readme" }
+generate-readme.workspace = true

--- a/sources/generate-readme/Cargo.toml
+++ b/sources/generate-readme/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-cargo-readme = "3"
-snafu = "0.8"
+cargo-readme.workspace = true
+snafu.workspace = true

--- a/sources/ghostdog/Cargo.toml
+++ b/sources/ghostdog/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-argh = "0.1"
-gptman = { version = "1", default-features = false }
-hex-literal = "0.4"
-lazy_static = "1"
-signpost = { path = "../updater/signpost", version = "0.1" }
-snafu = "0.8"
+argh.workspace = true
+gptman.workspace = true
+hex-literal.workspace = true
+lazy_static.workspace = true
+signpost.workspace = true
+snafu.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/imdsclient/Cargo.toml
+++ b/sources/imdsclient/Cargo.toml
@@ -10,17 +10,17 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-http = "0.2"
-log = "0.4"
-reqwest = { version = "0.11", default-features = false }
-serde_json = "1"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
-tokio-retry = "0.3"
+http.workspace = true
+log.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+tokio-retry.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true
 
 [dev-dependencies]
-httptest = "0.15"
-tokio-test = "0.4"
+httptest.workspace = true
+tokio-test.workspace = true

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1"
 shell-words = "1"
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
 tar = { version = "0.4", default-features = false }
-tempfile = { version = "3", default-features = false }
+tempfile = { version = "3" }
 tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
 url = "2"
 walkdir = "2"

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -9,17 +9,17 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-flate2 = "1"
-glob = "0.3"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
-serde_json = "1"
-shell-words = "1"
-snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
-tar = { version = "0.4", default-features = false }
-tempfile = { version = "3" }
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread"] }  # LTS
-url = "2"
-walkdir = "2"
+flate2 = { workspace = true, features = ["default"] }
+glob.workspace = true
+reqwest = { workspace = true, features = ["blocking", "rustls-tls-native-roots"] }
+serde_json.workspace = true
+shell-words.workspace = true
+snafu = { workspace = true, features = ["backtraces-impl-backtrace-crate"] }
+tar.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+url.workspace = true
+walkdir.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/metricdog/Cargo.toml
+++ b/sources/metricdog/Cargo.toml
@@ -25,4 +25,4 @@ generate-readme = { version = "0.1", path = "../generate-readme" }
 
 [dev-dependencies]
 httptest = "0.15"
-tempfile = { version = "3", default-features = false }
+tempfile = { version = "3" }

--- a/sources/metricdog/Cargo.toml
+++ b/sources/metricdog/Cargo.toml
@@ -9,20 +9,20 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-argh = "0.1"
-bottlerocket-release = { path = "../bottlerocket-release", version = "0.1" }
-log = "0.4"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-simplelog = "0.12"
-snafu = { version = "0.8" }
-toml = "0.8"
-url = "2"
+argh.workspace = true
+bottlerocket-release.workspace = true
+log.workspace = true
+reqwest = { workspace = true, features = ["blocking", "rustls-tls-native-roots"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+toml.workspace = true
+url.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true
 
 [dev-dependencies]
-httptest = "0.15"
-tempfile = { version = "3" }
+httptest.workspace = true
+tempfile.workspace = true

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -10,25 +10,16 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-bottlerocket-release = { path = "../bottlerocket-release", version = "0.1" }
-libc = "0.2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-toml = "0.8"
-
-# settings plugins
-[dependencies.bottlerocket-settings-plugin]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-plugin-v0.1.0"
-version = "0.1.0"
-
-[dependencies.bottlerocket-settings-models]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+bottlerocket-release.workspace = true
+libc.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+toml.workspace = true
+bottlerocket-settings-plugin.workspace = true
+bottlerocket-settings-models.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true
 
 [lib]
 # We're loading the correct *model* at runtime, so users shouldn't think about

--- a/sources/netdog/Cargo.toml
+++ b/sources/netdog/Cargo.toml
@@ -13,26 +13,26 @@ default = []
 wicked = []
 
 [dependencies]
-argh = "0.1"
-dogtag = { version = "0.1", path = "../dogtag" }
-ipnet = { version = "2", features = ["serde"] }
-indexmap = { version = "1", features = ["serde"] }
-envy = "0.4"
-lazy_static = "1"
-systemd-derive = { path = "systemd-derive", version = "0.1" }
-quick-xml = { version = "0.26", features = ["serialize"] }
-rand = { version = "0.8", default-features = false, features = ["std", "std_rng"] }
-regex = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_plain = "1"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["macros", "rt-multi-thread", "time"] }  # LTS
-toml = { version = "0.8", features = ["preserve_order"] }
+argh.workspace = true
+dogtag.workspace = true
+ipnet = { workspace = true, features = ["serde"] }
+indexmap = { workspace = true, features = ["serde"] }
+envy.workspace = true
+lazy_static.workspace = true
+systemd-derive.workspace = true
+quick-xml = { workspace = true, features = ["serialize"] }
+rand = { workspace = true, features = ["std", "std_rng"] }
+regex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_plain.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+toml = { workspace = true, features = ["preserve_order"] }
 
 [dev-dependencies]
-tempfile = "3"
-handlebars = "4"
+tempfile.workspace = true
+handlebars.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/netdog/systemd-derive/Cargo.toml
+++ b/sources/netdog/systemd-derive/Cargo.toml
@@ -14,10 +14,10 @@ path = "src/lib.rs"
 proc-macro = true
 
 [dependencies]
-darling = { version = "0.20", default-features = false }
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "2", default-features = false, features = ["derive"] }
+darling.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = ["derive"] }
 
 [build-dependencies]
-generate-readme = { path = "../../generate-readme", version = "0.1" }
+generate-readme.workspace = true

--- a/sources/parse-datetime/Cargo.toml
+++ b/sources/parse-datetime/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
+chrono = { workspace = true, features = ["clock", "std"] }
+snafu = { workspace = true, features = ["backtraces-impl-backtrace-crate"] }
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/retry-read/Cargo.toml
+++ b/sources/retry-read/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 exclude = ["README.md"]
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/shimpei/Cargo.toml
+++ b/sources/shimpei/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-log = "0.4"
-simplelog = "0.12"
-snafu = "0.8"
-nix = "0.26"
+log.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+nix.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/static-pods/Cargo.toml
+++ b/sources/static-pods/Cargo.toml
@@ -10,18 +10,14 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
-base64 = "0.22"
-log = "0.4"
-serde = { version = "1", features = ["default"]}
-simplelog = "0.12"
-snafu = "0.8"
-toml = "0.8"
-tempfile = "3"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+base64.workspace = true
+log.workspace = true
+serde = { workspace = true, features = ["default"] }
+simplelog.workspace = true
+snafu.workspace = true
+toml.workspace = true
+tempfile.workspace = true
+bottlerocket-modeled-types.workspace = true
 
 [build-dependencies]
-generate-readme = { version = "0.1", path = "../generate-readme" }
+generate-readme.workspace = true

--- a/sources/updater/block-party/Cargo.toml
+++ b/sources/updater/block-party/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-snafu = "0.8"
+snafu.workspace = true

--- a/sources/updater/signpost/Cargo.toml
+++ b/sources/updater/signpost/Cargo.toml
@@ -15,4 +15,4 @@ gptman = { version = "1", default-features = false }
 hex-literal = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_plain = "1"
-snafu = { version = "0.8", default-features = false, features = ["std"] }
+snafu = { version = "0.8" }

--- a/sources/updater/signpost/Cargo.toml
+++ b/sources/updater/signpost/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-bit_field = "0.10"
-block-party = { path = "../block-party", version = "0.1" }
-gptman = { version = "1", default-features = false }
-hex-literal = "0.4"
-serde = { version = "1", features = ["derive"] }
-serde_plain = "1"
-snafu = { version = "0.8" }
+bit_field.workspace = true
+block-party.workspace = true
+gptman.workspace = true
+hex-literal.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_plain.workspace = true
+snafu.workspace = true

--- a/sources/updater/update_metadata/Cargo.toml
+++ b/sources/updater/update_metadata/Cargo.toml
@@ -9,15 +9,15 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
-parse-datetime = { path = "../../parse-datetime", version = "0.1" }
-regex = "1"
-semver = { version = "1", features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_plain = "1"
-snafu = "0.8"
-toml = "0.8"
+chrono = { workspace = true, features = ["clock", "serde", "std"] }
+parse-datetime.workspace = true
+regex.workspace = true
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_plain.workspace = true
+snafu.workspace = true
+toml.workspace = true
 
 [lib]
 name = "update_metadata"

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -9,34 +9,30 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
-async-trait = "0.1"
-argh = "0.1"
-bottlerocket-release = { path = "../../bottlerocket-release", version = "0.1" }
-bytes = "1"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-futures = "0.3"
-futures-core = "0.3"
-log = "0.4"
-lz4 = "1"
-semver = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_plain = "1"
-signpost = { path = "../signpost", version = "0.1" }
-simplelog = "0.12"
-snafu = "0.8"
-tokio = { version = "~1.32", default-features = false, features = ["fs", "macros", "process", "rt-multi-thread"] }  # LTS
-tokio-util = { version = "0.7", features = ["compat", "io-util"] }
-toml = "0.8"
-tough = { version = "0.17", features = ["http"] }
-update_metadata = { path = "../update_metadata", version = "0.1" }
-url = "2"
-signal-hook = "0.3"
-
-[dependencies.bottlerocket-modeled-types]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+async-trait.workspace = true
+argh.workspace = true
+bottlerocket-release.workspace = true
+bytes.workspace = true
+chrono = { workspace = true, features = ["clock", "std"] }
+futures = { workspace = true, features = ["default"] }
+futures-core.workspace = true
+log.workspace = true
+lz4.workspace = true
+semver.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+serde_plain.workspace = true
+signpost.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["fs", "macros", "process", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["compat", "io-util"] }
+toml.workspace = true
+tough = { workspace = true, features = ["http"] }
+update_metadata.workspace = true
+url.workspace = true
+signal-hook.workspace = true
+bottlerocket-modeled-types.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true

--- a/sources/xfscli/Cargo.toml
+++ b/sources/xfscli/Cargo.toml
@@ -17,6 +17,6 @@ name = "fsck_xfs"
 path = "src/bin/fsck_xfs/main.rs"
 
 [dependencies]
-argh = "0.1"
-tempfile = "3"
-snafu = "0.8"
+argh.workspace = true
+tempfile.workspace = true
+snafu.workspace = true


### PR DESCRIPTION
**Description of changes:**
Most of the heavy lifting here was done by a modified fork of [cargo-autoinherit](https://github.com/cbgbt/cargo-autoinherit/tree/cbgbt-v0.1.6), save for some light formatting. I submitted my patches upstream, but it's not clear yet if they'll take them.

I'm currently working on updating `cargo-deny` in the SDK, which now includes a linter that can deny `workspace-dependency` antipatterns.

This PR is split into two commits, with my goal being that the `workspace` commit does not change Cargo.lock at all.

---
    move all dependencies to workspace dependencies
---
    sources: homogenize dependencies

    This fixes a few inconsistencies in dependency requirements:
    * base64 - this is the only semantic change in the commit. Two packages
      depended on a slightly older version of base64. cargo-deny did not
      catch this because we have disabled duplicate detection for base64 to
      accommodate other 3rd party packages.
    * tempfile - This package does not have any default features. Remove the
      `default-features = false` flag.
    * schnauzer - One package had an arbitrarily more-specific version
      requirement for schnauzer.
---

**Testing done:**
* Note that `Cargo.lock` has not changed upon the switch to workspace dependencies.
* Builds succeed

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
