### PR TITLE
Add the ability for driverdog to copy modules

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1776,6 +1776,7 @@ dependencies = [
  "snafu",
  "tempfile",
  "toml",
+ "walkdir",
 ]
 
 [[package]]

--- a/sources/driverdog/Cargo.toml
+++ b/sources/driverdog/Cargo.toml
@@ -16,6 +16,7 @@ snafu.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tempfile.workspace = true
 toml.workspace = true
+walkdir.workspace = true
 
 [build-dependencies]
 generate-readme.workspace = true

--- a/sources/driverdog/README.md
+++ b/sources/driverdog/README.md
@@ -9,6 +9,11 @@ driverdog is a tool to link kernel modules at runtime. It uses a toml configurat
 `object-files`: hash with the object files to be linked, each object in the map should include the files used to link it
 `kernel-modules`: hash with the kernel modules to be linked, each kernel module in the map should include the files used to link it
 
+There are two modes for driverdog: link then load and copy then load. Link then load takes unlinked files found in `objects-source`
+and matched in `object-files` and `kernel-modules` to link together these files then copy them to `lib-modules-path`. Copy then load
+finds the modules specified in `kernel-modules` and copies them to `lib-modules-path` from the source specified in `copy-source`. Both
+modes iterate over the `kernel-modules` and load them from that path with `modprobe`.
+
 ## Colophon
 
 This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/driverdog/src/main.rs
+++ b/sources/driverdog/src/main.rs
@@ -292,10 +292,11 @@ fn load_modules_sets(
             .get(&target)
             .context(error::MissingModuleSetSnafu { target })?;
         load_modules(driver_config)?
-    }
-    // Load all the modules sets if no target module was given
-    for driver_config in modules_sets.values() {
-        load_modules(driver_config)?;
+    } else {
+        // Load all the modules sets if no target module was given
+        for driver_config in modules_sets.values() {
+            load_modules(driver_config)?;
+        }
     }
 
     Ok(())

--- a/sources/driverdog/src/main.rs
+++ b/sources/driverdog/src/main.rs
@@ -5,6 +5,11 @@ driverdog is a tool to link kernel modules at runtime. It uses a toml configurat
 `objects-source`: path where the objects used to link the kernel module are
 `object-files`: hash with the object files to be linked, each object in the map should include the files used to link it
 `kernel-modules`: hash with the kernel modules to be linked, each kernel module in the map should include the files used to link it
+
+There are two modes for driverdog: link then load and copy then load. Link then load takes unlinked files found in `objects-source`
+and matched in `object-files` and `kernel-modules` to link together these files then copy them to `lib-modules-path`. Copy then load
+finds the modules specified in `kernel-modules` and copies them to `lib-modules-path` from the source specified in `copy-source`. Both
+modes iterate over the `kernel-modules` and load them from that path with `modprobe`.
 */
 
 #[macro_use]
@@ -17,7 +22,7 @@ use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 
 /// Path to the drivers configuration to use
