### PR TITLE
kubernetes-1.26: Apply upstream patch

### DIFF
--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -61,6 +61,10 @@ sha512 = "9328a84b0dbd3948f2a1ff87c4c2afe11d07f29f376cb845a115ba844e9f92a20438e6
 url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-26/patches/0013-EKS-PATCH-Update-aws-sdk-go-for-new-regions.patch"
 sha512 = "edb501bdc01863a7abe28a19369230ef94841630866644c3abdf42041d3876023ae359fea679133d403c517f6b43c9b0c24c5b59a28d9b6508c6f2d87a99f37f"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-26/patches/0014-EKS-PATCH-Fix-CVE-2024-5321.patch"
+sha512 = "6267486606741f25e12b2d0bd19d3243c485b21cce4ae992258a64db714c42ea3542c03f225bd8ce41a63e2dc3449f56e16e7c126a67107144c2da4bea820d81"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -77,6 +77,7 @@ Patch0010: 0010-EKS-PATCH-Update-log-verbosity-for-node-health-and-t.patch
 Patch0011: 0011-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch
 Patch0012: 0012-EKS-PATCH-Bumps-dependency-for-CVE-2023-45288.patch
 Patch0013: 0013-EKS-PATCH-Update-aws-sdk-go-for-new-regions.patch
+Patch0014: 0014-EKS-PATCH-Fix-CVE-2024-5321.patch
 
 BuildRequires: git
 BuildRequires: rsync


### PR DESCRIPTION
Mitigates CVE-2024-5321.

**Description of changes:**

Apply one upstream patch.

**Testing done:**

Built aws-k8s-1.26 AMIs for both architectures, verified boot.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
