### PR TITLE
Pluto settings models

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3120,6 +3120,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bottlerocket-modeled-types",
+ "bottlerocket-settings-models",
  "bytes",
  "constants",
  "futures-util",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1076,10 +1076,11 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+version = "0.3.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
+ "bottlerocket-model-derive",
  "bottlerocket-scalar",
  "bottlerocket-scalar-derive",
  "bottlerocket-string-impls-for",
@@ -1110,7 +1111,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1119,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1143,8 +1144,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+version = "0.3.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1164,10 +1165,12 @@ dependencies = [
  "settings-extension-ecs",
  "settings-extension-host-containers",
  "settings-extension-kernel",
+ "settings-extension-kubernetes",
  "settings-extension-metrics",
  "settings-extension-motd",
  "settings-extension-network",
  "settings-extension-ntp",
+ "settings-extension-nvidia-container-runtime",
  "settings-extension-oci-defaults",
  "settings-extension-oci-hooks",
  "settings-extension-pki",
@@ -1190,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1203,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "serde",
 ]
@@ -1211,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -1770,7 +1773,7 @@ dependencies = [
  "base64 0.22.1",
  "constants",
  "early-boot-config-provider",
- "env_logger 0.11.3",
+ "env_logger",
  "generate-readme",
  "http 0.2.12",
  "log",
@@ -1789,7 +1792,7 @@ name = "early-boot-config-provider"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "env_logger 0.11.3",
+ "env_logger",
  "flate2",
  "generate-readme",
  "hex-literal",
@@ -1852,19 +1855,6 @@ checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -2499,17 +2489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3678,12 +3657,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3691,12 +3670,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3704,12 +3683,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3717,12 +3696,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3730,12 +3709,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3743,12 +3722,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3756,12 +3735,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3769,12 +3748,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3782,12 +3761,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3795,25 +3774,39 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "settings-extension-metrics"
+name = "settings-extension-kubernetes"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
+ "serde",
+ "serde_json",
+ "toml",
+]
+
+[[package]]
+name = "settings-extension-metrics"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3821,11 +3814,11 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3833,12 +3826,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3846,12 +3839,25 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "settings-extension-nvidia-container-runtime"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3859,12 +3865,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
  "toml",
@@ -3873,12 +3879,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3886,12 +3892,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "serde",
  "serde_json",
 ]
@@ -3899,12 +3905,12 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.2.0#848b3153922c5202e4f38c428b7572a9ee313f3f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.3.0#cebbd4cdd4cf86b24b52554b9db7bdc21aa4e67e"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "env_logger 0.10.2",
+ "env_logger",
  "rand",
  "serde",
  "serde_json",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1062,7 +1062,6 @@ version = "0.1.0"
 dependencies = [
  "rand",
  "serde_json",
- "settings-extension-updates",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -190,13 +190,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+tag = "bottlerocket-settings-models-v0.3.0"
+version = "0.3.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.2.0"
+tag = "bottlerocket-settings-models-v0.3.0"
+version = "0.3.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -205,7 +205,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
+tag = "bottlerocket-settings-models-v0.3.0"
 version = "0.1.0"
 
 [profile.release]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -208,10 +208,5 @@ git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
 tag = "bottlerocket-settings-models-v0.2.0"
 version = "0.1.0"
 
-[workspace.dependencies.settings-extension-updates]
-git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.2.0"
-version = "0.1.0"
-
 [profile.release]
 debug = true

--- a/sources/api/bork/Cargo.toml
+++ b/sources/api/bork/Cargo.toml
@@ -11,4 +11,3 @@ exclude = ["README.md"]
 [dependencies]
 rand = { workspace = true, features = ["default"] }
 serde_json.workspace = true
-settings-extension-updates.workspace = true

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -10,6 +10,8 @@ build = "build.rs"
 exclude = ["README.md"]
 
 [dependencies]
+bottlerocket-modeled-types.workspace = true
+bottlerocket-settings-models.workspace = true
 bytes.workspace = true
 constants.workspace = true
 futures-util.workspace = true
@@ -32,7 +34,6 @@ tokio-retry.workspace = true
 tokio-rustls.workspace = true
 url.workspace = true
 log.workspace = true
-bottlerocket-modeled-types.workspace = true
 
 [build-dependencies]
 generate-readme.workspace = true

--- a/sources/api/pluto/src/ec2.rs
+++ b/sources/api/pluto/src/ec2.rs
@@ -40,12 +40,16 @@ pub(super) enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-pub(super) async fn get_private_dns_name(
+pub(super) async fn get_private_dns_name<H, N>(
     region: &str,
     instance_id: &str,
-    https_proxy: Option<String>,
-    no_proxy: Option<String>,
-) -> Result<String> {
+    https_proxy: Option<H>,
+    no_proxy: Option<&[N]>,
+) -> Result<String>
+where
+    H: AsRef<str>,
+    N: AsRef<str>,
+{
     let config = sdk_config(region).await;
 
     let client = if let Some(https_proxy) = https_proxy {

--- a/sources/api/pluto/src/eks.rs
+++ b/sources/api/pluto/src/eks.rs
@@ -33,12 +33,16 @@ type Result<T> = std::result::Result<T, Error>;
 
 /// Returns the cluster's [kubernetesNetworkConfig] by calling the EKS API.
 /// (https://docs.aws.amazon.com/eks/latest/APIReference/API_KubernetesNetworkConfigResponse.html)
-pub(super) async fn get_cluster_network_config(
+pub(super) async fn get_cluster_network_config<H, N>(
     region: &str,
     cluster: &str,
-    https_proxy: Option<String>,
-    no_proxy: Option<String>,
-) -> Result<ClusterNetworkConfig> {
+    https_proxy: Option<H>,
+    no_proxy: Option<&[N]>,
+) -> Result<ClusterNetworkConfig>
+where
+    H: AsRef<str>,
+    N: AsRef<str>,
+{
     let config = sdk_config(region).await;
 
     let client = if let Some(https_proxy) = https_proxy {

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -55,8 +55,6 @@ deny = [{ name = "structopt" }, { name = "clap", wrappers = ["cargo-readme"] }]
 skip = [
     # this can be removed once settings sdk is updated to base64 0.22.1
     { name = "base64", version = "=0.21.7" },
-    # this can be removed once settings sdk is updated to env_logger 0.11
-    { name = "env_logger", version = "=0.10.2" },
 ]
 
 skip-tree = [


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/4135

**Description of changes:**
Pluto requests an initial set of settings from the Bottlerocket API as dependencies needed to generate additional `kubernetes` settings.

There was a bug in pluto in which `no-proxy` settings were attempted to be deserialized into a `String` when the value in the model is stored as a `Vec`. This updates pluto to use the settings models from the settings SDK to deserialize the settings returned from the API.

**Testing done:**
* [x] unit tests pass
* [x] test with proxy enabled
* [x] test cluster dns IP properly set in a cluster
* [x] test max pods properly set
* [x] test provider_id properly set
* [x] test node_name properly set

I enabled `https-proxy` pointing to a `tinyproxy` that I configured, then tested instance startup with various `no-proxy` settings:
* Unset `no-proxy`: Noted traffic in my proxy logs and also that the Cloudtrail noted the IP address of my proxy as the source for EKS `DescribeCluster` traffic
* `no-proxy: ["*"]` bypassed the proxy when communicating with the EKS API
* No `proxy` settings: all EKS settings still set as usual


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
