### PR TITLE
Backfill kernel advisories for v2.3.0 and v2.3.2 releases

### DIFF
--- a/advisories/2.3.0/BRSA-3gu9z1ucas08.toml
+++ b/advisories/2.3.0/BRSA-3gu9z1ucas08.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "BRSA-3gu9z1ucas08"
+title = "kernel CVE-2024-42068"
+cve = "CVE-2024-42068"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: bpf: Take return from set_memory_ro() into account with bpf_prog_lock_ro()"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.162-107.160.amzn2"
+
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.97-104.177.amzn2023"
+
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-07-24T20:00:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.0"

--- a/advisories/2.3.0/BRSA-6emlsfoqaa70.toml
+++ b/advisories/2.3.0/BRSA-6emlsfoqaa70.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "BRSA-6emlsfoqaa70"
+title = "kernel CVE-2024-42070"
+cve = "CVE-2024-42070"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: netfilter: nf_tables: fully validate NFT_DATA_VALUE on store to data registers"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.162-107.160.amzn2"
+
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.97-104.177.amzn2023"
+
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-07-24T20:00:00Z
+arches = ["aarch64", "x86_64"]
+version = "2.3.0"

--- a/advisories/2.3.0/BRSA-r0ewbkma.toml
+++ b/advisories/2.3.0/BRSA-r0ewbkma.toml
@@ -3,7 +3,7 @@ id = "BRSA-r0ewbkma"
 title = "kernel CVE-2024-27397"
 cve = "CVE-2024-27397"
 severity = "moderate"
-description = "In the Linux kernel, the following vulnerability has been resolved: -  - netfilter: nf_tables: use timestamp to check for set element timeout"
+description = "In the Linux kernel, the following vulnerability has been resolved: netfilter: nf_tables: use timestamp to check for set element timeout"
 
 [[advisory.products]]
 package-name = "kernel-6.1"

--- a/advisories/2.3.0/BRSA-rarhyozpgvvx.toml
+++ b/advisories/2.3.0/BRSA-rarhyozpgvvx.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "BRSA-rarhyozpgvvx"
+title = "kernel CVE-2024-42096"
+cve = "CVE-2024-42096"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: x86: stop playing stack games in profile_pc()"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.162-107.160.amzn2"
+
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.97-104.177.amzn2023"
+
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-07-24T20:00:00Z
+arches = ["aarch64", "x86_64"]
+version = "2.3.0"

--- a/advisories/2.3.0/BRSA-tfps4zoe7xte.toml
+++ b/advisories/2.3.0/BRSA-tfps4zoe7xte.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-tfps4zoe7xte"
+title = "kernel CVE-2024-41009"
+cve = "CVE-2024-41009"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: bpf: Fix overrunning reservations in ringbuf"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.97-104.177.amzn2023"
+
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-07-24T20:00:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.0"

--- a/advisories/2.3.0/BRSA-trxsnksws0mo.toml
+++ b/advisories/2.3.0/BRSA-trxsnksws0mo.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "BRSA-trxsnksws0mo"
+title = "kernel CVE-2024-41092"
+cve = "CVE-2024-41092"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: drm/i915/gt: Fix potential UAF by revoke of fence registers"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.162-107.160.amzn2"
+
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.97-104.177.amzn2023"
+
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-07-24T20:00:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.0"

--- a/advisories/2.3.0/BRSA-ujml9ipz0gjp.toml
+++ b/advisories/2.3.0/BRSA-ujml9ipz0gjp.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "BRSA-ujml9ipz0gjp"
+title = "kernel CVE-2024-42090"
+cve = "CVE-2024-42090"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: pinctrl: fix deadlock in create_pinctrl() when handling -EPROBE_DEFER"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.162-107.160.amzn2"
+
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.97-104.177.amzn2023"
+
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-07-24T20:00:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.0"

