### PR TITLE
Build open source NVIDIA kernel modules 

### DIFF
--- a/packages/kmod-5.15-nvidia/.gitignore
+++ b/packages/kmod-5.15-nvidia/.gitignore
@@ -1,2 +1,3 @@
 NVidiaEULAforAWS.pdf
+COPYING
 *.rpm

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -36,6 +36,11 @@ url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidi
 sha512 = "6a646cd7ea11e668f7dbe6f6bb22516107a856e3c3755f8693c91d4bed706b8b3667b853f07e84c2d0da4de7ab1107337b6a1493879d75d8c201bfe9da071b32"
 force-upstream = true
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/535/COPYING"
+sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
+force-upstream = true
+
 [build-dependencies]
 glibc = { path = "../glibc" }
 kernel-5_15 = { path = "../kernel-5.15" }

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.183.01/NVIDIA-Linux-x86_64-535.183.01.run"
-sha512 = "02b6b679f4fc1d5305f32fca8ce0875eef04cb99f5611d0bb85ac7607ecdd5b2aa4d60b51bf47546477464531a07fffa5bf3db3859868648bd5e86565d85afbb"
+url = "https://us.download.nvidia.com/tesla/535.183.06/NVIDIA-Linux-x86_64-535.183.06.run"
+sha512 = "424950ef303ea39499e96f8c90c1e0c83aee12309779d4f335769ef554ad4f7c38e98f69c64b408adc85a7cf51ea600d85222792402b9c6b7941f1af066d2a33"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.183.01/NVIDIA-Linux-aarch64-535.183.01.run"
-sha512 = "d2ac1be8c19b359023c31941374911f3adfe1be34aa2821ef582df4c854ac4eefbbcb10aa22583ac8c9d5caf9326bda12ed1ce6343d67479ed37a4887bd17b5e"
+url = "https://us.download.nvidia.com/tesla/535.183.06/NVIDIA-Linux-aarch64-535.183.06.run"
+sha512 = "bb305f1703557461b0a0a29066c304658d9684841104c6f4d9ff44f9db90fee14ae619cd2fe3242823a5fe3a69b168b8174b163740014b15cdef36db88ba2d96"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.183.01-1.x86_64.rpm"
-sha512 = "d52879d1e552b949a529ede9c4ce3e7b66af0df96e8f43906f211673b99815561c83a7c382be17950b1308457ca496ce49adca41766f808cc5a340471353494b"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.183.06-1.x86_64.rpm"
+sha512 = "c3d98878363f857b2963665a0e485cb7b1afeaabd0040a970478d00ffb870ab4130ab9dfe1b7a40d1b38734636ebccec39fd1b3fc8c06abc5c07470f749b6025"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.183.01-1.aarch64.rpm"
-sha512 = "75e1d306b9aa6cc8737bce50f39dc641f64de6a944c50f2c9706345c656f203c4706414dcb51def7671f0fd02fd18605aa3d62958b690d2705cb7011c54ff48e"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.183.06-1.aarch64.rpm"
+sha512 = "6a646cd7ea11e668f7dbe6f6bb22516107a856e3c3755f8693c91d4bed706b8b3667b853f07e84c2d0da4de7ab1107337b6a1493879d75d8c201bfe9da071b32"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -1,6 +1,6 @@
 %global tesla_major 535
 %global tesla_minor 183
-%global tesla_patch 01
+%global tesla_patch 06
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa

--- a/packages/kmod-6.1-nvidia/.gitignore
+++ b/packages/kmod-6.1-nvidia/.gitignore
@@ -1,2 +1,3 @@
 NVidiaEULAforAWS.pdf
