### PR TITLE
Apply EKS-D Upstream patches v1.23 to v1.26

### DIFF
--- a/packages/kubernetes-1.23/Cargo.toml
+++ b/packages/kubernetes-1.23/Cargo.toml
@@ -241,6 +241,10 @@ sha512 = "775b7861f460e670fa44b71db257e7b895010d5f6380e34e471e4235719551fb9d8526
 url = "https://raw.githubusercontent.com/aws/eks-distro/71aed3084474ab65027b067d45e70081144384ea/projects/kubernetes/kubernetes/1-23/patches/0063-EKS-PATCH-Update-aws-sdk-go-to-include-NCL-region.patch"
 sha512 = "aff32046ed5644ef9c50a491534bbc1be19d5d255adb147a9bf90a142267be631caac23de3b3eb6a899a05e7ee43359dfccbecc3db4c84675e8627fbb5a5b63a"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/a1f321f01121388f79b119244f29c8d919b27250/projects/kubernetes/kubernetes/1-23/patches/0064-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch"
+sha512 = "381b3aca2c6760087628de20ba5061cfd1668c54f169cd5f928cde02d2b10a4ce1fdbdbf71b5d0e1ff244016b27e8c4236be1c88a02967288251eb979ee63ee3"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -116,6 +116,7 @@ Patch0060: 0060-EKS-PATCH-GO-UPDATE-feat-use-clock-instead.patch
 Patch0061: 0061-EKS-PATCH-GO-UPDATE-go-Bump-images-dependencies-and-.patch
 Patch0062: 0062-EKS-PATCH-CVE-2023-45288-Bump-dependecy-for-1.23.patch
 Patch0063: 0063-EKS-PATCH-Update-aws-sdk-go-to-include-NCL-region.patch
+Patch0064: 0064-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -137,6 +137,10 @@ sha512 = "c34ca3f3585137c7ec40be543da2b6f39f6751e89e2cf1bc4f16c5f98d8bcedb1cc8f0
 url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-24/patches/0035-EKS-PATCH-Fix-CVE-2024-5321.patch"
 sha512 = "974790a848aac14b22bce4f9248ede33a6131f3a5ea8f881f31d42ea0e03dd4b770c90571ea4383d9b5179d4de7bfbc39db3b80cf335a2b7a3b02a695d583b68"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-24/patches/0036-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch"
+sha512 = "287f530b8372ffb4384799bc6f53ac373132c851c306a9217c982814404af3bde92901a8362bcf078b01584d975aef225dbd06c934b8b1da18b26ef33724d3a7"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -96,6 +96,7 @@ Patch0032: 0032-EKS-PATCH-GO-UPDATE-Merge-pull-request-122077-from-B.patch
 Patch0033: 0033-EKS-PATCH-GO-UPDATE-go-Bump-images-dependencies-and-.patch
 Patch0034: 0034-EKS-PATCH-CVE-2023-45288-Bumps-1.24-dependency-for-C.patch
 Patch0035: 0035-EKS-PATCH-Fix-CVE-2024-5321.patch
+Patch0036: 0036-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -105,6 +105,10 @@ sha512 = "e226f5a70aeafa25ff010c607b1e7913b562f37674062a0aadbe77fd62532dd5bab10c
 url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-25/patches/0023-EKS-PATCH-Fix-CVE-2024-5321.patch"
 sha512 = "f74d550646b0bf0f4c0596c78337037034c29ada7f3683ad3f3dbbac0011f935185486a178212cd93ad3338aa59b20be3f899863b6ed726f81753f221e66e51f"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-25/patches/0024-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch"
+sha512 = "3b6cd81edaf9758fa6ef8d2843c96f075a47b13dd97f37a3ef01c7584e47c877cdce3dbb8e57c3869da83935a15374512c62600b5720b9415011d0d30001e936"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -88,6 +88,7 @@ Patch0020: 0020-EKS-PATCH-GO-UPDATE-Bump-images-dependencies-and-ver.patch
 Patch0021: 0021-EKS-PATCH-Bumps-dependencies-for-fixing-CVE-2023-452.patch
 Patch0022: 0022-EKS-PATCH-Update-aws-sdk-go-to-include-new-regions.patch
 Patch0023: 0023-EKS-PATCH-Fix-CVE-2024-5321.patch
+Patch0024: 0024-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -65,6 +65,10 @@ sha512 = "edb501bdc01863a7abe28a19369230ef94841630866644c3abdf42041d3876023ae359
 url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-26/patches/0014-EKS-PATCH-Fix-CVE-2024-5321.patch"
 sha512 = "6267486606741f25e12b2d0bd19d3243c485b21cce4ae992258a64db714c42ea3542c03f225bd8ce41a63e2dc3449f56e16e7c126a67107144c2da4bea820d81"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-26/patches/0015-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch"
+sha512 = "7b65bb30ee2863ea19dbcb74a855c2a898b85e99e43d772228eec81859017cad0949dd0758461a2c6f7c496907718153ddbd2c30eb578c6b5c11599d593ac72d"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -78,6 +78,7 @@ Patch0011: 0011-EKS-PATCH-aws_credentials-update-ecr-url-validation-.patch
 Patch0012: 0012-EKS-PATCH-Bumps-dependency-for-CVE-2023-45288.patch
 Patch0013: 0013-EKS-PATCH-Update-aws-sdk-go-for-new-regions.patch
 Patch0014: 0014-EKS-PATCH-Fix-CVE-2024-5321.patch
+Patch0015: 0015-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch
 
 BuildRequires: git
 BuildRequires: rsync


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

 Adds upstream patches

**Testing done:**

- [x] Testsys quick tests for x86_64
```
 NAME                                TYPE               STATE                     PASSED          FAILED          SKIPPED   BUILD ID                LAST UPDATE
 x86-64-aws-k8s-123-quick            Test               passed                         1               0             7051   8fb4129b-dirty          2024-09-04T00:00:53Z
 x86-64-aws-k8s-124-quick            Test               passed                         1               0             6972   8fb4129b-dirty          2024-09-04T00:01:13Z
 x86-64-aws-k8s-125-quick            Test               passed                         4               0             7065   8fb4129b-dirty          2024-09-04T00:00:39Z
 x86-64-aws-k8s-126-quick            Test               passed                         4               0             7068   8fb4129b-dirty          2024-09-03T23:59:29Z
```
- [x] Testsys quick tests for aarch64
```
 NAME                                      TYPE            STATE               PASSED       FAILED	 SKIPPED   BUILD ID             LAST UPDATE
 aarch64-aws-k8s-123-quick                 Test            passed                   1            0          7051   8fb4129b-dirty	2024-09-04T00:44:06Z
 aarch64-aws-k8s-124-quick                 Test            running                  1            0          6972   8fb4129b-dirty	2024-09-04T00:44:43Z
 aarch64-aws-k8s-125-quick                 Test            passed                   4            0          7065   8fb4129b-dirty	2024-09-04T00:44:30Z
 aarch64-aws-k8s-126-quick                 Test            passed                   4            0          7068   8fb4129b-dirty	2024-09-04T00:44:04Z
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
