### PR TITLE
ecs-gpu-init: fix unit dependencies on GPU drivers

### DIFF
--- a/packages/ecs-gpu-init/ecs-gpu-init.service
+++ b/packages/ecs-gpu-init/ecs-gpu-init.service
@@ -3,8 +3,7 @@ Description=Initialize ECS GPU config
 # This has to be executed after the kernel modules are loaded
 # otherwise the userspace component of the driver will fail to
 # query the /dev devices
-After=load-kernel-modules.service
-Requires=load-kernel-modules.service
+After=load-tesla-kernel-modules.service load-open-gpu-kernel-modules.service
 # Block manual interactions with this service. It doesn't
 # make sense to regenerate the GPU config file if the ECS
 # agent won't read it when it changes


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
The GPU driver functionality has split into two units, one for the proprietary driver and one for the open one. Depending on the version of the driver, one or both units might be present.

Update the dependencies to reflect this. Also drop the "Requires", as the "After" ordering should be sufficient, and "Requires" will cause a failure if the unit is not installed.


**Testing done:**
Tested `aws-ecs-1-nvidia` and `aws-ecs-2-nvidia`. Both came up successfully.

Ordering on `aws-ecs-1-nvidia`:
```
         Starting Load additional kernel modules...
[  OK  ] Finished Load additional kernel modules.
         Starting Initialize ECS GPU config...
[  OK  ] Finished Initialize ECS GPU config.
```

Ordering on `aws-ecs-2-nvidia`:
```
         Starting Load Tesla kernel modules...
[  OK  ] Finished Load Tesla kernel modules.
         Starting Initialize ECS GPU config...
[  OK  ] Finished Initialize ECS GPU config.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
