### PR TITLE
Update libnvidia-container and nvidia-container-toolkit

### DIFF
--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.13.5/libnvidia-container-1.13.5.tar.gz"
-sha512 = "00de15c2a0168b0c131eae21e10d186053be7f78021fe28785130ea541f1a592f44042697f01b3bf20717d9a93a85b34c7b510028adcc265cc0ac6f97be2bf0e"
+url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.16.1/libnvidia-container-1.16.1.tar.gz"
+sha512 = "b304c284c5ab0c3544362307dc16ffcca8d34497e4356a520dc6da81a86a62b2a262b528cba559bb0d7a3addf018c3b50b6cb78669c82c1b4acae159e5922548"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/nvidia-modprobe/archive/495.44/nvidia-modprobe-495.44.tar.gz"
-sha512 = "67486ed1b17c8962786e13880910bb2b1938206a0fd76b360ddef7faf80ee0c941a2e3fbc73fa92a92009e2c54130dce17a466c8079537a981a2fed09c07e4c9"
+url = "https://github.com/NVIDIA/nvidia-modprobe/archive/550.54.14/nvidia-modprobe-550.54.14.tar.gz"
+sha512 = "279228aa315ff5fd1a23df23527aff58b2319f11f9fc7d939fa285ea933b4cc6d223451e20ecf7f50baba9f6c9c100e57cb77675d0d17fa77f19d3fea2ccc193"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -1,7 +1,7 @@
-%global nvidia_modprobe_version 495.44
+%global nvidia_modprobe_version 550.54.14
 
 Name: %{_cross_os}libnvidia-container
-Version: 1.13.5
+Version: 1.16.1
 Release: 1%{?dist}
 Summary: NVIDIA container runtime library
 # The COPYING and COPYING.LESSER files in the sources don't apply to libnvidia-container
@@ -59,6 +59,7 @@ export WITH_TIRPC=yes \\\
 export WITH_NVCGO=yes \\\
 export prefix=%{_cross_prefix} \\\
 export DESTDIR=%{buildroot} \\\
+export LIB_VERSION=%{version} \\\
 %{nil}
 
 %build

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.13.5/nvidia-container-toolkit-1.13.5.tar.gz"
-sha512 = "7266e779abf27f2bc1b7c801e5eb4720b82be22bed3ec90171e4f5499b2bc7376f1369e4931d4db55edc8f5fd5e44d5e817eb258ec39bf55f16424fe725188d6"
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.16.1/nvidia-container-toolkit-1.16.1.tar.gz"
+sha512 = "691d4fc47ea60b730ec491b333aa8118bcfd62cdab20a42b84155c6a13484d920e758435b5029bbae4fbefce82352aa5764f1554992682f689c95615809fb83c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 %global gorepo nvidia-container-toolkit
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.13.5
+%global gover 1.16.1
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-container-toolkit
@@ -50,6 +50,12 @@ Conflicts: %{name}-ecs
 
 %build
 %cross_go_configure %{goimport}
+
+# We don't set `-Wl,-z,now`, because the binary uses lazy loading
+# to load the NVIDIA libraries in the host
+export CGO_LDFLAGS="-Wl,-z,relro -Wl,--export-dynamic"
+export GOLDFLAGS="-compressdwarf=false -linkmode=external -extldflags '${CGO_LDFLAGS}'"
+
 go build -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime-hook ./cmd/nvidia-container-runtime-hook
 go build -ldflags="${GOLDFLAGS}" -o nvidia-ctk ./cmd/nvidia-ctk
 

--- a/packages/nvidia-k8s-device-plugin/Cargo.toml
+++ b/packages/nvidia-k8s-device-plugin/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/k8s-device-plugin/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.14.4/v0.14.4.tar.gz"
-path = "k8s-device-plugin-0.14.4.tar.gz"
-sha512 = "055439c2aac797b2d594846d9fb572f2f46ad5caeb9f44107a2fc05211904823c01a8fd8a2329c13a47ef440fd017086067f7ec55d482970cdbc1663b36d714c"
+url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.16.2/v0.16.2.tar.gz"
+path = "k8s-device-plugin-0.16.2.tar.gz"
+sha512 = "0be166ba3f2ae51882e62e71dc625f6e83c4c18321e9e6beb05b7f2f6b3628e5ca7f480576f422faba0e6ad232085dff200b474f2453aeef307f9a6a5d13e1b6"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -2,7 +2,7 @@
 %global gorepo k8s-device-plugin
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.14.4
+%global gover 0.16.2
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-k8s-device-plugin
@@ -46,6 +46,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %cross_go_setup %{gorepo}-%{gover} %{goproject} %{goimport}
 
 %build
+export GO_MAJOR="1.22"
 %cross_go_configure %{goimport}
 # We don't set `-Wl,-z,now`, because the binary uses lazy loading
 # to load the NVIDIA libraries in the host


### PR DESCRIPTION
**Description of changes:**

This updates `libnvidia-container` and `nvidia-container-toolkit` to their latest versions. With this update, the flags to compile `nvidia-container-toolkit` were changed to allow lazy loading a library, since the upstream maintainers changed how the binaries load the `nvml`. This is similar to what we already do in other places that depend on `nvml` like the NVIDIA device plugin or `ecs-gpu-init`. 

**Testing done:**

Previously, the ECS aarch64 NVIDIA variant didn't work. With the latest version, I confirmed that the variant is functional and tasks run:

```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "b12d2708-dirty",
    "pretty_name": "Bottlerocket OS 1.21.0 (aws-ecs-2-nvidia)",
    "variant_id": "aws-ecs-2-nvidia",
    "version_id": "1.21.0"
  }
}
bash-5.1# docker ps
CONTAINER ID   IMAGE     COMMAND            CREATED          STATUS          PORTS     NAMES
f5f232f87884   fedora    "sleep infinity"   57 minutes ago   Up 57 minutes             ecs-nvidia-5-nvidia-a2e5afed989db3fd1500
bash-5.1# docker exec -it f5f232f87884 nvidia-smi
Tue Aug 13 22:28:20 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.01             Driver Version: 535.183.01   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA T4G                     Off | 00000000:00:1F.0 Off |                    0 |
| N/A   59C    P0              27W /  70W |      2MiB / 15360MiB |      8%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
bash-5.1#
```

Tested that k8s 1.29 x86_64 node joined a cluster, and run a pod with 1 GPU:

```
develop on  develop [$!] via 🦀 v1.79.0 on Fedora ❯ k exec gpu-tests-b9jfj -it -- nvidia-smi
Wed Aug 14 22:59:14 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.01             Driver Version: 535.183.01   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla T4                       Off | 00000000:00:1E.0 Off |                    0 |
| N/A   32C    P8              11W /  70W |      2MiB / 15360MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
