### PR TITLE
kubernetes-1.24: Apply upstream patch

### DIFF
--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -133,6 +133,10 @@ sha512 = "f7a486404dc156145b3114e430f3e2c4f34f1cc51f5c98d2b2364064588b2432fb161d
 url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-24/patches/0034-EKS-PATCH-CVE-2023-45288-Bumps-1.24-dependency-for-C.patch"
 sha512 = "c34ca3f3585137c7ec40be543da2b6f39f6751e89e2cf1bc4f16c5f98d8bcedb1cc8f05a39aabe363745cdfe78c0e4acfc72e9b5b3fc29b22b0b3cb56b9bb30c"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-24/patches/0035-EKS-PATCH-Fix-CVE-2024-5321.patch"
+sha512 = "974790a848aac14b22bce4f9248ede33a6131f3a5ea8f881f31d42ea0e03dd4b770c90571ea4383d9b5179d4de7bfbc39db3b80cf335a2b7a3b02a695d583b68"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -95,6 +95,7 @@ Patch0031: 0031-EKS-PATCH-GO-UPDATE-update-to-golangci-lint-v1.54.1-.patch
 Patch0032: 0032-EKS-PATCH-GO-UPDATE-Merge-pull-request-122077-from-B.patch
 Patch0033: 0033-EKS-PATCH-GO-UPDATE-go-Bump-images-dependencies-and-.patch
 Patch0034: 0034-EKS-PATCH-CVE-2023-45288-Bumps-1.24-dependency-for-C.patch
+Patch0035: 0035-EKS-PATCH-Fix-CVE-2024-5321.patch
 
 BuildRequires: git
 BuildRequires: rsync


### PR DESCRIPTION
Mitigates CVE-2024-5321.

**Description of changes:**

Add one upstream patch.

**Testing done:**

Built aws-k8s-1.24 AMIs for both architectures, verified boot.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
