### PR TITLE
Update kernel for kit release 2.3.5

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/80b412025b31bb458101f1b77be21026705d3050811f05dad47e25e943c2cfb5/kernel-5.10.223-211.872.amzn2.src.rpm"
-sha512 = "2e206345d88ed8f17363df1104dccad5d745116ecfeeac61b2ba84ca5a2dc9116b50754ea74f6ca79fe6eeeaf0bc0a5319469efde2726d8c0ced87ebcf5ecba8"
+url = "https://cdn.amazonlinux.com/blobstore/53ac58d4538601179e563feeda7d409981189fdde44ed02b0195fff959016432/kernel-5.10.223-212.873.amzn2.src.rpm"
+sha512 = "1d45f8480ee51dfc4a8e7200aa42b63aface8c7633d90565624788d9bbfbca017a3c24635d994994ac672dc565995e2067e526e2f1852817f77beaa5b1305749"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/80b412025b31bb458101f1b77be21026705d3050811f05dad47e25e943c2cfb5/kernel-5.10.223-211.872.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/53ac58d4538601179e563feeda7d409981189fdde44ed02b0195fff959016432/kernel-5.10.223-212.873.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/0ad0fc5918f243e524ea2a8b8608330d14e7683c7f8b13dd99a9a5620907f0c5/kernel-6.1.102-108.177.amzn2023.src.rpm"
-sha512 = "aed038b03b0c1d87cf4da28df475ed78286333a07f279b744da2dbccff72db65a83c5f7c5638acd28aa55910de5b8a223351226d248d149730eaa1afff93db23"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/bc929cd6c35e297ebc5760d75997d219080501a32b7936641003178bce778074/kernel-6.1.102-111.182.amzn2023.src.rpm"
+sha512 = "fab5cfd995c22a36a9815a3c8115a72d1a2e3a28e3fc49b7b490f664b562a6f48724616cc458b58a147d4b5fbdf16cb34a58676fbae72838a770d43334089300"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/0ad0fc5918f243e524ea2a8b8608330d14e7683c7f8b13dd99a9a5620907f0c5/kernel-6.1.102-108.177.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/bc929cd6c35e297ebc5760d75997d219080501a32b7936641003178bce778074/kernel-6.1.102-111.182.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Updates packages/kernel-5.10 to upstream 5.10.223-212.873
Updates packages/kernel-6.1 to upstream 6.1.102-111.182

** Configurations**
The 6.1 config added a commented line, which has no side effect
```
# CONFIG_SYSGENID is not set
```

**Testing done:**
- [x] Boot test done on `aws-k8s-1.28` and `aws-k8s-1.23` variants.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
