### PR TITLE
Update the changelog for 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v2.6.0 (2024-09-17)
+
+## Build Changes
+* Validate `twoliter` upon install ([#147])
+
+## OS Changes
+* Add the ability for driverdog to copy modules ([#119])
+* Add pciclient crate for high level access to `lspci` ([#149])
+* Update 6.1 kernel to 6.1.109 ([#151])
+
+[#119]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/119
+[#147]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/147
+[#149]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/149
+[#151]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/151
+
 # v2.5.0 (2024-09-11)
 
 ## Build Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "2.5.0"
+release-version = "2.6.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"


### PR DESCRIPTION
**Description of changes:**
Updates the release version to 2.6.0 and adds a changelog entry for 2.6.0


**Testing done:**
`make` worked.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