--- a/advisories/2.3.0/BRSA-vtsgvurtbvk0.toml
+++ b/advisories/2.3.0/BRSA-vtsgvurtbvk0.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-vtsgvurtbvk0"
+title = "kernel CVE-2024-42063"
+cve = "CVE-2024-42063"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: bpf: Mark bpf prog stack with kmsan_unposion_memory in interpreter mode"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.97-104.177.amzn2023"
+
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-07-24T20:00:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.0"

--- a/advisories/2.3.2/BRSA-2duj3sc5sukp.toml
+++ b/advisories/2.3.2/BRSA-2duj3sc5sukp.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "BRSA-2duj3sc5sukp"
+title = "kernel CVE-2024-41019"
+cve = "CVE-2024-41019"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: fs/ntfs3: Validate ff offset"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.164-108.161.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.102-108.177.amzn2023"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["aarch64", "x86_64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-5xlljzanovjo.toml
+++ b/advisories/2.3.2/BRSA-5xlljzanovjo.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-5xlljzanovjo"
+title = "kernel CVE-2024-36938"
+cve = "CVE-2024-36938"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: bpf, skmsg: Fix NULL pointer dereference in sk_psock_skb_ingress_enqueue"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["aarch64", "x86_64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-7mqkvnspebyz.toml
+++ b/advisories/2.3.2/BRSA-7mqkvnspebyz.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-7mqkvnspebyz"
+title = "kernel CVE-2024-41091"
+cve = "CVE-2024-41091"
+severity = "high"
+description = "kernel: virtio-net: tun: mlx5_core short frame denial of service"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.164-108.161.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.102-108.177.amzn2023"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-97gezkkzafis.toml
+++ b/advisories/2.3.2/BRSA-97gezkkzafis.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-97gezkkzafis"
+title = "kernel CVE-2024-42070"
+cve = "CVE-2024-42070"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: netfilter: nf_tables: fully validate NFT_DATA_VALUE on store to data registers"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-drtpd4y5t1p1.toml
+++ b/advisories/2.3.2/BRSA-drtpd4y5t1p1.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-drtpd4y5t1p1"
+title = "kernel CVE-2024-41041"
+cve = "CVE-2024-41041"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: udp: Set SOCK_RCU_FREE earlier in udp_lib_get_port()."
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.164-108.161.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.102-108.177.amzn2023"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-hb4rxpctgi5y.toml
+++ b/advisories/2.3.2/BRSA-hb4rxpctgi5y.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-hb4rxpctgi5y"
+title = "kernel CVE-2024-41049"
+cve = "CVE-2024-41049"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: filelock: fix potential use-after-free in posix_lock_inode"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.164-108.161.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.102-108.177.amzn2023"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-jgqmsbcvcaqj.toml
+++ b/advisories/2.3.2/BRSA-jgqmsbcvcaqj.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-jgqmsbcvcaqj"
+title = "kernel CVE-2024-41035"
+cve = "CVE-2024-41035"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: USB: core: Fix duplicate endpoint bug by clearing reserved bits in the descriptor"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.164-108.161.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.102-108.177.amzn2023"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-kcxrdh16d2iw.toml
+++ b/advisories/2.3.2/BRSA-kcxrdh16d2iw.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "BRSA-kcxrdh16d2iw"
+title = "kernel CVE-2024-41090"
+cve = "CVE-2024-41090"
+severity = "high"
+description = "kernel: virtio-net: tap: mlx5_core short frame denial of service"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.102-108.177.amzn2023"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["aarch64", "x86_64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-lifhg4x5tijk.toml
+++ b/advisories/2.3.2/BRSA-lifhg4x5tijk.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-lifhg4x5tijk"
+title = "kernel CVE-2022-3566"
+cve = "CVE-2022-3566"
+severity = "moderate"
+description = "A vulnerability, which was classified as problematic, was found in Linux Kernel. This affects the function tcp_getsockopt/tcp_setsockopt of the component TCP Handler. The manipulation leads to race condition."
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["aarch64", "x86_64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-nqhbflilufy0.toml
+++ b/advisories/2.3.2/BRSA-nqhbflilufy0.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-nqhbflilufy0"
+title = "kernel CVE-2024-42090"
+cve = "CVE-2024-42090"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: pinctrl: fix deadlock in create_pinctrl() when handling -EPROBE_DEFER"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-ovhu88l625qv.toml
+++ b/advisories/2.3.2/BRSA-ovhu88l625qv.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-ovhu88l625qv"
+title = "kernel CVE-2024-41055"
+cve = "CVE-2024-41055"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: mm: prevent derefencing NULL ptr in pfn_section_valid()"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.164-108.161.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.102-108.177.amzn2023"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-s8xcs0vfqpam.toml
+++ b/advisories/2.3.2/BRSA-s8xcs0vfqpam.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "BRSA-s8xcs0vfqpam"
+title = "kernel CVE-2024-41009"
+cve = "CVE-2024-41009"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: bpf: Fix overrunning reservations in ringbuf"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.164-108.161.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-t1uaadbruy6w.toml
+++ b/advisories/2.3.2/BRSA-t1uaadbruy6w.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-t1uaadbruy6w"
+title = "kernel CVE-2024-38619"
+cve = "CVE-2024-38619"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: usb-storage: alauda: Check whether the media is initialized"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-utw9tgnne4wm.toml
+++ b/advisories/2.3.2/BRSA-utw9tgnne4wm.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-utw9tgnne4wm"
+title = "kernel CVE-2024-36484"
+cve = "CVE-2024-36484"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: net: relax socket state check at accept time."
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-xqu45dktfdrz.toml
+++ b/advisories/2.3.2/BRSA-xqu45dktfdrz.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-xqu45dktfdrz"
+title = "kernel CVE-2024-42096"
+cve = "CVE-2024-42096"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: x86: stop playing stack games in profile_pc()"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-ycftkfubs8l1.toml
+++ b/advisories/2.3.2/BRSA-ycftkfubs8l1.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-ycftkfubs8l1"
+title = "kernel CVE-2024-41020"
+cve = "CVE-2024-41020"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: filelock: Fix fcntl/close race recovery compat path"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.164-108.161.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.102-108.177.amzn2023"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-yeus1zqrmbpd.toml
+++ b/advisories/2.3.2/BRSA-yeus1zqrmbpd.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-yeus1zqrmbpd"
+title = "kernel CVE-2024-41050"
+cve = "CVE-2024-41050"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: cachefiles: cyclic allocation of msg_id to avoid reuse"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.102-108.177.amzn2023"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-yizhaadxoh15.toml
+++ b/advisories/2.3.2/BRSA-yizhaadxoh15.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-yizhaadxoh15"
+title = "kernel CVE-2024-41092"
+cve = "CVE-2024-41092"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: drm/i915/gt: Fix potential UAF by revoke of fence registers"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-zl8oh7wilypl.toml
+++ b/advisories/2.3.2/BRSA-zl8oh7wilypl.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "BRSA-zl8oh7wilypl"
+title = "kernel CVE-2022-48666"
+cve = "CVE-2022-48666"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: scsi: core: Fix a use-after-free"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.164-108.161.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"

--- a/advisories/2.3.2/BRSA-zwqwmdmeqayr.toml
+++ b/advisories/2.3.2/BRSA-zwqwmdmeqayr.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-zwqwmdmeqayr"
+title = "kernel CVE-2022-3567"
+cve = "CVE-2022-3567"
+severity = "moderate"
+description = "A vulnerability has been found in Linux Kernel and classified as problematic. This vulnerability affects the function inet6_stream_ops/inet6_dgram_ops of the component IPv6 Handler. The manipulation leads to race condition."
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.223-211.872.amzn2"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-08-14T02:28:00Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.2"


### PR DESCRIPTION
**Issue number:**

n/a

**Description of changes:**

Add advisories for CVEs patched in kernel released in the v2.3.0 and v2.3.2 Bottlerocket core kits.

**Testing done:**

There were some duplicate CVEs I identified; I verified that these advisories are accurate and required. These duplicates were CVEs patched in the a kernel series (say, the 5.10 series) included in the v2.3.2 core kit release that were also patched by kernel series included in the v2.3.0 core kit (say, the 5.15 and 6.1 series).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
