### PR TITLE
login: start the getty services earlier

### DIFF
--- a/packages/login/getty.drop-in.conf
+++ b/packages/login/getty.drop-in.conf
@@ -1,0 +1,2 @@
+[Install]
+WantedBy=preconfigured.target

--- a/packages/login/login.spec
+++ b/packages/login/login.spec
@@ -6,10 +6,12 @@ Release: 1%{?dist}
 Summary: A login helper
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket
-Source0: login
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}bash
 Requires: %{_cross_os}systemd-console
+
+Source0: login
+Source1: getty.drop-in.conf
 
 %description
 %{summary}.
@@ -25,8 +27,12 @@ install -p -m 0755 %{S:0} %{buildroot}%{_cross_bindir}/login
 install -d %{buildroot}%{_cross_sbindir}
 ln -s ../bin/login %{buildroot}%{_cross_sbindir}/sulogin
 
+install -d %{buildroot}%{_cross_unitdir}/getty.target.d
+install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}/getty.target.d/001-login.conf
+
 %files
 %{_cross_bindir}/login
 %{_cross_sbindir}/sulogin
+%{_cross_unitdir}/getty.target.d/001-login.conf
 
 %changelog


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
The login package is intended to help debug failures that occur early in boot, but by default the getty services are not started until `multi-user.target`, which is only activated if everything works as expected.

Start the `getty.target` as part of `preconfigured.target` so that the login prompt will be available even if there are problems with networking or filesystem mounts.


**Testing done:**
Modified an `aws-dev` build to set the default network interface to a non-existent device. Logged in and was able to check system logs even though the system eventually failed to boot:
```
bash-5.2# journalctl -f
Oct 02 19:02:34 localhost systemd-networkd[1043]: lo: Gained carrier
Oct 02 19:02:34 localhost systemd-networkd[1043]: Enumeration completed
Oct 02 19:02:34 localhost systemd[1]: Started Network Configuration.
Oct 02 19:02:34 localhost systemd[1]: Reached target Network.
Oct 02 19:02:34 localhost systemd[1]: Starting Wait for Network to be Configured...
Oct 02 19:02:34 localhost prairiedog[1036]: 19:02:34 [INFO] Crash kernel loaded
Oct 02 19:02:34 localhost systemd[1]: Finished Load crash kernel.
Oct 02 19:02:34 localhost systemd[1]: Starting Disable kexec load syscalls...
Oct 02 19:02:34 localhost sysctl[1084]: kernel.kexec_load_disabled = 1
Oct 02 19:02:34 localhost systemd[1]: Finished Disable kexec load syscalls.
Oct 02 19:04:34 localhost systemd-networkd-wait-online[1083]: Timeout occurred while waiting for network connectivity.
Oct 02 19:04:34 localhost systemd[1]: systemd-networkd-wait-online.service: Main process exited, code=exited, status=1/FAILURE
Oct 02 19:04:34 localhost systemd[1]: systemd-networkd-wait-online.service: Failed with result 'exit-code'.
Oct 02 19:04:34 localhost systemd[1]: Failed to start Wait for Network to be Configured.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
