### PR TITLE
kernel-6.1: update to 6.1.106

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/bc929cd6c35e297ebc5760d75997d219080501a32b7936641003178bce778074/kernel-6.1.102-111.182.amzn2023.src.rpm"
-sha512 = "fab5cfd995c22a36a9815a3c8115a72d1a2e3a28e3fc49b7b490f664b562a6f48724616cc458b58a147d4b5fbdf16cb34a58676fbae72838a770d43334089300"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/f578e84fd35abf2a86cbe79936f7d773eed3ca0202ac5fa049cf01879ce9bbe3/kernel-6.1.106-116.188.amzn2023.src.rpm"
+sha512 = "253f601c2df406697fe9cff2a4cbfc3fb4c098a2ea8f36b3a1ce21c7c7d207612e18422a8eb832e6f3e105a59bb62b12bba6fb2f603e7740665ae38a78292645"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.102
+Version: 6.1.106
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/bc929cd6c35e297ebc5760d75997d219080501a32b7936641003178bce778074/kernel-6.1.102-111.182.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/f578e84fd35abf2a86cbe79936f7d773eed3ca0202ac5fa049cf01879ce9bbe3/kernel-6.1.106-116.188.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs
@@ -502,6 +502,7 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %endif
 %{_cross_kmoddir}/kernel/drivers/amazon/net/efa/efa.ko.*
 %{_cross_kmoddir}/kernel/drivers/amazon/net/ena/ena.ko.*
+%{_cross_kmoddir}/kernel/drivers/amazon/scsi/mpi3mr/mpi3mr.ko.gz
 %if "%{_cross_arch}" == "aarch64"
 %{_cross_kmoddir}/kernel/drivers/ata/ahci_platform.ko.*
 %{_cross_kmoddir}/kernel/drivers/ata/libahci_platform.ko.*
@@ -556,6 +557,7 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/kernel/drivers/edac/pnd2_edac.ko.*
 %{_cross_kmoddir}/kernel/drivers/edac/sb_edac.ko.*
 %{_cross_kmoddir}/kernel/drivers/edac/skx_edac.ko.*
+%{_cross_kmoddir}/kernel/drivers/edac/skx_edac_common.ko.gz
 %{_cross_kmoddir}/kernel/drivers/edac/x38_edac.ko.*
 %endif
 %{_cross_kmoddir}/kernel/drivers/firmware/dmi-sysfs.ko.*


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
- Update Kernel kernel-6.1: update to 6.1.106
Configuration changes: 
```
config-6.1-aarch64.config
3c3
< # Linux/arm64 6.1.102 Kernel Configuration
---
> # Linux/arm64 6.1.106 Kernel Configuration
380a381
> CONFIG_ARM64_ERRATUM_3194386=y
1035a1037
> CONFIG_PCP_BATCH_SCALE_MAX=5
2510c2512
< # CONFIG_MLX5_FPGA is not set
---
> CONFIG_MLX5_FPGA=y
2520,2521c2522,2523
< # CONFIG_MLX5_CORE_IPOIB is not set
< # CONFIG_MLX5_EN_IPSEC is not set
---
> CONFIG_MLX5_CORE_IPOIB=y
> CONFIG_MLX5_EN_IPSEC=y
2523c2525,2526
< # CONFIG_MLX5_SF is not set
---
> CONFIG_MLX5_SF=y
> CONFIG_MLX5_SF_MANAGER=y
4567a4571
> CONFIG_AMAZON_SCSI_MPI3MR=m


config-6.1-x86_64.config
3c3
< # Linux/x86 6.1.102 Kernel Configuration
---
> # Linux/x86 6.1.106 Kernel Configuration
1041a1042
> CONFIG_PCP_BATCH_SCALE_MAX=5
2492c2493
< # CONFIG_MLX5_FPGA is not set
---
> CONFIG_MLX5_FPGA=y
2502,2503c2503,2504
< # CONFIG_MLX5_CORE_IPOIB is not set
< # CONFIG_MLX5_EN_IPSEC is not set
---
> CONFIG_MLX5_CORE_IPOIB=y
> CONFIG_MLX5_EN_IPSEC=y
2505c2506,2507
< # CONFIG_MLX5_SF is not set
---
> CONFIG_MLX5_SF=y
> CONFIG_MLX5_SF_MANAGER=y
4510a4513
> CONFIG_AMAZON_SCSI_MPI3MR=m

```
Added patches:
```
Patches that changed:
Patches that were dropped:
Patches that were added:
0182-Add-out-of-tree-mpi3mr-8.9.1-driver.patch
0183-scsi-mpi3mr-Sanitise-num_phys.patch
0184-scsi-mpi3mr-Avoid-memcpy-field-spanning-write-WARNIN.patch
0185-bpf-add-mrtt-and-srtt-as-BPF_SOCK_OPS_RTT_CB-args.patch
0186-x86-kaslr-Expose-and-use-the-end-of-the-physical-mem.patch
0187-x86-ioremap-Use-is_ioremap_addr-in-iounmap.patch
```

**Testing done:**
- aarch64 aws-k8s-1.28
```
NAME                            TYPE           STATE               PASSED	 FAILED       SKIPPED   BUILD ID             LAST UPDATE
 aarch64-aws-k8s-128-quick	 Test           passed                   5            0          7389   d2ab432c-dirty       2024-09-05T00:21:46Z
 aarch64-aws-k8s-128             Resource	completed                                               d2ab432c-dirty       2024-09-05T00:20:06Z
```
- x86_64 aws-k8s-1.28 Boot test Successful
```
NAME                                   TYPE          STATE             PASSED      FAILED	SKIPPED   BUILD ID            LAST UPDATE
 x86-64-aws-k8s-128-quick               Test          passed                 5           0         7389   d2ab432c-dirty      2024-09-05T00:47:55Z
 x86-64-aws-k8s-128                     Resource      completed                                           d2ab432c-dirty      2024-09-05T00:46:15Z
 x86-64-aws-k8s-128-instances-nfip	Resource      completed                                           d2ab432c-dirty      2024-09-05T00:48:59Z


```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
