### PR TITLE
Use kubelet-device-plugin API

### DIFF
--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "2.4.1"
+release-version = "2.5.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -1,5 +1,5 @@
 [required-extensions]
-kubernetes = "v1"
+kubelet-device-plugins = "v1"
 std = { version = "v1", helpers = ["default"] }
 
 +++
@@ -8,6 +8,6 @@ flags:
   migStrategy: "none"
   failOnInitError: true
   plugin:
-    passDeviceSpecs: {{default true settings.kubernetes.device-plugins.nvidia.pass-device-specs}}
-    deviceListStrategy: {{default "volume-mounts" settings.kubernetes.device-plugins.nvidia.device-list-strategy}}
-    deviceIDStrategy: {{default "index" settings.kubernetes.device-plugins.nvidia.device-id-strategy}}
+    passDeviceSpecs: {{default true settings.kubelet-device-plugins.nvidia.pass-device-specs}}
+    deviceListStrategy: {{default "volume-mounts" settings.kubelet-device-plugins.nvidia.device-list-strategy}}
+    deviceIDStrategy: {{default "index" settings.kubelet-device-plugins.nvidia.device-id-strategy}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-exec-start-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-exec-start-conf
@@ -1,8 +1,8 @@
 [required-extensions]
-kubernetes = "v1"
+kubelet-device-plugins = "v1"
 +++
 [Service]
-{{#if settings.kubernetes.device-plugins.nvidia}}
+{{#if settings.kubelet-device-plugins.nvidia}}
 ExecStart=
 ExecStart=/usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml
 {{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1086,7 +1086,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1095,8 +1095,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+version = "0.5.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1163,8 +1163,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+version = "0.5.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1185,6 +1185,7 @@ dependencies = [
  "settings-extension-ecs",
  "settings-extension-host-containers",
  "settings-extension-kernel",
+ "settings-extension-kubelet-device-plugins",
  "settings-extension-kubernetes",
  "settings-extension-metrics",
  "settings-extension-motd",
@@ -1213,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1226,7 +1227,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "serde",
 ]
@@ -1234,7 +1235,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -3686,7 +3687,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3699,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3712,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3726,7 +3727,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3739,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3752,7 +3753,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3765,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3778,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3791,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3804,7 +3805,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3817,7 +3818,20 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "settings-extension-kubelet-device-plugins"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3830,7 +3844,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3844,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3857,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -3869,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3882,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3895,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3908,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3922,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3935,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3948,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.4.0#28f3c66b979bc48d32120b4e82d2c81b5841d7aa"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -194,13 +194,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.4.0"
-version = "0.4.0"
+tag = "bottlerocket-settings-models-v0.5.0"
+version = "0.5.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.4.0"
-version = "0.4.0"
+tag = "bottlerocket-settings-models-v0.5.0"
+version = "0.5.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -209,7 +209,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.4.0"
+tag = "bottlerocket-settings-models-v0.5.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
**Issue number:**

Related: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/60

**Description of changes:**

Per https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/57#issuecomment-2322174109, we are moving away from `kubernetes.device-plugin` to `kubelet-device-plugin`.

**Testing done:**

As part of https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/60 and https://github.com/bottlerocket-os/bottlerocket/pull/4182

1. Instance joined the cluster:

```
NAME                                           STATUS   ROLES    AGE    VERSION
ip-XXXX.us-west-2.compute.internal   Ready    <none>   22s    v1.30.1-eks-e564799
```

2. Files were generated using the new values

```
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugin": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "pass-device-specs": true
      }
    }
  }
}

bash-5.1# cat /etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf
[Service]
ExecStart=
ExecStart=/usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml
bash-5.1# cat /etc/nvidia-container-runtime/config.toml
### generated from the template file ###
accept-nvidia-visible-devices-as-volume-mounts = true
accept-nvidia-visible-devices-envvar-when-unprivileged = false

[nvidia-container-cli]
root = "/"
path = "/usr/bin/nvidia-container-cli"
environment = []
ldconfig = "@/sbin/ldconfig"
bash-5.1#
```

3. A container created after the settings were changed has access to all GPUs without requesting any:

```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: safe-defaults
spec:
  selector:
    matchLabels:
      name: safe-defaults
  template:
    metadata:
      labels:
        name: safe-defaults
    spec:
      # No GPUs requested
      containers:
        - name: safe-defaults
          image: nvidia/cuda:12.4.1-cudnn-devel-rockylinux8
          command: ['sh', '-c', 'sleep infinity']
```

```
bash-5.1# apiclient set kubelet-device-plugin.nvidia.device-list-strategy=envvar
bash-5.1# apiclient set nvidia-container-runtime.visible-devices-as-volume-mounts=false
bash-5.1# apiclient set nvidia-container-runtime.visible-devices-envvar-when-unprivileged=true
bash-5.1# cat /etc/nvidia-container-runtime/config.toml
### generated from the template file ###
accept-nvidia-visible-devices-as-volume-mounts = false
accept-nvidia-visible-devices-envvar-when-unprivileged = true

[nvidia-container-cli]
root = "/"
path = "/usr/bin/nvidia-container-cli"
environment = []
ldconfig = "@/sbin/ldconfig"
```

```
└─> ❯ k exec safe-defaults-cnsqn -- nvidia-smi
Mon Sep  9 15:31:38 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.01             Driver Version: 535.183.01   CUDA Version: 12.4     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A10G                    Off | 00000000:00:1E.0 Off |                    0 |
|  0%   25C    P8               8W / 300W |      0MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