@@ -62,8 +67,8 @@ struct Args {
 #[derive(FromArgs, Debug, PartialEq)]
 #[argh(subcommand)]
 enum Subcommand {
-    LinkModules(LinkModulesArgs),
-    LoadModules(LoadModulesArgs),
+    Link(LinkModulesArgs),
+    Load(LoadModulesArgs),
 }
 
 /// Links the kernel modules
@@ -76,17 +81,31 @@ struct LinkModulesArgs {}
 #[argh(subcommand, name = "load-modules")]
 struct LoadModulesArgs {}
 
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+/// Enum to hold the two types of configurations supported
+enum DriverType {
+    Linking(LinkingDriverConfig),
+    Copying(CopyingDriverConfig),
+}
+
 /// Holds the configuration used to link kernel modules
 #[derive(Deserialize, Debug)]
-struct DriverConfig {
+#[serde(rename_all = "kebab-case")]
+struct LinkingDriverConfig {
+    lib_modules_path: String,
+    objects_source: String,
+    kernel_modules: HashMap<String, Linkable>,
+    object_files: HashMap<String, Linkable>,
+}
+
+/// Holds the configuration used to copy kernel modules
+#[derive(Deserialize, Debug)]
+struct CopyingDriverConfig {
     #[serde(rename(deserialize = "lib-modules-path"))]
     lib_modules_path: String,
-    #[serde(rename(deserialize = "objects-source"))]
-    objects_source: String,
     #[serde(rename(deserialize = "kernel-modules"))]
-    kernel_modules: HashMap<String, Linkable>,
-    #[serde(rename(deserialize = "object-files"))]
-    object_files: HashMap<String, Linkable>,
+    kernel_modules: HashMap<String, NonLinkable>,
 }
 
 /// Holds the objects to be linked for the object/kernel module
@@ -96,9 +115,16 @@ struct Linkable {
     link_objects: Vec<String>,
 }
 
+/// Holds the modules to be copied and loaded
+#[derive(Deserialize, Debug)]
+struct NonLinkable {
+    #[serde(rename(deserialize = "copy-source"))]
+    copy_source: PathBuf,
+}
+
 // Links the modules in the modules sets
 fn link_modules_sets(
-    modules_sets: &HashMap<String, DriverConfig>,
+    modules_sets: &HashMap<String, DriverType>,
     target: Option<String>,
 ) -> Result<()> {
     // Get current kernel version
@@ -109,11 +135,17 @@ fn link_modules_sets(
         let driver_config = modules_sets
             .get(&target)
             .context(error::MissingModuleSetSnafu { target })?;
-        link_modules(driver_config, &kernel_version)?;
+        match driver_config {
+            DriverType::Copying(config) => copy_modules(config, &kernel_version)?,
+            DriverType::Linking(config) => link_modules(config, &kernel_version)?,
+        }
     } else {
         // Link all the modules sets if no target module was given
         for driver_config in modules_sets.values() {
-            link_modules(driver_config, &kernel_version)?;
+            match driver_config {
+                DriverType::Copying(config) => copy_modules(config, &kernel_version)?,
+                DriverType::Linking(config) => link_modules(config, &kernel_version)?,
+            }
         }
     }
 
@@ -121,7 +153,7 @@ fn link_modules_sets(
 }
 
 // Links the kernel modules for the given configuration, and for the given kernel version
-fn link_modules<S>(driver_config: &DriverConfig, kernel_version: S) -> Result<()>
+fn link_modules<S>(driver_config: &LinkingDriverConfig, kernel_version: S) -> Result<()>
 where
     S: AsRef<str>,
 {
@@ -144,7 +176,6 @@ where
         link_object_file(name, object_file, &build_dir, &driver_path)?;
     }
 
-    // Next, link the kernel modules
     for (name, kernel_module) in driver_config.kernel_modules.iter() {
         link_kernel_module(
             name,
@@ -276,9 +307,50 @@ where
     Ok(())
 }
 
+/// Copies the kernel modules for the given configuration, and for the given kernel version
+fn copy_modules<S>(driver_config: &CopyingDriverConfig, kernel_version: S) -> Result<()>
+where
+    S: AsRef<str>,
+{
+    let kernel_version = kernel_version.as_ref();
+
+    // Destination for the kernel modules
+    let modules_path = Path::new(LIB_MODULES_PATH)
+        .join(kernel_version)
+        .join(&driver_config.lib_modules_path);
+
+    // Next, copy the kernel modules
+    for (name, module) in driver_config.kernel_modules.iter() {
+        copy_kernel_module(name, &modules_path, &module.copy_source)?;
+    }
+
+    Ok(())
+}
+
+/// Copy the module to the modules path provided
+fn copy_kernel_module<S, P1, P2>(name: S, modules_path: P1, driver_source_path: P2) -> Result<()>
+where
+    S: AsRef<str>,
+    P1: AsRef<Path>,
+    P2: AsRef<Path>,
+{
+    let name = name.as_ref();
+    let driver_path = driver_source_path.as_ref();
+    let modules_path = modules_path.as_ref();
+
+    let source_path = driver_path.join(name);
+    let destination_path = modules_path.join(name);
+    fs::copy(&source_path, &destination_path).context(error::CopySnafu {
+        from: &source_path,
+        to: &destination_path,
+    })?;
+    info!("Copied {}", name);
+    Ok(())
+}
+
 // Loads the modules in the modules sets
 fn load_modules_sets(
-    modules_sets: &HashMap<String, DriverConfig>,
+    modules_sets: &HashMap<String, DriverType>,
     target: Option<String>,
 ) -> Result<()> {
     // Update the modules.dep before we attempt to load kernel modules
@@ -291,6 +363,7 @@ fn load_modules_sets(
         let driver_config = modules_sets
             .get(&target)
             .context(error::MissingModuleSetSnafu { target })?;
+
         load_modules(driver_config)?
     } else {
         // Load all the modules sets if no target module was given
@@ -302,12 +375,19 @@ fn load_modules_sets(
     Ok(())
 }
 
-fn load_modules(driver_config: &DriverConfig) -> Result<()> {
-    let mut kernel_modules: Vec<String> = driver_config
-        .kernel_modules
-        .keys()
-        .map(|k| k.split('.').collect::<Vec<&str>>()[0].to_string())
-        .collect();
+fn load_modules(driver_config: &DriverType) -> Result<()> {
+    let mut kernel_modules: Vec<String> = match driver_config {
+        DriverType::Copying(config) => config
+            .kernel_modules
+            .keys()
+            .map(|k| k.split('.').collect::<Vec<&str>>()[0].to_string())
+            .collect(),
+        DriverType::Linking(config) => config
+            .kernel_modules
+            .keys()
+            .map(|k| k.split('.').collect::<Vec<&str>>()[0].to_string())
+            .collect(),
+    };
 
     // Load kernel modules
     let mut args = vec!["-a".to_string()];
@@ -356,7 +436,7 @@ fn run() -> Result<()> {
     let args: Args = argh::from_env();
     setup_logger(&args)?;
     let driver_config_path = Path::new(&args.driver_config_path);
-    let mut all_modules_sets: HashMap<String, DriverConfig> = HashMap::new();
+    let mut all_modules_sets: HashMap<String, DriverType> = HashMap::new();
 
     for entry in (driver_config_path
         .read_dir()
@@ -366,7 +446,7 @@ fn run() -> Result<()> {
     .flatten()
     {
         let path = entry.path();
-        let modules_sets: HashMap<String, DriverConfig> = toml::from_str(
+        let modules_sets: HashMap<String, DriverType> = toml::from_str(
             &fs::read_to_string(&path).context(error::ReadPathSnafu { path: &path })?,
         )
         .context(error::DeserializeSnafu { path: &path })?;
@@ -375,8 +455,8 @@ fn run() -> Result<()> {
     }
 
     match args.subcommand {
-        Subcommand::LinkModules(_) => link_modules_sets(&all_modules_sets, args.modules_set),
-        Subcommand::LoadModules(_) => load_modules_sets(&all_modules_sets, args.modules_set),
+        Subcommand::Link(_) => link_modules_sets(&all_modules_sets, args.modules_set),
+        Subcommand::Load(_) => load_modules_sets(&all_modules_sets, args.modules_set),
     }
 }
 
@@ -440,3 +520,104 @@ mod error {
 }
 
 type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::path::PathBuf;
+    use walkdir::WalkDir;
+
+    fn test_data() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/tests")
+    }
+
+    #[test]
+    fn parse_linking_config() {
+        let driver_config_path = test_data();
+
+        let linking_path = driver_config_path.join("linking.conf");
+        let modules_sets: HashMap<String, DriverType> = toml::from_str(
+            &fs::read_to_string(&linking_path)
+                .context(error::ReadPathSnafu {
+                    path: &linking_path,
+                })
+                .unwrap(),
+        )
+        .context(error::DeserializeSnafu {
+            path: &linking_path,
+        })
+        .unwrap();
+        for (name, driver) in modules_sets {
+            assert_eq!(name, "linking-driver");
+            assert!(matches!(driver, DriverType::Linking { .. }));
+            match driver {
+                DriverType::Copying(_) => panic!("Wrong type of driver configuration found"),
+                DriverType::Linking(config) => {
+                    assert_eq!(config.object_files.len(), 2);
+                    assert_eq!(
+                        config.objects_source,
+                        "/usr/share/linking/module-objects.d/"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn parse_copying_config() {
+        let driver_config_path = test_data();
+
+        let copying_path = driver_config_path.join("copying.conf");
+        let modules_sets: HashMap<String, DriverType> = toml::from_str(
+            &fs::read_to_string(&copying_path)
+                .context(error::ReadPathSnafu {
+                    path: &copying_path,
+                })
+                .unwrap(),
+        )
+        .context(error::DeserializeSnafu {
+            path: &copying_path,
+        })
+        .unwrap();
+        let intended_copy_source = Path::new("/usr/share/factory/copying-driver");
+        for (name, driver) in modules_sets {
+            assert_eq!(name, "copying-driver");
+            assert!(matches!(driver, DriverType::Copying { .. }));
+            match driver {
+                DriverType::Linking(_) => panic!("Wrong type of driver configuration found"),
+                DriverType::Copying(config) => {
+                    for (_name, module) in config.kernel_modules.iter() {
+                        assert_eq!(module.copy_source, intended_copy_source);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn parse_invalid_config() {
+        let driver_config_path = test_data();
+
+        let invalid_files_path = driver_config_path.join("invalid");
+
+        // iterate over all .conf files in invalid/ directory
+        for invalid in WalkDir::new(invalid_files_path)
+            .into_iter()
+            .filter_map(|file| file.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".conf"))
+        {
+            let invalid_path = &invalid.path();
+            let modules_sets: Result<HashMap<String, DriverType>> = toml::from_str(
+                &fs::read_to_string(&invalid_path)
+                    .context(error::ReadPathSnafu {
+                        path: &invalid_path,
+                    })
+                    .unwrap(),
+            )
+            .context(error::DeserializeSnafu {
+                path: &invalid_path,
+            });
+            assert!(modules_sets.is_err());
+        }
+    }
+}

--- a/sources/driverdog/src/tests/copying.conf
+++ b/sources/driverdog/src/tests/copying.conf
@@ -1,0 +1,11 @@
+[copying-driver]
+lib-modules-path = "kernel/drivers/extra/copying"
+
+[copying-driver.kernel-modules."main.ko"]
+copy-source = "/usr/share/factory/copying-driver"
+
+[copying-driver.kernel-modules."secondary.ko"]
+copy-source = "/usr/share/factory/copying-driver"
+
+[copying-driver.kernel-modules."other.ko"]
+copy-source = "/usr/share/factory/copying-driver"

--- a/sources/driverdog/src/tests/invalid/missing-object-files.conf
+++ b/sources/driverdog/src/tests/invalid/missing-object-files.conf
@@ -1,0 +1,9 @@
+# Missing objects source
+[invalid-driver]
+lib-modules-path = "kernel/drivers/extra/linking"
+
+[invalid-driver.kernel-modules."main.ko"]
+
+[invalid-driver.kernel-modules."secondary.ko"]
+
+[invalid-driver.kernel-modules."other.ko"]

--- a/sources/driverdog/src/tests/invalid/missing-object-source.conf
+++ b/sources/driverdog/src/tests/invalid/missing-object-source.conf
@@ -1,0 +1,18 @@
+# Missing objects source
+[invalid-driver]
+lib-modules-path = "kernel/drivers/extra/linking"
+
+[invalid-driver.object-files."main.o"]
+link-objects = ["first.o", "second.o"]
+
+[invalid-driver.kernel-modules."main.ko"]
+link-objects = ["main.o", "main.mod.o"]
+
+[invalid-driver.object-files."secondary.o"]
+link-objects = ["third.o", "fourth.o"]
+
+[invalid-driver.kernel-modules."secondary.ko"]
+link-objects = ["secondary.o", "secondary.mod.o"]
+
+[invalid-driver.kernel-modules."other.ko"]
+link-objects = ["other.o", "other.mod.o"]

--- a/sources/driverdog/src/tests/linking.conf
+++ b/sources/driverdog/src/tests/linking.conf
@@ -1,0 +1,18 @@
+[linking-driver]
+lib-modules-path = "kernel/drivers/extra/linking"
+objects-source = "/usr/share/linking/module-objects.d/"
+
+[linking-driver.object-files."main.o"]
+link-objects = ["first.o", "second.o"]
+
+[linking-driver.kernel-modules."main.ko"]
+link-objects = ["main.o", "main.mod.o"]
+
+[linking-driver.object-files."secondary.o"]
+link-objects = ["third.o", "fourth.o"]
+
+[linking-driver.kernel-modules."secondary.ko"]
+link-objects = ["secondary.o", "secondary.mod.o"]
+
+[linking-driver.kernel-modules."other.ko"]
+link-objects = ["other.o", "other.mod.o"]


### PR DESCRIPTION
**Issue number:**

Related to  # https://github.com/bottlerocket-os/bottlerocket/issues/4172

**Description of changes:**
This PR fixes a bug in driverdog (see the first commit) and adds the ability for driverdog to read a configuration file that doesn't link. With that new logic it also supports a link option to only copy the drivers to the right place since some modules may already be linked, but still need to be loaded by driverdog. See https://github.com/bottlerocket-os/bottlerocket/issues/4172 for more background. 


**Testing done:**
Added unit tests to ensure the new loading of the file works for linking vs copying files. I also built an `aws-k8s-1.30-nvidia` AMI and ensured things still loaded correctly. More testing will come under the PR that combines all the work together to ensure the two drivers can be chosen at runtime.

```
bash-5.1# cat /proc/driver/nvidia/version
NVRM version: NVIDIA UNIX x86_64 Kernel Module  535.183.06  Wed Jun 26 06:46:07 UTC 2024
GCC version:  gcc version 11.3.0 (Buildroot 2022.11.1)
bash-5.1# exit
exit
[root@admin]# sheltie
bash-5.1# systemctl -u link-kernel-modules.service
systemctl: invalid option -- 'u'
bash-5.1# journalctl -u link-kernel-modules.service
Sep 03 03:21:25 localhost systemd[1]: Starting Link additional kernel modules...
Sep 03 03:21:25 localhost driverdog[2219]: 03:21:25 [INFO] Linked object 'nvidia-modeset.o'
Sep 03 03:21:26 localhost driverdog[2219]: 03:21:26 [INFO] Stripped object 'nvidia-modeset.o'
Sep 03 03:21:34 ip-192-168-92-157.us-west-2.compute.internal driverdog[2219]: 03:21:34 [INFO] Linked object 'nvidia.o'
Sep 03 03:21:34 ip-192-168-92-157.us-west-2.compute.internal driverdog[2219]: 03:21:34 [INFO] Stripped object 'nvidia.o'
Sep 03 03:21:34 ip-192-168-92-157.us-west-2.compute.internal driverdog[2219]: 03:21:34 [INFO] Linked nvidia-uvm.ko
Sep 03 03:21:35 ip-192-168-92-157.us-west-2.compute.internal driverdog[2219]: 03:21:35 [INFO] Linked nvidia.ko
Sep 03 03:21:35 ip-192-168-92-157.us-west-2.compute.internal driverdog[2219]: 03:21:35 [INFO] Linked nvidia-modeset.ko
Sep 03 03:21:35 ip-192-168-92-157.us-west-2.compute.internal systemd[1]: Finished Link additional kernel modules.
bash-5.1# journalctl -u load-kernel-modules.service
Sep 03 03:21:35 ip-192-168-92-157.us-west-2.compute.internal systemd[1]: Starting Load additional kernel modules...
Sep 03 03:21:37 ip-192-168-92-157.us-west-2.compute.internal driverdog[2960]: 03:21:37 [INFO] Updated modules dependencies
Sep 03 03:21:37 ip-192-168-92-157.us-west-2.compute.internal driverdog[2960]: 03:21:37 [INFO] Loaded kernel modules
Sep 03 03:21:37 ip-192-168-92-157.us-west-2.compute.internal systemd[1]: Finished Load additional kernel modules.
```

I also built on top of https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/118 for including both drivers and provided the following config file to make sure it works:
```
[nvidia-open-gpu]
lib-modules-path = "kernel/drivers/extra/video/nvidia/open-gpu"

[nvidia-open-gpu.kernel-modules."nvidia.ko"]
copy-source = "/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/nvidia/open-gpu/drivers/"

[nvidia-open-gpu.kernel-modules."nvidia-modeset.ko"]
copy-source = "/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/nvidia/open-gpu/drivers/"

[nvidia-open-gpu.kernel-modules."nvidia-uvm.ko"]
copy-source = "/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/nvidia/open-gpu/drivers/"
```
Which resulted in:
```
bash-5.1# mkdir -p /lib/modules/6.1.102/kernel/drivers/extra/video/nvidia/open-gpu/
bash-5.1# driverdog --modules-set nvidia-open-gpu link-modules
23:53:20 [INFO] Copied nvidia.ko
23:53:20 [INFO] Copied nvidia-modeset.ko
23:53:21 [INFO] Copied nvidia-uvm.ko
```
Note, to make this work we would need  `nvidia-modeset.ko` and `nvidia-peermem.ko` in the config file for it to fully work as intended.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
