### PR TITLE
Compile FIPS rust binaries

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -17,3 +17,9 @@ operating system images.
 Contains modified hyper-proxy files [mod.rs, stream.rs, tunnel.rs] from
 https://github.com/tafia/hyper-proxy 2021-09-20.
 Copyright (c) 2017 Johann Tuffe. Licensed under the MIT License.
+
+=^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+Contains aws-smithy-experimental from
+https://github.com/smithy-lang/smithy-rs/tree/release-2024-10-09.
+Licensed under the Apache-2.0 License.

--- a/packages/early-boot-config/early-boot-config.spec
+++ b/packages/early-boot-config/early-boot-config.spec
@@ -1,7 +1,5 @@
 %global _cross_first_party 1
 %undefine _debugsource_packages
-%undefine cross_check_fips
-%undefine cross_check_fips
 
 Name: %{_cross_os}early-boot-config
 Version: 0.1

--- a/packages/netdog/netdog.spec
+++ b/packages/netdog/netdog.spec
@@ -1,7 +1,5 @@
 %global _cross_first_party 1
 %undefine _debugsource_packages
-%undefine cross_check_fips
-%undefine cross_check_fips
 
 Name: %{_cross_os}netdog
 Version: 0.1.1

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -8,6 +8,7 @@ build = "../build.rs"
 [package.metadata.build-package]
 source-groups = [
     "api",
+    "aws-smithy-experimental",
     "bottlerocket-release",
     "metricdog",
     "parse-datetime",

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -1,7 +1,5 @@
 %global _cross_first_party 1
 %undefine _debugsource_packages
-%undefine cross_check_fips
-%undefine cross_check_fips
 
 Name: %{_cross_os}os
 Version: 0.0
@@ -121,7 +119,24 @@ Requires: %{_cross_os}settings-plugins
 
 %package -n %{_cross_os}apiclient
 Summary: Bottlerocket API client
+Requires: %{_cross_os}apiclient(binaries)
 %description -n %{_cross_os}apiclient
+%{summary}.
+
+%package -n %{_cross_os}apiclient-bin
+Summary: Bottlerocket API client binaries
+Provides: %{_cross_os}apiclient(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}apiclient)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}apiclient-fips-bin)
+%description -n %{_cross_os}apiclient-bin
+%{summary}.
+
+%package -n %{_cross_os}apiclient-fips-bin
+Summary: Bottlerocket API client binaries, FIPS edition
+Provides: %{_cross_os}apiclient(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}apiclient)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}apiclient-bin)
+%description -n %{_cross_os}apiclient-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}sundog
@@ -172,7 +187,26 @@ Requires: %{_cross_os}settings-defaults
 %package -n %{_cross_os}migration
 Summary: Tools to migrate version formats
 Conflicts: %{_cross_os}image-feature(no-in-place-updates)
+Requires: %{_cross_os}migration(binaries)
 %description -n %{_cross_os}migration
+
+%package -n %{_cross_os}migration-bin
+Summary: Binaries to migrate version formats
+Provides: %{_cross_os}migration(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}migration)
+Conflicts: %{_cross_os}image-feature(no-in-place-updates)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}migration-fips-bin)
+%description -n %{_cross_os}migration-bin
+%{summary}.
+
+%package -n %{_cross_os}migration-fips-bin
+Summary: Binaries to migrate version formats, FIPS edition
+Provides: %{_cross_os}migration(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}migration)
+Conflicts: %{_cross_os}image-feature(no-in-place-updates)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}migration-bin)
+%description -n %{_cross_os}migration-fips-bin
+%{summary}.
 
 %package -n %{_cross_os}settings-committer
 Summary: Commits settings from user data, defaults, and generators at boot
@@ -192,19 +226,72 @@ Summary: Bottlerocket GPT priority querier/switcher
 
 %package -n %{_cross_os}updog
 Summary: Bottlerocket updater CLI
+Requires: %{_cross_os}updog(binaries)
 Conflicts: %{_cross_os}image-feature(no-in-place-updates)
 %description -n %{_cross_os}updog
 not much what's up with you
 
+%package -n %{_cross_os}updog-bin
+Summary: Bottlerocket updater CLI binaries
+Provides: %{_cross_os}updog(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}updog)
+Conflicts: %{_cross_os}image-feature(no-in-place-updates)
+Conflicts: %{_cross_os}image-feature(fips) or %{_cross_os}updog-fips-bin
+%description -n %{_cross_os}updog-bin
+%{summary}.
+
+%package -n %{_cross_os}updog-fips-bin
+Summary: Bottlerocket updater CLI binaries, FIPS edition
+Provides: %{_cross_os}updog(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}updog)
+Conflicts: %{_cross_os}image-feature(no-in-place-updates)
+Conflicts: %{_cross_os}image-feature(no-fips) or %{_cross_os}updog-bin
+%description -n %{_cross_os}updog-fips-bin
+%{summary}.
+
 %package -n %{_cross_os}metricdog
 Summary: Bottlerocket health metrics sender
+Requires: %{_cross_os}metricdog(binaries)
 %description -n %{_cross_os}metricdog
+%{summary}.
+
+%package -n %{_cross_os}metricdog-bin
+Summary: Bottlerocket health metrics sender binaries
+Provides: %{_cross_os}metricdog(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}metricdog)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}metricdog-fips-bin)
+%description -n %{_cross_os}metricdog-bin
+%{summary}.
+
+%package -n %{_cross_os}metricdog-fips-bin
+Summary: Bottlerocket health metrics sender binaries, FIPS edition
+Provides: %{_cross_os}metricdog(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}metricdog)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}metricdog-bin)
+%description -n %{_cross_os}metricdog-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}logdog
 Summary: Bottlerocket log extractor
+Requires: %{_cross_os}logdog(binaries)
 %description -n %{_cross_os}logdog
-use logdog to extract logs from the Bottlerocket host
+%{summary}.
+
+%package -n %{_cross_os}logdog-bin
+Summary: Bottlerocket log extractor binaries
+Provides: %{_cross_os}logdog(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}logdog)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}logdog-fips-bin)
+%description -n %{_cross_os}logdog-bin
+%{summary}.
+
+%package -n %{_cross_os}logdog-fips-bin
+Summary: Bottlerocket log extractor binaries, FIPS edition
+Provides: %{_cross_os}logdog(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}logdog)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}logdog-bin)
+%description -n %{_cross_os}logdog-fips-bin
+%{summary}.
 
 %package -n %{_cross_os}prairiedog
 Summary: Tools for kdump support
@@ -220,12 +307,46 @@ Summary: Bottlerocket certificates handler
 
 %package -n %{_cross_os}pluto
 Summary: Dynamic setting generator for kubernetes
+Requires: %{_cross_os}pluto(binaries)
 %description -n %{_cross_os}pluto
 %{summary}.
 
+%package -n %{_cross_os}pluto-bin
+Summary: Dynamic setting generator for kubernetes binaries
+Provides: %{_cross_os}pluto(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}pluto)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}pluto-fips-bin)
+%description -n %{_cross_os}pluto-bin
+%{summary}.
+
+%package -n %{_cross_os}pluto-fips-bin
+Summary: Dynamic setting generator for kubernetes binaries, FIPS edition
+Provides: %{_cross_os}pluto(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}pluto)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}pluto-bin)
+%description -n %{_cross_os}pluto-fips-bin
+%{summary}.
+
 %package -n %{_cross_os}shibaken
-Summary: Run tasks reliant on IMDS
+Summary: IMDS client and settings generator
+Requires: %{_cross_os}shibaken(binaries)
 %description -n %{_cross_os}shibaken
+%{summary}.
+
+%package -n %{_cross_os}shibaken-bin
+Summary: IMDS client and settings generator binaries
+Provides: %{_cross_os}shibaken(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}shibaken)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}shibaken-fips-bin)
+%description -n %{_cross_os}shibaken-bin
+%{summary}.
+
+%package -n %{_cross_os}shibaken-fips-bin
+Summary: IMDS client and settings generator binaries, FIPS edition
+Provides: %{_cross_os}shibaken(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}shibaken)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}shibaken-bin)
+%description -n %{_cross_os}shibaken-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}warm-pool-wait
@@ -236,7 +357,24 @@ Requires: %{_cross_os}shibaken
 
 %package -n %{_cross_os}cfsignal
 Summary: Bottlerocket CloudFormation Stack signaler
+Requires: %{_cross_os}cfsignal(binaries)
 %description -n %{_cross_os}cfsignal
+%{summary}.
+
+%package -n %{_cross_os}cfsignal-bin
+Summary: Bottlerocket CloudFormation Stack signaler binaries
+Provides: %{_cross_os}cfsignal(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}cfsignal)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}cfsignal-fips-bin)
+%description -n %{_cross_os}cfsignal-bin
+%{summary}.
+
+%package -n %{_cross_os}cfsignal-fips-bin
+Summary: Bottlerocket CloudFormation Stack signaler binaries, FIPS edition
+Provides: %{_cross_os}cfsignal(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}cfsignal)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}cfsignal-bin)
+%description -n %{_cross_os}cfsignal-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}shimpei
@@ -291,6 +429,12 @@ Summary: XFS progs cli
 %setup -T -c
 %cargo_prep
 
+# Some of the AWS-LC sources are built with `-O0`. This is not compatible with
+# `-Wp,-D_FORTIFY_SOURCE=2`, which needs at least `-O2`.
+sed -i 's/-Wp,-D_FORTIFY_SOURCE=2//g' \
+  %_cross_cmake_toolchain_conf \
+  %_cross_cmake_toolchain_conf_static
+
 %build
 mkdir bin
 
@@ -321,20 +465,56 @@ exec 1>"${static_output}" 2>&1
 static_pid="$!"
 exec 1>&3 2>&4
 
-# The AWS SDK crates are extremely slow to build with only one codegen unit.
-# Pessimize the release build for just the crates that depend on them.
+exec 3>&1 4>&2
+static_fips_output="$(mktemp)"
+exec 1>"${static_fips_output}" 2>&1
+
+# Build static binaries in the background.
+%cargo_build_static_fips --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p apiclient \
+    &
+# Save the PID so we can wait for it later.
+static_fips_pid="$!"
+exec 1>&3 2>&4
+
+# Pessimize the release build for the crates with slow builds, e.g. those that
+# depend on the AWS SDK crates.
 # Store the output so we can print it after waiting for the backgrounded job.
 exec 3>&1 4>&2
 aws_sdk_output="$(mktemp)"
 exec 1>"${aws_sdk_output}" 2>&1
-
-%cargo_build_aws_sdk --manifest-path %{_builddir}/sources/Cargo.toml \
+  %cargo_build_aws_sdk --manifest-path %{_builddir}/sources/Cargo.toml \
   -p pluto \
   -p cfsignal \
   &
