### PR TITLE
Update kernels 5.10 and 5.15

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/3351af6379ce59bc5724cf19ad4819e5d6929dafdb2925afd0c9ea0e13d3be47/kernel-5.10.225-213.878.amzn2.src.rpm"
-sha512 = "96ff97176e92357e89171ebcf5eb5104e59947b92a0f0c7eb161552e2686ffac094db3d45da2bbbb9c343d94515e017f2732cf22ff84745a0c2a475a80b52abc"
+url = "https://cdn.amazonlinux.com/blobstore/11c2c91624bd7d42460b998b80573fa17717ab1fe853099730a373452bde11a2/kernel-5.10.226-214.879.amzn2.src.rpm"
+sha512 = "2609956c60e622c8f6eefcc0279fe2d67958f27ef12e64f3b3515a4c51b3a224160eeeffcc219314b7aa3172c52f41dc6504aba46449eba10cae34846af66101"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.225
+Version: 5.10.226
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/3351af6379ce59bc5724cf19ad4819e5d6929dafdb2925afd0c9ea0e13d3be47/kernel-5.10.225-213.878.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/11c2c91624bd7d42460b998b80573fa17717ab1fe853099730a373452bde11a2/kernel-5.10.226-214.879.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/1db73ff2ad4ac5d6ccf1f53e405b23ad5ee2715a6392faad73688bbb29c3374e/kernel-5.15.166-111.163.amzn2.src.rpm"
-sha512 = "59de7f13b4ab203b17ed4c1fb8260db560f95ade10f31db7c609129cc3043781a76eca79ca293ff9addff88431b5c20072472e952d6d75749b93d282d4cab374"
+url = "https://cdn.amazonlinux.com/blobstore/7d9322ae0af16962b5b12f984ec34e1644fe111beb5933bf6d75a1cf7f267201/kernel-5.15.167-112.165.amzn2.src.rpm"
+sha512 = "0d39cdc4a4bdcb66aa3f950af2f41ccb9d9f267524b3e5af7def532db68920321081684d2b37f1b0a1e24195b6d77a68f88dc92f5a47bccd3d12b665d2c36e7b"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.166
+Version: 5.15.167
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/1db73ff2ad4ac5d6ccf1f53e405b23ad5ee2715a6392faad73688bbb29c3374e/kernel-5.15.166-111.163.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/7d9322ae0af16962b5b12f984ec34e1644fe111beb5933bf6d75a1cf7f267201/kernel-5.15.167-112.165.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Update to 5.10.226 and 5.15.167

No config changes were detected:
```
diff directory-for-base-configs/config-5.10-aarch64.config directory-for-updated-configs/config-5.10-aarch64.config
3c3
< # Linux/arm64 5.10.225 Kernel Configuration
---
> # Linux/arm64 5.10.226 Kernel Configuration
diff directory-for-base-configs/config-5.10-x86_64.config directory-for-updated-configs/config-5.10-x86_64.config
3c3
< # Linux/x86 5.10.225 Kernel Configuration
---
> # Linux/x86 5.10.226 Kernel Configuration
diff directory-for-base-configs/config-5.15-aarch64.config directory-for-updated-configs/config-5.15-aarch64.config
3c3
< # Linux/arm64 5.15.166 Kernel Configuration
---
> # Linux/arm64 5.15.167 Kernel Configuration
diff directory-for-base-configs/config-5.15-x86_64.config directory-for-updated-configs/config-5.15-x86_64.config
3c3
< # Linux/x86 5.15.166 Kernel Configuration
---
> # Linux/x86 5.15.167 Kernel Configuration
```

**File: packages/kernel-5.10/patch_changes/summary**
```
Patches that changed:
Patches that were dropped:
0874-fou-Fix-null-ptr-deref-in-GRO.patch
Patches that were added:
0877-ima-Fix-use-after-free-on-a-dentry-s-dname.name.patch
0878-AL2-5.10-Update-lustrefsx-to-2.12.8-fsx11.patch
```
**File: packages/kernel-5.15/patch_changes/summary**
```
Patches that changed:
0114-mptcp-add-TCP_INQ-cmsg-support.patch -> 0114-mptcp-add-TCP_INQ-cmsg-support.patch
Patches that were dropped:
0161-fou-Fix-null-ptr-deref-in-GRO.patch
Patches that were added:
0162-ima-Fix-use-after-free-on-a-dentry-s-dname.name.patch
0163-AL2-5.15-Update-lustrefsx-to-2.12.8-fsx11-commit.patch
0164-net-tighten-bad-gso-csum-offset-check-in-virtio_net_.patch
```

**Testing done:**

- [x] 5.10 aarch64 boots
```
[ssm-user@control]$  uname -a
Linux ip-172-31-7-172.us-west-2.compute.internal 5.10.226 #1 SMP Thu Oct 3 03:04:14 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "e71878c9-dirty",
    "pretty_name": "Bottlerocket OS 1.24.0 (aws-k8s-1.23)",
    "variant_id": "aws-k8s-1.23",
    "version_id": "1.24.0"
  }
}
```
- [x] 5.10 x86_64 boots
```
[ssm-user@control]$  uname -a
Linux ip-172-31-3-48.us-west-2.compute.internal 5.10.226 #1 SMP Thu Oct 3 02:42:34 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "e71878c9-dirty",
    "pretty_name": "Bottlerocket OS 1.24.0 (aws-k8s-1.23)",
    "variant_id": "aws-k8s-1.23",
    "version_id": "1.24.0"
  }
}
```
- [x] 5.15 aarch64 boots
```
[ssm-user@control]$ uname -a
Linux ip-172-31-7-24.us-west-2.compute.internal 5.15.167 #1 SMP Thu Oct 3 03:04:04 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "e71878c9-dirty",
    "pretty_name": "Bottlerocket OS 1.24.0 (aws-k8s-1.27)",
    "variant_id": "aws-k8s-1.27",
    "version_id": "1.24.0"
  }
}
```
- [x] 5.15 x86_64 boots
```
[ssm-user@control]$ uname -a
Linux ip-172-31-2-8.us-west-2.compute.internal 5.15.167 #1 SMP Thu Oct 3 02:42:28 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "e71878c9-dirty",
    "pretty_name": "Bottlerocket OS 1.24.0 (aws-k8s-1.27)",
    "variant_id": "aws-k8s-1.27",
    "version_id": "1.24.0"
  }
}
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
