### PR TITLE
feat: nvidia-persistenced to Nvidia kmod packages

### DIFF
--- a/packages/ecs-gpu-init/ecs-gpu-init.service
+++ b/packages/ecs-gpu-init/ecs-gpu-init.service
@@ -4,6 +4,11 @@ Description=Initialize ECS GPU config
 # otherwise the userspace component of the driver will fail to
 # query the /dev devices
 After=load-tesla-kernel-modules.service load-open-gpu-kernel-modules.service
+# Running this unit after nvidia persistenced ensures that
+# the /dev devices are created and the hardware set to
+# persistence mode.
+Requires=nvidia-persistenced.service
+After=nvidia-persistenced.service
 # Block manual interactions with this service. It doesn't
 # make sense to regenerate the GPU config file if the ECS
 # agent won't read it when it changes

--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -88,6 +88,7 @@ install -d %{buildroot}%{_cross_libexecdir}
 install -d %{buildroot}%{_cross_libdir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_bindir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/{drivers,ld.so.conf.d}
 
 KERNEL_VERSION=$(cat %{kernel_sources}/include/config/kernel.release)
@@ -162,6 +163,7 @@ install -m 755 nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bi
 install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 install -m 755 nvidia-persistenced %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
+install -m 4755 nvidia-modprobe %{buildroot}%{_cross_bindir}
 %if "%{_cross_arch}" == "x86_64"
 install -m 755 nvidia-ngx-updater %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 %endif
@@ -218,6 +220,7 @@ popd
 %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-debugdump
 %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-smi
 %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-persistenced
+%{_cross_bindir}/nvidia-modprobe
 
 # Configuration files
 %{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-tesla-%{tesla_470}.toml

--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -19,6 +19,8 @@ Source2: NVidiaEULAforAWS.pdf
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in
 Source202: nvidia-dependencies-modules-load.conf
+Source203: nvidia-sysusers.conf
+Source204: nvidia-persistenced.service.in
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf.in
@@ -105,6 +107,7 @@ install -d %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 install -d %{buildroot}%{tesla_470_libdir}
 install -d %{buildroot}%{_cross_datadir}/nvidia/tesla/%{tesla_470}/module-objects.d
 install -d %{buildroot}%{_cross_factorydir}/nvidia/tesla/%{tesla_470}
+install -d %{buildroot}%{_cross_sysusersdir}
 
 sed -e 's|__NVIDIA_VERSION__|%{tesla_470}|' %{S:300} > nvidia-tesla-%{tesla_470}.conf
 install -m 0644 nvidia-tesla-%{tesla_470}.conf %{buildroot}%{_cross_tmpfilesdir}/
@@ -158,9 +161,17 @@ install -m 755 nvidia-smi %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{te
 install -m 755 nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
+install -m 755 nvidia-persistenced %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 %if "%{_cross_arch}" == "x86_64"
 install -m 755 nvidia-ngx-updater %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}
 %endif
+
+# Users
+install -m 0644 %{S:203} %{buildroot}%{_cross_sysusersdir}/nvidia.conf
+
+# Systemd units
+sed -e 's|__NVIDIA_BINDIR__|%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}|' %{S:204} > nvidia-persistenced.service
+install -m 0644 nvidia-persistenced.service %{buildroot}%{_cross_unitdir}
 
 # We install all the libraries, and filter them out in the 'files' section, so we can catch
 # when new libraries are added
@@ -206,6 +217,7 @@ popd
 # Binaries
 %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-debugdump
 %{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-smi
+%{_cross_libexecdir}/nvidia/tesla/bin/%{tesla_470}/nvidia-persistenced
 
 # Configuration files
 %{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-tesla-%{tesla_470}.toml
@@ -228,6 +240,12 @@ popd
 
 # tmpfiles
 %{_cross_tmpfilesdir}/nvidia-tesla-%{tesla_470}.conf
+
+# sysuser files
+%{_cross_sysusersdir}/nvidia.conf
+
+# systemd units
+%{_cross_unitdir}/nvidia-persistenced.service
 
 # We only install the libraries required by all the DRIVER_CAPABILITIES, described here:
 # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities

--- a/packages/kmod-5.10-nvidia/nvidia-persistenced.service.in
+++ b/packages/kmod-5.10-nvidia/nvidia-persistenced.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=NVIDIA Persistence Daemon
+After=load-tesla-kernel-modules.service load-open-gpu-kernel-modules.service
+
+[Service]
+Type=forking
+ExecStart=__NVIDIA_BINDIR__/nvidia-persistenced --user nvidia --verbose
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/kmod-5.10-nvidia/nvidia-sysusers.conf
+++ b/packages/kmod-5.10-nvidia/nvidia-sysusers.conf
@@ -1,0 +1,1 @@
+u nvidia - "nvidia-persistenced user"

--- a/packages/kmod-5.10-nvidia/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-5.10-nvidia/nvidia-tmpfiles.conf.in
@@ -1,2 +1,3 @@
 R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/tesla - - - - -
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/tesla 0755 root root - -
+D /var/run/nvidia-persistenced 0755 nvidia nvidia - -

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -40,6 +40,8 @@ Source200: nvidia-tmpfiles.conf.in
 Source202: nvidia-dependencies-modules-load.conf
 Source203: nvidia-fabricmanager.service
 Source204: nvidia-fabricmanager.cfg
+Source205: nvidia-sysusers.conf
+Source206: nvidia-persistenced.service
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -173,6 +175,7 @@ install -d %{buildroot}%{_cross_libdir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/{drivers,ld.so.conf.d}
+install -d %{buildroot}%{_cross_sysusersdir}
 
 KERNEL_VERSION=$(cat %{kernel_sources}/include/config/kernel.release)
 sed \
@@ -279,9 +282,16 @@ install -m 755 nvidia-smi %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 install -m 755 nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -m 755 nvidia-persistenced %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/
 %if "%{_cross_arch}" == "x86_64"
 install -m 755 nvidia-ngx-updater %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 %endif
+
+# Users
+install -m 0644 %{S:205} %{buildroot}%{_cross_sysusersdir}/nvidia.conf
+
+# Systemd units
+install -m 0644 %{S:206} %{buildroot}%{_cross_unitdir}
 
 # We install all the libraries, and filter them out in the 'files' section, so we can catch
 # when new libraries are added
@@ -353,6 +363,7 @@ popd
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-smi
 %{_cross_libexecdir}/nvidia/tesla/bin/nv-fabricmanager
 %{_cross_libexecdir}/nvidia/tesla/bin/nvswitch-audit
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-persistenced
 
 # nvswitch topologies
 %dir %{_cross_datadir}/nvidia/tesla/nvswitch
@@ -385,6 +396,12 @@ popd
 
 # tmpfiles
 %{_cross_tmpfilesdir}/nvidia-tesla.conf
+
+# sysuser files
+%{_cross_sysusersdir}/nvidia.conf
+
+# systemd units
+%{_cross_unitdir}/nvidia-persistenced.service
 
 # We only install the libraries required by all the DRIVER_CAPABILITIES, described here:
 # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -176,6 +176,7 @@ install -d %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/{drivers,ld.so.conf.d}
 install -d %{buildroot}%{_cross_sysusersdir}
+install -d %{buildroot}%{_cross_bindir}
 
 KERNEL_VERSION=$(cat %{kernel_sources}/include/config/kernel.release)
 sed \
@@ -283,6 +284,7 @@ install -m 755 nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bi
 install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 install -m 755 nvidia-persistenced %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/
+install -m 4755 nvidia-modprobe %{buildroot}%{_cross_bindir}
 %if "%{_cross_arch}" == "x86_64"
 install -m 755 nvidia-ngx-updater %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 %endif
@@ -364,6 +366,7 @@ popd
 %{_cross_libexecdir}/nvidia/tesla/bin/nv-fabricmanager
 %{_cross_libexecdir}/nvidia/tesla/bin/nvswitch-audit
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-persistenced
+%{_cross_bindir}/nvidia-modprobe
 
 # nvswitch topologies
 %dir %{_cross_datadir}/nvidia/tesla/nvswitch

--- a/packages/kmod-5.15-nvidia/nvidia-persistenced.service
+++ b/packages/kmod-5.15-nvidia/nvidia-persistenced.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=NVIDIA Persistence Daemon
+After=load-tesla-kernel-modules.service load-open-gpu-kernel-modules.service
+
+[Service]
+Type=forking
+ExecStart=/usr/libexec/nvidia/tesla/bin/nvidia-persistenced --user nvidia --verbose
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/kmod-5.15-nvidia/nvidia-sysusers.conf
+++ b/packages/kmod-5.15-nvidia/nvidia-sysusers.conf
@@ -1,0 +1,1 @@
+u nvidia - "nvidia-persistenced user"

--- a/packages/kmod-5.15-nvidia/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-5.15-nvidia/nvidia-tmpfiles.conf.in
@@ -4,3 +4,4 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/op
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/open-gpu 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 d /run/nvidia 0700 root root -
+D /var/run/nvidia-persistenced 0755 nvidia nvidia - -

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -40,6 +40,8 @@ Source200: nvidia-tmpfiles.conf.in
 Source202: nvidia-dependencies-modules-load.conf
 Source203: nvidia-fabricmanager.service
 Source204: nvidia-fabricmanager.cfg
+Source205: nvidia-sysusers.conf
+Source206: nvidia-persistenced.service
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -173,6 +175,7 @@ install -d %{buildroot}%{_cross_libdir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/{drivers,ld.so.conf.d}
+install -d %{buildroot}%{_cross_sysusersdir}
 
 KERNEL_VERSION=$(cat %{kernel_sources}/include/config/kernel.release)
 sed \
@@ -279,9 +282,16 @@ install -m 755 nvidia-smi %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 install -m 755 nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
+install -m 755 nvidia-persistenced %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/
 %if "%{_cross_arch}" == "x86_64"
 install -m 755 nvidia-ngx-updater %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 %endif
+
+# Users
+install -m 0644 %{S:205} %{buildroot}%{_cross_sysusersdir}/nvidia.conf
+
+# Systemd units
+install -m 0644 %{S:206} %{buildroot}%{_cross_unitdir}
 
 # We install all the libraries, and filter them out in the 'files' section, so we can catch
 # when new libraries are added
@@ -353,6 +363,7 @@ popd
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-smi
 %{_cross_libexecdir}/nvidia/tesla/bin/nv-fabricmanager
 %{_cross_libexecdir}/nvidia/tesla/bin/nvswitch-audit
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-persistenced
 
 # nvswitch topologies
 %dir %{_cross_datadir}/nvidia/tesla/nvswitch
@@ -385,6 +396,12 @@ popd
 
 # tmpfiles
 %{_cross_tmpfilesdir}/nvidia-tesla.conf
+
+# sysuser files
+%{_cross_sysusersdir}/nvidia.conf
+
+# systemd units
+%{_cross_unitdir}/nvidia-persistenced.service
 
 # We only install the libraries required by all the DRIVER_CAPABILITIES, described here:
 # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -176,6 +176,7 @@ install -d %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/{drivers,ld.so.conf.d}
 install -d %{buildroot}%{_cross_sysusersdir}
+install -d %{buildroot}%{_cross_bindir}
 
 KERNEL_VERSION=$(cat %{kernel_sources}/include/config/kernel.release)
 sed \
@@ -283,6 +284,7 @@ install -m 755 nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bi
 install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 install -m 755 nvidia-persistenced %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/
+install -m 4755 nvidia-modprobe %{buildroot}%{_cross_bindir}
 %if "%{_cross_arch}" == "x86_64"
 install -m 755 nvidia-ngx-updater %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin
 %endif
@@ -364,6 +366,7 @@ popd
 %{_cross_libexecdir}/nvidia/tesla/bin/nv-fabricmanager
 %{_cross_libexecdir}/nvidia/tesla/bin/nvswitch-audit
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-persistenced
+%{_cross_bindir}/nvidia-modprobe
 
 # nvswitch topologies
 %dir %{_cross_datadir}/nvidia/tesla/nvswitch

--- a/packages/kmod-6.1-nvidia/nvidia-persistenced.service
+++ b/packages/kmod-6.1-nvidia/nvidia-persistenced.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=NVIDIA Persistence Daemon
+After=load-tesla-kernel-modules.service load-open-gpu-kernel-modules.service
+
+[Service]
+Type=forking
+ExecStart=/usr/libexec/nvidia/tesla/bin/nvidia-persistenced --user nvidia --verbose
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/kmod-6.1-nvidia/nvidia-sysusers.conf
+++ b/packages/kmod-6.1-nvidia/nvidia-sysusers.conf
@@ -1,0 +1,1 @@
+u nvidia - "nvidia-persistenced user"

--- a/packages/kmod-6.1-nvidia/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.1-nvidia/nvidia-tmpfiles.conf.in
@@ -4,3 +4,4 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/op
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/open-gpu 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 d /run/nvidia 0700 root root -
+D /var/run/nvidia-persistenced 0755 nvidia nvidia - -


### PR DESCRIPTION
Closes bottlerocket-os/bottlerocket#3960

**Description of changes:**

Whenever the NVIDIA device resources are no longer in use, the NVIDIA
kernel driver will tear down the device state. `nvidia-persistenced`
activates persistence mode, which keeps the device files open preventing
the kernel from removing the device state [[1]]. This is desirable in
applications that may suffer performance hits due to repeated device
initialization.

The NVIDIA device drivers ship with templates for running
`nvidia-persistenced` as a systemd unit [[2]]. This change uses that template.

The `nvidia-persistenced` documentation advises that while the systemd
unit can run as root, the unit should provide a non-root user under which
`nvidia-persistenced` will run. This change adds a non-root user for `nvidia-persistenced`. 

See the documentation included with the NVIDIA driver for more
information about `nvidia-persistenced` [[3]].

[1]: https://docs.nvidia.com/deploy/driver-persistence/index.html
[2]: https://github.com/NVIDIA/nvidia-persistenced/blob/main/init/systemd/nvidia-persistenced.service.template
[3]: https://github.com/NVIDIA/nvidia-persistenced

**Testing Done:**

ECS: The unit sets the devices to persistence mode, and we can see that the
device is set correctly inside a task container.

k8s: Node successfully joined cluster and persistence mode is enabled inside test pod.

**aws-ecs-1-nvidia**

``` example
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "39f91d5d-dirty",
    "pretty_name": "Bottlerocket OS 1.21.1 (aws-ecs-1-nvidia)",
    "variant_id": "aws-ecs-1-nvidia",
    "version_id": "1.21.1"
  }
}
bash-5.1# docker ps
CONTAINER ID   IMAGE                                  COMMAND                  CREATED          STATUS          PORTS     NAMES
b90b0fec4e7e   fedora                                 "sh -c 'sleep infini…"   38 seconds ago   Up 37 seconds             ecs-ecs-test-4-main-948ee88ccac2abbd6d00
6a16e877533f   amazon/amazon-ecs-pause:bottlerocket   "/usr/bin/pause"         44 seconds ago   Up 44 seconds             ecs-ecs-test-4-internalecspause-f4fbfab2fde3e3f60600
bash-5.1# docker exec -it b90b0fec4e7e nvidia-smi
Tue Sep  3 19:03:36 2024
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.256.02   Driver Version: 470.256.02   CUDA Version: 11.4     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA A10G         On   | 00000000:00:1E.0 Off |                    0 |
|  0%   28C    P8     9W / 300W |      0MiB / 22731MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
bash-5.1# systemctl status nvidia-persistenced
● nvidia-persistenced.service - NVIDIA Persistence Daemon
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-persistenced.service; enabled; preset: enabled)
     Active: active (running) since Tue 2024-09-03 19:00:29 UTC; 3min 17s ago
   Main PID: 1914 (nvidia-persiste)
      Tasks: 1 (limit: 18928)
     Memory: 4.5M
     CGroup: /system.slice/nvidia-persistenced.service
             └─1914 /x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/nvidia/tesla/bin/470.256.02/nvidia-persistenced --user nvidia

Sep 03 19:00:28 ip-10-194-20-18.us-west-2.compute.internal nvidia-smi[1889]:
Sep 03 19:00:28 ip-10-194-20-18.us-west-2.compute.internal nvidia-smi[1889]: +-----------------------------------------------------------------------------+
Sep 03 19:00:28 ip-10-194-20-18.us-west-2.compute.internal nvidia-smi[1889]: | Processes:                                                                  |
Sep 03 19:00:28 ip-10-194-20-18.us-west-2.compute.internal nvidia-smi[1889]: |  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
Sep 03 19:00:28 ip-10-194-20-18.us-west-2.compute.internal nvidia-smi[1889]: |        ID   ID                                                   Usage      |
Sep 03 19:00:28 ip-10-194-20-18.us-west-2.compute.internal nvidia-smi[1889]: |=============================================================================|
Sep 03 19:00:28 ip-10-194-20-18.us-west-2.compute.internal nvidia-smi[1889]: |  No running processes found                                                 |
Sep 03 19:00:28 ip-10-194-20-18.us-west-2.compute.internal nvidia-smi[1889]: +-----------------------------------------------------------------------------+
Sep 03 19:00:28 ip-10-194-20-18.us-west-2.compute.internal nvidia-persistenced[1914]: Started (1914)
Sep 03 19:00:29 ip-10-194-20-18.us-west-2.compute.internal systemd[1]: Started NVIDIA Persistence Daemon.
bash-5.1#
```

**aws-ecs-2-nvidia**

``` example
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "39f91d5d-dirty",
    "pretty_name": "Bottlerocket OS 1.21.1 (aws-ecs-2-nvidia)",
    "variant_id": "aws-ecs-2-nvidia",
    "version_id": "1.21.1"
  }
}
bash-5.1# docker ps
CONTAINER ID   IMAGE                                  COMMAND                  CREATED          STATUS          PORTS     NAMES
e87a4e93439c   fedora                                 "sh -c 'sleep infini…"   8 seconds ago    Up 6 seconds              ecs-ecs-test-2-main-8883a48ba4b884efda01
3eca5efed891   amazon/amazon-ecs-pause:bottlerocket   "/usr/bin/pause"         13 seconds ago   Up 12 seconds             ecs-ecs-test-2-internalecspause-96db8af6f891edf5b501
bash-5.1# docker exec -it e87a4e93439c nvidia-smi
Wed Sep  4 16:57:12 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.01             Driver Version: 535.183.01   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A10G                    On  | 00000000:00:1E.0 Off |                    0 |
|  0%   26C    P8               8W / 300W |      0MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
bash-5.1# systemctl status nvidia-persistenced
● nvidia-persistenced.service - NVIDIA Persistence Daemon
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-persistenced.service; enabled; preset: enabled)
     Active: active (running) since Wed 2024-09-04 16:42:22 UTC; 15min ago
   Main PID: 1430 (nvidia-persiste)
      Tasks: 1 (limit: 18906)
     Memory: 41.3M
        CPU: 4.445s
     CGroup: /system.slice/nvidia-persistenced.service
             └─1430 /x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/nvidia/tesla/bin/nvidia-persistenced --user nvidia

Sep 04 16:42:20 ip-172-31-83-142.ec2.internal nvidia-smi[1412]:
Sep 04 16:42:20 ip-172-31-83-142.ec2.internal nvidia-smi[1412]: +---------------------------------------------------------------------------------------+
Sep 04 16:42:20 ip-172-31-83-142.ec2.internal nvidia-smi[1412]: | Processes:                                                                            |
Sep 04 16:42:20 ip-172-31-83-142.ec2.internal nvidia-smi[1412]: |  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
Sep 04 16:42:20 ip-172-31-83-142.ec2.internal nvidia-smi[1412]: |        ID   ID                                                             Usage      |
Sep 04 16:42:20 ip-172-31-83-142.ec2.internal nvidia-smi[1412]: |=======================================================================================|
Sep 04 16:42:20 ip-172-31-83-142.ec2.internal nvidia-smi[1412]: |  No running processes found                                                           |
Sep 04 16:42:20 ip-172-31-83-142.ec2.internal nvidia-smi[1412]: +---------------------------------------------------------------------------------------+
Sep 04 16:42:20 ip-172-31-83-142.ec2.internal nvidia-persistenced[1430]: Started (1430)
Sep 04 16:42:22 ip-172-31-83-142.ec2.internal systemd[1]: Started NVIDIA Persistence Daemon.
bash-5.1#
```

**aws-k8s-1.23-nvidia**

``` example
[nix-shell:~/workplace/bottlerocket]$  kubectl exec gpu-test -c main -- nvidia-smi
 kubectl exec gpu-test -c main -- nvidia-smi
Tue Sep  3 23:10:20 2024       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.256.02   Driver Version: 470.256.02   CUDA Version: 11.4     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA A10G         On   | 00000000:00:1E.0 Off |                    0 |
|  0%   25C    P8     9W / 300W |      0MiB / 22731MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+

[nix-shell:~/workplace/bottlerocket]$  kubectl exec gpu-test -c main -- nvidia-smi --query-gpu=gpu_name,persistence_mode --format=csv
 kubectl exec gpu-test -c main -- nvidia-smi --query-gpu=gpu_name,persistence_mode --format=csv
name, persistence_mode
NVIDIA A10G, Enabled
```

**aws-k8s-1.26-nvidia**

``` example
[nix-shell:~/workplace/bottlerocket]$  kubectl exec gpu-test -c main -- nvidia-smi
 kubectl exec gpu-test -c main -- nvidia-smi
Wed Sep  4 16:59:43 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.01             Driver Version: 535.183.01   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A10G                    On  | 00000000:00:1E.0 Off |                    0 |
|  0%   24C    P8               9W / 300W |      0MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+


[nix-shell:~/workplace/bottlerocket]$  kubectl exec gpu-test -c main -- nvidia-smi --query-gpu=gpu_name,persistence_mode --format=csv
 kubectl exec gpu-test -c main -- nvidia-smi --query-gpu=gpu_name,persistence_mode --format=csv
name, persistence_mode
NVIDIA A10G, Enabled
```

**aws-k8s-1.30-nvidia**

``` example
[nix-shell:~/workplace/bottlerocket]$  kubectl exec gpu-test -c main -- nvidia-smi
 kubectl exec gpu-test -c main -- nvidia-smi
Wed Sep  4 17:25:29 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.01             Driver Version: 535.183.01   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A10G                    On  | 00000000:00:1E.0 Off |                    0 |
|  0%   26C    P8              12W / 300W |      0MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+

[nix-shell:~/workplace/bottlerocket]$  kubectl exec gpu-test -c main -- nvidia-smi --query-gpu=gpu_name,persistence_mode --format=csv
 kubectl exec gpu-test -c main -- nvidia-smi --query-gpu=gpu_name,persistence_mode --format=csv
name, persistence_mode
NVIDIA A10G, Enabled
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is
dual-licensed under the terms of both the Apache License, version 2.0,
and the MIT license.
