### PR TITLE
kernel-6.1: update to 6.1.102

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/d99ee343f454259e069b83f9c5b6c672d3e166a424243a4ae9fc2634a8d7d4d4/kernel-6.1.97-104.177.amzn2023.src.rpm"
-sha512 = "c368f7e9f999e6b95d0ca12a32af5944fe91e2ac410d06b289f2ef9b0722fe97e2ae8abab8859dba26ab18fcd85e17f9065a864e13be7aff1f4015bf5e670b12"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/0ad0fc5918f243e524ea2a8b8608330d14e7683c7f8b13dd99a9a5620907f0c5/kernel-6.1.102-108.177.amzn2023.src.rpm"
+sha512 = "aed038b03b0c1d87cf4da28df475ed78286333a07f279b744da2dbccff72db65a83c5f7c5638acd28aa55910de5b8a223351226d248d149730eaa1afff93db23"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/config-bottlerocket
+++ b/packages/kernel-6.1/config-bottlerocket
@@ -352,3 +352,8 @@ CONFIG_QLCNIC_SRIOV=y
 # Cisco UCS HBA support
 CONFIG_FCOE_FNIC=m
 CONFIG_SCSI_SNIC=m
+
+# Disable virtio drivers unused in Bottlerocket
+# CONFIG_DRM_VIRTIO_GPU is not set
+# CONFIG_VIRTIO_DMA_SHARED_BUFFER is not set
+

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.97
+Version: 6.1.102
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/d99ee343f454259e069b83f9c5b6c672d3e166a424243a4ae9fc2634a8d7d4d4/kernel-6.1.97-104.177.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/0ad0fc5918f243e524ea2a8b8608330d14e7683c7f8b13dd99a9a5620907f0c5/kernel-6.1.102-108.177.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs


### PR DESCRIPTION
Rebase to Amazon Linux upstream version 6.1.102-108.177.amzn2023. Disable two newly selected virtio drivers from upstream.

**Description of changes:**

Update to the latest upstream 6.1.102-108.177, and add two variables to `config-bottlerocket` to disable drivers newly added in this upstream release:

```
# CONFIG_DRM_VIRTIO_GPU is not set
# CONFIG_VIRTIO_DMA_SHARED_BUFFER is not set
```
These were not set in prior releases, so this maintains the Bottlerocket status quo. Aside from that, there is one new configuration from upstream:
```
CONFIG_PTP_1588_CLOCK_VMCLOCK=y
```
No patches in this update conflict with Bottlerocket patches.


**Testing done:**

* bottlerocket-core-kit builds (both architectures)
* bottlerocket variant aws-k8s-1.29 builds and boots (both architectures)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
