### PR TITLE
Add pciutils to packages in release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,7 @@ dependencies = [
  "oci-add-hooks",
  "open-vm-tools",
  "os",
+ "pciutils",
  "pigz",
  "policycoreutils",
  "procps",
@@ -930,6 +931,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pciutils"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "pigz"
 version = "0.1.0"
 dependencies = [
@@ -996,6 +1004,7 @@ dependencies = [
  "nvme-cli",
  "oci-add-hooks",
  "os",
+ "pciutils",
  "policycoreutils",
  "procps",
  "selinux-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ members = [
   "packages/oci-add-hooks",
   "packages/open-vm-tools",
   "packages/os",
+  "packages/pciutils",
   "packages/pigz",
   "packages/policycoreutils",
   "packages/procps",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -114,6 +114,7 @@ nvme-cli = { path = "../../packages/nvme-cli" }
 oci-add-hooks = { path = "../../packages/oci-add-hooks" }
 open-vm-tools = { path = "../../packages/open-vm-tools" }
 os = { path = "../../packages/os" }
+pciutils = { path = "../../packages/pciutils" }
 pigz = { path = "../../packages/pigz" }
 policycoreutils = { path = "../../packages/policycoreutils" }
 procps = { path = "../../packages/procps" }

--- a/packages/pciutils/Cargo.toml
+++ b/packages/pciutils/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pciutils"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://www.kernel.org/pub/software/utils/pciutils/"
+
+[[package.metadata.build-package.external-files]]
+url = "https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.13.0.tar.gz"
+sha512 = "39cf4141c87c9a39fb42ec7a2412525f4283c62a1d1aa3533eb92bae4c59d3beb9a2ab1a9fcfe89b1f6cb8f0a011ef2f32fbed3111d357ce43d9569b3d0253d9"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/pciutils/pciutils.spec
+++ b/packages/pciutils/pciutils.spec
@@ -1,0 +1,48 @@
+Name: %{_cross_os}pciutils
+Version: 3.13.0
+Release: 1%{?dist}
+Summary: PCI bus related utilities
+License: GPL-2.0-only
+URL: https://www.kernel.org/pub/software/utils/pciutils/
+Source0:  https://mirrors.edge.kernel.org/pub/software/utils/pciutils/pciutils-%{version}.tar.gz
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n pciutils-%{version} -p1
+
+%global pciutils_make \
+make\\\
+  CROSS_COMPILE="%{_cross_target}-"\\\
+  HOST="%{_cross_arch}-linux"\\\
+  OPT="%{_cross_cflags}"\\\
+  LDFLAGS="%{_cross_ldflags}"\\\
+  PREFIX="%{_cross_prefix}"\\\
+  LIBDIR="%{_cross_libdir}"\\\
+  MANDIR="%{_cross_mandir}"\\\
+  DESTDIR="%{buildroot}"\\\
+  STRIP=""\\\
+  SHARED=no\\\
+  DNS=no\\\
+  HWDB=no\\\
+  LIBKMOD=no\\\
+  ZLIB=no\\\
+%{nil}
+
+%build
+%pciutils_make
+
+%install
+%pciutils_make install
+
+%files
+%license COPYING
+%{_cross_attribution_file}
+%{_cross_bindir}/lspci
+%{_cross_datadir}/pci.ids
+%exclude %{_cross_sbindir}/pcilmr
+%exclude %{_cross_sbindir}/setpci
+%exclude %{_cross_sbindir}/update-pciids
+%exclude %{_cross_mandir}

--- a/packages/release/Cargo.toml
+++ b/packages/release/Cargo.toml
@@ -45,6 +45,7 @@ makedumpfile = { path = "../../packages/makedumpfile" }
 netdog = {path = "../netdog" }
 os = { path = "../os" }
 oci-add-hooks = { path = "../oci-add-hooks" }
+pciutils = { path = "../pciutils" }
 policycoreutils = { path = "../policycoreutils" }
 procps = { path = "../procps" }
 selinux-policy = { path = "../selinux-policy" }

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -124,6 +124,7 @@ Requires: %{_cross_os}makedumpfile
 Requires: %{_cross_os}mdadm
 Requires: %{_cross_os}netdog
 Requires: %{_cross_os}os
+Requires: %{_cross_os}pciutils
 Requires: %{_cross_os}policycoreutils
 Requires: %{_cross_os}procps
 Requires: %{_cross_os}selinux-policy


### PR DESCRIPTION

**Description of changes:**
This adds the `pciutils` package to the release package dependencies so that lspci is available for debugging devices on Bottlerocket images.


**Testing done:**
Booted an image and checked `lspci` works on x86_64 and aarch64
### aarch t4g.large
```
[root@admin]# sheltie
bash-5.1# lspci
00:00.0 Host bridge: Amazon.com, Inc. Device 0200
00:01.0 Serial controller: Amazon.com, Inc. Device 8250
00:04.0 Non-Volatile memory controller: Amazon.com, Inc. NVMe EBS Controller
00:05.0 Ethernet controller: Amazon.com, Inc. Elastic Network Adapter (ENA)
00:1f.0 Non-Volatile memory controller: Amazon.com, Inc. NVMe EBS Controller
```

### NVIDIA x86_64
```
[root@admin]# sheltie
bash-5.1# lspci
00:00.0 Host bridge: Intel Corporation 440FX - 82441FX PMC [Natoma]
00:01.0 ISA bridge: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II]
00:01.3 Non-VGA unclassified device: Intel Corporation 82371AB/EB/MB PIIX4 ACPI (rev 08)
00:03.0 VGA compatible controller: Amazon.com, Inc. Device 1111
00:04.0 Non-Volatile memory controller: Amazon.com, Inc. NVMe EBS Controller
00:05.0 Ethernet controller: Amazon.com, Inc. Elastic Network Adapter (ENA)
00:1d.0 Non-Volatile memory controller: Amazon.com, Inc. NVMe EBS Controller
00:1e.0 3D controller: NVIDIA Corporation TU104GL [Tesla T4] (rev a1)
00:1f.0 Non-Volatile memory controller: Amazon.com, Inc. NVMe SSD Controller
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
