### PR TITLE
workspace: add .vscode settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ on:
       - '**.yaml'
       # Bottlerocket Security Advisories
       - 'advisories/**'
+      # VSCode configurations
+      - '.vscode/**'
 
 concurrency:
   group: ${{ github.ref }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "sources/Cargo.toml"
+    ]
+}


### PR DESCRIPTION
This configures the VSCode rust-analyzer plugin to provide hints under 'sources/'. Without this configuration, rust-analyzer is tripped up by `buildsys` build scripts under 'packages/'

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
