### PR TITLE
bootstrap-commands: fix for boot failure in absence of config

### DIFF
--- a/packages/os/bootstrap-commands.service
+++ b/packages/os/bootstrap-commands.service
@@ -5,6 +5,7 @@ After=systemd-logind.service settings-applier.service apiserver.service
 Requires=systemd-logind.service settings-applier.service apiserver.service
 RefuseManualStart=true
 RefuseManualStop=true
+ConditionPathExists=/etc/bootstrap-commands/bootstrap-commands.toml
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
* Adds check for `bootstrap-commands.service` to run only if config file is present


**Testing done:**
1. Successful boot in AMI without variant related changes for bootstrap commands
2. Successful boot in AMI with variant related changes for bootstrap commands


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
