### PR TITLE
kernel-6.1: fix kernel-devel requirement

### DIFF
--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -73,8 +73,7 @@ Requires: (%{name}-fips if %{_cross_os}image-feature(fips))
 
 %package devel
 Summary: Configured Linux kernel source for module building
-Requires: (%{name}-devel-squashed if %{_cross_os}image-feature(no-erofs-root-partition))
-Requires: (%{name}-devel-unpacked if %{_cross_os}image-feature(erofs-root-partition))
+Requires: (%{name}-devel-unpacked if %{_cross_os}image-feature(erofs-root-partition) else %{name}-devel-squashed)
 
 %description devel
 %{summary}.


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Older versions of Twoliter might not define either the positive or negative versions of the erofs image feature, which would result in neither of the kernel-devel subpackages getting installed. Fix this by always installing the squashed version unless the positive form of the erofs image feature is present.


**Testing done:**
Built `aws-ecs-2` with the released version of Twoliter 0.4.6, which does not support the erofs image feature.

Before this change, it failed to build with this error:
```
  8.666 /host/build/tools/rpm2img: line 255: /tmp/tmp.Z7V67CvhLc/usr/share/bottlerocket/application-inventory.json: No such file or directory
```

After, the build completed. I confirmed that the "squashed" version was installed:
```
❯ rg squashed target/x86_64/debug/build/aws-ecs-2*/output
647:#18 7.005 bottlerocket-kernel-6.1-devel-squashed-6.1.109-1.1727405070.ce58ab78.br1.x86_64
```

Using a local build of Twoliter which does support the erofs image feature, I confirmed that the "unpacked" version was installed after enabling the feature:
```
❯ rg unpacked target/x86_64/debug/build/aws-dev-*/output
613:#18 6.861 bottlerocket-kernel-6.1-devel-unpacked-6.1.109-1.1727405070.ce58ab78.br1.x86_64
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
