### PR TITLE
Fix udev rule for EBS mappings

### DIFF
--- a/packages/os/ebs-volumes.rules
+++ b/packages/os/ebs-volumes.rules
@@ -7,9 +7,9 @@ ATTRS{model}!="Amazon Elastic Block Store", GOTO="ebs_volumes_end"
 ENV{DEVTYPE}=="disk", ATTR{queue/io_timeout}="4294967295"
 
 # Add symlink for disk
-KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", IMPORT{program}="/usr/bin/ghostdog ebs-device-name $devnode", SYMLINK+="$env{XVD_DEVICE_NAME}"
+KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", IMPORT{program}="/usr/bin/ghostdog ebs-device-name $devnode", SYMLINK+="disk/by-ebs-id/$env{XVD_DEVICE_NAME}"
 
 # Add symlink for partition
-KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", IMPORT{parent}="XVD_DEVICE_NAME", SYMLINK+="$env{XVD_DEVICE_NAME}$number"
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", IMPORT{parent}="XVD_DEVICE_NAME", SYMLINK+="disk/by-ebs-id/$env{XVD_DEVICE_NAME}$number"
 
 LABEL="ebs_volumes_end"


### PR DESCRIPTION
**Issue number:**
#97 

**Description of changes:**

With this change, symlinks to the underlying EBS volumes will be created under `/dev/by-ebs-id` instead of the root of `/dev`. This will help prevent collisions with actual devices created by the kernel (as described in this https://github.com/amazonlinux/amazon-ec2-utils/issues/37).

As part of this change, `/dev/` will be removed from the device name if it is found after querying the device identifier, so that only the device id is returned to udev.


**Testing done:**

I ran my change in an EC2 instance, and confirmed that the devices are listed under `/dev/by-ebs-id` when the mapping is added:

```
ls -la /dev/disk/by-ebs-id
total 0
drwxr-xr-x.  2 root root 240 Aug 19 20:50 .
drwxr-xr-x. 10 root root 200 Aug 19 20:50 ..
lrwxrwxrwx.  1 root root  13 Aug 19 20:50 xvda -> ../../nvme0n1
lrwxrwxrwx.  1 root root  15 Aug 19 20:50 xvda1 -> ../../nvme0n1p1
lrwxrwxrwx.  1 root root  15 Aug 19 20:50 xvda2 -> ../../nvme0n1p2
lrwxrwxrwx.  1 root root  15 Aug 19 20:50 xvda3 -> ../../nvme0n1p3
lrwxrwxrwx.  1 root root  15 Aug 19 20:50 xvda4 -> ../../nvme0n1p4
lrwxrwxrwx.  1 root root  15 Aug 19 20:50 xvda5 -> ../../nvme0n1p5
lrwxrwxrwx.  1 root root  15 Aug 19 20:50 xvda6 -> ../../nvme0n1p6
lrwxrwxrwx.  1 root root  15 Aug 19 20:50 xvda7 -> ../../nvme0n1p7
lrwxrwxrwx.  1 root root  15 Aug 19 20:50 xvda8 -> ../../nvme0n1p8
lrwxrwxrwx.  1 root root  13 Aug 19 20:50 xvdcz -> ../../nvme1n1
```

I confirmed that in the workflow that prepends the device ID with `/dev/`, this prefix is removed and the symlink is created under `/dev/by-ebs-id/`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
