### PR TITLE
Update eight third-party packages

### DIFF
--- a/advisories/staging/BRSA-himt1tjhhps5.toml
+++ b/advisories/staging/BRSA-himt1tjhhps5.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-himt1tjhhps5"
+title = "amazon-ssm-agent CVE-2023-1732"
+cve = "CVE-2023-1732"
+severity = "high"
+description = "A flaw was found in a dependency of amazon-ssm-agent which could lead to a predictable shared secret."
+
+[[advisory.products]]
+package-name = "amazon-ssm-agent"
+patched-version = "3.3.808.0"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-08-28T17:54:56Z
+arches = ["x86_64", "aarch64"]
+version = "staging"

--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -9,8 +9,8 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.418.0/amazon-ssm-agent-3.3.418.0.tar.gz"
-sha512 = "b614803911b5f248dff6882f58da7a37d0d0397ea531f1f9cf30f52762ff2e80a7f0e7bf45b23fdfaecb4106a1acdbbc3b343c16940b5807bea3f953ef8e0e05"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.808.0/amazon-ssm-agent-3.3.808.0.tar.gz"
+sha512 = "d8c8fe3aaa1362bde3c449e5eebfa0f0e728c514c8671e3990bfa4351d343a0000542d26f67c019ba8783d26e28e88417a4de4fd83706bd494f14ef7c4da7b86"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.3.418.0
+Version: 3.3.808.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0

--- a/packages/bash/Cargo.toml
+++ b/packages/bash/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://ftp.gnu.org/gnu/bash"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/bash/bash-5.2.21.tar.gz"
-sha512 = "68af0b6b04b6825a3cb294ed8e1061d14d51d786aa7fb1c88d2848257409122f308ef4b8006ed401e2897aabe2adf6837074cea6f3a0523077308e45f49319fd"
+url = "https://ftp.gnu.org/gnu/bash/bash-5.2.32.tar.gz"
+sha512 = "92a66ff5159964d430a29027a259a9f4ab45e22ee57483d21ace58a731182627092fbf3032e1cd531ff359cf91c691b088eb647f41b06e113e53c01a2f057405"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/bash/bash.spec
+++ b/packages/bash/bash.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}bash
-Version: 5.2.21
+Version: 5.2.32
 Release: 1%{?dist}
 Summary: The GNU Bourne Again shell
 License: GPL-3.0-or-later

--- a/packages/cni/Cargo.toml
+++ b/packages/cni/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containernetworking/cni/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/cni/archive/v1.1.2/cni-1.1.2.tar.gz"
-sha512 = "dc4795fb03b8dc9d116692e0dd0feb1b57a481ed7414c8dc376a892725b0b3d9dd8b04b2be09073b95c8c9eec2c0165d0353f6be643647f4c4de0114b9dd5930"
+url = "https://github.com/containernetworking/cni/archive/v1.2.3/cni-1.2.3.tar.gz"
+sha512 = "7df2a2d01b85ace4e73ea577017e7c98a5d3b86373da5cf9e4ec7f50a1439753ed447c8f7fc871876c624336d91848fd42f309481bffbccc388377dbfad2e133"
 bundle-modules = [ "go" ]
 
 # RPM BuildRequires

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -2,7 +2,7 @@
 %global gorepo cni
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.1.2
+%global gover 1.2.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/dbus-broker/Cargo.toml
+++ b/packages/dbus-broker/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/bus1/dbus-broker/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/bus1/dbus-broker/releases/download/v35/dbus-broker-35.tar.xz"
-sha512 = "409e415889bd53b78e92ba077455e5583852a071e233e4b23dcbb23d8a367f177d6c8138e6fc113dcfe48440b68d594c1a076cb43ef445d472645f671d5ae033"
+url = "https://github.com/bus1/dbus-broker/releases/download/v36/dbus-broker-36.tar.xz"
+sha512 = "47ff345e27ae2ba41f43a4a6eb09b813583ef43392d1dfa2fc1805578c0ed3a1e414c3eae63f78ca3806904dc017a138e283aa32ba973de51ed613050b244a0f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}dbus-broker
-Version: 35
+Version: 36
 Release: 1%{?dist}
 Summary: D-BUS message broker
 License: Apache-2.0

