### PR TITLE
Update datastore serializer to expect JSON and correctly handle null values

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -4112,6 +4112,7 @@ dependencies = [
  "models",
  "rand",
  "semver",
+ "serde_json",
  "simplelog",
  "snafu",
  "toml",

--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -94,6 +94,9 @@ pub enum Error {
     #[snafu(display("Unable to serialize data: {}", source))]
     Serialize { source: serde_json::Error },
 
+    #[snafu(display("Error serializing settings to JSON: {}", source))]
+    SettingsToJson { source: serde_json::Error },
+
     #[snafu(display("Error serializing {}: {} ", given, source))]
     DataStoreSerialization {
         given: String,

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -792,6 +792,7 @@ impl ResponseError for error::Error {
             SystemdNotifyStatus {} => StatusCode::INTERNAL_SERVER_ERROR,
             SetPermissions { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             SetGroup { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            SettingsToJson { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ReleaseData { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Shutdown { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Reboot { .. } => StatusCode::INTERNAL_SERVER_ERROR,

--- a/sources/api/datastore/src/serialization/pairs.rs
+++ b/sources/api/datastore/src/serialization/pairs.rs
@@ -229,9 +229,12 @@ impl<'a> ser::Serializer for Serializer<'a> {
         bad_type("bytes")
     }
 
-    // We just don't expect to need these, and we doesn't have a great way to represent them.
+    // serde_json::Value::Null is the only case where we should see this, so we can essentially
+    // consider this to be serialize_null(). Since we should only see null values in a settings
+    // input when the settings structure has an Option<T>, it should be safe to omit the key/value
+    // pair from the serialization output if the value is null.
     fn serialize_unit(self) -> Result<()> {
-        bad_type("unit")
+        Ok(())
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<()> {

--- a/sources/api/datastore/src/serialization/pairs.rs
+++ b/sources/api/datastore/src/serialization/pairs.rs
@@ -489,6 +489,7 @@ mod test {
     use crate::{Key, KeyType};
     use maplit::hashmap;
     use serde::Serialize;
+    use serde_json::json;
 
     // Helper macro for making a data Key for testing whose name we know is valid.
     macro_rules! key {
@@ -639,6 +640,133 @@ mod test {
             hashmap!(
                 key!("A.id") => "\"alpha\"".to_string(),
                 key!("A.ie") => "\"beta\"".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn json_null() {
+        let j = json!(null);
+        let keys = to_pairs_with_prefix("null", &j).unwrap();
+        // the null value and its key should be skipped in serialization, resulting in an empty
+        // hashmap
+        assert_eq!(keys, hashmap!());
+    }
+
+    #[test]
+    fn json_bool() {
+        let j = json!(true);
+        let keys = to_pairs_with_prefix("bool", &j).unwrap();
+        assert_eq!(
+            keys,
+            hashmap!(
+                key!("bool") => "true".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn json_number() {
+        let j = json!(42);
+        let keys = to_pairs_with_prefix("number", &j).unwrap();
+        assert_eq!(
+            keys,
+            hashmap!(
+                key!("number") => "42".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn json_number_float() {
+        let j = json!(4.2);
+        let keys = to_pairs_with_prefix("number", &j).unwrap();
+        assert_eq!(
+            keys,
+            hashmap!(
+                key!("number") => "4.2".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn json_string() {
+        let j = json!("hello");
+        let keys = to_pairs_with_prefix("string", &j).unwrap();
+        assert_eq!(
+            keys,
+            hashmap!(
+                key!("string") => "\"hello\"".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn json_array() {
+        let j = json!(["foo", true, 42]);
+        let keys = to_pairs_with_prefix("array", &j).unwrap();
+        assert_eq!(
+            keys,
+            hashmap!(
+                key!("array") => "[\"foo\",true,42]".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn json_array_with_null() {
+        let j = json!(["foo", null, true, 42]);
+        let keys = to_pairs_with_prefix("array", &j).unwrap();
+        assert_eq!(
+            keys,
+            hashmap!(
+                key!("array") => "[\"foo\",null,true,42]".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn json_object() {
+        let j = json!({
+            "bool": true,
+            "number": 42,
+            "string": "foo",
+            "array": ["foo", true, null, 42],
+            "object": {"number": 4.2}
+        });
+        let keys = to_pairs_with_prefix("object", &j).unwrap();
+        assert_eq!(
+            keys,
+            hashmap!(
+                key!("object.bool") => "true".to_string(),
+                key!("object.number") => "42".to_string(),
+                key!("object.string") => "\"foo\"".to_string(),
+                key!("object.array") => "[\"foo\",true,null,42]".to_string(),
+                key!("object.object.number") => "4.2".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn json_object_with_null() {
+        let j = json!({
+            "null": null,
+            "bool": true,
+            "number": 42,
+            "string": "foo",
+            "array": ["foo", true, null, 42],
+            "object": {"number": 4.2}
+        });
+        let keys = to_pairs_with_prefix("object", &j).unwrap();
+        // the null value and its key should be skipped in serialization
+        assert_eq!(
+            keys,
+            hashmap!(
+                key!("object.bool") => "true".to_string(),
+                key!("object.number") => "42".to_string(),
+                key!("object.string") => "\"foo\"".to_string(),
+                key!("object.array") => "[\"foo\",true,null,42]".to_string(),
+                key!("object.object.number") => "4.2".to_string(),
             )
         );
     }

--- a/sources/api/storewolf/Cargo.toml
+++ b/sources/api/storewolf/Cargo.toml
@@ -17,6 +17,7 @@ log.workspace = true
 models.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
 semver.workspace = true
+serde_json.workspace = true
 simplelog.workspace = true
 snafu.workspace = true
 toml.workspace = true


### PR DESCRIPTION
**Issue number:**

This is a more robust/comprehensive fix to the first issue seen in https://github.com/bottlerocket-os/bottlerocket/issues/4135

**Description of changes:**

Previously, the datastore serializer handled basically any serializable data type, which allowed us to use a range of input types, but also required us to be very generic in the implementation, making it difficult to special-case particular types.

As we move towards Out-of-Tree Builds and Settings Extensions, allowing this broad range of types as an input to the datastore serializer is actually becoming less helpful, since settings will be passed around as a more generic type that will be validated against a more concrete type on set.

Because of this, it makes sense to limit the input space of the Serializer to only allow this generic type, and to ensure that all edge cases for this generic type are handled correctly. Since Settings Plugins do all of their serialization and deserialization across the FFI border using JSON, it makes sense for JSON to be this generic type.

After we've limited the datastore serializer to only accept JSON, implementors of Settings Plugins and Settings Extensions can just focus on ensuring that their types serialize correctly to JSON, and they can be sure that it will serialize correctly to the datastore format for free.

_A note for discussion: now that the datastore serializer has been limited to only accept JSON, there is serialization logic for a broader range of types than necessary. Does make sense to clean up these unused types to help hint that this serializer should only be used with `serde_json::Value`?_

**Testing done:**

I added a bunch of unit tests to the datastore serializer to ensure that all of the types in `serde_json::Value` serialize correctly.

Then, I built the core-kit, and built an AMI using my core-kit to ensure that there was no strange behavior. The instance I launched booted fine, and was able to handle settings correctly.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
