### PR TITLE
kmod-6.1-neuron: update to 2.18.12.0

### DIFF
--- a/packages/kmod-6.1-neuron/0001-kbuild-do-not-outline-atomics-for-arm64.patch
+++ b/packages/kmod-6.1-neuron/0001-kbuild-do-not-outline-atomics-for-arm64.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] kbuild: do not outline atomics for arm64
 
 Signed-off-by: Ben Cressey <bcressey@amazon.com>
 ---
- usr/src/aws-neuronx-2.17.17.0/Kbuild | 1 +
+ usr/src/aws-neuronx-2.18.12.0/Kbuild | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/usr/src/aws-neuronx-2.17.17.0/Kbuild b/usr/src/aws-neuronx-2.17.17.0/Kbuild
+diff --git a/usr/src/aws-neuronx-2.18.12.0/Kbuild b/usr/src/aws-neuronx-2.18.12.0/Kbuild
 index 11f8490..6535608 100644
---- a/usr/src/aws-neuronx-2.17.17.0/Kbuild
-+++ b/usr/src/aws-neuronx-2.17.17.0/Kbuild
+--- a/usr/src/aws-neuronx-2.18.12.0/Kbuild
++++ b/usr/src/aws-neuronx-2.18.12.0/Kbuild
 @@ -16,3 +16,4 @@ neuron-objs += v3/notific.o v3/neuron_dhal_v3.o
  
  ccflags-y += -O3 -Wall -Werror -Wno-declaration-after-statement -Wunused-macros -Wunused-local-typedefs

--- a/packages/kmod-6.1-neuron/Cargo.toml
+++ b/packages/kmod-6.1-neuron/Cargo.toml
@@ -13,8 +13,8 @@ package-name = "kmod-6.1-neuron"
 releases-url = "https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/runtime/aws-neuronx-dkms/index.html"
 
 [[package.metadata.build-package.external-files]]
-url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.17.17.0.noarch.rpm"
-sha512 = "8ff07280fc2864677d9401d56939f8b8f8cd59dc1ae9df53d49aced500cd62c3071a61639e9f5381b557d29cc7a2b72be71020f90880680a59d10a1f8b28580b"
+url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.18.12.0.noarch.rpm"
+sha512 = "4ed92e661d0ba368eaf8f60e1a68c202062a26819231fcfd42a5ff05d20ad2f34b82b23359a88e80eea22ee5d0056ad769b6febd5d7e7b161da0e36434ba2579"
 
 [build-dependencies]
 kernel-6_1 = { path = "../kernel-6.1" }

--- a/packages/kmod-6.1-neuron/kmod-6.1-neuron.spec
+++ b/packages/kmod-6.1-neuron/kmod-6.1-neuron.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}kmod-6.1-neuron
-Version: 2.17.17.0
+Version: 2.18.12.0
 Release: 1%{?dist}
 Summary: Neuron drivers for the 6.1 kernel
 License: GPL-2.0-only


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Update to the 2.18.12.0 release of the Neuron driver. See [release notes](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/runtime/aws-neuronx-dkms/index.html#neuron-driver-release-2-18-12-0) for more details.


**Testing done:**
Added `kmod-6.1-neuron` to the `aws-dev` variant, started it, and verified that the neuron tools ran:
```
bash-5.1# docker run -it --rm --device=/dev/neuron0 863599026182.dkr.ecr.us-west-2.amazonaws.com/neuron-tools:latest neuron-ls
instance-type: inf2.xlarge
instance-id: i-01937b1bd51e090f9
+--------+--------+--------+---------+
| NEURON | NEURON | NEURON |   PCI   |
| DEVICE | CORES  | MEMORY |   BDF   |
+--------+--------+--------+---------+
| 0      | 2      | 32 GB  | 00:1f.0 |
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
