### PR TITLE
kubernetes: apply upstream patches.

### DIFF
--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -133,6 +133,10 @@ sha512 = "f7a486404dc156145b3114e430f3e2c4f34f1cc51f5c98d2b2364064588b2432fb161d
 url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0034-EKS-PATCH-CVE-2023-45288-Bumps-1.24-dependency-for-C.patch"
 sha512 = "c34ca3f3585137c7ec40be543da2b6f39f6751e89e2cf1bc4f16c5f98d8bcedb1cc8f05a39aabe363745cdfe78c0e4acfc72e9b5b3fc29b22b0b3cb56b9bb30c"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-24/patches/0035-EKS-PATCH-Fix-CVE-2024-5321.patch"
+sha512 = "974790a848aac14b22bce4f9248ede33a6131f3a5ea8f881f31d42ea0e03dd4b770c90571ea4383d9b5179d4de7bfbc39db3b80cf335a2b7a3b02a695d583b68"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -95,6 +95,7 @@ Patch0031: 0031-EKS-PATCH-GO-UPDATE-update-to-golangci-lint-v1.54.1-.patch
 Patch0032: 0032-EKS-PATCH-GO-UPDATE-Merge-pull-request-122077-from-B.patch
 Patch0033: 0033-EKS-PATCH-GO-UPDATE-go-Bump-images-dependencies-and-.patch
 Patch0034: 0034-EKS-PATCH-CVE-2023-45288-Bumps-1.24-dependency-for-C.patch
+Patch0035: 0035-EKS-PATCH-Fix-CVE-2024-5321.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -101,6 +101,9 @@ sha512 = "ceb1a7844e4e2ed5fa3a838949086ebf86114bba8007a3125ea4ebd6aba7e790eb19b1
 url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-25/patches/0022-EKS-PATCH-Update-aws-sdk-go-to-include-new-regions.patch"
 sha512 = "e226f5a70aeafa25ff010c607b1e7913b562f37674062a0aadbe77fd62532dd5bab10c3bfc38af455a00232da0548f82cd77a86d124b17149d5f9e4bcc96fa30"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-25/patches/0023-EKS-PATCH-Fix-CVE-2024-5321.patch"
+sha512 = "f74d550646b0bf0f4c0596c78337037034c29ada7f3683ad3f3dbbac0011f935185486a178212cd93ad3338aa59b20be3f899863b6ed726f81753f221e66e51f"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -87,6 +87,7 @@ Patch0019: 0019-EKS-PATCH-GO-UPDATE-handle-GOTOOLCHAIN-in-kube-golan.patch
 Patch0020: 0020-EKS-PATCH-GO-UPDATE-Bump-images-dependencies-and-ver.patch
 Patch0021: 0021-EKS-PATCH-Bumps-dependencies-for-fixing-CVE-2023-452.patch
 Patch0022: 0022-EKS-PATCH-Update-aws-sdk-go-to-include-new-regions.patch
+Patch0023: 0023-EKS-PATCH-Fix-CVE-2024-5321.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -61,6 +61,10 @@ sha512 = "9328a84b0dbd3948f2a1ff87c4c2afe11d07f29f376cb845a115ba844e9f92a20438e6
 url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0013-EKS-PATCH-Update-aws-sdk-go-for-new-regions.patch"
 sha512 = "edb501bdc01863a7abe28a19369230ef94841630866644c3abdf42041d3876023ae359fea679133d403c517f6b43c9b0c24c5b59a28d9b6508c6f2d87a99f37f"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-26/patches/0014-EKS-PATCH-Fix-CVE-2024-5321.patch"
+sha512 = "6267486606741f25e12b2d0bd19d3243c485b21cce4ae992258a64db714c42ea3542c03f225bd8ce41a63e2dc3449f56e16e7c126a67107144c2da4bea820d81"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -77,6 +77,7 @@ Patch0010: 0010-EKS-PATCH-Update-log-verbosity-for-node-health-and-t.patch
 Patch0011: 0011-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch
 Patch0012: 0012-EKS-PATCH-Bumps-dependency-for-CVE-2023-45288.patch
 Patch0013: 0013-EKS-PATCH-Update-aws-sdk-go-for-new-regions.patch
+Patch0014: 0014-EKS-PATCH-Fix-CVE-2024-5321.patch
 
 BuildRequires: git
 BuildRequires: rsync


### PR DESCRIPTION
Apply upstream patches for kubernetes-1.24, kubernetes-1.25, and kubernetes-1.26, to mitigate CVE-2024-5321.

**Description of changes:**

EKS-D published patches for versions 1.24, 1.25, and 1.26.

**Testing done:**

Built core kit (both architectures) and variants (also both architectures), and verified that the images boot and the kubernetes services attempt to start. Did not create a cluster to run the 6 AMIs.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
