### PR TITLE
add package-level support for erofs as root filesystem

### DIFF
--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -45,6 +45,9 @@ Requires: %{name}-devel = %{version}-%{release}
 # The 5.10 kernel is not FIPS certified.
 Conflicts: %{_cross_os}image-feature(fips)
 
+# Using EROFS for the root partition requires a 6.1+ kernel.
+Conflicts: %{_cross_os}image-feature(erofs-root-partition)
+
 %global kernel_sourcedir %{_cross_usrsrc}/kernels
 %global kernel_libdir %{_cross_libdir}/modules/%{version}
 

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -40,6 +40,9 @@ Requires: %{name}-devel = %{version}-%{release}
 # The 5.15 kernel is not FIPS certified.
 Conflicts: %{_cross_os}image-feature(fips)
 
+# Using EROFS for the root partition requires a 6.1+ kernel.
+Conflicts: %{_cross_os}image-feature(erofs-root-partition)
+
 %global kernel_sourcedir %{_cross_usrsrc}/kernels
 %global kernel_libdir %{_cross_libdir}/modules/%{version}
 

--- a/packages/kernel-6.1/config-bottlerocket
+++ b/packages/kernel-6.1/config-bottlerocket
@@ -1,8 +1,9 @@
 # Because Bottlerocket does not have an initramfs, modules required to mount
 # the root filesystem must be set to y.
 
-# The root filesystem is ext4
+# The root filesystem is ext4 or erofs
 CONFIG_EXT4_FS=y
+CONFIG_EROFS_FS=y
 
 # btrfs support for compatibility
 CONFIG_BTRFS_FS=m

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -923,7 +923,6 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/kernel/lib/crypto/libpoly1305.ko.*
 %{_cross_kmoddir}/kernel/lib/lru_cache.ko.*
 %{_cross_kmoddir}/kernel/lib/lz4/lz4_compress.ko.*
-%{_cross_kmoddir}/kernel/lib/lz4/lz4_decompress.ko.*
 %{_cross_kmoddir}/kernel/lib/lz4/lz4hc_compress.ko.*
 %{_cross_kmoddir}/kernel/lib/raid6/raid6_pq.ko.*
 %{_cross_kmoddir}/kernel/lib/reed_solomon/reed_solomon.ko.*

--- a/packages/kernel-6.1/var-lib-kernel-devel-lower.mount.drop-in.conf.in
+++ b/packages/kernel-6.1/var-lib-kernel-devel-lower.mount.drop-in.conf.in
@@ -1,0 +1,4 @@
+[Mount]
+What=PREFIX/share/bottlerocket/kernel-devel
+Type=none
+Options=rbind,rshared

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -211,22 +211,22 @@ install -p -m 0644 %{S:1102} \
 install -d %{buildroot}%{_cross_unitdir}/check-fips-modules.service.d
 
 LOWERPATH=$(systemd-escape --path %{_cross_sharedstatedir}/kernel-devel/.overlay/lower)
-sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1080} > ${LOWERPATH}.mount
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:1080} > ${LOWERPATH}.mount
 install -p -m 0644 ${LOWERPATH}.mount %{buildroot}%{_cross_unitdir}
 
 # Mounting on usr/src/kernels requires using the real path: %{_cross_usrsrc}/kernels
 KERNELPATH=$(systemd-escape --path %{_cross_usrsrc}/kernels)
-sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1081} > ${KERNELPATH}.mount
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:1081} > ${KERNELPATH}.mount
 install -p -m 0644 ${KERNELPATH}.mount %{buildroot}%{_cross_unitdir}
 
 # Mounting on usr/share/licenses requires using the real path: %{_cross_datadir}/licenses
 LICENSEPATH=$(systemd-escape --path %{_cross_licensedir})
-sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1082} > ${LICENSEPATH}.mount
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:1082} > ${LICENSEPATH}.mount
 install -p -m 0644 ${LICENSEPATH}.mount %{buildroot}%{_cross_unitdir}
 
 # Mounting on lib/modules requires using the real path: %{_cross_libdir}/modules
 LIBDIRPATH=$(systemd-escape --path %{_cross_libdir})
