### PR TITLE
kubernetes: handle null in credential provider template

### DIFF
--- a/packages/kubernetes-1.23/credential-provider-config-yaml
+++ b/packages/kubernetes-1.23/credential-provider-config-yaml
@@ -16,8 +16,13 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
-{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
+{{#if (eq @key "ecr-credential-provider")}}
     env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
 {{#if this.environment}}
 {{#each this.environment}}
       - name: {{@key}}
@@ -30,7 +35,6 @@ providers:
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
         value: '{{@root.settings.aws.profile}}'
-{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.24/credential-provider-config-yaml
+++ b/packages/kubernetes-1.24/credential-provider-config-yaml
@@ -16,8 +16,13 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
-{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
+{{#if (eq @key "ecr-credential-provider")}}
     env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
 {{#if this.environment}}
 {{#each this.environment}}
       - name: {{@key}}
@@ -30,7 +35,6 @@ providers:
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
         value: '{{@root.settings.aws.profile}}'
-{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.25/credential-provider-config-yaml
+++ b/packages/kubernetes-1.25/credential-provider-config-yaml
@@ -16,8 +16,13 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
-{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
+{{#if (eq @key "ecr-credential-provider")}}
     env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
 {{#if this.environment}}
 {{#each this.environment}}
       - name: {{@key}}
@@ -30,7 +35,6 @@ providers:
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
         value: '{{@root.settings.aws.profile}}'
-{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.26/credential-provider-config-yaml
+++ b/packages/kubernetes-1.26/credential-provider-config-yaml
@@ -16,8 +16,13 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
-{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
+{{#if (eq @key "ecr-credential-provider")}}
     env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
 {{#if this.environment}}
 {{#each this.environment}}
       - name: {{@key}}
@@ -30,7 +35,6 @@ providers:
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
         value: '{{@root.settings.aws.profile}}'
-{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.27/credential-provider-config-yaml
+++ b/packages/kubernetes-1.27/credential-provider-config-yaml
@@ -16,8 +16,13 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
-{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
+{{#if (eq @key "ecr-credential-provider")}}
     env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
 {{#if this.environment}}
 {{#each this.environment}}
       - name: {{@key}}
@@ -30,7 +35,6 @@ providers:
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
         value: '{{@root.settings.aws.profile}}'
-{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.28/credential-provider-config-yaml
+++ b/packages/kubernetes-1.28/credential-provider-config-yaml
@@ -16,8 +16,13 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
-{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
+{{#if (eq @key "ecr-credential-provider")}}
     env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
 {{#if this.environment}}
 {{#each this.environment}}
       - name: {{@key}}
@@ -30,7 +35,6 @@ providers:
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
         value: '{{@root.settings.aws.profile}}'
-{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.29/credential-provider-config-yaml
+++ b/packages/kubernetes-1.29/credential-provider-config-yaml
@@ -16,8 +16,13 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
-{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
+{{#if (eq @key "ecr-credential-provider")}}
     env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
 {{#if this.environment}}
 {{#each this.environment}}
       - name: {{@key}}
@@ -30,7 +35,6 @@ providers:
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
         value: '{{@root.settings.aws.profile}}'
-{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.30/credential-provider-config-yaml
+++ b/packages/kubernetes-1.30/credential-provider-config-yaml
@@ -16,8 +16,13 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
-{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
+{{#if (eq @key "ecr-credential-provider")}}
     env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
 {{#if this.environment}}
 {{#each this.environment}}
       - name: {{@key}}
@@ -30,7 +35,6 @@ providers:
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
         value: '{{@root.settings.aws.profile}}'
-{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}

--- a/packages/kubernetes-1.31/credential-provider-config-yaml
+++ b/packages/kubernetes-1.31/credential-provider-config-yaml
@@ -16,8 +16,13 @@ providers:
 {{/each}}
     defaultCacheDuration: "{{default "12h" this.cache-duration}}"
     apiVersion: credentialprovider.kubelet.k8s.io/v1
-{{#if (or (eq @key "ecr-credential-provider") this.environment)}}
+{{#if (eq @key "ecr-credential-provider")}}
     env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
 {{#if this.environment}}
 {{#each this.environment}}
       - name: {{@key}}
@@ -30,7 +35,6 @@ providers:
 {{#if @root.settings.aws.profile}}
       - name: AWS_PROFILE
         value: '{{@root.settings.aws.profile}}'
-{{/if}}
 {{/if}}
 {{/if}}
 {{/if}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Prior to [bottlerocket-settings-sdk@3c24f0e], the credential providers would have explicitly returned null from APIServer for the Option<T>s in the CredentialProvider struct. The `or` helper used in this template behaves correctly if `this.environment` is explicitly null, but not if it's unset.

This should correctly handle an unset `this.environment`.

[bottlerocket-settings-sdk@3c24f0e]: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/commit/3c24f0eaf7229937adcd1ac560bd83e80474a1e9

**Testing done:**

Checklist:

- [x] Copied the template to a local handlebars-rust test project and tried:
  - [x] this.environment not set and credential provider not named "ecr-credential-helper": no env section
  - [x] this.environment not set and credential provider named "ecr-credential-helper": env section exists, just default ecr-cred-helper vars
  - [x] this.environment set and credential provider not named "ecr-credential-helper": env section exists, just provided vars in this.environment
  - [x] this.environment set and credential provider named "ecr-credential-helper": only one env section exists, and contains both vars in this.environment and default ecr-cred-helper vars
- [x] Launch variant and verify that the template is rendered

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
