### PR TITLE
deny: add workspace dependency lints

### DIFF
--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -69,6 +69,11 @@ skip-tree = [
     { name = "darling", version = "=0.14" },
 ]
 
+[bans.workspace-dependencies]
+duplicates = "deny"
+include-path-dependencies = true
+unused = "deny"
+
 [advisories]
 # generational-arena is currently unmaintained.
 ignore = [


### PR DESCRIPTION
**Description of changes:**
This adds [workspace dependency checks](https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html#the-workspace-dependencies-field-optional) with `cargo-deny`.

The options enforce the following:
* `duplicates = deny`: emit an error for each dependency declaration that does not use `workspace = true`
* `include-path-dependencies = true`: Include path dependencies in duplication check
* `unused = "deny"`: emit an error for each dependency not used in the workspace

**Testing done:**
I rewrote a `Cargo.toml` under sources to express its own dependency, and noted that `make twoliter check-licenses` caught the error.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