-sed -e 's|PREFIX|%{_cross_prefix}|' %{S:1083} > ${LIBDIRPATH}-modules.mount
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:1083} > ${LIBDIRPATH}-modules.mount
 install -p -m 0644 ${LIBDIRPATH}-modules.mount %{buildroot}%{_cross_unitdir}
 
 # Mounting on usr/bin requires using the real path: %{_cross_bindir}

--- a/packages/release/usr-share-licenses.mount.in
+++ b/packages/release/usr-share-licenses.mount.in
@@ -4,6 +4,7 @@ DefaultDependencies=no
 Conflicts=umount.target
 Before=umount.target
 After=local-fs.target
+ConditionPathExists=PREFIX/share/bottlerocket/licenses.squashfs
 
 [Mount]
 What=PREFIX/share/bottlerocket/licenses.squashfs

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -2,6 +2,7 @@
 (fsuse xattr ext4 local)
 (fsuse xattr overlay local)
 (fsuse xattr xfs local)
+(fsuse xattr erofs local)
 
 ; Label inodes by using the type of the creating task.
 (fsuse task eventpollfs any)


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/twoliter/pull/379

**Description of changes:**
This implements the core kit side of erofs support.

Require a 6.1 kernel for using erofs, and add the necessary kernel config and SELinux policy statements to make it work.

The ugly parts come from my goal of avoiding multiple forms of compression; since erofs includes its own compression, we can avoid compressing license and attribution data, kernel modules, and kernel development files.

Kernel module decompression is handled by `twoliter`: if we're building an erofs root filesystem, it decompresses any kernel modules. Uncompressed license and attribution data is *mostly* handled by `twoliter`, which skips generating the squashfs when using the erofs feature. However, we need to tell the OS not to try to mount the missing squashfs.

Handling the kernel development files is more complicated, because there's a lot of logic in the `release` package to handle setting up `/usr/src/kernels` as a writable mount. I couldn't see a great way to prevent the `kernel-6.1` package from depending on some of the specific units in `release`, but I tried to minimize it. We now create two `kernel-devel` packages, one compressed with squashfs and the other left unpacked, and we use a drop-in to replace [the squashfs mount](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/47f92e4f61696716ed0703a13d9af4ba6eb9e6c5/packages/release/var-lib-kernel-devel-lower.mount.in) in `release` with a regular bind mount.


**Testing done:**
Built `aws-k8s-1.30` with and without the image feature enabled.

Without:
```
bash-5.1# findmnt / -o FSTYPE -n
ext4

bash-5.1# df -h /
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       904M  700M  143M  84% /

# kernel-devel lower is a squashfs mount
bash-5.1# findmnt /var/lib/kernel-devel/.overlay/lower/ -o FSTYPE -n
squashfs

# /usr/share/licenses is a squashfs mount
bash-5.1# findmnt /usr/share/licenses -o FSTYPE -n
squashfs

# all licenses are present
bash-5.1# find /usr/share/licenses -type f | wc -l
2907

# mount has the correct label
bash-5.1# ls -latrZ /usr/bin/mount
-rwsr-xr-x. 1 root root system_u:object_r:mount_exec_t:s0 65608 Sep 22 00:56 /usr/bin/mount
```

With:
```
bash-5.1# findmnt / -o FSTYPE -n
erofs

bash-5.1# df -h /
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       337M  337M     0 100% /

# kernel-devel lower is a bind mount
bash-5.1# findmnt /var/lib/kernel-devel/.overlay/lower/ -o FSTYPE -n
erofs

# /usr/share/licenses is not a mount
bash-5.1# findmnt /usr/share/licenses -o FSTYPE -n
<no output>

# all licenses are present
bash-5.1# find /usr/share/licenses -type f |wc -l
2907

# mount has the correct label
bash-5.1# ls -latrZ /usr/bin/mount
-rwsr-xr-x. 1 root root system_u:object_r:mount_exec_t:s0 65608 Sep 23 23:05 /usr/bin/mount
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
