### PR TITLE
Update libnvidia-container and nvidia-container-toolkit

### DIFF
--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.16.1/libnvidia-container-1.16.1.tar.gz"
-sha512 = "b304c284c5ab0c3544362307dc16ffcca8d34497e4356a520dc6da81a86a62b2a262b528cba559bb0d7a3addf018c3b50b6cb78669c82c1b4acae159e5922548"
+url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.16.2/libnvidia-container-1.16.2.tar.gz"
+sha512 = "fd24a7eb12b861e5e5712ea5bc3f70c44e19d84c57431ed992d1cbb41d6a057b219886bb6d60d166556ad9843ca142b91cca5de956d0558fffd6a0931f3ad654"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/NVIDIA/nvidia-modprobe/archive/550.54.14/nvidia-modprobe-550.54.14.tar.gz"

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -1,7 +1,7 @@
 %global nvidia_modprobe_version 550.54.14
 
 Name: %{_cross_os}libnvidia-container
-Version: 1.16.1
+Version: 1.16.2
 Release: 1%{?dist}
 Summary: NVIDIA container runtime library
 # The COPYING and COPYING.LESSER files in the sources don't apply to libnvidia-container

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.16.1/nvidia-container-toolkit-1.16.1.tar.gz"
-sha512 = "691d4fc47ea60b730ec491b333aa8118bcfd62cdab20a42b84155c6a13484d920e758435b5029bbae4fbefce82352aa5764f1554992682f689c95615809fb83c"
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.16.2/nvidia-container-toolkit-1.16.2.tar.gz"
+sha512 = "529baa5335232bd7d3eb13cbe92a81c2e22459445fa2476e10d5199f1b2be342d57db0545b8834ea47aeac51e8abf2ae9eb54c001bdbb22fb4da7ea55f89078e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 %global gorepo nvidia-container-toolkit
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.16.1
+%global gover 1.16.2
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-container-toolkit


### PR DESCRIPTION
**Description of changes:**

This updates `libnvidia-container` and `nvidia-container-toolkit` to their latest versions.

nvidia-container-toolkit Changelog: https://github.com/NVIDIA/nvidia-container-toolkit/releases/tag/v1.16.2

libnvidia-container Changelog: https://github.com/NVIDIA/libnvidia-container/releases/tag/v1.16.2

**Testing done:**

- `aws-ecs-2-nvidia` x86_64 instance launches and is able to connect to a cluster:
```
bash-5.1# docker ps
CONTAINER ID   IMAGE           COMMAND            CREATED          STATUS          PORTS     NAMES
308db6dda1d3   fedora:latest   "sleep infinity"   11 minutes ago   Up 11 minutes             ecs-test-ecs-gpu-2-nvidia-e0aae2e7b181e5fc6200
bash-5.1# docker exec -it 308db6dda1d3 nvidia-smi
Thu Sep 26 19:32:32 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla T4                       Off | 00000000:00:1E.0 Off |                    0 |
| N/A   29C    P0              25W /  70W |      2MiB / 15360MiB |      5%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
```
- `aws-k8s-1.29-nvidia` x86_64 node launches and is able to connect to a cluster: 
```
bash-5.1# /usr/libexec/nvidia/tesla/bin/nvidia-smi
Thu Sep 26 20:31:55 2024
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla T4                       Off | 00000000:00:1E.0 Off |                    0 |
| N/A   25C    P8              11W /  70W |      2MiB / 15360MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|  No running processes found                                                           |
+---------------------------------------------------------------------------------------+
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
