### PR TITLE
advisories: add libexpat BRSAs for 2.4.1 release

### DIFF
--- a/advisories/2.4.1/BRSA-6zgfowt0osgt.toml
+++ b/advisories/2.4.1/BRSA-6zgfowt0osgt.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-6zgfowt0osgt"
+title = "libexpat CVE-2024-45490"
+cve = "CVE-2024-45490"
+severity = "high"
+description = "An issue was discovered in libexpat before 2.6.3. xmlparse.c does not reject a negative length for XML_ParseBuffer."
+
+[[advisory.products]]
+package-name = "libexpat"
+patched-version = "2.6.3"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "yeazelm"
+issue-date = 2024-09-10T02:19:24Z
+arches = ["x86_64", "aarch64"]
+version = "2.4.1"

--- a/advisories/2.4.1/BRSA-rsshgwurguax.toml
+++ b/advisories/2.4.1/BRSA-rsshgwurguax.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-rsshgwurguax"
+title = "libexpat CVE-2024-45491"
+cve = "CVE-2024-45491"
+severity = "high"
+description = "An issue was discovered in libexpat before 2.6.3. dtdCopy in xmlparse.c can have an integer overflow for nDefaultAtts on 32-bit platforms (where UINT_MAX equals SIZE_MAX)."
+
+[[advisory.products]]
+package-name = "libexpat"
+patched-version = "2.6.3"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "yeazelm"
+issue-date = 2024-09-10T02:19:37Z
+arches = ["aarch64", "x86_64"]
+version = "2.4.1"

--- a/advisories/2.4.1/BRSA-zij7i3861ei3.toml
+++ b/advisories/2.4.1/BRSA-zij7i3861ei3.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-zij7i3861ei3"
+title = "libexpat CVE-2024-45492"
+cve = "CVE-2024-45492"
+severity = "moderate"
+description = "An issue was discovered in libexpat before 2.6.3. nextScaffoldPart in xmlparse.c can have an integer overflow for m_groupSize on 32-bit platforms (where UINT_MAX equals SIZE_MAX)."
+
+[[advisory.products]]
+package-name = "libexpat"
+patched-version = "2.6.3"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "yeazelm"
+issue-date = 2024-09-10T02:18:11Z
+arches = ["x86_64", "aarch64"]
+version = "2.4.1"


### PR DESCRIPTION

**Description of changes:**
Adding advisories for libexpat 2.6.3


**Testing done:**
NA

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
