### PR TITLE
Change Go version for k8s 1.23-1.29

### DIFF
--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -194,6 +194,7 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
+export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make generated_files
 

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -174,6 +174,7 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
+export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make generated_files
 

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -166,6 +166,7 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
+export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make generated_files
 

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -156,6 +156,7 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
+export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -142,6 +142,7 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
+export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -142,6 +142,7 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
+export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -142,6 +142,7 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
+export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 


### PR DESCRIPTION
Go 1.23 leaks file descriptors if os/exec fails.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes issue https://github.com/bottlerocket-os/bottlerocket/issues/4201 once consumed.

**Description of changes:**

Add GO_MAJOR=1.22 for kubernetes packages 1.23 through 1.29. kubernetes 1.30 already had GO_MAJOR=1.22, and kubernetes 1.31 will require 1.23.

**Testing done:**

Built nodegroups, added to cluster with the Calico configuration that rapidly reproduces the failure.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
