### PR TITLE
packages: add sources for kubernetes-1.31 and ecr-credential-provider-1.31

### DIFF
--- a/packages/ecr-credential-provider-1.31/Cargo.toml
+++ b/packages/ecr-credential-provider-1.31/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.31"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.30.3"
-path = "cloud-provider-aws-1.30.3.tar.gz"
-sha512 = "aa351cd531e452dd4ccead4a591a9161a25737ada93a7317c5c181c3d4fe55b279e94b686d8c03665ebee01191129a52b01c9dabfba7075c5e9bde52e6a341c8"
+url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.31.0"
+path = "cloud-provider-aws-1.31.0.tar.gz"
+sha512 = "962973013984a802853311182e1cfd1eabb1bcdf164000f607aeb2631ac98a0b4fd5ba1f7aff08491040979bd2321bcd5debd567c9aa74889b09d7599bc4dcfd"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.31/clarify.toml
+++ b/packages/ecr-credential-provider-1.31/clarify.toml
@@ -1,5 +1,8 @@
 [clarify."sigs.k8s.io/yaml"]
-expression = "MIT AND BSD-3-Clause"
+expression = "MIT AND BSD-3-Clause AND Apache-2.0"
 license-files = [
-    { path = "LICENSE", hash = 0xcdf3ae00 },
+    { path = "LICENSE", hash = 0x617d80bc },
+    { path = "goyaml.v2/LICENSE", hash = 0xe569d630 },
+    { path = "goyaml.v2/LICENSE.libyaml", hash = 0xa2e4ce3 },
+    { path = "goyaml.v2/NOTICE", hash = 0x49bceeb9 },
 ]

--- a/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
+++ b/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.30.3
+%global gover 1.31.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/9/artifacts/kubernetes/v1.30.1/kubernetes-src.tar.gz"
-sha512 = "314c4cdc3705fa6ded932bb2780e63b78040e75fe7e284aa2cbff93eac177d40eae5dfbe90b7482b682ed97b9d4723b55e4a1d598ec6424df77543e00e7fd6a2"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/2/artifacts/kubernetes/v1.31.0/kubernetes-src.tar.gz"
+sha512 = "d27f975200294a24b902ed7bf64fb3cb93d67ed5edb03e47929fe08cb851d90404102d369671f7be268212978f78d317d6954c4938603993d464182ebcf1891c"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.31/clarify.toml
+++ b/packages/kubernetes-1.31/clarify.toml
@@ -40,9 +40,14 @@ license-files = [
 ]
 
 [clarify."sigs.k8s.io/yaml"]
-expression = "MIT AND BSD-3-Clause"
+expression = "MIT AND BSD-3-Clause AND Apache-2.0"
 license-files = [
-    { path = "LICENSE", hash = 0xcdf3ae00 },
+    { path = "LICENSE", hash = 0x617d80bc },
+    { path = "goyaml.v2/LICENSE", hash = 0xe569d630 },
+    { path = "goyaml.v2/LICENSE.libyaml", hash = 0xa2e4ce3 },
+    { path = "goyaml.v2/NOTICE", hash = 0x49bceeb9 },
+    { path = "goyaml.v3/LICENSE", hash = 0x176b1f44 },
+    { path = "goyaml.v3/NOTICE", hash = 0x49bceeb9 },
 ]
 
 [clarify."honnef.co/go/tools"]

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.30.1
+%global gover 1.31.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

**Description of changes:**
This updates boilerplate for kubernetes-1.31 and ecr-credential-provider-1.31 packages to use upstream releases of 1.31 sources.

**Testing done:**
- [x] aarch64 IPv4 conformance tests
- [x] aarch64 IPv6 conformance tests
- [x] aarch64 NVIDIA conformance tests
- [x] aarch64 NVIDIA smoke tests
- [x] x86_64 IPv4 conformance tests
- [x] x86_64 IPv6 conformance tests
- [x] x86_64 NVIDIA conformance tests
- [x] x86_64 NVIDIA smoke tests