-
 # Save the PID so we can wait for it later.
 aws_sdk_pid="$!"
+exec 1>&3 2>&4
+
+exec 3>&1 4>&2
+fips_aws_sdk_output="$(mktemp)"
+exec 1>"${fips_aws_sdk_output}" 2>&1
+  %cargo_build_fips_aws_sdk --manifest-path %{_builddir}/sources/Cargo.toml \
+  -p pluto \
+  -p cfsignal \
+  &
+# Save the PID so we can wait for it later.
+fips_aws_sdk_pid="$!"
+exec 1>&3 2>&4
+
+# Build non-static FIPS builds in the background
+exec 3>&1 4>&2
+fips_output="$(mktemp)"
+exec 1>"${fips_output}" 2>&1
+  %cargo_build_fips --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p logdog \
+    -p metricdog \
+    -p migrator \
+    -p updog \
+    -p shibaken \
+    &
+# Save the PID so we can wait for it later.
+fips_pid="$!"
 exec 1>&3 2>&4
 
 # Run non-static builds in the foreground.
@@ -367,24 +547,53 @@ echo "** Output from non-static builds:"
     -p driverdog \
     %{nil}
 
+# Wait for fips builds from the background, if they're not already done.
+set +e; wait "${fips_pid}"; fips_rc="${?}"; set -e
+echo -e "\n** Output from FIPS builds:"
+cat "${fips_output}"
+
 # Wait for static builds from the background, if they're not already done.
 set +e; wait "${static_pid}"; static_rc="${?}"; set -e
 echo -e "\n** Output from static builds:"
 cat "${static_output}"
-if [ "${static_rc}" -ne 0 ]; then
-   exit "${static_rc}"
-fi
+
+set +e; wait "${static_fips_pid}"; static_fips_rc="${?}"; set -e
+echo -e "\n** Output from FIPS static builds:"
+cat "${static_fips_output}"
 
 # Wait for AWS SDK builds from the background, if they're not already done.
 set +e; wait "${aws_sdk_pid}"; aws_sdk_rc="${?}"; set -e
 echo -e "\n** Output from AWS SDK builds:"
 cat "${aws_sdk_output}"
+
+set +e; wait "${fips_aws_sdk_pid}"; fips_aws_sdk_rc="${?}"; set -e
+echo -e "\n** Output from AWS SDK FIPS builds:"
+cat "${fips_aws_sdk_output}"
+
+if [ "${fips_rc}" -ne 0 ]; then
+   exit "${fips_rc}"
+fi
+
+if [ "${fips_aws_sdk_rc}" -ne 0 ]; then
+   exit "${fips_aws_sdk_rc}"
+fi
+
+if [ "${static_fips_rc}" -ne 0 ]; then
+   exit "${static_fips_rc}"
+fi
+
+if [ "${static_rc}" -ne 0 ]; then
+   exit "${static_rc}"
+fi
+
 if [ "${aws_sdk_rc}" -ne 0 ]; then
    exit "${aws_sdk_rc}"
 fi
 
+
 %install
 install -d %{buildroot}%{_cross_bindir}
+install -d %{buildroot}%{_cross_fips_bindir}
 for p in \
   apiserver \
   sundog schnauzer schnauzer-v2 bork \
@@ -404,10 +613,18 @@ for p in \
 done
 
 for p in \
+  logdog migrator metricdog \
+  shibaken updog \
+; do
+  install -p -m 0755 %{__cargo_outdir_fips}/${p} %{buildroot}%{_cross_fips_bindir}
+done
+
+for p in \
   pluto \
   cfsignal \
 ; do
   install -p -m 0755 %{__cargo_outdir_aws_sdk}/${p} %{buildroot}%{_cross_bindir}
+  install -p -m 0755 %{__cargo_outdir_aws_sdk_fips}/${p} %{buildroot}%{_cross_fips_bindir}
 done
 
 install -d %{buildroot}%{_cross_sbindir}
@@ -458,6 +675,7 @@ install -m 0644 %{S:13} %{buildroot}%{_cross_libexecdir}/cis-checks/kubernetes/m
 
 for p in apiclient ; do
   install -p -m 0755 %{__cargo_outdir_static}/${p} %{buildroot}%{_cross_bindir}
+  install -p -m 0755 %{__cargo_outdir_static_fips}/${p} %{buildroot}%{_cross_fips_bindir}
 done
 
 install -d %{buildroot}%{_cross_datadir}/bottlerocket
@@ -528,7 +746,12 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %{_cross_sysusersdir}/api.conf
 
 %files -n %{_cross_os}apiclient
+
+%files -n %{_cross_os}apiclient-bin
 %{_cross_bindir}/apiclient
+
+%files -n %{_cross_os}apiclient-fips-bin
+%{_cross_fips_bindir}/apiclient
 
 %files -n %{_cross_os}corndog
 %{_cross_bindir}/corndog
@@ -568,9 +791,14 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %{_cross_tmpfilesdir}/storewolf.conf
 
 %files -n %{_cross_os}migration
-%{_cross_bindir}/migrator
 %{_cross_unitdir}/migrator.service
 %{_cross_tmpfilesdir}/migration.conf
+
+%files -n %{_cross_os}migration-bin
+%{_cross_bindir}/migrator
+
+%files -n %{_cross_os}migration-fips-bin
+%{_cross_fips_bindir}/migrator
 
 %files -n %{_cross_os}settings-committer
 %{_cross_bindir}/settings-committer
@@ -587,44 +815,74 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %{_cross_unitdir}/has-boot-ever-succeeded.service
 
 %files -n %{_cross_os}updog
-%{_cross_bindir}/updog
 %{_cross_datadir}/updog
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/updog-toml
 
+%files -n %{_cross_os}updog-bin
+%{_cross_bindir}/updog
+
+%files -n %{_cross_os}updog-fips-bin
+%{_cross_fips_bindir}/updog
+
 %files -n %{_cross_os}metricdog
-%{_cross_bindir}/metricdog
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/metricdog-toml
 %{_cross_unitdir}/metricdog.service
 %{_cross_unitdir}/metricdog.timer
 %{_cross_unitdir}/send-boot-success.service
 
+%files -n %{_cross_os}metricdog-bin
+%{_cross_bindir}/metricdog
+
+%files -n %{_cross_os}metricdog-fips-bin
+%{_cross_fips_bindir}/metricdog
+
 %files -n %{_cross_os}logdog
+
+%files -n %{_cross_os}logdog-bin
 %{_cross_bindir}/logdog
 
+%files -n %{_cross_os}logdog-fips-bin
+%{_cross_fips_bindir}/logdog
+
 %files -n %{_cross_os}shibaken
-%{_cross_bindir}/shibaken
 %dir %{_cross_templatedir}
+
+%files -n %{_cross_os}shibaken-bin
+%{_cross_bindir}/shibaken
+
+%files -n %{_cross_os}shibaken-fips-bin
+%{_cross_fips_bindir}/shibaken
 
 %files -n %{_cross_os}warm-pool-wait
 %{_cross_templatedir}/warm-pool-wait-toml
 %{_cross_unitdir}/warm-pool-wait.service
 
 %files -n %{_cross_os}cfsignal
-%{_cross_bindir}/cfsignal
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/cfsignal-toml
 %{_cross_unitdir}/cfsignal.service
+
+%files -n %{_cross_os}cfsignal-bin
+%{_cross_bindir}/cfsignal
+
+%files -n %{_cross_os}cfsignal-fips-bin
+%{_cross_fips_bindir}/cfsignal
 
 %files -n %{_cross_os}driverdog
 %{_cross_bindir}/driverdog
 
 %files -n %{_cross_os}pluto
-%{_cross_bindir}/pluto
 %{_cross_unitdir}/pluto.service
 %dir %{_cross_datadir}/eks
 %{_cross_datadir}/eks/eni-max-pods
+
+%files -n %{_cross_os}pluto-bin
+%{_cross_bindir}/pluto
+
+%files -n %{_cross_os}pluto-fips-bin
+%{_cross_fips_bindir}/pluto
 
 %files -n %{_cross_os}shimpei
 %{_cross_bindir}/shimpei

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -384,6 +384,7 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 name = "apiclient"
 version = "0.1.0"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
  "constants",
  "datastore",
