### PR TITLE
Update kernels 5.10 and 5.15

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/090ee50d7c80b80f41f8e3c8c7d63efaa9592371f48bc9f769b2d52cb358a238/kernel-5.10.224-212.876.amzn2.src.rpm"
-sha512 = "1a5d1066aa061b4b8cc2d97671d86c4aee727266386f0507b8a841adfc51235d3fa74eab3cfc64ca3d78397294f789ae3ee48f45c16f330929691d14ce7153c0"
+url = "https://cdn.amazonlinux.com/blobstore/3351af6379ce59bc5724cf19ad4819e5d6929dafdb2925afd0c9ea0e13d3be47/kernel-5.10.225-213.878.amzn2.src.rpm"
+sha512 = "96ff97176e92357e89171ebcf5eb5104e59947b92a0f0c7eb161552e2686ffac094db3d45da2bbbb9c343d94515e017f2732cf22ff84745a0c2a475a80b52abc"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.224
+Version: 5.10.225
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/090ee50d7c80b80f41f8e3c8c7d63efaa9592371f48bc9f769b2d52cb358a238/kernel-5.10.224-212.876.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/3351af6379ce59bc5724cf19ad4819e5d6929dafdb2925afd0c9ea0e13d3be47/kernel-5.10.225-213.878.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/5fc19dbcdad79c0964001228b7f301dc9726ba49f28248fe04f44186bb318e51/kernel-5.15.165-110.161.amzn2.src.rpm"
-sha512 = "dcb77a87aa343d10936a40e155d6d3b67e78a42f04f817157731b97caa4de113564edfba37dd9ed66712081ae0df1102cd5703cd895a493e4ec7348886eb303b"
+url = "https://cdn.amazonlinux.com/blobstore/1db73ff2ad4ac5d6ccf1f53e405b23ad5ee2715a6392faad73688bbb29c3374e/kernel-5.15.166-111.163.amzn2.src.rpm"
+sha512 = "59de7f13b4ab203b17ed4c1fb8260db560f95ade10f31db7c609129cc3043781a76eca79ca293ff9addff88431b5c20072472e952d6d75749b93d282d4cab374"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.165
+Version: 5.15.166
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/5fc19dbcdad79c0964001228b7f301dc9726ba49f28248fe04f44186bb318e51/kernel-5.15.165-110.161.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/1db73ff2ad4ac5d6ccf1f53e405b23ad5ee2715a6392faad73688bbb29c3374e/kernel-5.15.166-111.163.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.


### PR DESCRIPTION
**Issue number:**

N / A

**Description of changes:**

Update to 5.10.225 and 5.15.166

No config changes were detected:

```bash
diff '--color=auto' directory-for-base-configs/config-5.10-aarch64.config directory-for-updated-configs/config-5.10-aarch64.config
3c3
< # Linux/arm64 5.10.224 Kernel Configuration
---
> # Linux/arm64 5.10.225 Kernel Configuration
diff '--color=auto' directory-for-base-configs/config-5.10-x86_64.config directory-for-updated-configs/config-5.10-x86_64.config
3c3
< # Linux/x86 5.10.224 Kernel Configuration
---
> # Linux/x86 5.10.225 Kernel Configuration
diff '--color=auto' directory-for-base-configs/config-5.15-aarch64.config directory-for-updated-configs/config-5.15-aarch64.config
3c3
< # Linux/arm64 5.15.165 Kernel Configuration
---
> # Linux/arm64 5.15.166 Kernel Configuration
diff '--color=auto' directory-for-base-configs/config-5.15-x86_64.config directory-for-updated-configs/config-5.15-x86_64.config
3c3
< # Linux/x86 5.15.165 Kernel Configuration
---
> # Linux/x86 5.15.166 Kernel Configuration
```

```bash
File: packages/kernel-5.10/patch_changes/summary
Patches that changed:
0226-tools-Add-some-generic-functions-and-headers.patch -> 0226-tools-Add-some-generic-functions-and-headers.patch
0229-objtool-arm64-Add-base-definition-for-arm64-backend.patch -> 0229-objtool-arm64-Add-base-definition-for-arm64-backend.patch
0259-objtool-arm64-Add-unwind_hint-support.patch -> 0259-objtool-arm64-Add-unwind_hint-support.patch
Patches that were dropped:
0271-ipc-replace-costly-bailout-check-in-sysvipc_find_ipc.patch
0872-nfsd-Don-t-call-freezable_schedule_timeout-after-eac.patch
Patches that were added:
0874-fou-Fix-null-ptr-deref-in-GRO.patch
0875-net-mlx5-Update-log_max_qp-value-to-FW-max-capabilit.patch
0876-x86-cpu-Add-several-Intel-server-CPU-model-numbers.patch
0877-intel_idle-add-Emerald-Rapids-Xeon-support.patch
```

```bash
File: packages/kernel-5.15/patch_changes/summary
Patches that changed:
Patches that were dropped:
Patches that were added:
0161-fou-Fix-null-ptr-deref-in-GRO.patch
0162-tools-Drop-downstream-version-of-ALIGN_DOWN-macro.patch
```


**Testing done:**

5.10 aarch64 boots

```bash
[ssm-user@control]$ uname -a
Linux ip-172-31-20-163.us-west-2.compute.internal 5.10.225 #1 SMP Thu Sep 19 00:28:41 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "6ac4c13a-dirty",
    "pretty_name": "Bottlerocket OS 1.23.0 (aws-ecs-1)",
    "variant_id": "aws-ecs-1",
    "version_id": "1.23.0"
  }
}
[ssm-user@control]$
```

5.10 x86_64 boots

```bash
[ssm-user@control]$ uname -a
Linux ip-172-31-23-64.us-west-2.compute.internal 5.10.225 #1 SMP Thu Sep 19 00:20:22 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "6ac4c13a-dirty",
    "pretty_name": "Bottlerocket OS 1.23.0 (aws-ecs-1)",
    "variant_id": "aws-ecs-1",
    "version_id": "1.23.0"
  }
}
[ssm-user@control]$
```

5.15 aarch64 boots

```bash
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "6ac4c13a-dirty",
    "pretty_name": "Bottlerocket OS 1.23.0 (aws-k8s-1.25)",
    "variant_id": "aws-k8s-1.25",
    "version_id": "1.23.0"
  }
}
[ssm-user@control]$ uname -a
Linux ip-172-31-26-206.us-west-2.compute.internal 5.15.166 #1 SMP Thu Sep 19 00:28:31 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
[ssm-user@control]$
```

5.15 x86_64 boots
```bash
[ssm-user@control]$ uname -a
Linux ip-172-31-29-154.us-west-2.compute.internal 5.15.166 #1 SMP Thu Sep 19 00:20:18 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "6ac4c13a-dirty",
    "pretty_name": "Bottlerocket OS 1.23.0 (aws-k8s-1.25)",
    "variant_id": "aws-k8s-1.25",
    "version_id": "1.23.0"
  }
}
[ssm-user@control]$
```




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
