### PR TITLE
packages: use GO_MAJOR for selecting Go version

### DIFF
--- a/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
+++ b/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
@@ -49,7 +49,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %build
 %set_cross_go_flags
 
-export GO_VERSION="1.22.2"
+export GO_MAJOR="1.22"
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -44,7 +44,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 cp -r %{_builddir}/sources/%{workspace_name}/* .
 
 %build
-export GO_VERSION="1.22.2"
+export GO_MAJOR="1.22"
 
 %set_cross_go_flags
 go build -ldflags="${GOLDFLAGS}" -o host-ctr ./cmd/host-ctr

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -143,7 +143,7 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 %build
 export FORCE_HOST_GO=1
 
-export GO_VERSION="1.22.2"
+export GO_MAJOR="1.22"
 
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

set `GO_MAJOR` for packages that are overriding the default in the SDK

**Testing done:**

`make ARCH=x86_64 && make ARCH=aarch64`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