@@ -401,6 +402,7 @@ dependencies = [
  "rand",
  "reqwest",
  "retry-read",
+ "rustls 0.23.14",
  "serde",
  "serde_json",
  "signal-hook",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -527,6 +527,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259cbe96513d2f1073027a259fc2ca917feb3026a5a8d984e3628e490255cc0"
+dependencies = [
+ "extend",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +580,12 @@ dependencies = [
  "quote",
  "syn 2.0.79",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -859,6 +876,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-experimental"
+version = "0.1.4"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
+ "once_cell",
+ "pin-project-lite",
+ "rustls 0.23.14",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.60.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +926,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-protocol-test"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b92b62199921f10685c6b588fdbeb81168ae4e7950ae3e5f50145a01bb5f1ad"
+dependencies = [
+ "assert-json-diff",
+ "aws-smithy-runtime-api",
+ "base64-simd",
+ "cbor-diag",
+ "ciborium",
+ "http 0.2.12",
+ "pretty_assertions",
+ "regex-lite",
+ "roxmltree",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "aws-smithy-query"
 version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,23 +962,28 @@ checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-protocol-test",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
  "hyper 0.14.30",
  "hyper-rustls 0.24.2",
+ "indexmap",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
  "rustls 0.21.12",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1355,6 +1417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1534,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1624,33 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1724,6 +1841,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1993,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.79",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2076,6 +2205,18 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "extend"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2302,7 +2443,7 @@ dependencies = [
  "bstr 1.10.0",
  "log",
  "regex-automata 0.4.8",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2334,6 +2475,35 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -2554,7 +2724,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2577,6 +2747,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -2953,6 +3124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3307,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,6 +3471,12 @@ name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -3505,6 +3701,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,6 +3718,30 @@ checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -3638,7 +3868,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.8",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3646,6 +3876,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
 
 [[package]]
 name = "regex-automata"
@@ -3655,7 +3888,7 @@ checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3663,6 +3896,12 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3744,6 +3983,15 @@ dependencies = [
  "spin",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
 ]
 
 [[package]]
@@ -4013,6 +4261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
+
+[[package]]
 name = "serde"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4050,6 +4304,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -4423,6 +4678,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -4831,6 +5095,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5061,6 +5335,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5096,6 +5387,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -5288,6 +5622,12 @@ name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -5733,6 +6073,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1603,11 +1603,14 @@ name = "cfsignal"
 version = "0.1.0"
 dependencies = [
  "aws-config",
+ "aws-lc-rs",
  "aws-sdk-cloudformation",
+ "aws-smithy-experimental",
  "aws-types",
  "generate-readme",
  "imdsclient",
  "log",
+ "rustls 0.23.14",
  "serde",
  "simplelog",
  "snafu",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3156,11 +3156,13 @@ name = "metricdog"
 version = "0.1.0"
 dependencies = [
  "argh",
+ "aws-lc-rs",
  "bottlerocket-release",
  "generate-readme",
  "httptest",
  "log",
  "reqwest",
+ "rustls 0.23.14",
  "serde",
  "serde_json",
  "simplelog",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3647,8 +3647,10 @@ name = "pluto"
 version = "0.1.0"
 dependencies = [
  "aws-config",
+ "aws-lc-rs",
  "aws-sdk-ec2",
  "aws-sdk-eks",
+ "aws-smithy-experimental",
  "aws-smithy-runtime",
  "aws-smithy-types",
  "aws-types",
@@ -3665,6 +3667,7 @@ dependencies = [
  "hyper-rustls 0.24.2",
  "imdsclient",
  "log",
+ "rustls 0.23.14",
  "serde",
  "serde_json",
  "snafu",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3176,6 +3176,7 @@ dependencies = [
 name = "migrator"
 version = "0.1.0"
 dependencies = [
+ "aws-lc-rs",
  "bottlerocket-release",
  "bytes",
  "chrono",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -4702,10 +4702,12 @@ name = "shibaken"
 version = "0.1.0"
 dependencies = [
  "argh",
+ "aws-lc-rs",
  "base64 0.22.1",
  "generate-readme",
  "imdsclient",
  "log",
+ "rustls 0.23.14",
  "serde",
  "serde_json",
  "simplelog",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3086,10 +3086,12 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 name = "logdog"
 version = "0.1.0"
 dependencies = [
+ "aws-lc-rs",
  "flate2",
  "generate-readme",
  "glob",
  "reqwest",
+ "rustls 0.23.14",
  "serde_json",
  "shell-words",
  "snafu",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "api/shibaken",
     "api/prairiedog",
     "api/simple-settings-plugin",
+    "aws-smithy-experimental",
 
     "bloodhound",
 
@@ -82,6 +83,7 @@ members = [
 
 [workspace.dependencies]
 apiclient = { version = "0.1", path = "api/apiclient" }
+aws-smithy-experimental = { version = "0.1", path = "aws-smithy-experimental" }
 block-party = { version = "0.1", path = "updater/block-party" }
 bottlerocket-release = { version = "0.1", path = "bottlerocket-release" }
 constants = { version = "0.1", path = "constants" }
@@ -115,7 +117,9 @@ aws-sdk-cloudformation = "1"
 aws-sdk-ec2 = "1"
 aws-sdk-eks = "1"
 aws-smithy-runtime = "1"
+aws-smithy-runtime-api = "1"
 aws-smithy-types = "1"
+aws-smithy-async = "1"
 aws-types = "1"
 bit_field = "0.10"
 bon = "2"
@@ -138,12 +142,15 @@ futures-util = { version = "0.3", default-features = false }
 glob = "0.3"
 gptman = { version = "1", default-features = false }
 handlebars = "4"
+h2 = "0.4"
 headers = "0.3"
 hex-literal = "0.4"
 http = "0.2"
 httparse = "1"
 httptest = "0.15"
 hyper = { version = "0.14", default-features = false }
+hyper-util = "0.1"
+# FIXME: bump to 0.27 once hyper-proxy is dropped
 hyper-rustls = { version = "0.24", default-features = false }
 hyper-unix-connector = "0.2"
 indexmap = "2"
@@ -159,16 +166,19 @@ num = "0.4"
 num-derive = "0.4"
 num-traits = "0.2"
 num_cpus = "1"
+once_cell = "1"
 pentacle = "1"
 percent-encoding = "2"
 pest = "2.5"
 pest_derive = "2.5"
+pin-project-lite = "0.2"
 proc-macro2 = "1"
 quick-xml = "0.26"
 quote = "1"
 rand = { version = "0.8", default-features = false }
 regex = "1"
 reqwest = { version = "0.12", default-features = false }
+rustls = "0.23"
 semver = "1"
 serde = "1"
 serde-xml-rs = "0.6"
@@ -192,6 +202,8 @@ tokio-tungstenite = { version = "0.20", default-features = false }
 tokio-util = "0.7"
 toml = "0.8"
 tough = "0.19"
+tower = "0.4"
+tracing = "0.1"
 unindent = "0.2"
 url = "2"
 walkdir = "2.4"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -82,7 +82,7 @@ members = [
 ]
 
 [workspace.dependencies]
-apiclient = { version = "0.1", path = "api/apiclient" }
+apiclient = { version = "0.1", path = "api/apiclient", default-features = false }
 aws-smithy-experimental = { version = "0.1", path = "aws-smithy-experimental" }
 block-party = { version = "0.1", path = "updater/block-party" }
 bottlerocket-release = { version = "0.1", path = "bottlerocket-release" }

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -9,7 +9,13 @@ build = "build.rs"
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
+[features]
+default = ["tls"]
+tls = ["dep:rustls", "dep:aws-lc-rs", "reqwest/rustls-tls-native-roots"]
+fips = ["tls", "aws-lc-rs/fips", "rustls/fips"]
+
 [dependencies]
+aws-lc-rs = { workspace = true, optional = true, features = ["bindgen"] }
 base64.workspace = true
 constants.workspace = true
 datastore.workspace = true
@@ -24,8 +30,9 @@ log.workspace = true
 models.workspace = true
 nix.workspace = true
 rand = { workspace = true, features = ["default"] }
-reqwest = { workspace = true, features = ["rustls-tls-native-roots"] }
+reqwest.workspace = true
 retry-read.workspace = true
+rustls = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 signal-hook.workspace = true

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -902,6 +902,9 @@ async fn run() -> Result<()> {
     )
     .context(error::LoggerSnafu)?;
 
+    #[cfg(feature = "tls")]
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     match subcommand {
         Subcommand::Raw(raw) => {
             let (status, body) =

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -9,7 +9,11 @@ build = "build.rs"
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
+[features]
+fips = ["tough/fips"]
+
 [dependencies]
+aws-lc-rs = { workspace = true, features = ["bindgen"] }
 bottlerocket-release.workspace = true
 bytes.workspace = true
 futures = { workspace = true, features = ["default"] }

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -9,6 +9,12 @@ build = "build.rs"
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
+[features]
+fips = ["aws-lc-rs/fips", "aws-smithy-experimental/crypto-aws-lc-fips", "rustls/fips"]
+
+[package.metadata.build-package]
+source-groups = ["aws-smithy-experimental"]
+
 [dependencies]
 bottlerocket-modeled-types.workspace = true
 bottlerocket-settings-models.workspace = true
@@ -21,11 +27,14 @@ hyper = { workspace = true, features = ["default"] }
 hyper-rustls = { workspace = true, features = ["http2", "logging", "native-tokio", "tls12"] }
 imdsclient.workspace = true
 aws-config.workspace = true
+aws-lc-rs = { workspace = true, features = ["bindgen"] }
 aws-sdk-eks.workspace = true
 aws-sdk-ec2.workspace = true
 aws-types.workspace = true
 aws-smithy-types.workspace = true
 aws-smithy-runtime.workspace = true
+aws-smithy-experimental = { workspace = true, features = ["crypto-aws-lc"] }
+rustls.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 snafu.workspace = true

--- a/sources/api/pluto/src/ec2.rs
+++ b/sources/api/pluto/src/ec2.rs
@@ -1,5 +1,8 @@
 use crate::aws::sdk_config;
 use crate::proxy;
+#[cfg(feature = "fips")]
+use aws_smithy_experimental::hyper_1_0::{CryptoMode, HyperClientBuilder as Hyper10ClientBuilder};
+#[cfg(not(feature = "fips"))]
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
 use aws_smithy_types::error::display::DisplayErrorContext;
 use snafu::{OptionExt, ResultExt, Snafu};
@@ -52,16 +55,12 @@ where
 {
     let config = sdk_config(region).await;
 
-    let client = if let Some(https_proxy) = https_proxy {
-        let http_connector = proxy::setup_http_client(https_proxy, no_proxy)?;
-        let http_client = HyperClientBuilder::new().build(http_connector);
-        let ec2_config = aws_sdk_ec2::config::Builder::from(&config)
-            .http_client(http_client)
-            .build();
-        aws_sdk_ec2::Client::from_conf(ec2_config)
-    } else {
-        aws_sdk_ec2::Client::new(&config)
-    };
+    #[cfg(not(feature = "fips"))]
+    let client = build_client(https_proxy, no_proxy, config)?;
+
+    // FIXME!: support proxies in FIPS mode
+    #[cfg(feature = "fips")]
+    let client = build_client(config)?;
 
     tokio::time::timeout(
         FETCH_PRIVATE_DNS_NAME_TIMEOUT,
@@ -93,4 +92,41 @@ where
     )
     .await
     .context(FetchPrivateDnsNameTimeoutSnafu)?
+}
+
+#[cfg(not(feature = "fips"))]
+fn build_client<H, N>(
+    https_proxy: Option<H>,
+    no_proxy: Option<&[N]>,
+    config: aws_config::SdkConfig,
+) -> Result<aws_sdk_ec2::Client>
+where
+    H: AsRef<str>,
+    N: AsRef<str>,
+{
+    let client = if let Some(https_proxy) = https_proxy {
+        let http_connector = proxy::setup_http_client(https_proxy, no_proxy)?;
+        let http_client = HyperClientBuilder::new().build(http_connector);
+        let ec2_config = aws_sdk_ec2::config::Builder::from(&config)
+            .http_client(http_client)
+            .build();
+        aws_sdk_ec2::Client::from_conf(ec2_config)
+    } else {
+        aws_sdk_ec2::Client::new(&config)
+    };
+
+    Ok(client)
+}
+
+// FIXME!: support proxies in FIPS mode
+#[cfg(feature = "fips")]
+fn build_client(config: aws_config::SdkConfig) -> Result<aws_sdk_ec2::Client> {
+    let http_client = Hyper10ClientBuilder::new()
+        .crypto_mode(CryptoMode::AwsLcFips)
+        .build_https();
+    let ec2_config = aws_sdk_ec2::config::Builder::from(&config)
+        .http_client(http_client)
+        .build();
+
+    Ok(aws_sdk_ec2::Client::from_conf(ec2_config))
 }

--- a/sources/api/pluto/src/eks.rs
+++ b/sources/api/pluto/src/eks.rs
@@ -1,6 +1,9 @@
 use crate::aws::sdk_config;
 use crate::proxy;
 use aws_sdk_eks::types::KubernetesNetworkConfigResponse;
+#[cfg(feature = "fips")]
+use aws_smithy_experimental::hyper_1_0::{CryptoMode, HyperClientBuilder as Hyper10ClientBuilder};
+#[cfg(not(feature = "fips"))]
 use aws_smithy_runtime::client::http::hyper_014::HyperClientBuilder;
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::time::Duration;
@@ -45,16 +48,12 @@ where
 {
     let config = sdk_config(region).await;
 
-    let client = if let Some(https_proxy) = https_proxy {
-        let http_connector = proxy::setup_http_client(https_proxy, no_proxy)?;
-        let http_client = HyperClientBuilder::new().build(http_connector);
-        let eks_config = aws_sdk_eks::config::Builder::from(&config)
-            .http_client(http_client)
-            .build();
-        aws_sdk_eks::Client::from_conf(eks_config)
-    } else {
-        aws_sdk_eks::Client::new(&config)
-    };
+    #[cfg(not(feature = "fips"))]
+    let client = build_client(https_proxy, no_proxy, config)?;
+
+    // FIXME!: support proxies in FIPS mode
+    #[cfg(feature = "fips")]
+    let client = build_client(config)?;
 
     tokio::time::timeout(
         EKS_DESCRIBE_CLUSTER_TIMEOUT,
@@ -69,4 +68,41 @@ where
     .context(MissingSnafu {
         field: "kubernetes_network_config",
     })
+}
+
+#[cfg(not(feature = "fips"))]
+fn build_client<H, N>(
+    https_proxy: Option<H>,
+    no_proxy: Option<&[N]>,
+    config: aws_config::SdkConfig,
+) -> Result<aws_sdk_eks::Client>
+where
+    H: AsRef<str>,
+    N: AsRef<str>,
+{
+    let client = if let Some(https_proxy) = https_proxy {
+        let http_connector = proxy::setup_http_client(https_proxy, no_proxy)?;
+        let http_client = HyperClientBuilder::new().build(http_connector);
+        let eks_config = aws_sdk_eks::config::Builder::from(&config)
+            .http_client(http_client)
+            .build();
+        aws_sdk_eks::Client::from_conf(eks_config)
+    } else {
+        aws_sdk_eks::Client::new(&config)
+    };
+
+    Ok(client)
+}
+
+// FIXME!: support proxies in FIPS mode
+#[cfg(feature = "fips")]
+fn build_client(config: aws_config::SdkConfig) -> Result<aws_sdk_eks::Client> {
+    let http_client = Hyper10ClientBuilder::new()
+        .crypto_mode(CryptoMode::AwsLcFips)
+        .build_https();
+    let eks_config = aws_sdk_eks::config::Builder::from(&config)
+        .http_client(http_client)
+        .build();
+
+    Ok(aws_sdk_eks::Client::from_conf(eks_config))
 }

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -429,6 +429,8 @@ async fn run() -> Result<()> {
     let current_settings = api::get_aws_k8s_info().await.context(error::AwsInfoSnafu)?;
     let mut aws_k8s_info = SettingsViewDelta::from_api_response(current_settings);
 
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     generate_cluster_dns_ip(&mut client, &mut aws_k8s_info).await?;
     generate_node_ip(&mut client, &mut aws_k8s_info).await?;
     generate_max_pods(&mut client, &mut aws_k8s_info).await?;

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -9,11 +9,16 @@ build = "build.rs"
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
+[features]
+fips = ["rustls/fips", "aws-lc-rs/fips"]
+
 [dependencies]
 argh.workspace = true
+aws-lc-rs = { workspace = true, features = ["bindgen"] }
 base64.workspace = true
 imdsclient.workspace = true
 log.workspace = true
+rustls.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 simplelog.workspace = true

--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -53,6 +53,8 @@ enum Commands {
 async fn run() -> Result<()> {
     let args: Args = argh::from_env();
 
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // TerminalMode::Stderr will send all logs to stderr, as sundog only expects the json output of
     // the setting on stdout.
     TermLogger::init(

--- a/sources/aws-smithy-experimental/Cargo.toml
+++ b/sources/aws-smithy-experimental/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "aws-smithy-experimental"
+version = "0.1.4"
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
+description = "Experiments for the smithy-rs ecosystem"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[features]
+crypto-ring = ["rustls/ring"]
+crypto-aws-lc = ["rustls/aws_lc_rs"]
+crypto-aws-lc-fips = ["rustls/fips"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crypto_unstable)'] }
+
+[dependencies]
+aws-smithy-types = { workspace = true, features = ["http-body-1-x"] }
+aws-smithy-runtime-api = { workspace = true, features = ["client", "http-1x"] }
+aws-smithy-runtime = { workspace = true, features = ["client"] }
+aws-smithy-async.workspace = true 
+h2.workspace = true
+hyper-util.workspace = true
+once_cell.workspace = true
+pin-project-lite.workspace = true
+rustls.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+tower.workspace = true
+# FIXME: migrate these dependencies once we migrate to http-hyper-proxy
+hyper = { version = "1", features = ["client", "http1", "http2"] }
+hyper-rustls = { version = "0.27", features = ["http2", "http1", "native-tokio", "tls12"], default-features = false }
+http = "1"
+
+[dev-dependencies]
+aws-smithy-async = { workspace = true, features = ["rt-tokio", "test-util"] }
+aws-smithy-runtime = { workspace = true, features = ["client", "test-util", "connector-hyper-0-14-x"]}
+tokio = { workspace = true, features = ["full", "test-util"]}

--- a/sources/aws-smithy-experimental/LICENSE
+++ b/sources/aws-smithy-experimental/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/sources/aws-smithy-experimental/README.md
+++ b/sources/aws-smithy-experimental/README.md
@@ -1,0 +1,14 @@
+# aws-smithy-experimental
+
+See [`aws-smithy-experimental`](https://github.com/smithy-lang/smithy-rs/tree/42751e5dbf4d51c06c085e4193bf013a7333a6f5/rust-runtime/aws-smithy-experimental)
+
+
+## Changes
+- Remove `examples` and `tests` directories
+- Remove `external-types.toml`
+- Remove `examples` section in `Cargo.toml`
+- Remove `package.metadata` section in `Cargo.toml`
+- Remove `package.repository` in `Cargo.toml`
+- Prevent crate from being published with `publish = false` in `Cargo.toml`
+- Use workspace dependencies wherever possible
+- Add linting rule to warn for missing `crypto_unstable` flag

--- a/sources/aws-smithy-experimental/src/hyper_1_0.rs
+++ b/sources/aws-smithy-experimental/src/hyper_1_0.rs
@@ -1,0 +1,1246 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_smithy_async::future::timeout::TimedOutError;
+use aws_smithy_async::rt::sleep::{default_async_sleep, AsyncSleep, SharedAsyncSleep};
+use aws_smithy_runtime::client::http::connection_poisoning::CaptureSmithyConnection;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::connection::ConnectionMetadata;
+use aws_smithy_runtime_api::client::connector_metadata::ConnectorMetadata;
+use aws_smithy_runtime_api::client::dns::ResolveDns;
+use aws_smithy_runtime_api::client::http::{
+    HttpClient, HttpConnector, HttpConnectorFuture, HttpConnectorSettings, SharedHttpClient,
+    SharedHttpConnector,
+};
+use aws_smithy_runtime_api::client::orchestrator::{HttpRequest, HttpResponse};
+use aws_smithy_runtime_api::client::result::ConnectorError;
+use aws_smithy_runtime_api::client::runtime_components::{
+    RuntimeComponents, RuntimeComponentsBuilder,
+};
+use aws_smithy_runtime_api::shared::IntoShared;
+use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::config_bag::ConfigBag;
+use aws_smithy_types::error::display::DisplayErrorContext;
+use aws_smithy_types::retry::ErrorKind;
+use client::connect::Connection;
+use h2::Reason;
+use http::{Extensions, Uri};
+use hyper::rt::{Read, Write};
+use hyper_util::client::legacy as client;
+use hyper_util::client::legacy::connect::dns::Name;
+use hyper_util::client::legacy::connect::{
+    capture_connection, CaptureConnection, Connect, HttpInfo,
+};
+use hyper_util::rt::TokioExecutor;
+use rustls::crypto::CryptoProvider;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::error::Error;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::RwLock;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use std::{fmt, vec};
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[non_exhaustive]
+pub enum CryptoMode {
+    #[cfg(feature = "crypto-ring")]
+    Ring,
+    #[cfg(feature = "crypto-aws-lc")]
+    AwsLc,
+    #[cfg(feature = "crypto-aws-lc-fips")]
+    AwsLcFips,
+}
+
+impl CryptoMode {
+    fn provider(self) -> CryptoProvider {
+        match self {
+            #[cfg(feature = "crypto-aws-lc")]
+            CryptoMode::AwsLc => rustls::crypto::aws_lc_rs::default_provider(),
+
+            #[cfg(feature = "crypto-ring")]
+            CryptoMode::Ring => rustls::crypto::ring::default_provider(),
+
+            #[cfg(feature = "crypto-aws-lc-fips")]
+            CryptoMode::AwsLcFips => {
+                let provider = rustls::crypto::default_fips_provider();
+                assert!(
+                    provider.fips(),
+                    "FIPS was requested but the provider did not support FIPS"
+                );
+                provider
+            }
+        }
+    }
+}
+
+/// A bridge that allows our `ResolveDns` trait to work with Hyper's `Resolver` interface (based on tower)
+#[derive(Clone)]
+struct HyperUtilResolver<R> {
+    resolver: R,
+}
+
+impl<R: ResolveDns + Clone + 'static> tower::Service<Name> for HyperUtilResolver<R> {
+    type Response = vec::IntoIter<SocketAddr>;
+    type Error = Box<dyn Error + Send + Sync>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Name) -> Self::Future {
+        let resolver = self.resolver.clone();
+        Box::pin(async move {
+            let dns_entries = resolver.resolve_dns(req.as_str()).await?;
+            Ok(dns_entries
+                .into_iter()
+                .map(|ip_addr| SocketAddr::new(ip_addr, 0))
+                .collect::<Vec<_>>()
+                .into_iter())
+        })
+    }
+}
+
+#[allow(unused_imports)]
+mod cached_connectors {
+    use client::connect::HttpConnector;
+    use hyper_util::client::legacy as client;
+    use hyper_util::client::legacy::connect::dns::GaiResolver;
+
+    use crate::hyper_1_0::build_connector::make_tls;
+    use crate::hyper_1_0::{CryptoMode, Inner};
+
+    #[cfg(feature = "crypto-ring")]
+    pub(crate) static HTTPS_NATIVE_ROOTS_RING: once_cell::sync::Lazy<
+        hyper_rustls::HttpsConnector<HttpConnector>,
+    > = once_cell::sync::Lazy::new(|| make_tls(GaiResolver::new(), CryptoMode::Ring.provider()));
+
+    #[cfg(feature = "crypto-aws-lc")]
+    pub(crate) static HTTPS_NATIVE_ROOTS_AWS_LC: once_cell::sync::Lazy<
+        hyper_rustls::HttpsConnector<HttpConnector>,
+    > = once_cell::sync::Lazy::new(|| make_tls(GaiResolver::new(), CryptoMode::AwsLc.provider()));
+
+    #[cfg(feature = "crypto-aws-lc-fips")]
+    pub(crate) static HTTPS_NATIVE_ROOTS_AWS_LC_FIPS: once_cell::sync::Lazy<
+        hyper_rustls::HttpsConnector<HttpConnector>,
+    > = once_cell::sync::Lazy::new(|| {
+        make_tls(GaiResolver::new(), CryptoMode::AwsLcFips.provider())
+    });
+
+    pub(super) fn cached_https(mode: Inner) -> hyper_rustls::HttpsConnector<HttpConnector> {
+        match mode {
+            #[cfg(feature = "crypto-ring")]
+            Inner::Standard(CryptoMode::Ring) => HTTPS_NATIVE_ROOTS_RING.clone(),
+            #[cfg(feature = "crypto-aws-lc")]
+            Inner::Standard(CryptoMode::AwsLc) => HTTPS_NATIVE_ROOTS_AWS_LC.clone(),
+            #[cfg(feature = "crypto-aws-lc-fips")]
+            Inner::Standard(CryptoMode::AwsLcFips) => HTTPS_NATIVE_ROOTS_AWS_LC_FIPS.clone(),
+            #[allow(unreachable_patterns)]
+            Inner::Standard(_) => unreachable!("unexpected mode"),
+            Inner::Custom(provider) => make_tls(GaiResolver::new(), provider),
+        }
+    }
+}
+
+mod build_connector {
+    use crate::hyper_1_0::{HyperUtilResolver, Inner};
+    use aws_smithy_runtime_api::client::dns::ResolveDns;
+    use client::connect::HttpConnector;
+    use hyper_util::client::legacy as client;
+    use rustls::crypto::CryptoProvider;
+    use std::sync::Arc;
+
+    fn restrict_ciphers(base: CryptoProvider) -> CryptoProvider {
+        let suites = &[
+            rustls::CipherSuite::TLS13_AES_256_GCM_SHA384,
+            rustls::CipherSuite::TLS13_AES_128_GCM_SHA256,
+            // TLS1.2 suites
+            rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+            rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        ];
+        let supported_suites = suites
+            .iter()
+            .flat_map(|suite| {
+                base.cipher_suites
+                    .iter()
+                    .find(|s| &s.suite() == suite)
+                    .cloned()
+            })
+            .collect::<Vec<_>>();
+        CryptoProvider {
+            cipher_suites: supported_suites,
+            ..base
+        }
+    }
+
+    pub(crate) fn make_tls<R>(
+        resolver: R,
+        crypto_provider: CryptoProvider,
+    ) -> hyper_rustls::HttpsConnector<HttpConnector<R>> {
+        use hyper_rustls::ConfigBuilderExt;
+        let mut base_connector = HttpConnector::new_with_resolver(resolver);
+        base_connector.enforce_http(false);
+        hyper_rustls::HttpsConnectorBuilder::new()
+               .with_tls_config(
+                rustls::ClientConfig::builder_with_provider(Arc::new(restrict_ciphers(crypto_provider)))
+                    .with_safe_default_protocol_versions()
+                    .expect("Error with the TLS configuration. Please file a bug report under https://github.com/smithy-lang/smithy-rs/issues.")
+                    .with_native_roots().expect("error with TLS configuration.")
+                    .with_no_client_auth()
+            )
+            .https_or_http()
+            .enable_http1()
+            .enable_http2()
+            .wrap_connector(base_connector)
+    }
+
+    pub(super) fn https_with_resolver<R: ResolveDns>(
+        crypto_provider: Inner,
+        resolver: R,
+    ) -> hyper_rustls::HttpsConnector<HttpConnector<HyperUtilResolver<R>>> {
+        make_tls(HyperUtilResolver { resolver }, crypto_provider.provider())
+    }
+}
+
+/// [`HttpConnector`] that uses [`hyper`] to make HTTP requests.
+///
+/// This connector also implements socket connect and read timeouts.
+///
+/// This shouldn't be used directly in most cases.
+/// See the docs on [`HyperClientBuilder`] for examples of how
+/// to customize the Hyper client.
+#[derive(Debug)]
+pub struct HyperConnector {
+    adapter: Box<dyn HttpConnector>,
+}
+
+impl HyperConnector {
+    /// Builder for a Hyper connector.
+    pub fn builder() -> HyperConnectorBuilder {
+        Default::default()
+    }
+}
+
+impl HttpConnector for HyperConnector {
+    fn call(&self, request: HttpRequest) -> HttpConnectorFuture {
+        self.adapter.call(request)
+    }
+}
+
+/// Builder for [`HyperConnector`].
+#[derive(Default, Debug)]
+pub struct HyperConnectorBuilder<Crypto = CryptoUnset> {
+    connector_settings: Option<HttpConnectorSettings>,
+    sleep_impl: Option<SharedAsyncSleep>,
+    client_builder: Option<hyper_util::client::legacy::Builder>,
+    #[allow(unused)]
+    crypto: Crypto,
+}
+
+#[derive(Default)]
+#[non_exhaustive]
+pub struct CryptoUnset {}
+
+pub struct CryptoProviderSelected {
+    crypto_provider: Inner,
+}
+
+#[derive(Clone)]
+enum Inner {
+    Standard(CryptoMode),
+    #[allow(dead_code)]
+    Custom(CryptoProvider),
+}
+
+impl Inner {
+    fn provider(&self) -> CryptoProvider {
+        match self {
+            Inner::Standard(mode) => mode.provider(),
+            Inner::Custom(provider) => provider.clone(),
+        }
+    }
+}
+
+#[cfg(any(feature = "crypto-aws-lc", feature = "crypto-ring"))]
+impl HyperConnectorBuilder<CryptoProviderSelected> {
+    pub fn build_from_resolver<R: ResolveDns + Clone + 'static>(
+        self,
+        resolver: R,
+    ) -> HyperConnector {
+        let connector =
+            build_connector::https_with_resolver(self.crypto.crypto_provider.clone(), resolver);
+        self.build(connector)
+    }
+}
+
+impl<Any> HyperConnectorBuilder<Any> {
+    /// Create a [`HyperConnector`] from this builder and a given connector.
+    pub(crate) fn build<C>(self, tcp_connector: C) -> HyperConnector
+    where
+        C: Send + Sync + 'static,
+        C: Clone,
+        C: tower::Service<Uri>,
+        C::Response: Read + Write + Connection + Send + Sync + Unpin,
+        C: Connect,
+        C::Future: Unpin + Send + 'static,
+        C::Error: Into<BoxError>,
+    {
+        let client_builder =
+            self.client_builder
+                .unwrap_or(hyper_util::client::legacy::Builder::new(
+                    TokioExecutor::new(),
+                ));
+        let sleep_impl = self.sleep_impl.or_else(default_async_sleep);
+        let (connect_timeout, read_timeout) = self
+            .connector_settings
+            .map(|c| (c.connect_timeout(), c.read_timeout()))
+            .unwrap_or((None, None));
+
+        let connector = match connect_timeout {
+            Some(duration) => timeout_middleware::ConnectTimeout::new(
+                tcp_connector,
+                sleep_impl
+                    .clone()
+                    .expect("a sleep impl must be provided in order to have a connect timeout"),
+                duration,
+            ),
+            None => timeout_middleware::ConnectTimeout::no_timeout(tcp_connector),
+        };
+        let base = client_builder.build(connector);
+        let read_timeout = match read_timeout {
+            Some(duration) => timeout_middleware::HttpReadTimeout::new(
+                base,
+                sleep_impl.expect("a sleep impl must be provided in order to have a read timeout"),
+                duration,
+            ),
+            None => timeout_middleware::HttpReadTimeout::no_timeout(base),
+        };
+        HyperConnector {
+            adapter: Box::new(Adapter {
+                client: read_timeout,
+            }),
+        }
+    }
+
+    /// Set the async sleep implementation used for timeouts
+    ///
+    /// Calling this is only necessary for testing or to use something other than
+    /// [`default_async_sleep`].
+    pub fn sleep_impl(mut self, sleep_impl: impl AsyncSleep + 'static) -> Self {
+        self.sleep_impl = Some(sleep_impl.into_shared());
+        self
+    }
+
+    /// Set the async sleep implementation used for timeouts
+    ///
+    /// Calling this is only necessary for testing or to use something other than
+    /// [`default_async_sleep`].
+    pub fn set_sleep_impl(&mut self, sleep_impl: Option<SharedAsyncSleep>) -> &mut Self {
+        self.sleep_impl = sleep_impl;
+        self
+    }
+
+    /// Configure the HTTP settings for the `HyperAdapter`
+    pub fn connector_settings(mut self, connector_settings: HttpConnectorSettings) -> Self {
+        self.connector_settings = Some(connector_settings);
+        self
+    }
+
+    /// Configure the HTTP settings for the `HyperAdapter`
+    pub fn set_connector_settings(
+        &mut self,
+        connector_settings: Option<HttpConnectorSettings>,
+    ) -> &mut Self {
+        self.connector_settings = connector_settings;
+        self
+    }
+
+    /// Override the Hyper client [`Builder`](hyper_util::client::legacy::Builder) used to construct this client.
+    ///
+    /// This enables changing settings like forcing HTTP2 and modifying other default client behavior.
+    pub(crate) fn hyper_builder(
+        mut self,
+        hyper_builder: hyper_util::client::legacy::Builder,
+    ) -> Self {
+        self.set_hyper_builder(Some(hyper_builder));
+        self
+    }
+
+    /// Override the Hyper client [`Builder`](hyper_util::client::legacy::Builder) used to construct this client.
+    ///
+    /// This enables changing settings like forcing HTTP2 and modifying other default client behavior.
+    pub(crate) fn set_hyper_builder(
+        &mut self,
+        hyper_builder: Option<hyper_util::client::legacy::Builder>,
+    ) -> &mut Self {
+        self.client_builder = hyper_builder;
+        self
+    }
+}
+
+/// Adapter to use a Hyper 1.0-based Client as an `HttpConnector`
+///
+/// This adapter also enables TCP `CONNECT` and HTTP `READ` timeouts via [`HyperConnector::builder`].
+struct Adapter<C> {
+    client: timeout_middleware::HttpReadTimeout<
+        hyper_util::client::legacy::Client<timeout_middleware::ConnectTimeout<C>, SdkBody>,
+    >,
+}
+
+impl<C> fmt::Debug for Adapter<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Adapter")
+            .field("client", &"** hyper client **")
+            .finish()
+    }
+}
+
+/// Extract a smithy connection from a hyper CaptureConnection
+fn extract_smithy_connection(capture_conn: &CaptureConnection) -> Option<ConnectionMetadata> {
+    let capture_conn = capture_conn.clone();
+    if let Some(conn) = capture_conn.clone().connection_metadata().as_ref() {
+        let mut extensions = Extensions::new();
+        conn.get_extras(&mut extensions);
+        let http_info = extensions.get::<HttpInfo>();
+        let mut builder = ConnectionMetadata::builder()
+            .proxied(conn.is_proxied())
+            .poison_fn(move || match capture_conn.connection_metadata().as_ref() {
+                Some(conn) => conn.poison(),
+                None => tracing::trace!("no connection existed to poison"),
+            });
+
+        builder
+            .set_local_addr(http_info.map(|info| info.local_addr()))
+            .set_remote_addr(http_info.map(|info| info.remote_addr()));
+
+        let smithy_connection = builder.build();
+
+        Some(smithy_connection)
+    } else {
+        None
+    }
+}
+
+impl<C> HttpConnector for Adapter<C>
+where
+    C: Clone + Send + Sync + 'static,
+    C: tower::Service<Uri>,
+    C::Response: Connection + Read + Write + Unpin + 'static,
+    timeout_middleware::ConnectTimeout<C>: Connect,
+    C::Future: Unpin + Send + 'static,
+    C::Error: Into<BoxError>,
+{
+    fn call(&self, request: HttpRequest) -> HttpConnectorFuture {
+        let mut request = match request.try_into_http1x() {
+            Ok(request) => request,
+            Err(err) => {
+                return HttpConnectorFuture::ready(Err(ConnectorError::user(err.into())));
+            }
+        };
+        let capture_connection = capture_connection(&mut request);
+        if let Some(capture_smithy_connection) =
+            request.extensions().get::<CaptureSmithyConnection>()
+        {
+            capture_smithy_connection
+                .set_connection_retriever(move || extract_smithy_connection(&capture_connection));
+        }
+        let mut client = self.client.clone();
+        use tower::Service;
+        let fut = client.call(request);
+        HttpConnectorFuture::new(async move {
+            let response = fut
+                .await
+                .map_err(downcast_error)?
+                .map(SdkBody::from_body_1_x);
+            match HttpResponse::try_from(response) {
+                Ok(response) => Ok(response),
+                Err(err) => Err(ConnectorError::other(err.into(), None)),
+            }
+        })
+    }
+}
+
+/// Downcast errors coming out of hyper into an appropriate `ConnectorError`
+fn downcast_error(err: BoxError) -> ConnectorError {
+    // is a `TimedOutError` (from aws_smithy_async::timeout) in the chain? if it is, this is a timeout
+    if find_source::<TimedOutError>(err.as_ref()).is_some() {
+        return ConnectorError::timeout(err);
+    }
+    // is the top of chain error actually already a `ConnectorError`? return that directly
+    let err = match err.downcast::<ConnectorError>() {
+        Ok(connector_error) => return *connector_error,
+        Err(box_error) => box_error,
+    };
+    // generally, the top of chain will probably be a hyper error. Go through a set of hyper specific
+    // error classifications
+    let err = match find_source::<hyper::Error>(err.as_ref()) {
+        Some(hyper_error) => return to_connector_error(hyper_error)(err),
+        None => err,
+    };
+
+    // otherwise, we have no idea!
+    ConnectorError::other(err, None)
+}
+
+/// Convert a [`hyper::Error`] into a [`ConnectorError`]
+fn to_connector_error(err: &hyper::Error) -> fn(BoxError) -> ConnectorError {
+    if err.is_timeout() || find_source::<timeout_middleware::HttpTimeoutError>(err).is_some() {
+        return ConnectorError::timeout;
+    }
+    if err.is_user() {
+        return ConnectorError::user;
+    }
+    if err.is_closed() || err.is_canceled() || find_source::<std::io::Error>(err).is_some() {
+        return ConnectorError::io;
+    }
+    // We sometimes receive this from S3: hyper::Error(IncompleteMessage)
+    if err.is_incomplete_message() {
+        return |err: BoxError| ConnectorError::other(err, Some(ErrorKind::TransientError));
+    }
+
+    if let Some(h2_err) = find_source::<h2::Error>(err) {
+        if h2_err.is_go_away()
+            || (h2_err.is_reset() && h2_err.reason() == Some(Reason::REFUSED_STREAM))
+        {
+            return ConnectorError::io;
+        }
+    }
+
+    tracing::warn!(err = %DisplayErrorContext(&err), "unrecognized error from Hyper. If this error should be retried, please file an issue.");
+    |err: BoxError| ConnectorError::other(err, None)
+}
+
+fn find_source<'a, E: Error + 'static>(err: &'a (dyn Error + 'static)) -> Option<&'a E> {
+    let mut next = Some(err);
+    while let Some(err) = next {
+        if let Some(matching_err) = err.downcast_ref::<E>() {
+            return Some(matching_err);
+        }
+        next = err.source();
+    }
+    None
+}
+
+// TODO(https://github.com/awslabs/aws-sdk-rust/issues/1090): CacheKey must also include ptr equality to any
+// runtime components that are used—sleep_impl as a base (unless we prohibit overriding sleep impl)
+// If we decide to put a DnsResolver in RuntimeComponents, then we'll need to handle that as well.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+struct CacheKey {
+    connect_timeout: Option<Duration>,
+    read_timeout: Option<Duration>,
+}
+
+impl From<&HttpConnectorSettings> for CacheKey {
+    fn from(value: &HttpConnectorSettings) -> Self {
+        Self {
+            connect_timeout: value.connect_timeout(),
+            read_timeout: value.read_timeout(),
+        }
+    }
+}
+
+struct HyperClient<F> {
+    connector_cache: RwLock<HashMap<CacheKey, SharedHttpConnector>>,
+    client_builder: hyper_util::client::legacy::Builder,
+    tcp_connector_fn: F,
+}
+
+impl<F> fmt::Debug for HyperClient<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HyperClient")
+            .field("connector_cache", &self.connector_cache)
+            .field("client_builder", &self.client_builder)
+            .finish()
+    }
+}
+
+impl<C, F> HttpClient for HyperClient<F>
+where
+    F: Fn() -> C + Send + Sync,
+    C: Clone + Send + Sync + 'static,
+    C: tower::Service<Uri>,
+    C::Response: Connection + Read + Write + Send + Sync + Unpin + 'static,
+    C::Future: Unpin + Send + 'static,
+    C::Error: Into<BoxError>,
+{
+    fn http_connector(
+        &self,
+        settings: &HttpConnectorSettings,
+        components: &RuntimeComponents,
+    ) -> SharedHttpConnector {
+        let key = CacheKey::from(settings);
+        let mut connector = self.connector_cache.read().unwrap().get(&key).cloned();
+        if connector.is_none() {
+            let mut cache = self.connector_cache.write().unwrap();
+            // Short-circuit if another thread already wrote a connector to the cache for this key
+            if !cache.contains_key(&key) {
+                let mut builder = HyperConnector::builder()
+                    .hyper_builder(self.client_builder.clone())
+                    .connector_settings(settings.clone());
+                builder.set_sleep_impl(components.sleep_impl());
+
+                let start = components.time_source().map(|ts| ts.now());
+                let tcp_connector = (self.tcp_connector_fn)();
+                let end = components.time_source().map(|ts| ts.now());
+                if let (Some(start), Some(end)) = (start, end) {
+                    if let Ok(elapsed) = end.duration_since(start) {
+                        tracing::debug!("new TCP connector created in {:?}", elapsed);
+                    }
+                }
+                let connector = SharedHttpConnector::new(builder.build(tcp_connector));
+                cache.insert(key.clone(), connector);
+            }
+            connector = cache.get(&key).cloned();
+        }
+
+        connector.expect("cache populated above")
+    }
+
+    fn validate_base_client_config(
+        &self,
+        _: &RuntimeComponentsBuilder,
+        _: &ConfigBag,
+    ) -> Result<(), BoxError> {
+        // Initialize the TCP connector at this point so that native certs load
+        // at client initialization time instead of upon first request. We do it
+        // here rather than at construction so that it won't run if this is not
+        // the selected HTTP client for the base config (for example, if this was
+        // the default HTTP client, and it was overridden by a later plugin).
+        let _ = (self.tcp_connector_fn)();
+        Ok(())
+    }
+
+    fn connector_metadata(&self) -> Option<ConnectorMetadata> {
+        Some(ConnectorMetadata::new("hyper", Some(Cow::Borrowed("1.x"))))
+    }
+}
+
+/// Builder for a hyper-backed [`HttpClient`] implementation.
+///
+/// This builder can be used to customize the underlying TCP connector used, as well as
+/// hyper client configuration.
+///
+/// # Examples
+///
+/// Construct a Hyper client with the RusTLS TLS implementation.
+/// This can be useful when you want to share a Hyper connector between multiple
+/// generated Smithy clients.
+#[derive(Clone, Default, Debug)]
+pub struct HyperClientBuilder<Crypto = CryptoUnset> {
+    client_builder: Option<hyper_util::client::legacy::Builder>,
+    crypto_provider: Crypto,
+}
+
+impl HyperClientBuilder<CryptoProviderSelected> {
+    /// Create a hyper client using RusTLS for TLS
+    ///
+    /// The trusted certificates will be loaded later when this becomes the selected
+    /// HTTP client for a Smithy client.
+    pub fn build_https(self) -> SharedHttpClient {
+        let crypto = self.crypto_provider.crypto_provider;
+        build_with_fn(self.client_builder, move || {
+            cached_connectors::cached_https(crypto.clone())
+        })
+    }
+
+    /// Create a hyper client using a custom DNS resolver
+    pub fn build_with_resolver(
+        self,
+        resolver: impl ResolveDns + Clone + 'static,
+    ) -> SharedHttpClient {
+        build_with_fn(self.client_builder, move || {
+            build_connector::https_with_resolver(
+                self.crypto_provider.crypto_provider.clone(),
+                resolver.clone(),
+            )
+        })
+    }
+}
+
+impl HyperClientBuilder<CryptoUnset> {
+    /// Creates a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn crypto_mode(self, provider: CryptoMode) -> HyperClientBuilder<CryptoProviderSelected> {
+        HyperClientBuilder {
+            client_builder: self.client_builder,
+            crypto_provider: CryptoProviderSelected {
+                crypto_provider: Inner::Standard(provider),
+            },
+        }
+    }
+
+    /// This interface will be broken in the future
+    ///
+    /// This exposes `CryptoProvider` from `rustls` directly and this API has no stability guarantee.
+    #[cfg(crypto_unstable)]
+    pub fn crypto_provider_unstable(
+        self,
+        provider: CryptoProvider,
+    ) -> HyperClientBuilder<CryptoProviderSelected> {
+        HyperClientBuilder {
+            client_builder: self.client_builder,
+            crypto_provider: CryptoProviderSelected {
+                crypto_provider: Inner::Custom(provider),
+            },
+        }
+    }
+}
+
+fn build_with_fn<C, F>(
+    client_builder: Option<hyper_util::client::legacy::Builder>,
+    tcp_connector_fn: F,
+) -> SharedHttpClient
+where
+    F: Fn() -> C + Send + Sync + 'static,
+    C: Clone + Send + Sync + 'static,
+    C: tower::Service<Uri>,
+    C::Response: Connection + Read + Write + Send + Sync + Unpin + 'static,
+    C::Future: Unpin + Send + 'static,
+    C::Error: Into<BoxError>,
+    C: Connect,
+{
+    SharedHttpClient::new(HyperClient {
+        connector_cache: RwLock::new(HashMap::new()),
+        client_builder: client_builder
+            .unwrap_or_else(|| hyper_util::client::legacy::Builder::new(TokioExecutor::new())),
+        tcp_connector_fn,
+    })
+}
+
+mod timeout_middleware {
+    use std::error::Error;
+    use std::fmt::Formatter;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+
+    use http::Uri;
+    use pin_project_lite::pin_project;
+
+    use aws_smithy_async::future::timeout::{TimedOutError, Timeout};
+    use aws_smithy_async::rt::sleep::Sleep;
+    use aws_smithy_async::rt::sleep::{AsyncSleep, SharedAsyncSleep};
+    use aws_smithy_runtime_api::box_error::BoxError;
+
+    #[derive(Debug)]
+    pub(crate) struct HttpTimeoutError {
+        kind: &'static str,
+        duration: Duration,
+    }
+
+    impl std::fmt::Display for HttpTimeoutError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "{} timeout occurred after {:?}",
+                self.kind, self.duration
+            )
+        }
+    }
+
+    impl Error for HttpTimeoutError {
+        // We implement the `source` function as returning a `TimedOutError` because when `downcast_error`
+        // or `find_source` is called with an `HttpTimeoutError` (or another error wrapping an `HttpTimeoutError`)
+        // this method will be checked to determine if it's a timeout-related error.
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            Some(&TimedOutError)
+        }
+    }
+
+    /// Timeout wrapper that will timeout on the initial TCP connection
+    ///
+    /// # Stability
+    /// This interface is unstable.
+    #[derive(Clone, Debug)]
+    pub(super) struct ConnectTimeout<I> {
+        inner: I,
+        timeout: Option<(SharedAsyncSleep, Duration)>,
+    }
+
+    impl<I> ConnectTimeout<I> {
+        /// Create a new `ConnectTimeout` around `inner`.
+        ///
+        /// Typically, `I` will implement [`hyper_util::client::legacy::connect::Connect`].
+        pub(crate) fn new(inner: I, sleep: SharedAsyncSleep, timeout: Duration) -> Self {
+            Self {
+                inner,
+                timeout: Some((sleep, timeout)),
+            }
+        }
+
+        pub(crate) fn no_timeout(inner: I) -> Self {
+            Self {
+                inner,
+                timeout: None,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub(crate) struct HttpReadTimeout<I> {
+        inner: I,
+        timeout: Option<(SharedAsyncSleep, Duration)>,
+    }
+
+    impl<I> HttpReadTimeout<I> {
+        /// Create a new `HttpReadTimeout` around `inner`.
+        ///
+        /// Typically, `I` will implement [`tower::Service<http::Request<SdkBody>>`].
+        pub(crate) fn new(inner: I, sleep: SharedAsyncSleep, timeout: Duration) -> Self {
+            Self {
+                inner,
+                timeout: Some((sleep, timeout)),
+            }
+        }
+
+        pub(crate) fn no_timeout(inner: I) -> Self {
+            Self {
+                inner,
+                timeout: None,
+            }
+        }
+    }
+
+    pin_project! {
+        /// Timeout future for Tower services
+        ///
+        /// Timeout future to handle timing out, mapping errors, and the possibility of not timing out
+        /// without incurring an additional allocation for each timeout layer.
+        #[project = MaybeTimeoutFutureProj]
+        pub enum MaybeTimeoutFuture<F> {
+            Timeout {
+                #[pin]
+                timeout: Timeout<F, Sleep>,
+                error_type: &'static str,
+                duration: Duration,
+            },
+            NoTimeout {
+                #[pin]
+                future: F
+            }
+        }
+    }
+
+    impl<F, T, E> Future for MaybeTimeoutFuture<F>
+    where
+        F: Future<Output = Result<T, E>>,
+        E: Into<BoxError>,
+    {
+        type Output = Result<T, BoxError>;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let (timeout_future, kind, &mut duration) = match self.project() {
+                MaybeTimeoutFutureProj::NoTimeout { future } => {
+                    return future.poll(cx).map_err(|err| err.into());
+                }
+                MaybeTimeoutFutureProj::Timeout {
+                    timeout,
+                    error_type,
+                    duration,
+                } => (timeout, error_type, duration),
+            };
+            match timeout_future.poll(cx) {
+                Poll::Ready(Ok(response)) => Poll::Ready(response.map_err(|err| err.into())),
+                Poll::Ready(Err(_timeout)) => {
+                    Poll::Ready(Err(HttpTimeoutError { kind, duration }.into()))
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+
+    impl<I> tower::Service<Uri> for ConnectTimeout<I>
+    where
+        I: tower::Service<Uri>,
+        I::Error: Into<BoxError>,
+    {
+        type Response = I::Response;
+        type Error = BoxError;
+        type Future = MaybeTimeoutFuture<I::Future>;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx).map_err(|err| err.into())
+        }
+
+        fn call(&mut self, req: Uri) -> Self::Future {
+            match &self.timeout {
+                Some((sleep, duration)) => {
+                    let sleep = sleep.sleep(*duration);
+                    MaybeTimeoutFuture::Timeout {
+                        timeout: Timeout::new(self.inner.call(req), sleep),
+                        error_type: "HTTP connect",
+                        duration: *duration,
+                    }
+                }
+                None => MaybeTimeoutFuture::NoTimeout {
+                    future: self.inner.call(req),
+                },
+            }
+        }
+    }
+
+    impl<I, B> tower::Service<http::Request<B>> for HttpReadTimeout<I>
+    where
+        I: tower::Service<http::Request<B>>,
+        I::Error: Send + Sync + Error + 'static,
+    {
+        type Response = I::Response;
+        type Error = BoxError;
+        type Future = MaybeTimeoutFuture<I::Future>;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx).map_err(|err| err.into())
+        }
+
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            match &self.timeout {
+                Some((sleep, duration)) => {
+                    let sleep = sleep.sleep(*duration);
+                    MaybeTimeoutFuture::Timeout {
+                        timeout: Timeout::new(self.inner.call(req), sleep),
+                        error_type: "HTTP read",
+                        duration: *duration,
+                    }
+                }
+                None => MaybeTimeoutFuture::NoTimeout {
+                    future: self.inner.call(req),
+                },
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) mod test {
+        use std::time::Duration;
+
+        use hyper::rt::ReadBufCursor;
+        use hyper_util::client::legacy::connect::Connected;
+        use hyper_util::rt::TokioIo;
+        use tokio::net::TcpStream;
+
+        use aws_smithy_async::assert_elapsed;
+        use aws_smithy_async::future::never::Never;
+        use aws_smithy_async::rt::sleep::{SharedAsyncSleep, TokioSleep};
+        use aws_smithy_types::error::display::DisplayErrorContext;
+
+        use super::super::*;
+
+        #[allow(unused)]
+        fn connect_timeout_is_correct<T: Send + Sync + Clone + 'static>() {
+            is_send_sync::<super::ConnectTimeout<T>>();
+        }
+
+        #[allow(unused)]
+        fn is_send_sync<T: Send + Sync>() {}
+
+        /// A service that will never return whatever it is you want
+        ///
+        /// Returned futures will return Pending forever
+        #[non_exhaustive]
+        #[derive(Clone, Default, Debug)]
+        pub(crate) struct NeverConnects;
+        impl tower::Service<Uri> for NeverConnects {
+            type Response = TokioIo<TcpStream>;
+            type Error = ConnectorError;
+            type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, _uri: Uri) -> Self::Future {
+                Box::pin(async move {
+                    Never::new().await;
+                    unreachable!()
+                })
+            }
+        }
+
+        /// A service that will connect but never send any data
+        #[derive(Clone, Debug, Default)]
+        struct NeverReplies;
+        impl tower::Service<Uri> for NeverReplies {
+            type Response = EmptyStream;
+            type Error = BoxError;
+            type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, _req: Uri) -> Self::Future {
+                std::future::ready(Ok(EmptyStream))
+            }
+        }
+
+        /// A stream that will never return or accept any data
+        #[non_exhaustive]
+        #[derive(Debug, Default)]
+        struct EmptyStream;
+        impl Read for EmptyStream {
+            fn poll_read(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                _buf: ReadBufCursor<'_>,
+            ) -> Poll<Result<(), std::io::Error>> {
+                Poll::Pending
+            }
+        }
+        impl Write for EmptyStream {
+            fn poll_write(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                _buf: &[u8],
+            ) -> Poll<Result<usize, std::io::Error>> {
+                Poll::Pending
+            }
+
+            fn poll_flush(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+            ) -> Poll<Result<(), std::io::Error>> {
+                Poll::Pending
+            }
+
+            fn poll_shutdown(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+            ) -> Poll<Result<(), std::io::Error>> {
+                Poll::Pending
+            }
+        }
+        impl Connection for EmptyStream {
+            fn connected(&self) -> Connected {
+                Connected::new()
+            }
+        }
+
+        #[tokio::test]
+        async fn http_connect_timeout_works() {
+            let tcp_connector = NeverConnects::default();
+            let connector_settings = HttpConnectorSettings::builder()
+                .connect_timeout(Duration::from_secs(1))
+                .build();
+            let hyper = HyperConnector::builder()
+                .connector_settings(connector_settings)
+                .sleep_impl(SharedAsyncSleep::new(TokioSleep::new()))
+                .build(tcp_connector)
+                .adapter;
+            let now = tokio::time::Instant::now();
+            tokio::time::pause();
+            let resp = hyper
+                .call(HttpRequest::get("https://static-uri.com").unwrap())
+                .await
+                .unwrap_err();
+            assert!(
+                resp.is_timeout(),
+                "expected resp.is_timeout() to be true but it was false, resp == {:?}",
+                resp
+            );
+            let message = DisplayErrorContext(&resp).to_string();
+            let expected =
+                "timeout: client error (Connect): HTTP connect timeout occurred after 1s";
+            assert!(
+                message.contains(expected),
+                "expected '{message}' to contain '{expected}'"
+            );
+            assert_elapsed!(now, Duration::from_secs(1));
+        }
+
+        #[tokio::test]
+        async fn http_read_timeout_works() {
+            let tcp_connector = NeverReplies;
+            let connector_settings = HttpConnectorSettings::builder()
+                .connect_timeout(Duration::from_secs(1))
+                .read_timeout(Duration::from_secs(2))
+                .build();
+            let hyper = HyperConnector::builder()
+                .connector_settings(connector_settings)
+                .sleep_impl(SharedAsyncSleep::new(TokioSleep::new()))
+                .build(tcp_connector)
+                .adapter;
+            let now = tokio::time::Instant::now();
+            tokio::time::pause();
+            let err = hyper
+                .call(HttpRequest::get("https://fake-uri.com").unwrap())
+                .await
+                .unwrap_err();
+            assert!(
+                err.is_timeout(),
+                "expected err.is_timeout() to be true but it was false, err == {err:?}",
+            );
+            let message = format!("{}", DisplayErrorContext(&err));
+            let expected = "timeout: HTTP read timeout occurred after 2s";
+            assert!(
+                message.contains(expected),
+                "expected '{message}' to contain '{expected}'"
+            );
+            assert_elapsed!(now, Duration::from_secs(2));
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::{Error, ErrorKind};
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+
+    use http::Uri;
+    use hyper::rt::ReadBufCursor;
+    use hyper_util::client::legacy::connect::Connected;
+
+    use aws_smithy_async::time::SystemTimeSource;
+    use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
+
+    use crate::hyper_1_0::timeout_middleware::test::NeverConnects;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn connector_selection() {
+        // Create a client that increments a count every time it creates a new HyperConnector
+        let creation_count = Arc::new(AtomicU32::new(0));
+        let http_client = build_with_fn(None, {
+            let count = creation_count.clone();
+            move || {
+                count.fetch_add(1, Ordering::Relaxed);
+                NeverConnects
+            }
+        });
+
+        // This configuration should result in 4 separate connectors with different timeout settings
+        let settings = [
+            HttpConnectorSettings::builder()
+                .connect_timeout(Duration::from_secs(3))
+                .build(),
+            HttpConnectorSettings::builder()
+                .read_timeout(Duration::from_secs(3))
+                .build(),
+            HttpConnectorSettings::builder()
+                .connect_timeout(Duration::from_secs(3))
+                .read_timeout(Duration::from_secs(3))
+                .build(),
+            HttpConnectorSettings::builder()
+                .connect_timeout(Duration::from_secs(5))
+                .read_timeout(Duration::from_secs(3))
+                .build(),
+        ];
+
+        // Kick off thousands of parallel tasks that will try to create a connector
+        let components = RuntimeComponentsBuilder::for_tests()
+            .with_time_source(Some(SystemTimeSource::new()))
+            .build()
+            .unwrap();
+        let mut handles = Vec::new();
+        for setting in &settings {
+            for _ in 0..1000 {
+                let client = http_client.clone();
+                handles.push(tokio::spawn({
+                    let setting = setting.clone();
+                    let components = components.clone();
+                    async move {
+                        let _ = client.http_connector(&setting, &components);
+                    }
+                }));
+            }
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // Verify only 4 connectors were created amidst the chaos
+        assert_eq!(4, creation_count.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn hyper_io_error() {
+        let connector = TestConnection {
+            inner: HangupStream,
+        };
+        let adapter = HyperConnector::builder().build(connector).adapter;
+        let err = adapter
+            .call(HttpRequest::get("https://socket-hangup.com").unwrap())
+            .await
+            .expect_err("socket hangup");
+        assert!(err.is_io(), "unexpected error type: {:?}", err);
+    }
+
+    // ---- machinery to make a Hyper connector that responds with an IO Error
+    #[derive(Clone)]
+    struct HangupStream;
+
+    impl Connection for HangupStream {
+        fn connected(&self) -> Connected {
+            Connected::new()
+        }
+    }
+
+    impl Read for HangupStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: ReadBufCursor<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Err(Error::new(
+                ErrorKind::ConnectionReset,
+                "connection reset",
+            )))
+        }
+    }
+
+    impl Write for HangupStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<Result<usize, Error>> {
+            Poll::Pending
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+            Poll::Pending
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+            Poll::Pending
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestConnection<T> {
+        inner: T,
+    }
+
+    impl<T> tower::Service<Uri> for TestConnection<T>
+    where
+        T: Clone + Connection,
+    {
+        type Response = T;
+        type Error = BoxError;
+        type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: Uri) -> Self::Future {
+            std::future::ready(Ok(self.inner.clone()))
+        }
+    }
+}

--- a/sources/aws-smithy-experimental/src/lib.rs
+++ b/sources/aws-smithy-experimental/src/lib.rs
@@ -1,0 +1,10 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Automatically managed default lints */
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+/* End of automatically managed default lints */
+
+pub mod hyper_1_0;

--- a/sources/cfsignal/Cargo.toml
+++ b/sources/cfsignal/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
+[features]
+fips = ["rustls/fips", "aws-lc-rs/fips", "aws-smithy-experimental/crypto-aws-lc-fips"]
+
 [dependencies]
 log.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -15,9 +18,12 @@ snafu.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 aws-config.workspace = true
+aws-lc-rs = { workspace = true, features = ["bindgen"] }
 aws-sdk-cloudformation.workspace = true
+aws-smithy-experimental = { workspace = true, features = ["crypto-aws-lc"] }
 aws-types.workspace = true
 imdsclient.workspace = true
+rustls.workspace = true
 
 [build-dependencies]
 generate-readme.workspace = true

--- a/sources/clarify.toml
+++ b/sources/clarify.toml
@@ -223,3 +223,8 @@ license-files = [
 skip-files = [
     "aws-lc/third_party/jitterentropy/LICENSE.gplv2"
 ]
+[clarify.half]
+expression = "MIT OR Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xa9f8b3a2 },
+]

--- a/sources/logdog/Cargo.toml
+++ b/sources/logdog/Cargo.toml
@@ -8,10 +8,15 @@ publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
+[features]
+fips = ["rustls/fips", "aws-lc-rs/fips"]
+
 [dependencies]
+aws-lc-rs = { workspace = true, features = ["bindgen"] }
 flate2 = { workspace = true, features = ["default"] }
 glob.workspace = true
 reqwest = { workspace = true, features = ["blocking", "rustls-tls-native-roots"] }
+rustls.workspace = true
 serde_json.workspace = true
 shell-words.workspace = true
 snafu = { workspace = true, features = ["backtraces-impl-backtrace-crate"] }

--- a/sources/logdog/src/log_request.rs
+++ b/sources/logdog/src/log_request.rs
@@ -286,6 +286,8 @@ where
 
 /// Uses the reqwest library to send a GET request to `URL` and returns the response.
 fn send_get_request(url: &str) -> Result<Response> {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let url = Url::parse(url).context(error::HttpUrlParseSnafu { url })?;
     let client = Client::builder()
         .build()

--- a/sources/metricdog/Cargo.toml
+++ b/sources/metricdog/Cargo.toml
@@ -8,11 +8,16 @@ publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
+[features]
+fips = ["rustls/fips", "aws-lc-rs/fips"]
+
 [dependencies]
 argh.workspace = true
+aws-lc-rs = { workspace = true, features = ["bindgen"] }
 bottlerocket-release.workspace = true
 log.workspace = true
 reqwest = { workspace = true, features = ["blocking", "rustls-tls-native-roots"] }
+rustls.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 simplelog.workspace = true

--- a/sources/metricdog/src/main.rs
+++ b/sources/metricdog/src/main.rs
@@ -125,6 +125,8 @@ pub(crate) fn main_inner(
     // instantiate the metricdog object
     let metricdog = Metricdog::from_parts(config, os_release, service_check, host_check)?;
 
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // execute the specified command
     match arguments.command {
         Command::SendBootSuccess(_) => {

--- a/sources/updater/updog/Cargo.toml
+++ b/sources/updater/updog/Cargo.toml
@@ -8,10 +8,13 @@ publish = false
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
+[features]
+fips = ["tough/fips", "aws-lc-rs/fips"]
+
 [dependencies]
-aws-lc-rs = { workspace = true, features = ["bindgen"] }
 async-trait.workspace = true
 argh.workspace = true
+aws-lc-rs = { workspace = true, features = ["bindgen"] }
 bottlerocket-release.workspace = true
 bytes.workspace = true
 chrono = { workspace = true, features = ["clock", "std"] }


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/1667

**Description of changes:**

The first commit in the series adds `rustls` and `aws-smithy-experimental` to the workspace dependencies, so that crates that depend on these libraries can enforce the FIPS flags each expose. 

The subsequent commits add a `fips` flag to the binaries flagged by the `check-fips` script in the Bottlerocket SDK. In https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/191, the `check-fips` was disabled in Rust programs that required the FIPS treatment but in this series the checks are re-enabled.

The spec files for `os` was updated to provide the `fips-bin` package for any binary that needs it. This resembles  what's already done for `Go` packages so that the correct binaries are installed in the image when the `fips` image flag is used while building a variant.

`pluto` was modified to split the HTTP Proxy support, given that `aws-smithy-experimental` doesn't expose the same APIs as the "stable" `aws-smithy`. 

**Testing done:**
- I enabled the `fips` image flag in `aws-k8s-1.30`, and confirmed the `fips-bin` packages were installed:

```bash
[root@admin]# cat /.bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/application-inventory.json | jq '.Content[].Name' -r | grep fips-bin
apiclient-fips-bin
aws-iam-authenticator-fips-bin
aws-signing-helper-fips-bin
cfsignal-fips-bin
cni-plugins-fips-bin
containerd-fips-bin
early-boot-config-aws-fips-bin
ecr-credential-provider-1.30-fips-bin
host-ctr-fips-bin
hostname-imds-fips-bin
kubelet-1.30-fips-bin
logdog-fips-bin
metricdog-fips-bin
migration-fips-bin
pluto-fips-bin
runc-fips-bin
shibaken-fips-bin
updog-fips-bin
```
- The instance joined the cluster:
 
```bash
└─> ❯ k get nodes
NAME                                          STATUS   ROLES    AGE     VERSION
ip-192-168-81-52.us-west-2.compute.internal   Ready    <none>   3h18m   v1.30.1-eks-e564799
```

- I checked the FIPS binaries in `/usr/bin/ ` and `/usr/libexec` are actually the FIPS binaries and not their non-FIPS counterpart. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
