### PR TITLE
add: nvidia-cdi-hook to nvidia-container-toolkit

### DIFF
--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -58,6 +58,7 @@ export GOLDFLAGS="-compressdwarf=false -linkmode=external -extldflags '${CGO_LDF
 
 go build -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime-hook ./cmd/nvidia-container-runtime-hook
 go build -ldflags="${GOLDFLAGS}" -o nvidia-ctk ./cmd/nvidia-ctk
+go build -ldflags="${GOLDFLAGS}" -o nvidia-cdi-hook ./cmd/nvidia-cdi-hook
 
 %install
 install -d %{buildroot}%{_cross_bindir}
@@ -69,6 +70,7 @@ install -d %{buildroot}%{_cross_factorydir}/nvidia-container-runtime
 install -d %{buildroot}%{_cross_templatedir}/nvidia-container-runtime
 install -p -m 0755 nvidia-container-runtime-hook %{buildroot}%{_cross_bindir}/
 install -p -m 0755 nvidia-ctk %{buildroot}%{_cross_bindir}/
+install -p -m 0755 nvidia-cdi-hook %{buildroot}%{_cross_bindir}/
 install -m 0644 %{S:1} %{buildroot}%{_cross_factorydir}/nvidia-container-runtime/
 install -m 0644 %{S:2} %{buildroot}%{_cross_factorydir}/nvidia-container-runtime/
 install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-oci-hooks-json
@@ -83,6 +85,7 @@ ln -s shimpei %{buildroot}%{_cross_bindir}/nvidia-oci
 %{_cross_attribution_file}
 %{_cross_bindir}/nvidia-container-runtime-hook
 %{_cross_bindir}/nvidia-ctk
+%{_cross_bindir}/nvidia-cdi-hook
 %{_cross_bindir}/nvidia-oci
 %{_cross_templatedir}/nvidia-oci-hooks-json
 %{_cross_udevrulesdir}/90-nvidia-gpu-devices.rules


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # N/A

**Description of changes:**

Downstream users want to use the base `nvidia-container-toolkit` package with CDI. For full CDI support, the `nvidia-container-toolkit` package should include the `nvidia-cdi-hook`. The hook `nvidia-cdi-hook` is the CLI tool that is expected to be called by the container runtime, when specified by the CDI file.

For more information about how this hook is packaged by NVIDIA, see the official RPM [1]. 
For how the CDI hook interacts with the container runtime, see the CDI hook documentation [2].

[1]: https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/packaging/rpm/SPECS/nvidia-container-toolkit.spec
[2]: https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/cmd/nvidia-cdi-hook/README.md



**Testing done:**

Before this change, running `nvidia-ctk cdi generate` includes the following log message:
```
...
WARN[0000] Failed to locate nvidia-cdi-hook: pattern nvidia-cdi-hook not found
...
```

Running the same command with this change. The output spec contains references to `nvidia-cdi-hook` and the binary is found on the host:
```
bash-5.2# find . -name nvidia-cdi-hook
./x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/nvidia-cdi-hook
bash-5.2# $(find . -name nvidia-cdi-hook)
NAME:
   NVIDIA CDI Hook - Command to structure files for usage inside a container, called as hooks from a container runtime, defined in a CDI yaml file

USAGE:
   NVIDIA CDI Hook [global options] command [command options]

VERSION:
   unknown

COMMANDS:
   update-ldcache   Update ldcache in a container by running ldconfig
   create-symlinks  A hook to create symlinks in the container. This can be used to process CSV mount specs
   chmod            Set the permissions of folders in the container by running chmod. The container root is prefixed to the specified paths.
   help, h          Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --debug, -d    Enable debug-level logging (default: false) [$NVIDIA_CDI_DEBUG]
   --quiet        Suppress all output except for errors; overrides --debug (default: false) [$NVIDIA_CDI_QUIET]
   --help, -h     show help
   --version, -v  print the version
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
