### PR TITLE
ecs-agent: update to v1.86.3

### DIFF
--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.82.3/amazon-ecs-agent-1.82.3.tar.gz"
-sha512 = "a26fdbe5c6cb96f5357afea701a97ccaa208ab3ae2149cd0205aa34b8686edd38c194ee8e0389b5385295bf284fcc1bee73dcacc2313c4b560e807eb27c1bafa"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.86.3/amazon-ecs-agent-1.86.3.tar.gz"
+sha512 = "d93129c290c06cff332318644dced900618575b7e540674d58d69f8db1ef90c5a2cf8e41f5af63f97df06df1b20cf9f22bd2252d3e2317984f0ef79252ce25c5"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,7 +2,7 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.82.3
+%global agent_gover 1.86.3
 
 # git rev-parse --short=8
 %global agent_gitrev b7e96508


### PR DESCRIPTION
**Description of changes:**

Update to upstream v1.86.3

**Testing done:**

Verified that an EC2 instance running Bottlerocket built with this core kit joins the cluster and runs busybox.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
