### PR TITLE
source: add pciclient crate for high level access to lspci

### DIFF
--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -11,6 +11,7 @@ source-groups = [
     "bottlerocket-release",
     "metricdog",
     "parse-datetime",
+    "pciclient",
     "ghostdog",
     "updater",
     "logdog",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1041,6 +1041,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4f37d875011af3196e4828024742a84dcff6b0d027d272f2944f9a99f2c8af"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b4b686e7ebf76cfa591052482d8c3c8242722518560798631974bf899d5565"
+dependencies = [
+ "darling 0.20.10",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "bootstrap-commands"
 version = "0.1.0"
 dependencies = [
@@ -1707,6 +1730,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3035,6 +3069,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pciclient"
+version = "0.1.0"
+dependencies = [
+ "bon",
+ "derive-getters",
+ "generate-readme",
+ "log",
+ "serde_json",
+ "snafu",
+ "test-case",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,6 +3519,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -64,6 +64,8 @@ members = [
 
     "parse-datetime",
 
+    "pciclient",
+
     "retry-read",
 
     "updater/block-party",
@@ -90,6 +92,7 @@ generate-readme = { version = "0.1", path = "generate-readme" }
 imdsclient = { version = "0.1", path = "imdsclient" }
 models = { version = "0.1", path = "models" }
 parse-datetime = { version = "0.1", path = "parse-datetime" }
+pciclient = { version = "0.1", path = "pciclient" }
 retry-read = { version = "0.1", path = "retry-read" }
 signpost = { version = "0.1", path = "updater/signpost" }
 storewolf = { version = "0.1", path = "api/storewolf" }
@@ -114,12 +117,14 @@ aws-smithy-runtime = "1"
 aws-smithy-types = "1"
 aws-types = "1"
 bit_field = "0.10"
+bon = "2"
 bytes = "1"
 cached = "0.49"
 cargo-readme = "3"
 chrono = { version = "0.4", default-features = false }
 cidr = "0.2"
 darling = { version = "0.20", default-features = false }
+derive-getters = "0.5"
 dns-lookup = "2"
 env_logger = "0.11"
 envy = "0.4"

--- a/sources/pciclient/Cargo.toml
+++ b/sources/pciclient/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pciclient"
+version = "0.1.0"
+authors = ["Yutong Sun <yutongsu@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+bon.workspace = true
+derive-getters.workspace = true
+log.workspace = true
+serde_json.workspace = true
+snafu.workspace = true
+
+[build-dependencies]
+generate-readme.workspace = true
+
+[dev-dependencies]
+test-case.workspace = true

--- a/sources/pciclient/README.md
+++ b/sources/pciclient/README.md
@@ -1,0 +1,13 @@
+# pciclient
+
+Current version: 0.1.0
+
+`pciclient` provides high-level methods to invoke `lspci` and query for attached devices information.
+
+pciclient provides util functions that can:
+- List the devices attached with some filtering option.
+- Detect specifically if EFA device is attached.
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/sources/pciclient/README.tpl
+++ b/sources/pciclient/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated from `README.tpl` using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/sources/pciclient/build.rs
+++ b/sources/pciclient/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    generate_readme::from_lib().unwrap();
+}

--- a/sources/pciclient/src/lib.rs
+++ b/sources/pciclient/src/lib.rs
@@ -1,0 +1,146 @@
+/*!
+`pciclient` provides high-level methods to invoke `lspci` and query for attached devices information.
+
+pciclient provides util functions that can:
+- List the devices attached with some filtering option.
+- Detect specifically if EFA device is attached.
+*/
+mod private;
+
+use private::{call_list_devices, check_efa_attachment, PciClient};
+
+use bon::Builder;
+use derive_getters::Getters;
+use std::ffi::OsString;
+
+/// This [`ListDevicesParam`] is based on the "-d" flag for `lspci`, which
+/// allows selection/filtering of the output. Spec for "-d":
+/// ```sh
+/// -d [<vendor>]:[<device>][:<class>[:<prog-if>]]
+///
+/// Show only devices with specified vendor, device, class ID,
+/// and programming interface.  The ID's are given in
+/// hexadecimal and may be omitted or given as "*", both
+/// meaning "any value". The class ID can contain "x"
+/// characters which stand for "any digit".
+/// ```
+#[derive(Debug, Default, PartialEq, Builder)]
+pub struct ListDevicesParam {
+    #[builder(into)]
+    vendor: Option<String>,
+    #[builder(into)]
+    device: Option<String>,
+    #[builder(into)]
+    class: Option<String>,
+    #[builder(into)]
+    program_interface: Option<String>,
+}
+
+impl ListDevicesParam {
+    /// Convert the ListDevicesParam into proper command line arguments so that
+    /// we can feed it to the lspci() function where it makes the actual call to the
+    /// lspci binary.
+    ///
+    /// As mentioned in [`list_devices`], we will use "-n" and "-m" to decorate the output
+    /// so that it returns machine-readable format which ensures compatibility and numeric output
+    /// for the vendor code and device codes.
+    fn into_command_args(self) -> Vec<OsString> {
+        let mut args: Vec<String> = vec!["-n".into(), "-m".into()];
+        if self != ListDevicesParam::default() {
+            let parts: Vec<String> =
+                vec![self.vendor, self.device, self.class, self.program_interface]
+                    .into_iter()
+                    .map(|part| part.unwrap_or_default())
+                    .collect();
+            let additional_args = parts.join(":");
+            args.push("-d".to_string());
+            args.push(additional_args);
+        }
+        args.into_iter().map(OsString::from).collect()
+    }
+}
+
+/// The [`ListDevicesOutput`] is based on the output format that is decorated by "-n -m".
+#[derive(Debug, Default, PartialEq, Eq, Getters)]
+pub struct ListDevicesOutput {
+    pci_slot: String,
+    class: String,
+    vendor: String,
+    device: String,
+    subsystem_vendor: Option<String>,
+    subsystem_device: Option<String>,
+    revision: Option<String>,
+    program_interface: Option<String>,
+}
+
+/// Query the list of the devices with options to filter the output.
+/// # Input
+/// list_devices_param: [`ListDevicesParam`]. We will under the hood convert the [`ListDevicesParam`]
+/// to the low level arguments to `lspci`.
+/// According to https://man7.org/linux/man-pages/man8/lspci.8.html#MACHINE_READABLE_OUTPUT,
+/// > If you intend to process the output of lspci automatically,
+/// > please use one of the machine-readable output formats (-m, -vm, -vmm)
+/// > described in this section. All other formats are likely to change between versions of lspci.
+///
+/// * We will use `-m` to get the machine-readable format which ensures compatibility.
+/// * We will use `-n` to get the numeric output for the vendor code and device codes.
+/// * We will optionally insert `-d <selection_expression>` to filter the output.
+///
+/// # Output
+/// Output is [`Result<Vec<ListDevicesOutput>>`], the [`ListDevicesOutput`] is based on
+/// the output format that is decorated by "-n -m".
+///
+/// # Example
+/// ```rust,ignore
+/// use pciclient::{ListDevicesParam, list_devices};
+///
+/// let list_devices_param = ListDevicesParam::builder().vendor("1d0f").build();
+/// match list_devices(list_devices_param) {
+///     Ok(list_devices_output) => {
+///         for device_info in list_devices_output {
+///             println!("vendor: {}, class: {}, device: {}", device_info.vendor(), device_info.class(), device_info.device());
+///         }
+///     },
+///     Err(_) => {
+///         println!("Failed to list devices");
+///     }
+/// }
+/// ```
+pub fn list_devices(list_devices_param: ListDevicesParam) -> Result<Vec<ListDevicesOutput>> {
+    call_list_devices(PciClient {}, list_devices_param)
+}
+
+/// Call `lspci` and check if there is any EFA device attached.
+pub fn is_efa_attached() -> Result<bool> {
+    check_efa_attachment(PciClient {})
+}
+
+mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+
+    pub enum PciClientError {
+        #[snafu(display("Deserialization error: {}", source))]
+        Serde { source: serde_json::Error },
+
+        #[snafu(display("Command lspci failed: {}", source))]
+        CommandFailure { source: std::io::Error },
+
+        #[snafu(display("Exection of lspci failed: {}", reason))]
+        ExecutionFailure { reason: String },
+
+        #[snafu(display("Failed to parse the lspci output: {}, reason: {}", output, reason))]
+        ParseListDevicesOutputFailure { output: String, reason: String },
+
+        #[snafu(display(
+            "Failed to parse the lspci output, missing required field: {}",
+            required_field
+        ))]
+        MissingRequiredField { required_field: String },
+    }
+}
+
+pub use error::PciClientError;
+pub type Result<T> = std::result::Result<T, PciClientError>;

--- a/sources/pciclient/src/private.rs
+++ b/sources/pciclient/src/private.rs
@@ -1,0 +1,335 @@
+use std::{ffi::OsStr, process::Command};
+
+use snafu::{ensure, OptionExt, ResultExt};
+
+use crate::{
+    error::{
+        CommandFailureSnafu, ExecutionFailureSnafu, MissingRequiredFieldSnafu,
+        ParseListDevicesOutputFailureSnafu,
+    },
+    ListDevicesOutput, ListDevicesParam, Result,
+};
+
+const AMAZON_VENDOR_CODE: &str = "1d0f";
+const EFA_KEYWORD: &str = "efa";
+
+const LSPCI_PATH: &str = "/usr/bin/lspci";
+
+pub(crate) trait CommandExecutor {
+    fn execute<I, S>(self, args: I) -> Result<Vec<String>>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>;
+}
+
+pub(crate) struct PciClient;
+
+impl CommandExecutor for PciClient {
+    /// Call `lspci`, it takes in the command line arguments and return the result as vector of strings.
+    fn execute<I, S>(self, args: I) -> Result<Vec<String>>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let result = Command::new(LSPCI_PATH)
+            .args(args)
+            .output()
+            .context(CommandFailureSnafu)?;
+        ensure!(
+            result.status.success(),
+            ExecutionFailureSnafu {
+                reason: String::from_utf8_lossy(&result.stderr),
+            }
+        );
+
+        let output = String::from_utf8_lossy(&result.stdout)
+            .lines()
+            .map(str::to_string)
+            .collect();
+        Ok(output)
+    }
+}
+
+/// Parsing the lspci output and convert it to [`ListDevicesOutput`].
+///
+/// As mentioned in [`list_devices`], the parsing logic is based on
+/// the output format that is decorated by "-n -m".
+///
+/// Sample output:
+///
+/// ```sh
+/// bash-5.1# lspci -n -m -d :efa0
+/// 00:1d.0 "0200" "1d0f" "efa0" -p00 "1d0f" "efa0"
+/// ```
+/// Quoting from the manual of `lspci` (https://man7.org/linux/man-pages/man8/lspci.8.html):
+/// Some of the arguments are positional: slot, class, vendor name, device name, subsystem vendor name
+/// and subsystem name (the last two are empty if the device has no subsystem). the remaining arguments
+/// are option-like:
+///
+///    -r<rev>  Revision number.
+///
+///    -p<progif>  Programming interface.
+/// The relative order of positional arguments and options is undefined.
+fn parse_list_devices_output(lspci_output: Vec<String>) -> Result<Vec<ListDevicesOutput>> {
+    lspci_output
+        .iter()
+        .map(|line| -> Result<ListDevicesOutput> {
+            let mut tokens = line.split_whitespace().peekable();
+            let mut list_devices_output = ListDevicesOutput {
+                pci_slot: unquote(tokens.next().context(MissingRequiredFieldSnafu {
+                    required_field: "pci_slot",
+                })?),
+                class: unquote(tokens.next().context(MissingRequiredFieldSnafu {
+                    required_field: "class",
+                })?),
+                vendor: unquote(tokens.next().context(MissingRequiredFieldSnafu {
+                    required_field: "vendor",
+                })?),
+                device: unquote(tokens.next().context(MissingRequiredFieldSnafu {
+                    required_field: "device",
+                })?),
+                ..Default::default()
+            };
+            // Parse the remaining optional fields.
+            // Note that the s_vendor and s_device will be together and positional. They will be empty string if the
+            // device has no subsystem.
+            // The "-r" (revision) and "-p" (program interface) will be inserted before the subsystems optionally, we
+            // need to account for that by checking if the current token starts with the `-r` or `-p` notation.
+            while let Some(token) = tokens.next() {
+                if token.starts_with("-r") {
+                    list_devices_output.revision = Some(token.trim_start_matches("-r").to_string())
+                } else if token.starts_with("-p") {
+                    list_devices_output.program_interface =
+                        Some(token.trim_start_matches("-p").to_string())
+                } else {
+                    // This is when subsystem is matched. We will try to parse both in the same iteration so that
+                    // s_vendor and s_device is captured together.
+                    if list_devices_output.subsystem_vendor.is_some() {
+                        // We will ignore this token since we do not recognize them.
+                        // According to the doc:
+                        // > New options can be added in future versions, but they will always have a single argument not
+                        // > separated from the option by any spaces, so they can be easily ignored if not recognized.
+                        continue;
+                    }
+                    // Here the "filter" ensures empty string would be parsed as None.
+                    list_devices_output.subsystem_vendor =
+                        Some(unquote(token)).filter(|s| !s.is_empty());
+                    let s_device_token =
+                        tokens.next().context(ParseListDevicesOutputFailureSnafu {
+                            output: line.clone(),
+                            reason: "Incomplete subsystem vendor/device fields",
+                        })?;
+                    // Here the "filter" ensures empty string would be parsed as None.
+                    list_devices_output.subsystem_device =
+                        Some(unquote(s_device_token)).filter(|s| !s.is_empty());
+                }
+            }
+            Ok(list_devices_output)
+        })
+        .collect()
+}
+
+/// Some of the token in the lspci output is quoted, this is a simple helper to unquote it.
+/// Sample output: 00:1d.0 "0200" "1d0f" "efa0" -p00 "1d0f" "efa0"
+fn unquote(s: &str) -> String {
+    s.trim_matches('"').to_string()
+}
+
+/// Call `lspci` and check if there is any EFA device attached.
+/// Internal usage, adding command_executor as parameter allows us to better unit test.
+/// For external usage, check [`crate::is_efa_attached`].
+pub(crate) fn check_efa_attachment<T: CommandExecutor>(command_executor: T) -> Result<bool> {
+    let list_devices_param = ListDevicesParam::builder()
+        .vendor(AMAZON_VENDOR_CODE.to_string())
+        .build();
+    let list_device_results = call_list_devices(command_executor, list_devices_param)?;
+    Ok(list_device_results
+        .iter()
+        .any(|device_info| device_info.device.contains(EFA_KEYWORD)))
+}
+
+/// Internal usage, adding command_executor as parameter allows us to better unit test.
+/// For external usage, check [`list_devices`].
+pub(crate) fn call_list_devices<T: CommandExecutor>(
+    command_executor: T,
+    list_devices_param: ListDevicesParam,
+) -> Result<Vec<ListDevicesOutput>> {
+    let list_device_output = command_executor.execute(list_devices_param.into_command_args())?;
+    parse_list_devices_output(list_device_output)
+}
+
+#[cfg(test)]
+mod test {
+    use std::ffi::{OsStr, OsString};
+
+    use test_case::test_case;
+
+    use crate::{ListDevicesOutput, ListDevicesParam, Result};
+
+    use super::{
+        call_list_devices, check_efa_attachment, parse_list_devices_output, CommandExecutor,
+    };
+
+    struct MockPciClient {
+        output: Vec<String>,
+    }
+
+    impl CommandExecutor for MockPciClient {
+        fn execute<I, S>(self, _: I) -> Result<Vec<String>>
+        where
+            I: IntoIterator<Item = S>,
+            S: AsRef<OsStr>,
+        {
+            Ok(self.output)
+        }
+    }
+
+    #[test_case(
+        ListDevicesParam::default(),
+        vec!["-n", "-m"]
+    )]
+    #[test_case(
+        ListDevicesParam::builder().vendor("1d0f").build(),
+        vec!["-n", "-m", "-d", "1d0f:::"]
+    )]
+    #[test_case(
+        ListDevicesParam::builder().device("efa0").build(),
+        vec!["-n", "-m", "-d", ":efa0::"]
+    )]
+    #[test_case(
+        ListDevicesParam::builder().class("0200").build(),
+        vec!["-n", "-m", "-d", "::0200:"]
+    )]
+    #[test_case(
+        ListDevicesParam::builder().program_interface("00").build(),
+        vec!["-n", "-m", "-d", ":::00"]
+    )]
+    #[test_case(
+        ListDevicesParam::builder().vendor("1d0f").device("efa0").build(),
+        vec!["-n", "-m", "-d", "1d0f:efa0::"]
+    )]
+    #[test_case(
+        ListDevicesParam::builder().vendor("1d0f").program_interface("00").build(),
+        vec!["-n", "-m", "-d", "1d0f:::00"]
+    )]
+    #[test_case(
+        ListDevicesParam::builder().vendor("1d0f").class("0200").build(),
+        vec!["-n", "-m", "-d", "1d0f::0200:"]
+    )]
+    #[test_case(
+        ListDevicesParam::builder().vendor("1d0f")
+            .device("efa0")
+            .class("0200")
+            .program_interface("01")
+            .build(),
+        vec!["-n", "-m", "-d", "1d0f:efa0:0200:01"]
+    )]
+    fn list_device_param_to_command_args_test(param: ListDevicesParam, args: Vec<&str>) {
+        let actual_param = param.into_command_args();
+        let expected_param: Vec<OsString> = args.into_iter().map(OsString::from).collect();
+        assert_eq!(actual_param, expected_param);
+    }
+
+    #[test]
+    fn test_parse_list_devices_output() {
+        let raw_lspci_output = r#"00:00.0 "0600" "8086" "1237" -p00 "1d0f" "1237"
+        00:01.0 "0601" "8086" "7000" -p00 "" ""
+        00:1e.0 "0302" "10de" "1eb8" -ra1 -p00 "10de" "12a2""#;
+        let lspci_output = raw_lspci_output.lines().map(str::to_string).collect();
+        let list_devices_output_result = parse_list_devices_output(lspci_output);
+        assert!(list_devices_output_result.is_ok());
+        let list_devices_output = list_devices_output_result.unwrap();
+        assert_eq!(list_devices_output.len(), 3); // Three items in the list_devices_output
+        assert_eq!(
+            list_devices_output[0],
+            ListDevicesOutput {
+                pci_slot: "00:00.0".to_string(),
+                class: "0600".to_string(),
+                vendor: "8086".to_string(),
+                device: "1237".to_string(),
+                program_interface: Some("00".to_string()),
+                subsystem_vendor: Some("1d0f".to_string()),
+                subsystem_device: Some("1237".to_string()),
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            list_devices_output[1],
+            ListDevicesOutput {
+                pci_slot: "00:01.0".to_string(),
+                class: "0601".to_string(),
+                vendor: "8086".to_string(),
+                device: "7000".to_string(),
+                program_interface: Some("00".to_string()),
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            list_devices_output[2],
+            ListDevicesOutput {
+                pci_slot: "00:1e.0".to_string(),
+                class: "0302".to_string(),
+                vendor: "10de".to_string(),
+                device: "1eb8".to_string(),
+                program_interface: Some("00".to_string()),
+                revision: Some("a1".to_string()),
+                subsystem_vendor: Some("10de".to_string()),
+                subsystem_device: Some("12a2".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_list_devices() {
+        let mock_pci_client = MockPciClient {
+            output: vec![r#"00:00.0 "0600" "8086" "1237" -p00 "1d0f" "1237""#.to_string()],
+        };
+        let list_devices_param = ListDevicesParam::builder()
+            .vendor("8086")
+            .device("1237")
+            .class("0600")
+            .program_interface("00")
+            .build();
+        let list_devices_result = call_list_devices(mock_pci_client, list_devices_param);
+        assert!(list_devices_result.is_ok());
+        assert_eq!(
+            list_devices_result.unwrap(),
+            vec![ListDevicesOutput {
+                pci_slot: "00:00.0".to_string(),
+                class: "0600".to_string(),
+                vendor: "8086".to_string(),
+                device: "1237".to_string(),
+                program_interface: Some("00".to_string()),
+                subsystem_vendor: Some("1d0f".to_string()),
+                subsystem_device: Some("1237".to_string()),
+                ..Default::default()
+            }]
+        )
+    }
+
+    #[test]
+    fn test_is_efa_attached() {
+        let mock_pci_client = MockPciClient {
+            // EFA device has class code: 0200 for ethernet controller, vendor 1d0f for amazon, device code efa0.
+            // Below is an actual output from lspci for efa device.
+            output: vec![
+                r#"00:1d.0 "0200" "1d0f" "efa0" -p00 "1d0f" "efa0""#.to_string(),
+                r#"00:1e.0 "0302" "10de" "1eb8" -ra1 -p00 "10de" "12a2""#.to_string(),
+            ],
+        };
+        let check_efa_attachment_result = check_efa_attachment(mock_pci_client);
+        assert!(check_efa_attachment_result.is_ok());
+        assert_eq!(check_efa_attachment_result.unwrap(), true);
+    }
+
+    #[test]
+    fn test_is_efa_attached_negative_case() {
+        let mock_pci_client = MockPciClient {
+            // Below is an actual output from lspci for ena device (not efa).
+            output: vec![r#"00:06.0 "0200" "1d0f" "ec20" -p00 "1d0f" "ec20""#.to_string()],
+        };
+        let check_efa_attachment_result = check_efa_attachment(mock_pci_client);
+        assert!(check_efa_attachment_result.is_ok());
+        assert_eq!(check_efa_attachment_result.unwrap(), false);
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
Added crate pciclient to provide a high level helper to query the PCI information and get the device information.


**Testing done:**
Unit tests.

More tests are done in https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/141 which uses the crate to call lspci and detect EFA.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
