### PR TITLE
feat: add nvidia time-slicing

### DIFF
--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -11,3 +11,14 @@ flags:
     passDeviceSpecs: {{default true settings.kubelet-device-plugins.nvidia.pass-device-specs}}
     deviceListStrategy: {{default "volume-mounts" settings.kubelet-device-plugins.nvidia.device-list-strategy}}
     deviceIDStrategy: {{default "index" settings.kubelet-device-plugins.nvidia.device-id-strategy}}
+{{#if settings.kubelet-device-plugins.nvidia.device-sharing-strategy}}
+{{#if (eq settings.kubelet-device-plugins.nvidia.device-sharing-strategy "time-slicing")}}
+sharing:
+  timeSlicing:
+    renameByDefault: {{default true settings.kubelet-device-plugins.nvidia.time-slicing.rename-by-default}}
+    failRequestsGreaterThanOne: {{default true settings.kubelet-device-plugins.nvidia.time-slicing.fail-requests-greater-than-one}}
+    resources:
+    - name: "nvidia.com/gpu"
+      replicas: {{default 2 settings.kubelet-device-plugins.nvidia.time-slicing.replicas}}
+{{/if}}
+{{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1109,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1118,14 +1118,15 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+version = "0.6.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
  "bottlerocket-scalar",
  "bottlerocket-scalar-derive",
  "bottlerocket-string-impls-for",
+ "bounded-integer",
  "indexmap 2.2.6",
  "lazy_static",
  "regex",
@@ -1153,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1162,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1186,8 +1187,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+version = "0.6.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1237,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1250,7 +1251,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "serde",
 ]
@@ -1258,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -1274,6 +1275,15 @@ dependencies = [
  "generate-readme",
  "serde",
  "snafu",
+]
+
+[[package]]
+name = "bounded-integer"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a6932c88f1d2c29533a3b8a5f5a2f84cc19c3339b431677c3160c5c2e6ca85"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3748,7 +3758,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3761,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3774,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3788,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3801,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3814,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3827,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3840,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3853,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3866,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3879,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3892,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3905,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3919,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3932,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -3944,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3957,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3970,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3983,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -3997,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4010,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4023,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.5.0#ae697ef73e494a789fc2bed9c0f6f03629048c32"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.6.0#276b8e8f6db01c9a03469613e82ece11d729b908"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -199,13 +199,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.5.0"
-version = "0.5.0"
+tag = "bottlerocket-settings-models-v0.6.0"
+version = "0.6.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.5.0"
-version = "0.5.0"
+tag = "bottlerocket-settings-models-v0.6.0"
+version = "0.6.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -214,7 +214,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.5.0"
+tag = "bottlerocket-settings-models-v0.6.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: 
* https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/62
* https://github.com/bottlerocket-os/bottlerocket/issues/2347


**Description of changes:**
Adding time-slicing configs to the core-kit and pointing to the latest settings-sdk.  


**Testing done:**

1. Instance joined the cluster

```
NAME                                           STATUS   ROLES    AGE   VERSION
ip-XXXX.us-west-2.compute.internal   Ready    <none>   15h   v1.29.5-eks-1109419
```

2. Model Default:

```
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-sharing-strategy": "none",
        "pass-device-specs": true,
      }
    }
  }
}
```

3. Model Updates:
```
bash-5.1#: apiclient set settings.kubelet-device-plugins.nvidia.device-sharing-strategy=time-slicing settings.kubelet-device-plugins.nvidia.time-slicing.replicas=2 settings.kubelet-device-plugins.nvidia.time-slicing.rename-by-default=true settings.kubelet-device-plugins.nvidia.time-slicing.fail-requests-greater-than-one=true
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-sharing-strategy": "none",
        "pass-device-specs": true,
        "time-slicing": {
          "fail-requests-greater-than-one": true,
          "rename-by-default": true,
          "replicas": 2
        }
      }
    }
  }
}
```

4. Bounded check:

```
bash-5.1# apiclient set settings.kubelet-device-plugins.nvidia.time-slicing.replicas=1
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-Ne2SavnsTF7Fweq0': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-Ne2SavnsTF7Fweq0: Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error during deserialization: integer out of range, expected it to be between 2 and 2147483647 at line 1 column 107
bash-5.1#
```

5. Files generated:

```
bash-5.1# cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: volume-mounts
    deviceIDStrategy: index
sharing:
  timeSlicing:
    renameByDefault: true
    failRequestsGreaterThanOne: true
    resources:
    - name: "nvidia.com/gpu"
      replicas: 2
 ``` 
 
 ```
 nvidia-device-plugin[360007]:   "resources": {
nvidia-device-plugin[360007]:     "gpus": [
nvidia-device-plugin[360007]:       {
nvidia-device-plugin[360007]:         "pattern": "*",
nvidia-device-plugin[360007]:         "name": "nvidia.com/gpu"
nvidia-device-plugin[360007]:       }
nvidia-device-plugin[360007]:     ]
nvidia-device-plugin[360007]:   },
nvidia-device-plugin[360007]:   "sharing": {
nvidia-device-plugin[360007]:     "timeSlicing": {
nvidia-device-plugin[360007]:       "renameByDefault": true,
nvidia-device-plugin[360007]:       "failRequestsGreaterThanOne": true,
nvidia-device-plugin[360007]:       "resources": [
nvidia-device-plugin[360007]:         {
nvidia-device-plugin[360007]:           "name": "nvidia.com/gpu",
nvidia-device-plugin[360007]:           "rename": "nvidia.com/gpu.shared",
nvidia-device-plugin[360007]:           "devices": "all",
nvidia-device-plugin[360007]:           "replicas": 2
nvidia-device-plugin[360007]:         }
nvidia-device-plugin[360007]:       ]
nvidia-device-plugin[360007]:     }
nvidia-device-plugin[360007]:   }
nvidia-device-plugin[360007]: }
```

6. Time slicing on 1 instance with 1 GPU with 2 containers:

```
bash-5.1# apiclient set settings.kubelet-device-plugins.nvidia.device-sharing-strategy=time-slicing settings.kubelet-device-plugins.nvidia.time-slicing.replicas=2 
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-sharing-strategy": "time-slicing",
        "pass-device-specs": true,
        "time-slicing": {
          "replicas": 2
        }
      }
    }
  }
}

bash-5.1# cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: volume-mounts
    deviceIDStrategy: index
sharing:
  timeSlicing:
    renameByDefault: true
    failRequestsGreaterThanOne: true
    resources:
    - name: "nvidia.com/gpu"
      replicas: 2
bash-5.1#

➜  kubectl apply -f node-1-gpu-2.yaml
pod/gpu-test-2-pod-node-one created

 ➜  kubectl get pods
NAME                      READY   STATUS    RESTARTS   AGE
gpu-test-1-pod-node-one   1/1     Running   0          13m
gpu-test-2-pod-node-one   1/1     Running   0          3s
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