+COPYING
 *.rpm

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -36,6 +36,11 @@ url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidi
 sha512 = "6a646cd7ea11e668f7dbe6f6bb22516107a856e3c3755f8693c91d4bed706b8b3667b853f07e84c2d0da4de7ab1107337b6a1493879d75d8c201bfe9da071b32"
 force-upstream = true
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/535/COPYING"
+sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
+force-upstream = true
+
 [build-dependencies]
 glibc = { path = "../glibc" }
 kernel-6_1 = { path = "../kernel-6.1" }

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.183.01/NVIDIA-Linux-x86_64-535.183.01.run"
-sha512 = "02b6b679f4fc1d5305f32fca8ce0875eef04cb99f5611d0bb85ac7607ecdd5b2aa4d60b51bf47546477464531a07fffa5bf3db3859868648bd5e86565d85afbb"
+url = "https://us.download.nvidia.com/tesla/535.183.06/NVIDIA-Linux-x86_64-535.183.06.run"
+sha512 = "424950ef303ea39499e96f8c90c1e0c83aee12309779d4f335769ef554ad4f7c38e98f69c64b408adc85a7cf51ea600d85222792402b9c6b7941f1af066d2a33"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.183.01/NVIDIA-Linux-aarch64-535.183.01.run"
-sha512 = "d2ac1be8c19b359023c31941374911f3adfe1be34aa2821ef582df4c854ac4eefbbcb10aa22583ac8c9d5caf9326bda12ed1ce6343d67479ed37a4887bd17b5e"
+url = "https://us.download.nvidia.com/tesla/535.183.06/NVIDIA-Linux-aarch64-535.183.06.run"
+sha512 = "bb305f1703557461b0a0a29066c304658d9684841104c6f4d9ff44f9db90fee14ae619cd2fe3242823a5fe3a69b168b8174b163740014b15cdef36db88ba2d96"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.183.01-1.x86_64.rpm"
-sha512 = "d52879d1e552b949a529ede9c4ce3e7b66af0df96e8f43906f211673b99815561c83a7c382be17950b1308457ca496ce49adca41766f808cc5a340471353494b"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.183.06-1.x86_64.rpm"
+sha512 = "c3d98878363f857b2963665a0e485cb7b1afeaabd0040a970478d00ffb870ab4130ab9dfe1b7a40d1b38734636ebccec39fd1b3fc8c06abc5c07470f749b6025"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.183.01-1.aarch64.rpm"
-sha512 = "75e1d306b9aa6cc8737bce50f39dc641f64de6a944c50f2c9706345c656f203c4706414dcb51def7671f0fd02fd18605aa3d62958b690d2705cb7011c54ff48e"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.183.06-1.aarch64.rpm"
+sha512 = "6a646cd7ea11e668f7dbe6f6bb22516107a856e3c3755f8693c91d4bed706b8b3667b853f07e84c2d0da4de7ab1107337b6a1493879d75d8c201bfe9da071b32"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -1,6 +1,6 @@
 %global tesla_major 535
 %global tesla_minor 183
-%global tesla_patch 01
+%global tesla_patch 06
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa


### PR DESCRIPTION
**Issue number:**

Relates to https://github.com/bottlerocket-os/bottlerocket/issues/4172

**Description of changes:**
This PR updates the 535 branch drivers to the latest version from NVIDIA. This also adds the open source driver to the `kmod-5.15-nvidia` and `kmod-6.1-nvidia` packages but doesn't make them immediately loadable. It is related to https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/114 and helps break out the changes in a smaller change. The intention is to rebase #114 on this change once merged so that the focus of that PR can be on the choosing and loading, not on the packaging. This doesn't affect any functionality as it is right now and will come with the other related PRs as part of https://github.com/bottlerocket-os/bottlerocket/issues/4172


**Testing done:**
Build `aws-k8s-1.30-nvidia` and launched on g5.2xlarge and g3.4xlarge to ensure they boot and load the proprietary driver:
```
[root@admin]# sheltie
bash-5.1# cat /proc/driver/nvidia/version
NVRM version: NVIDIA UNIX x86_64 Kernel Module  535.183.06  Wed Jun 26 06:46:07 UTC 2024
GCC version:  gcc version 11.3.0 (Buildroot 2022.11.1)
bash-5.1# find / -name "open-gpu"
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/nvidia/open-gpu
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/factory/nvidia/open-gpu
bash-5.1# ls -al /x86_64-bottlerocket-linux-gnu/sys-root/usr/share/nvidia/open-gpu/drivers/
total 85780
drwxr-xr-x. 2 root root     4096 Sep  2 23:35 .
drwxr-xr-x. 3 root root     4096 Sep  2 23:35 ..
-rwxr-xr-x. 1 root root  4347040 Aug 31 00:39 nvidia-drm.ko
-rwxr-xr-x. 1 root root  3319056 Aug 31 00:39 nvidia-modeset.ko
-rwxr-xr-x. 1 root root   315704 Aug 31 00:39 nvidia-peermem.ko
-rwxr-xr-x. 1 root root 58070824 Aug 31 00:39 nvidia-uvm.ko
-rwxr-xr-x. 1 root root 22592744 Aug 31 00:39 nvidia.ko
bash-5.1# ls -al /x86_64-bottlerocket-linux-gnu/sys-root/usr/share/factory/nvidia/open-gpu/
total 8
drwxr-xr-x. 2 root root 4096 Aug 31 00:39 .
drwxr-xr-x. 4 root root 4096 Sep  2 23:35 ..
```
The expectation is that the drivers are there, but not doing anything until later changes.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
