### PR TITLE
kernel-6.1: update to 6.1.109

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/f578e84fd35abf2a86cbe79936f7d773eed3ca0202ac5fa049cf01879ce9bbe3/kernel-6.1.106-116.188.amzn2023.src.rpm"
-sha512 = "253f601c2df406697fe9cff2a4cbfc3fb4c098a2ea8f36b3a1ce21c7c7d207612e18422a8eb832e6f3e105a59bb62b12bba6fb2f603e7740665ae38a78292645"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/60b1be96cb0d00c8998e26b855b51b54e1cc82a655bb47a1d4f51c5ffbdd3148/kernel-6.1.109-118.189.amzn2023.src.rpm"
+sha512 = "2a40b73e7fbc28f48b01e3d0f463e6c72660662ce498fc91c4727617201ed1714480d731c9e59e8de632cb829ba1dc6cf0a07838eb9b90e61a2b422cb17aae8b"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.106
+Version: 6.1.109
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/f578e84fd35abf2a86cbe79936f7d773eed3ca0202ac5fa049cf01879ce9bbe3/kernel-6.1.106-116.188.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/60b1be96cb0d00c8998e26b855b51b54e1cc82a655bb47a1d4f51c5ffbdd3148/kernel-6.1.109-118.189.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs
@@ -376,7 +376,6 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/System.map
 
 %if "%{_cross_arch}" == "x86_64"
-%{_cross_kmoddir}/kernel/arch/x86/crypto/aesni-intel.ko.*
 %{_cross_kmoddir}/kernel/arch/x86/crypto/blowfish-x86_64.ko.*
 %{_cross_kmoddir}/kernel/arch/x86/crypto/camellia-aesni-avx2.ko.*
 %{_cross_kmoddir}/kernel/arch/x86/crypto/camellia-aesni-avx-x86_64.ko.*
@@ -451,7 +450,6 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/kernel/crypto/chacha_generic.ko.*
 %{_cross_kmoddir}/kernel/crypto/cmac.ko.*
 %{_cross_kmoddir}/kernel/crypto/crc32_generic.ko.*
-%{_cross_kmoddir}/kernel/crypto/cryptd.ko.*
 %{_cross_kmoddir}/kernel/crypto/crypto_user.ko.*
 %{_cross_kmoddir}/kernel/crypto/cts.ko.*
 %{_cross_kmoddir}/kernel/crypto/des_generic.ko.*
@@ -485,12 +483,10 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/kernel/crypto/xts.ko.*
 %{_cross_kmoddir}/kernel/crypto/xxhash_generic.ko.*
 %{_cross_kmoddir}/kernel/crypto/zstd.ko.*
-%if "%{_cross_arch}" == "x86_64"
-%{_cross_kmoddir}/kernel/crypto/crypto_simd.ko.*
-%endif
 %if "%{_cross_arch}" == "aarch64"
 %{_cross_kmoddir}/kernel/crypto/sm3.ko.*
 %{_cross_kmoddir}/kernel/crypto/sm4.ko.*
+%{_cross_kmoddir}/kernel/crypto/cryptd.ko.*
 %endif
 %{_cross_kmoddir}/kernel/drivers/acpi/ac.ko.*
 %{_cross_kmoddir}/kernel/drivers/acpi/button.ko.*
@@ -702,6 +698,7 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/kernel/drivers/pci/hotplug/acpiphp_ibm.ko.*
 %{_cross_kmoddir}/kernel/drivers/pci/pci-stub.ko.*
 %if "%{_cross_arch}" == "x86_64"
+%{_cross_kmoddir}/kernel/drivers/pci/controller/pci-hyperv-intf.ko.*
 %{_cross_kmoddir}/kernel/drivers/pci/hotplug/cpcihp_generic.ko.*
 %{_cross_kmoddir}/kernel/drivers/platform/x86/wmi-bmof.ko.*
 %{_cross_kmoddir}/kernel/drivers/platform/x86/wmi.ko.*
@@ -783,6 +780,7 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/kernel/drivers/usb/usbip/usbip-core.ko.*
 %{_cross_kmoddir}/kernel/drivers/usb/usbip/usbip-host.ko.*
 %{_cross_kmoddir}/kernel/drivers/usb/usbip/vhci-hcd.ko.*
+%{_cross_kmoddir}/kernel/drivers/vfio/pci/mlx5/mlx5-vfio-pci.ko.*
 %{_cross_kmoddir}/kernel/drivers/vfio/pci/vfio-pci-core.ko.*
 %{_cross_kmoddir}/kernel/drivers/vfio/pci/vfio-pci.ko.*
 %{_cross_kmoddir}/kernel/drivers/vfio/vfio_iommu_type1.ko.*


### PR DESCRIPTION

**Description of changes:**
Updated the kernel to 6.1.109

Config diff:
```
config-6.1-aarch64.config
3c3
< # Linux/arm64 6.1.106 Kernel Configuration
---
> # Linux/arm64 6.1.109 Kernel Configuration
4257c4257
< # CONFIG_MLX5_VFIO_PCI is not set
---
> CONFIG_MLX5_VFIO_PCI=m

config-6.1-x86_64.config
3c3
< # Linux/x86 6.1.106 Kernel Configuration
---
> # Linux/x86 6.1.109 Kernel Configuration
1829c1829
< # CONFIG_PCI_HYPERV_INTERFACE is not set
---
> CONFIG_PCI_HYPERV_INTERFACE=m
4168c4168
< # CONFIG_MLX5_VFIO_PCI is not set
---
> CONFIG_MLX5_VFIO_PCI=m
4948c4948
< CONFIG_CRYPTO_CRYPTD=m
---
> CONFIG_CRYPTO_CRYPTD=y
4951c4951
< CONFIG_CRYPTO_SIMD=m
---
> CONFIG_CRYPTO_SIMD=y
5098c5098
< CONFIG_CRYPTO_AES_NI_INTEL=m
---
> CONFIG_CRYPTO_AES_NI_INTEL=y
```

Added patches:
```
Patches that changed:
Patches that were dropped:
Patches that were added:
0188-fou-Fix-null-ptr-deref-in-GRO.patch
```

**Testing done:**

Booted aarch64 `aws-k8s-1.29`
```
Linux ip-172-31-62-66.us-west-2.compute.internal 6.1.109 #1 SMP Tue Sep 17 01:53:25 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
```

Booted x86_64 `aws-k8s-1.29`
```
Linux ip-172-31-51-194.us-west-2.compute.internal 6.1.109 #1 SMP PREEMPT_DYNAMIC Tue Sep 17 01:45:27 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
