### PR TITLE
Prepare for Core kit 2.3.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v2.3.6 (2024-08-28)
+
+## Build Changes
+* Update Twoliter to 0.4.5 (#106)
+* schnauzer: add reflective template helpers (#105)
+* Update bottlerocket-sdk to v0.44.0 ([#109])
+
+## OS Changes
+* Third party package updates (#108)
+
+[#105]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/105
+[#106]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/106
+[#108]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/108
+[#109]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/109
+
 # v2.3.5 (2024-08-21)
 
 ## Orchestrator Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "2.3.5"
+release-version = "2.3.6"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/advisories/2.3.6/BRSA-himt1tjhhps5.toml
+++ b/advisories/2.3.6/BRSA-himt1tjhhps5.toml
@@ -15,4 +15,4 @@ patched-epoch = "0"
 author = "mharrimn"
 issue-date = 2024-08-28T17:54:56Z
 arches = ["x86_64", "aarch64"]
-version = "staging"
+version = "2.3.6"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

This PR prepares for the v2.3.6 release. Changes include:

    * CHANGELOG.md update for the v2.3.6 release.
    * Bumping release-version to 2.3.6 in Twoliter
    * Move staging BRSA's to 2.3.6


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