```
 NAME                                                            TYPE                        STATE                                         PASSED                    FAILED                    SKIPPED   BUILD ID                    LAST UPDATE
 aarch64-aws-k8s-131-conformance-test                      Test                  passed                              408                  0                6199                        2024-08-31T01:50:14Z
 aarch64-aws-k8s-131-ipv6-conformance-test                 Test                  passed                              408                  0                6199                        2024-08-31T01:53:31Z
 aarch64-aws-k8s-131-nvidia-conformance-test               Test                  passed                              408                  0                6199                        2024-08-31T02:00:30Z
 aarch64-aws-k8s-131-nvidia-nvidia-smoke-test              Test                  passed                                1                  0                   0                        2024-08-31T00:05:56Z
 aarch64-aws-k8s-131-instances                             Resource              completed                                                                                             2024-08-31T00:03:48Z
 aarch64-aws-k8s-131-ipv6-instances                        Resource              completed                                                                                             2024-08-31T00:04:06Z
 aarch64-aws-k8s-131-nvidia-instances                      Resource              completed                                                                                             2024-08-31T00:03:56Z

 x86-64-aws-k8s-nvidia-conformance-test                    Test                  running                               0                  0                   0                        2024-08-31T00:10:06Z
 x86-64-aws-k8s-nvidia-nvidia-smoke-test                   Test                  passed                                1                  0                   0                        2024-08-31T00:05:50Z
 x86-64-aws-k8s-nvidia-instances                           Resource              completed                                                                                             2024-08-31T00:03:44Z
 x86-64-aws-k8s-instances                                  Resource              completed                                                                                             2024-08-31T00:03:22Z
 x86-64-aws-k8s-conformance-test                           Test                  passed                              408                  0                6199                        2024-08-31T01:47:11Z
 x86-64-aws-k8s-ipv6-conformance-test                      Test                  passed                              408                  0                6199                        2024-08-31T02:02:05Z
 x86-64-aws-k8s-nvidia-conformance-test                    Test                  passed                              408                  0                6199                        2024-08-31T01:49:40Z
 x86-64-aws-k8s-nvidia-nvidia-smoke-test                   Test                  passed                                1                  0                   0                        2024-08-31T00:05:50Z
 x86-64-aws-k8s-ipv6-instances                             Resource              completed                                                                                             2024-08-31T00:03:36Z
```

-  [x] EBS driver testing
```
KUBECONFIG=aarch64-aws-k8s-131.kubeconfig kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-ebs-csi-driver
NAME                                  READY   STATUS    RESTARTS   AGE
ebs-csi-controller-7687fcccf8-2ffqz   6/6     Running   0          21s
ebs-csi-controller-7687fcccf8-gjq69   6/6     Running   0          21s
ebs-csi-node-6qxd5                    3/3     Running   0          21s
ebs-csi-node-g89x6                    3/3     Running   0          21s
```

- [x] cloud-provider-credential test
Following the instruction https://github.com/bottlerocket-os/bottlerocket/pull/3329#issuecomment-1667895484 with modification to apply settings in sequence rather than in one batch `apiclient apply`:

```
apiclient apply <<EOF
[settings.kubernetes.credential-providers.ecr-credential-provider]
enabled = true
cache-duration = "30m"
image-patterns = [
  "*.dkr.ecr.us-east-2.amazonaws.com",
  "*.dkr.ecr.us-west-2.amazonaws.com"
]
EOF
```
followed by
```
apiclient set settings.aws.profile="ecr"
apiclient set settings.aws.config="<base64 encoded credentials for some 'ecr' profile>"
```

```
  Normal   Pulled     54s               kubelet            Successfully pulled image "458358962224.dkr.ecr.us-west-2.amazonaws.com/alpine-clone:latest" in 95ms (95ms including waiting). Image size: 4088948 bytes.
  Normal   Pulled     38s               kubelet            Successfully pulled image "458358962224.dkr.ecr.us-west-2.amazonaws.com/alpine-clone:latest" in 127ms (127ms including waiting). Image size: 4088948 bytes.
  Normal   Pulling    8s (x4 over 56s)  kubelet            Pulling image "458358962224.dkr.ecr.us-west-2.amazonaws.com/alpine-clone:latest"
  Normal   Created    8s (x4 over 54s)  kubelet            Created container private-registry-container
  Normal   Started    8s (x4 over 54s)  kubelet            Started container private-registry-container
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
