### PR TITLE
Core kit 2.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# v2.3.5 (2024-08-21)
+
+## Orchestrator Changes
+
+### Kubernetes
+
+ * Fix issue where a null value would fail to render the credential
+   provider template for Kubernetes ([#101])
+
+## OS Changes
+
+ * Improve EBS volume udev rules by adding a symlink to `/dev/by-ebs-id`
+   and remove `/dev/` from the device name returned by ghostdog ([#98])
+ * Update kernels to 5.10.223-212 and 6.1.102-111 ([#99])
+
+## tools
+
+ * Add collect-kernel-config script to tools ([#84])
+
+[#84]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/84
+[#98]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/98
+[#99]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/99
+[#101]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/101
+
+
 # v2.3.4 (2024-08-19)
 ## OS Changes
 

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -1,7 +1,7 @@
 schema-version = 1
-release-version = "2.3.4"
+release-version = "2.3.5"
 kit = []
-digest = "0GtG+VqO6O8vG8pPfaoarrd1BomfYLM7N2ynIV9weYU="
+digest = "hP5ZzzxvKgm29WXQsO79SpOq467UpW9dXLfzKbtI5Lg="
 
 [sdk]
 name = "bottlerocket-sdk"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "2.3.4"
+release-version = "2.3.5"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"


### PR DESCRIPTION


**Description of changes:**

* Update Twoliter.toml and Twoliter.lock for 2.3.5
* Update CHANGELOG.md for 2.3.5

**Testing done:**

Core kit builds, bob can build a variant.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
