### PR TITLE
Update libexpat package to 2.6.3

### DIFF
--- a/packages/libexpat/Cargo.toml
+++ b/packages/libexpat/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/libexpat/libexpat/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/libexpat/libexpat/releases/download/R_2_6_2/expat-2.6.2.tar.xz"
-sha512 = "47b60967d6346d330dded87ea1a2957aa7d34dd825043386a89aa131054714f618ede57bfe97cf6caa40582a4bc67e198d2a915e7d8dbe8ee4f581857c2e3c2e"
+url = "https://github.com/libexpat/libexpat/releases/download/R_2_6_3/expat-2.6.3.tar.xz"
+sha512 = "e02c4ad88f9d539258aa1c1db71ded7770a8f12c77b5535e5b34f040ae5b1361ef23132f16d96bdb7c096a83acd637a7c907916bdfcc6d5cfb9e35d04020ca0b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libexpat/libexpat.spec
+++ b/packages/libexpat/libexpat.spec
@@ -1,4 +1,4 @@
-%global unversion 2_6_2
+%global unversion 2_6_3
 
 Name: %{_cross_os}libexpat
 Version: %(echo %{unversion} | sed 's/_/./g')
@@ -43,7 +43,6 @@ Requires: %{name}
 %{_cross_libdir}/*.so
 %{_cross_includedir}/*.h
 %{_cross_pkgconfigdir}/*.pc
-%exclude %{_cross_libdir}/*.la
 %exclude %{_cross_libdir}/cmake
 
 %changelog


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # N/A

**Description of changes:**
Update libexpat to 2.6.3

**Testing done:**
```
NAME                               TYPE               STATE                     PASSED          FAILED          SKIPPED   BUILD ID                LAST UPDATE
 x86-64-aws-ecs-1-quick             Test               passed                         1               0                0   562219f9-dirty          2024-09-06T04:02:30Z
 x86-64-aws-k8s-125-quick           Test               passed                         4               0             7065   562219f9-dirty          2024-09-06T04:01:10Z
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