--- a/packages/ethtool/Cargo.toml
+++ b/packages/ethtool/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/software/network/ethtool/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.9.tar.xz"
-sha512 = "bc7e56a1a27a0679119491d6fce076e68374cf47a86fa4c0533851df0aa737cb9139920a9f3f3733deca672923d01bbb579f3d79bd17a2c6738f9f93aa469570"
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.10.tar.xz"
+sha512 = "1b6a0f5d2b89de57d1f003779557f2be786e26660ec430e80a966ad047f2fe1fe41bb573738b93454f32cf9089000ae879fc7feba0532bb559636a301ea61b10"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ethtool/ethtool.spec
+++ b/packages/ethtool/ethtool.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}ethtool
-Version: 6.9
+Version: 6.10
 Release: 1%{?dist}
 Summary: Settings tool for Ethernet NICs
 License: GPL-2.0-only AND GPL-2.0-or-later

--- a/packages/grep/Cargo.toml
+++ b/packages/grep/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://mirrors.kernel.org/gnu/grep"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.kernel.org/gnu/grep/grep-3.9.tar.xz"
-sha512 = "38aaa28bded9f6d1d527356e9e63bb1dafb4ec8f09e83f2d3bc86c1d6af1a5a8cb9895067375b5b8929ec2cba6ab71c369ed4c6e2a0f7a01dec3c11a6f4c1836"
+url = "https://mirrors.kernel.org/gnu/grep/grep-3.11.tar.xz"
+sha512 = "f254a1905a08c8173e12fbdd4fd8baed9a200217fba9d7641f0d78e4e002c1f2a621152d67027d9b25f0bb2430898f5233dc70909d8464fd13d7dd9298e65c42"
 
 [dependencies]
 libpcre = { path = "../libpcre" }

--- a/packages/grep/grep.spec
+++ b/packages/grep/grep.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}grep
-Version: 3.9
+Version: 3.11
 Release: 1%{?dist}
 Summary: GNU grep utility
 URL: https://www.gnu.org/software/grep/

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -13,8 +13,8 @@ releases-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libca
 # Changelog can be found here: https://sites.google.com/site/fullycapable/release-notes-for-libcap
 
 [[package.metadata.build-package.external-files]]
-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.69.tar.gz"
-sha512 = "75ee0fe8e1ac835f29cb76d233f731dcf126b73eed5229a130bbe4308a42441934d4e9cefeaaab45f774de2ed6859c752fbbfb9908e792f2f9f3d0f841e01aee"
+url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.70.tar.gz"
+sha512 = "2a4a5959958989e6a0d54ea795a706b0f12596778ac660b19b7b1479910af01b4d870111b060dac0b1cd4671b98d815ea5953cefd4edde1a0ba9efe22f897842"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libcap
-Version: 2.69
+Version: 2.70
 Release: 1%{?dist}
 Summary: Library for getting and setting POSIX.1e capabilities
 License: GPL-2.0-only OR BSD-3-Clause

--- a/packages/libnl/Cargo.toml
+++ b/packages/libnl/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/thom311/libnl/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/thom311/libnl/archive/libnl3_9_0.tar.gz"
-sha512 = "7182752ccd3663f14fc7bce20d134c42e54b8305b67e44e509027aab0150a5ef056f373332d22f87386a827f8ca8b7bdaf2bd5d410982210d28ec071f31ccc73"
+url = "https://github.com/thom311/libnl/archive/libnl3_10_0.tar.gz"
+sha512 = "4950bf94371bc238df416546b63a0181fd0f684c4476b6e9dd99e14a63a42a3e5d1ec2b7bfe7249aa31e4ae5d43c33575031ec3eafba3de5a63e11936f66e89e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnl/libnl.spec
+++ b/packages/libnl/libnl.spec
@@ -1,5 +1,5 @@
-%global rpmver 3.9.0
-%global srcver 3_9_0
+%global rpmver 3.10.0
+%global srcver 3_10_0
 
 Name: %{_cross_os}libnl
 Version: %{rpmver}


### PR DESCRIPTION

**Description of changes:**

Update:

* amazon-ssm-agent 3.3.808.0
* bash 5.2.32
* cni 1.2.3
* dbus-broker 36
* ethtool 6.10
* grep 3.11
* libcap 2.70
* libnl 3.10.0

**Testing done:**

Built aws-ecs-2 and aws-k8s-1.29 AMIs, verified that they join clusters and can run a busybox image. Verified that busybox can ls, ifconfig, and ping.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
