### PR TITLE
EFA Support - Automated host configurations

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3575,6 +3575,7 @@ dependencies = [
  "maplit",
  "models",
  "num_cpus",
+ "pciclient",
  "percent-encoding",
  "pest",
  "pest_derive",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2149,6 +2149,7 @@ dependencies = [
  "gptman",
  "hex-literal",
  "lazy_static",
+ "pciclient",
  "signpost",
  "snafu",
 ]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1553,10 +1553,13 @@ dependencies = [
  "bottlerocket-modeled-types",
  "generate-readme",
  "log",
+ "num_cpus",
+ "pciclient",
  "serde",
  "serde_json",
  "simplelog",
  "snafu",
+ "test-case",
  "toml",
 ]
 

--- a/sources/api/corndog/Cargo.toml
+++ b/sources/api/corndog/Cargo.toml
@@ -11,6 +11,8 @@ exclude = ["README.md"]
 
 [dependencies]
 log.workspace = true
+num_cpus.workspace = true
+pciclient.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 simplelog.workspace = true
@@ -20,3 +22,6 @@ bottlerocket-modeled-types.workspace = true
 
 [build-dependencies]
 generate-readme.workspace = true
+
+[dev-dependencies]
+test-case.workspace = true

--- a/sources/api/corndog/README.md
+++ b/sources/api/corndog/README.md
@@ -7,6 +7,8 @@ It sets kernel-related settings, for example:
 * sysctl values, based on key/value pairs in `settings.kernel.sysctl`
 * lockdown mode, based on the value of `settings.kernel.lockdown`
 
+corndog also provides a settings generator for hugepages, subcommand "generate-hugepages-setting".
+
 ## Colophon
 
 This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/api/schnauzer/Cargo.toml
+++ b/sources/api/schnauzer/Cargo.toml
@@ -29,6 +29,7 @@ log.workspace = true
 maplit.workspace = true
 models.workspace = true
 num_cpus.workspace = true
+pciclient.workspace = true
 percent-encoding.workspace = true
 pest.workspace = true
 pest_derive.workspace = true

--- a/sources/ghostdog/Cargo.toml
+++ b/sources/ghostdog/Cargo.toml
@@ -13,6 +13,7 @@ argh.workspace = true
 gptman.workspace = true
 hex-literal.workspace = true
 lazy_static.workspace = true
+pciclient.workspace = true
 signpost.workspace = true
 snafu.workspace = true
 

--- a/sources/ghostdog/README.md
+++ b/sources/ghostdog/README.md
@@ -4,6 +4,7 @@ Current version: 0.1.0
 
 ghostdog is a tool to manage ephemeral disks.
 It can be called as a udev helper program to identify ephemeral disks.
+It can also be called for EFA device detection which can be used for ExecCondition in systemd units.
 
 ## Colophon
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Related to: https://github.com/bottlerocket-os/bottlerocket/issues/1031

Closes #140

**Description of changes:**

Add EFA support which would automatically apply host configurations for hugepages allocation and rlimit bump based on the EFA Device attachment.

- Extended `oci_defaults` helper in schnauzer to apply higher MEMLOCK limits when EFA is attached.
- Add subcommand in `corndog` with a settings generator for hugepages, which will dynamically generate settings for `settings.kernel.sysctl."vm/nr_hugepages"`.
- Add subcommand `efa-present` in `ghostdog` for EFA device detection. It can be used by systemd unit for `ExecCondition` so that we can conditionally register systemd services based on EFA Card attachment.

**Testing done:**
1. Built a custom AMI that: 
- Has `pciutils` installed.
- Is configured with settings generator for `settings.kernel.sysctl."vm/nr_hugepages"` in https://github.com/bottlerocket-os/bottlerocket/blob/develop/sources/shared-defaults/defaults.toml#L143
```
[metadata.settings.kernel.sysctl."vm/nr_hugepages"]
setting-generator = "corndog generate-hugepages-setting"
```

2. Launched a EKS nodegroup with the custom AMI on `g4dn.8xlarge` instances with spec:
```
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: my-efa-cluster-v2
  region: us-west-2
  version: '1.29'

iam:
  withOIDC: true

nodeGroups:
  - name: my-efa-ng-g4dn-bottlerocket
    instanceType: g4dn.8xlarge
    minSize: 0
    desiredCapacity: 2
    maxSize: 3
    availabilityZones: ["us-west-2a"]
    amiFamily: Bottlerocket
    ami: ami-xxxxxx
    volumeSize: 400
    privateNetworking: true
    efaEnabled: true
``` 
3. Connect to the node and inspect the hugepage settings.
```
[ssm-user@control]$ apiclient get settings.kernel.sysctl
{
  "settings": {
    "kernel": {
      "sysctl": {
        "vm/nr_hugepages": "3520"
      }
    }
  }
}
```
4. Verified that the hugepage settings were applied to the actual `sysctl` and `sysfs` settings.
```
bash-5.1# cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
3520

bash-5.1# cat /proc/sys/vm/nr_hugepages
3520
```

5. The describe node output indicates that the hugepages are pre-allocated and can be scheduled for the pods.
```
  cpu:                    32
  ...
  hugepages-1Gi:          0
  hugepages-2Mi:          7040Mi
  ...
  vpc.amazonaws.com/efa:  1
Allocatable:
  cpu:                    31850m
  ...
  hugepages-1Gi:          0
  hugepages-2Mi:          7040Mi
  ...
  vpc.amazonaws.com/efa:  1
```

6. Ran NCCL tests with MPIJobs which requests hugepages
```
 ...
resources:
  limits:
    nvidia.com/gpu: 1
    hugepages-2Mi: 5120Mi
    vpc.amazonaws.com/efa: 1
    memory: 8000Mi
  requests:
    nvidia.com/gpu: 1
    hugepages-2Mi: 5120Mi
    vpc.amazonaws.com/efa: 1
    memory: 8000Mi
``` 

7. Verified that the pod has locked memory limit configured as `unlimited` where the default in Bottlerocket would be 8192KB.
```
# ulimit -l

unlimited
```

8. The NCCL tests ran successfully with expected test result.
```
[1,0]<stdout>:#                                                              out-of-place                       in-place          
[1,0]<stdout>:#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
[1,0]<stdout>:#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
[1,0]<stdout>:           8             2     float     sum      -1    72.39    0.00    0.00      0    71.98    0.00    0.00      0
[1,0]<stdout>:          16             4     float     sum      -1    72.42    0.00    0.00      0    72.05    0.00    0.00      0
[1,0]<stdout>:          32             8     float     sum      -1    72.59    0.00    0.00      0    72.46    0.00    0.00      0
[1,0]<stdout>:          64            16     float     sum      -1    72.55    0.00    0.00      0    72.39    0.00    0.00      0
[1,0]<stdout>:         128            32     float     sum      -1    72.28    0.00    0.00      0    72.66    0.00    0.00      0
[1,0]<stdout>:         256            64     float     sum      -1    73.06    0.00    0.00      0    72.40    0.00    0.00      0
[1,0]<stdout>:         512           128     float     sum      -1    72.92    0.01    0.01      0    72.97    0.01    0.01      0
[1,0]<stdout>:        1024           256     float     sum      -1    74.28    0.01    0.01      0    75.09    0.01    0.01      0
[1,0]<stdout>:        2048           512     float     sum      -1    75.79    0.03    0.03      0    75.62    0.03    0.03      0
[1,0]<stdout>:        4096          1024     float     sum      -1    77.81    0.05    0.05      0    77.94    0.05    0.05      0
[1,0]<stdout>:        8192          2048     float     sum      -1    83.01    0.10    0.10      0    82.59    0.10    0.10      0
[1,0]<stdout>:       16384          4096     float     sum      -1    96.81    0.17    0.17      0    96.54    0.17    0.17      0
[1,0]<stdout>:       32768          8192     float     sum      -1    107.6    0.30    0.30      0    106.7    0.31    0.31      0
[1,0]<stdout>:       65536         16384     float     sum      -1    123.0    0.53    0.53      0    124.4    0.53    0.53      0
[1,0]<stdout>:      131072         32768     float     sum      -1    155.3    0.84    0.84      0    155.7    0.84    0.84      0
[1,0]<stdout>:      262144         65536     float     sum      -1    208.0    1.26    1.26      0    194.3    1.35    1.35      0
[1,0]<stdout>:      524288        131072     float     sum      -1    290.8    1.80    1.80      0    290.4    1.81    1.81      0
[1,0]<stdout>:     1048576        262144     float     sum      -1    604.2    1.74    1.74      0    602.8    1.74    1.74      0
[1,0]<stdout>:     2097152        524288     float     sum      -1   1006.6    2.08    2.08      0   1013.7    2.07    2.07      0
[1,0]<stdout>:     4194304       1048576     float     sum      -1   1731.7    2.42    2.42      0   1732.0    2.42    2.42      0
[1,0]<stdout>:     8388608       2097152     float     sum      -1   3117.2    2.69    2.69      0   3174.8    2.64    2.64      0
[1,0]<stdout>:    16777216       4194304     float     sum      -1   6117.1    2.74    2.74      0   6113.3    2.74    2.74      0
[1,0]<stdout>:    33554432       8388608     float     sum      -1    11653    2.88    2.88      0    11722    2.86    2.86      0
[1,0]<stdout>:    67108864      16777216     float     sum      -1    22642    2.96    2.96      0    22367    3.00    3.00      0
[1,0]<stdout>:   134217728      33554432     float     sum      -1    44380    3.02    3.02      0    43808    3.06    3.06      0
[1,0]<stdout>:   268435456      67108864     float     sum      -1    87872    3.05    3.05      0    89709    2.99    2.99      0
[1,0]<stdout>:   536870912     134217728     float     sum      -1   176409    3.04    3.04      0   177627    3.02    3.02      0
[1,0]<stdout>:  1073741824     268435456     float     sum      -1   351989    3.05    3.05      0   351789    3.05    3.05      0
[1,0]<stdout>:  2147483648     536870912     float     sum      -1   700468    3.07    3.07      0   706521    3.04    3.04      0
[1,0]<stdout>:# Out of bounds values : 0 OK
[1,0]<stdout>:# Avg bus bandwidth    : 1.30573 
```

9. Registered a dummy systemd unit:
```
[Unit]
Description=Example Service with ExecCondition for EFA detection
After=network.target sundog.service

[Service]
Type=simple
ExecCondition=/usr/bin/ghostdog efa-present
ExecStart=/bin/echo "EFA Device Detected!!! Here is the confirming message!"

[Install]
WantedBy=multi-user.target
```

Verified from the g4dn.8xlarge instance that the custom systemd unit was invoked.
```
bash-5.1# systemctl status test-efa-attach
○ test-efa-attach.service - Example Service with ExecCondition
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/test-efa-attach.service; enabled; preset: enabled)
     Active: inactive (dead) since Fri 2024-09-13 06:11:17 UTC; 43min ago
   Duration: 2ms
   Main PID: 3857 (code=exited, status=0/SUCCESS)
        CPU: 4ms

Sep 13 06:11:17 ip-192-168-87-183.us-west-2.compute.internal systemd[1]: Starting Example Service with ExecCondition...
Sep 13 06:11:17 ip-192-168-87-183.us-west-2.compute.internal systemd[1]: Started Example Service with ExecCondition.
Sep 13 06:11:17 ip-192-168-87-183.us-west-2.compute.internal echo[3857]: EFA Device Detected!!! Here is the confirming message!
Sep 13 06:11:17 ip-192-168-87-183.us-west-2.compute.internal systemd[1]: test-efa-attach.service: Deactivated successfully.
```

10. Launched a g4dn instance with EFA disabled. Verified that the hugepages were set to 0 by default
```
bash-5.1# apiclient get settings.kernel
{
  "settings": {
    "kernel": {
      "lockdown": "none",
      "sysctl": {
        "vm/nr_hugepages": "0"
      }
    }
  }
}
```

Also verified that the locked memory limit is 8096KB (as before).
```
max locked memory (kb)          (-l) 8192
```

And the systemd unit was not enabled due to ExecCondition was not met.
```
bash-5.1# systemctl status test-efa-attach
○ test-efa-attach.service - Example Service with ExecCondition
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/test-efa-attach.service; enabled; preset: enabled)
     Active: inactive (dead) (Result: exec-condition) since Wed 2024-09-18 04:38:00 UTC; 19min ago
  Condition: start condition failed at Wed 2024-09-18 04:38:00 UTC; 19min ago
        CPU: 4ms

Sep 18 04:38:00 ip-192-168-72-59.us-west-2.compute.internal systemd[1]: Starting Example Service with ExecCondition...
Sep 18 04:38:00 ip-192-168-72-59.us-west-2.compute.internal ghostdog[1476]: Does not detect EFA
Sep 18 04:38:00 ip-192-168-72-59.us-west-2.compute.internal systemd[1]: test-efa-attach.service: Skipped due to 'exec-condition'.
Sep 18 04:38:00 ip-192-168-72-59.us-west-2.compute.internal systemd[1]: Condition check resulted in Example Service with ExecCondition being skipped.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
