### PR TITLE
twoliter: bump to 0.4.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TWOLITER_DIR := $(TOOLS_DIR)/twoliter
 TWOLITER := $(TWOLITER_DIR)/twoliter
 CARGO_HOME := $(TOP).cargo
 
-TWOLITER_VERSION ?= "0.4.3"
+TWOLITER_VERSION ?= "0.4.5"
 KIT ?= bottlerocket-core-kit
 ARCH ?= $(shell uname -m)
 VENDOR ?= bottlerocket


### PR DESCRIPTION
**Description of changes:**
Updates to twoliter v0.4.5

**Testing done:**
* [x] locally built `bottlerocket-core-kit`
* [x] locally built `bottlerocket-os/bottlerocket`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
