### PR TITLE
Update kernels 5.10 and 5.15 

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/53ac58d4538601179e563feeda7d409981189fdde44ed02b0195fff959016432/kernel-5.10.223-212.873.amzn2.src.rpm"
-sha512 = "1d45f8480ee51dfc4a8e7200aa42b63aface8c7633d90565624788d9bbfbca017a3c24635d994994ac672dc565995e2067e526e2f1852817f77beaa5b1305749"
+url = "https://cdn.amazonlinux.com/blobstore/090ee50d7c80b80f41f8e3c8c7d63efaa9592371f48bc9f769b2d52cb358a238/kernel-5.10.224-212.876.amzn2.src.rpm"
+sha512 = "1a5d1066aa061b4b8cc2d97671d86c4aee727266386f0507b8a841adfc51235d3fa74eab3cfc64ca3d78397294f789ae3ee48f45c16f330929691d14ce7153c0"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.223
+Version: 5.10.224
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/53ac58d4538601179e563feeda7d409981189fdde44ed02b0195fff959016432/kernel-5.10.223-212.873.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/090ee50d7c80b80f41f8e3c8c7d63efaa9592371f48bc9f769b2d52cb358a238/kernel-5.10.224-212.876.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/ff595c6c1967d028475f9c56e3ba3bb174fbf0d2273b80c798b00394c14e2e4d/kernel-5.15.164-108.161.amzn2.src.rpm"
-sha512 = "8f791fd583e06c2a822b8dede8e4b5abdac2cbfed60fe998e79b7129b46aeeb2a21126e06acda5a7b7e11015ae6658115015a653d0caff48b28855bfaf6a350b"
+url = "https://cdn.amazonlinux.com/blobstore/5fc19dbcdad79c0964001228b7f301dc9726ba49f28248fe04f44186bb318e51/kernel-5.15.165-110.161.amzn2.src.rpm"
+sha512 = "dcb77a87aa343d10936a40e155d6d3b67e78a42f04f817157731b97caa4de113564edfba37dd9ed66712081ae0df1102cd5703cd895a493e4ec7348886eb303b"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.164
+Version: 5.15.165
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/ff595c6c1967d028475f9c56e3ba3bb174fbf0d2273b80c798b00394c14e2e4d/kernel-5.15.164-108.161.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/5fc19dbcdad79c0964001228b7f301dc9726ba49f28248fe04f44186bb318e51/kernel-5.15.165-110.161.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
- Update Kernel 5.15 to 5.15.165
- Update Kernel-5.10 to 5.10.224

Configuration changes:
```
config-5.10-aarch64.config
3c3
< # Linux/arm64 5.10.223 Kernel Configuration
---
> # Linux/arm64 5.10.224 Kernel Configuration
368a369
> CONFIG_ARM64_ERRATUM_3194386=y
diff directory-for-base-configs/config-5.10-x86_64.config directory-for-updated-configs-al2/config-5.10-x86_64.config
3c3
< # Linux/x86 5.10.223 Kernel Configuration
---
> # Linux/x86 5.10.224 Kernel Configuration
diff directory-for-base-configs/config-5.15-aarch64.config directory-for-updated-configs-al2/config-5.15-aarch64.config
3c3
< # Linux/arm64 5.15.164 Kernel Configuration
---
> # Linux/arm64 5.15.165 Kernel Configuration
378a379
> CONFIG_ARM64_ERRATUM_3194386=y

config-5.15-x86_64.config
3c3
< # Linux/x86 5.15.164 Kernel Configuration
---
> # Linux/x86 5.15.165 Kernel Configuration
```
Patches changes:
```
Kernel-5.15
Patches that changed:
Patches that were dropped:
Patches that were added:

Kernel-5.10
Patches that changed:
Patches that were dropped:
0586-Add-mpi3mr-8.2.1.0.0.patch
Patches that were added:
0872-nfsd-Don-t-call-freezable_schedule_timeout-after-eac.patch
0873-Upgrade-mpi3mr-from-8.2.1-to-8.9.1.patch
0874-scsi-mpi3mr-Avoid-memcpy-field-spanning-write-WARNIN.patch
0875-scsi-mpi3mr-Sanitise-num_phys.patch

```

**Testing done:**

- x86_64 aws-k8s-1.23
```
NAME                              TYPE              STATE                     PASSED          FAILED          SKIPPED   BUILD ID                LAST UPDATE
 x86-64-aws-k8s-123-quick          Test              passed                         1               0             7051   d2ab432c-dirty          2024-09-05T01:48:55Z
 x86-64-aws-k8s-123                Resource          completed                                                           d2ab432c-dirty          2024-09-05T01:46:47Z
```
- x86_64 aws-k8s-1.25
```
NAME                              TYPE              STATE                     PASSED          FAILED          SKIPPED   BUILD ID                LAST UPDATE
 x86-64-aws-k8s-125-quick          Test              passed                         4               0             7065   d2ab432c-dirty          2024-09-05T02:45:44Z
 x86-64-aws-k8s-125                Resource          completed                                                           d2ab432c-dirty          2024-09-05T02:43:36Z
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
