### PR TITLE
kernel-6.1: exclude more object files from devel

### DIFF
--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -236,20 +236,20 @@ chmod 600 System.map
     \( -name module.lds -o -name vmlinux.lds.S -o -name Platform -o -name \*.tbl \) \
     -print
 
-  find arch/%{_cross_karch}/{include,lib}/ -type f ! -name \*.o ! -name \*.o.d -print
+  find arch/%{_cross_karch}/{include,lib}/ -type f ! -name \*.o ! -name \*.o.d ! -name \*.a -print
   echo arch/%{_cross_karch}/kernel/asm-offsets.s
   echo lib/vdso/gettimeofday.c
 
   for d in \
     arch/%{_cross_karch}/tools \
     arch/%{_cross_karch}/kernel/vdso ; do
-    [ -d "${d}" ] && find "${d}/" -type f -print
+    [ -d "${d}" ] && find "${d}/" -type f ! -name \*.o -print
   done
 
   find include -type f -print
   find scripts -type f ! -name \*.l ! -name \*.y ! -name \*.o -print
 
-  find tools/{arch/%{_cross_karch},include,objtool,scripts}/ -type f ! -name \*.o -print
+  find tools/{arch/%{_cross_karch},include,objtool,scripts}/ -type f ! -name \*.o ! -name \*.a -print
   echo tools/build/fixdep.c
   find tools/lib/subcmd -type f -print
   find tools/lib/{ctype,hweight,rbtree,string,str_error_r}.c


### PR DESCRIPTION
**Issue number:**
Closes #171

**Description of changes:**
Now that an unpacked set of kernel-devel files is present in the buildroot, object files will be found by the `/usr/lib/rpm/brp-strip` invocation that tries to ensure all files are stripped.

This can lead to build failures if the host and target arch don't match, and if the target arch requires a host tool to be built. The object files will be built for the host, and the target's `strip` command will not recognize the format.

In any case, these object files shouldn't be included, as they may need to be rebuilt to match the running host architecture at the time the kernel-devel files are used.

Fixes: 76af8bef ("kernel-6.1: also provide uncompressed devel files")


**Testing done:**
Collected files before and after:
```
rpm -qlp build/rpms/kernel-6.1/bottlerocket-kernel-6.1-devel-unpacked-6.1.109-1.*.rpm
```

Confirmed that `.o` and `.a` files were removed:
```
/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/arch/arm64/kernel/vdso/note.o
/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/arch/arm64/kernel/vdso/sigreturn.o
/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/arch/arm64/kernel/vdso/vgettimeofday.o
/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/arch/arm64/lib/built-in.a
/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/arch/arm64/lib/lib.a
/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/tools/objtool/libsubcmd.a

/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/arch/x86/lib/built-in.a
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/arch/x86/lib/lib.a
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/arch/x86/tools/relocs_32.o
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/arch/x86/tools/relocs_64.o
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/arch/x86/tools/relocs_common.o
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel/6.1.109/tools/objtool/libsubcmd.a
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
