### PR TITLE
install-twoliter: validate binary checksum on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,18 @@ TWOLITER := $(TWOLITER_DIR)/twoliter
 CARGO_HOME := $(TOP).cargo
 
 TWOLITER_VERSION ?= "0.4.5"
+TWOLITER_SHA256_AARCH64 ?= "799103bcc00e1daf931e11eb58630ca7c4d93c14752c3f4dcf25594759e3c3e7"
+TWOLITER_SHA256_X86_64 ?= "b0cd35c0a1257fc98992821eb5ea7a96c021dba166ee2b9d04449b9206b3d941"
 KIT ?= bottlerocket-core-kit
 ARCH ?= $(shell uname -m)
 VENDOR ?= bottlerocket
+
+ifeq ($(ARCH), aarch64)
+	TWOLITER_SHA256=$(TWOLITER_SHA256_AARCH64)
+else
+	TWOLITER_SHA256=$(TWOLITER_SHA256_X86_64)
+endif
+
 
 export GO_MODULES = ecs-gpu-init host-ctr
 
@@ -21,7 +30,7 @@ prep:
 		--version v$(TWOLITER_VERSION) \
 		--directory $(TWOLITER_DIR) \
 		--reuse-existing-install \
-		--allow-binary-install \
+		--allow-binary-install $(TWOLITER_SHA256) \
 		--allow-from-source
 
 update: prep

--- a/tools/install-twoliter.sh
+++ b/tools/install-twoliter.sh
@@ -41,7 +41,8 @@ Usage: $0 -r GIT_REPO -v TWOLITER_VERSION -d INSTALL_DIR [-e REUSE_EXISTING] [-b
     -d, --directory               the directory to install twoliter into
     -e, --reuse-existing-install  we will skip installation if we find the correct version installed
     -b, --allow-binary-install    we will try to install a GitHub release-attached binary if the
-                                  host we are on is Linux.
+                                  host we are on is Linux. Takes an expected sha256 sum for the
+                                  binary as input.
     -s, --allow-from-source       we will install from source using cargo install pointed to a git
                                   repo and rev when binary install is either not allowed or not
                                   possible
@@ -96,7 +97,7 @@ while [[ $# -gt 0 ]]; do
         -e|--reuse-existing-install)
             reuse_existing="true" ;;
         -b|--allow-binary-install)
-            allow_bin="true" ;;
+            allow_bin="true"; shift; bin_checksum=$1 ;;
         -s|--allow-from-source)
             from_source="true" ;;
         -k|--skip-version-check)
@@ -143,6 +144,8 @@ if [ "${allow_bin}" = "true" ] ; then
       twoliter_target="${host_arch}-unknown-${host_kernel}-musl"
       cd "${workdir}"
       curl -sSL "${twoliter_release}/twoliter-${twoliter_target}.tar.xz" -o "twoliter.tar.xz"
+      echo "Checking binary checksum..."
+      sha256sum -c <<< "${bin_checksum} twoliter.tar.xz"
       tar xf twoliter.tar.xz
       mv "./twoliter-${twoliter_target}/twoliter" "${dir}"
       exit 0


### PR DESCRIPTION
**Description of changes:**
This performs checksum validation of the downloaded twoliter binary prior to unpacking the tarball.

**Testing done:**
* Ran `make build` and noted that the checksum validated and the installation succeeded
* Modified the checksum to be incorrect and noted that installation failed (for both architectures)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
