### PR TITLE
apiserver: fix incorrect error handling

### DIFF
--- a/sources/api/apiserver/src/server/controller.rs
+++ b/sources/api/apiserver/src/server/controller.rs
@@ -136,7 +136,7 @@ where
     let os = BottlerocketRelease::new().context(error::ReleaseDataSnafu)?;
 
     // Turn into a serde Value we can manipulate.
-    let val = serde_json::to_value(os).context(error::SettingsToJsonSnafu)?;
+    let val = serde_json::to_value(os).expect("struct to value can't fail");
 
     // Structs are Objects in serde_json, which have a map of field -> value inside.  We
     // destructure to get it by value, instead of as_object() which gives references.
@@ -366,7 +366,7 @@ pub(crate) fn set_settings<D: DataStore>(
     transaction: &str,
 ) -> Result<()> {
     trace!("Serializing Settings to write to data store");
-    let settings_json = serde_json::to_value(settings).expect("struct to value can't fail");
+    let settings_json = serde_json::to_value(settings).context(error::SettingsToJsonSnafu)?;
     let pairs = to_pairs_with_prefix("settings", &settings_json)
         .context(error::DataStoreSerializationSnafu { given: "Settings" })?;
     let pending = Committed::Pending {


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Mixed up which line I was on in https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/80. This puts the correct error handling with the correct `serde_json::to_value` call.

**Testing done:**

`cargo build`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
