### PR TITLE
packages: set Epoch of 1 if package version less than Bottlerocket release version

### DIFF
--- a/packages/acpid/acpid.spec
+++ b/packages/acpid/acpid.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}acpid
 Version: 2.0.34
 Release: 1%{?dist}
+Epoch: 1
 Summary: ACPI event daemon
 License: GPL-2.0-or-later
 URL: http://sourceforge.net/projects/acpid2/

--- a/packages/conntrack-tools/conntrack-tools.spec
+++ b/packages/conntrack-tools/conntrack-tools.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}conntrack-tools
 Version: 1.4.8
 Release: 1%{?dist}
+Epoch: 1
 Summary: Tools for managing Linux kernel connection tracking
 # src/utils.c contains GPLv2-only code from linux
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -11,6 +11,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
+Epoch: 1
 Summary: An industry-standard container runtime
 License: Apache-2.0
 URL: https://%{goimport}

--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}e2fsprogs
 Version: 1.47.1
 Release: 1%{?dist}
+Epoch: 1
 Summary: Tools for managing ext2, ext3, and ext4 file systems
 License: GPL-2.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND BSD-3-Clause
 URL: http://e2fsprogs.sourceforge.net/

--- a/packages/early-boot-config/early-boot-config.spec
+++ b/packages/early-boot-config/early-boot-config.spec
@@ -3,7 +3,7 @@
 
 Name: %{_cross_os}early-boot-config
 Version: 0.1
-Release: 0%{?dist}
+Release: 1%{?dist}
 Epoch: 1
 Summary: early-boot-config
 License: Apache-2.0 OR MIT

--- a/packages/early-boot-config/early-boot-config.spec
+++ b/packages/early-boot-config/early-boot-config.spec
@@ -4,6 +4,7 @@
 Name: %{_cross_os}early-boot-config
 Version: 0.1
 Release: 0%{?dist}
+Epoch: 1
 Summary: early-boot-config
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket

--- a/packages/ecs-gpu-init/ecs-gpu-init.spec
+++ b/packages/ecs-gpu-init/ecs-gpu-init.spec
@@ -3,7 +3,7 @@
 
 Name: %{_cross_os}%{workspace_name}
 Version: 0.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 Summary: Tool to generate the ECS agent's GPU configuration
 License: Apache-2.0 OR MIT
 Source1: ecs-gpu-init.service

--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -4,6 +4,7 @@
 Name: %{_cross_os}filesystem
 Version: 1.0
 Release: 1%{?dist}
+Epoch: 1
 Summary: The basic directory layout
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket

--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}glibc
 Version: 2.38
 Release: 1%{?dist}
+Epoch: 1
 Summary: The GNU libc libraries
 License: LGPL-2.1-or-later AND (LGPL-2.1-or-later WITH GCC-exception-2.0) AND GPL-2.0-or-later AND (GPL-2.0-or-later WITH GCC-exception-2.0) AND BSD-3-Clause AND ISC
 URL: http://www.gnu.org/software/glibc/

--- a/packages/grep/grep.spec
+++ b/packages/grep/grep.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}grep
 Version: 3.11
 Release: 1%{?dist}
+Epoch: 1
 Summary: GNU grep utility
 URL: https://www.gnu.org/software/grep/
 License: GPL-3.0-or-later

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -12,6 +12,7 @@
 Name: %{_cross_os}grub
 Version: 2.06
 Release: 1%{?dist}
+Epoch: 1
 Summary: Bootloader with support for Linux and more
 License: GPL-3.0-or-later AND Unicode-DFS-2015
 URL: https://www.gnu.org/software/grub/

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -4,6 +4,7 @@
 Name: %{_cross_os}%{workspace_name}
 Version: 0.0
 Release: 0%{?dist}
+Epoch: 1
 Summary: Bottlerocket host container runner
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -3,7 +3,7 @@
 
 Name: %{_cross_os}%{workspace_name}
 Version: 0.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 Epoch: 1
 Summary: Bottlerocket host container runner
 License: Apache-2.0 OR MIT

--- a/packages/iptables/iptables.spec
+++ b/packages/iptables/iptables.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}iptables
 Version: 1.8.10
 Release: 1%{?dist}
+Epoch: 1
 Summary: Tools for managing Linux kernel packet filtering capabilities
 License: GPL-2.0-or-later AND GPL-2.0-only
 URL: http://www.netfilter.org/

--- a/packages/kexec-tools/kexec-tools.spec
+++ b/packages/kexec-tools/kexec-tools.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}kexec-tools
 Version: 2.0.29
 Release: 1%{?dist}
+Epoch: 1
 Summary: Linux tool to load kernels from the running system
 License: GPL-2.0-or-later AND GPL-2.0-only
 URL: https://www.kernel.org/doc/html/latest/admin-guide/kdump/kdump.html

--- a/packages/keyutils/keyutils.spec
+++ b/packages/keyutils/keyutils.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}keyutils
 Version: 1.6.1
 Release: 1%{?dist}
+Epoch: 1
 Summary: Linux key management utilities
 License: GPL-2.0-or-later AND GPL-2.1-or-later
 Url: http://people.redhat.com/~dhowells/keyutils/

--- a/packages/kubernetes-1.23/kubernetes-1.23.spec
+++ b/packages/kubernetes-1.23/kubernetes-1.23.spec
@@ -25,6 +25,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
+Epoch: 1
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -33,6 +33,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
+Epoch: 1
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -33,6 +33,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
+Epoch: 1
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -33,6 +33,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
+Epoch: 1
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -33,6 +33,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
+Epoch: 1
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -33,6 +33,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
+Epoch: 1
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -33,6 +33,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
+Epoch: 1
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -33,6 +33,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
+Epoch: 1
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -33,6 +33,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
 Release: 1%{?dist}
+Epoch: 1
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause

--- a/packages/libacl/libacl.spec
+++ b/packages/libacl/libacl.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libacl
 Version: 2.3.2
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for access control list support
 License: LGPL-2.1-or-later
 URL: https://savannah.nongnu.org/projects/acl

--- a/packages/libattr/libattr.spec
+++ b/packages/libattr/libattr.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libattr
 Version: 2.5.2
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for extended attribute support
 License: LGPL-2.1-or-later
 URL: https://savannah.nongnu.org/projects/attr

--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libaudit
 Version: 3.1.4
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for the audit subsystem
 License: GPL-2.0-or-later AND LGPL-2.1-or-later
 URL: https://github.com/linux-audit/audit-userspace/

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libcap
 Version: 2.70
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for getting and setting POSIX.1e capabilities
 License: GPL-2.0-only OR BSD-3-Clause
 URL: https://sites.google.com/site/fullycapable/

--- a/packages/libelf/libelf.spec
+++ b/packages/libelf/libelf.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libelf
 Version: 0.191
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for ELF files
 License: GPL-2.0-or-later OR LGPL-3.0-or-later
 URL: https://sourceware.org/elfutils/

--- a/packages/libexpat/libexpat.spec
+++ b/packages/libexpat/libexpat.spec
@@ -3,6 +3,7 @@
 Name: %{_cross_os}libexpat
 Version: %(echo %{unversion} | sed 's/_/./g')
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for XML parsing
 License: MIT
 URL: https://libexpat.github.io/

--- a/packages/libffi/libffi.spec
+++ b/packages/libffi/libffi.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libffi
 Version: 3.4.6
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for FFI
 License: MIT
 URL: https://sourceware.org/libffi/

--- a/packages/libgcc/libgcc.spec
+++ b/packages/libgcc/libgcc.spec
@@ -6,6 +6,7 @@
 Name: %{_cross_os}libgcc
 Version: 0.0
 Release: 1%{?dist}
+Epoch: 1
 Summary: GCC runtime library
 License: GPL-3.0-or-later WITH GCC-exception-3.1
 URL: https://gcc.gnu.org/

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libglib
 Version: 2.78.4
 Release: 1%{?dist}
+Epoch: 1
 Summary: The GLib libraries
 # glib2 is LGPL-2.1-only
 License: LGPL-2.1-only

--- a/packages/libmnl/libmnl.spec
+++ b/packages/libmnl/libmnl.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libmnl
 Version: 1.0.5
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for netlink
 License: LGPL-2.1-or-later
 URL: http://netfilter.org/projects/libmnl

--- a/packages/libnetfilter_conntrack/libnetfilter_conntrack.spec
+++ b/packages/libnetfilter_conntrack/libnetfilter_conntrack.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libnetfilter_conntrack
 Version: 1.0.9
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for netfilter conntrack
 License: GPL-2.0-or-later
 URL: http://netfilter.org

--- a/packages/libnetfilter_cthelper/libnetfilter_cthelper.spec
+++ b/packages/libnetfilter_cthelper/libnetfilter_cthelper.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libnetfilter_cthelper
 Version: 1.0.1
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for netfilter cthelper
 License: GPL-2.0-or-later
 URL: http://netfilter.org

--- a/packages/libnetfilter_cttimeout/libnetfilter_cttimeout.spec
+++ b/packages/libnetfilter_cttimeout/libnetfilter_cttimeout.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libnetfilter_cttimeout
 Version: 1.0.1
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for netfilter cttimeout
 License: GPL-2.0-or-later
 URL: http://netfilter.org

--- a/packages/libnetfilter_queue/libnetfilter_queue.spec
+++ b/packages/libnetfilter_queue/libnetfilter_queue.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libnetfilter_queue
 Version: 1.0.5
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for netfilter queue
 License: GPL-2.0-or-later
 URL: http://netfilter.org

--- a/packages/libnfnetlink/libnfnetlink.spec
+++ b/packages/libnfnetlink/libnfnetlink.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libnfnetlink
 Version: 1.0.2
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for netfilter netlink
 License: GPL-2.0-only
 URL: http://netfilter.org

--- a/packages/libnftnl/libnftnl.spec
+++ b/packages/libnftnl/libnftnl.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libnftnl
 Version: 1.2.7
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for nftables netlink
 License: GPL-2.0-or-later AND GPL-2.0-only
 URL: http://netfilter.org/projects/libnftnl/

--- a/packages/libnvme/libnvme.spec
+++ b/packages/libnvme/libnvme.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libnvme
 Version: 1.10
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for NVM Express
 License: LGPL-2.1-only AND CC0-1.0 AND MIT
 URL: https://github.com/linux-nvme/libnvme

--- a/packages/libseccomp/libseccomp.spec
+++ b/packages/libseccomp/libseccomp.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libseccomp
 Version: 2.5.5
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for enhanced seccomp
 License: LGPL-2.1-only
 URL: https://github.com/seccomp/libseccomp

--- a/packages/libselinux/libselinux.spec
+++ b/packages/libselinux/libselinux.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libselinux
 Version: 3.6
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for SELinux
 License: LicenseRef-SELinux-PD
 URL: https://github.com/SELinuxProject/

--- a/packages/libsemanage/libsemanage.spec
+++ b/packages/libsemanage/libsemanage.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libsemanage
 Version: 3.6
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for SELinux binary policy manipulation
 License: LGPL-2.1-or-later
 URL: https://github.com/SELinuxProject/

--- a/packages/libsepol/libsepol.spec
+++ b/packages/libsepol/libsepol.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libsepol
 Version: 3.6
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for SELinux policy manipulation
 License: LGPL-2.1-or-later
 URL: https://github.com/SELinuxProject/

--- a/packages/libstd-rust/libstd-rust.spec
+++ b/packages/libstd-rust/libstd-rust.spec
@@ -6,6 +6,7 @@
 Name: %{_cross_os}libstd-rust
 Version: 0.0
 Release: 1%{?dist}
+Epoch: 1
 Summary: Rust standard library
 License: Apache-2.0 OR MIT
 URL: https://www.rust-lang.org/

--- a/packages/libtirpc/libtirpc.spec
+++ b/packages/libtirpc/libtirpc.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libtirpc
 Version: 1.3.5
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for RPC
 License: BSD-3-Clause
 URL: http://git.linux-nfs.org/?p=steved/libtirpc.git;a=summary

--- a/packages/liburcu/liburcu.spec
+++ b/packages/liburcu/liburcu.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}liburcu
 Version: 0.14.0
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for userspace RCU
 License: LGPL-2.1-only AND GPL-2.0-or-later AND MIT
 URL: http://liburcu.org

--- a/packages/libz/libz.spec
+++ b/packages/libz/libz.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libz
 Version: 1.3.1
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for zlib compression
 URL: https://www.zlib.net/
 License: Zlib

--- a/packages/libzstd/libzstd.spec
+++ b/packages/libzstd/libzstd.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}libzstd
 Version: 1.5.6
 Release: 1%{?dist}
+Epoch: 1
 Summary: Library for Zstandard compression
 License: BSD-3-Clause AND GPL-2.0-only
 URL: https://github.com/facebook/zstd/

--- a/packages/login/login.spec
+++ b/packages/login/login.spec
@@ -3,6 +3,7 @@
 Name: %{_cross_os}login
 Version: 0.0.1
 Release: 1%{?dist}
+Epoch: 1
 Summary: A login helper
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket

--- a/packages/makedumpfile/makedumpfile.spec
+++ b/packages/makedumpfile/makedumpfile.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}makedumpfile
 Version: 1.7.5
 Release: 1%{?dist}
+Epoch: 1
 Summary: Tool to create dumps from kernel memory images
 License: GPL-2.0-or-later AND GPL-2.0-only
 URL: https://github.com/makedumpfile/makedumpfile

--- a/packages/microcode/microcode.spec
+++ b/packages/microcode/microcode.spec
@@ -9,6 +9,7 @@
 Name: %{_cross_os}microcode
 Version: 0.0
 Release: 1%{?dist}
+Epoch: 1
 Summary: Microcode for AMD and Intel processors
 License: LicenseRef-scancode-amd-linux-firmware-export AND LicenseRef-scancode-intel-mcu-2018
 

--- a/packages/netdog/netdog.spec
+++ b/packages/netdog/netdog.spec
@@ -3,7 +3,7 @@
 
 Name: %{_cross_os}netdog
 Version: 0.1.1
-Release: 0%{?dist}
+Release: 1%{?dist}
 Epoch: 1
 Summary: Bottlerocket network configuration helper
 License: Apache-2.0 OR MIT

--- a/packages/netdog/netdog.spec
+++ b/packages/netdog/netdog.spec
@@ -4,6 +4,7 @@
 Name: %{_cross_os}netdog
 Version: 0.1.1
 Release: 0%{?dist}
+Epoch: 1
 Summary: Bottlerocket network configuration helper
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket

--- a/packages/nvme-cli/nvme-cli.spec
+++ b/packages/nvme-cli/nvme-cli.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}nvme-cli
 Version: 2.10.2
 Release: 1%{?dist}
+Epoch: 1
 Summary: CLI to interact with NVMe devices
 License: LGPL-2.1-only AND GPL-2.0-only AND CC0-1.0 AND MIT
 URL: https://github.com/linux-nvme/nvme-cli

--- a/packages/oci-add-hooks/oci-add-hooks.spec
+++ b/packages/oci-add-hooks/oci-add-hooks.spec
@@ -8,6 +8,7 @@
 Name: %{_cross_os}oci-add-hooks
 Version: 1.0.0
 Release: 1%{?dist}
+Epoch: 1
 Summary: OCI runtime wrapper that injects OCI hooks
 License: Apache-2.0 AND MIT
 URL: https://github.com/awslabs/oci-add-hooks

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -3,7 +3,7 @@
 
 Name: %{_cross_os}os
 Version: 0.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 Epoch: 1
 Summary: Bottlerocket's first-party code
 License: Apache-2.0 OR MIT

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -4,6 +4,7 @@
 Name: %{_cross_os}os
 Version: 0.0
 Release: 0%{?dist}
+Epoch: 1
 Summary: Bottlerocket's first-party code
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket

--- a/packages/pciutils/pciutils.spec
+++ b/packages/pciutils/pciutils.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}pciutils
 Version: 3.13.0
 Release: 1%{?dist}
+Epoch: 1
 Summary: PCI bus related utilities
 License: GPL-2.0-only
 URL: https://www.kernel.org/pub/software/utils/pciutils/

--- a/packages/pigz/pigz.spec
+++ b/packages/pigz/pigz.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}pigz
 Version: 2.8
 Release: 1%{?dist}
+Epoch: 1
 Summary: pigz is a parallel implementation of gzip which utilizes multiple cores
 License: Zlib AND Apache-2.0
 URL: http://www.zlib.net/pigz

--- a/packages/policycoreutils/policycoreutils.spec
+++ b/packages/policycoreutils/policycoreutils.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}policycoreutils
 Version: 3.6
 Release: 1%{?dist}
+Epoch: 1
 Summary: A set of SELinux policy tools
 License: GPL-2.0-only
 URL: https://github.com/SELinuxProject/

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -4,6 +4,7 @@
 Name: %{_cross_os}release
 Version: 0.0
 Release: 0%{?dist}
+Epoch: 1
 Summary: Bottlerocket release
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -3,7 +3,7 @@
 
 Name: %{_cross_os}release
 Version: 0.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 Epoch: 1
 Summary: Bottlerocket release
 License: Apache-2.0 OR MIT

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -9,6 +9,7 @@
 Name: %{_cross_os}%{gorepo}
 Version: %{gover}
 Release: 1%{?dist}
+Epoch: 1
 Summary: CLI for running Open Containers
 License: Apache-2.0
 URL: https://%{goimport}

--- a/packages/selinux-policy/selinux-policy.spec
+++ b/packages/selinux-policy/selinux-policy.spec
@@ -5,7 +5,7 @@
 
 Name: %{_cross_os}selinux-policy
 Version: 0.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 Epoch: 1
 Summary: SELinux policy
 License: Apache-2.0 OR MIT

--- a/packages/selinux-policy/selinux-policy.spec
+++ b/packages/selinux-policy/selinux-policy.spec
@@ -6,6 +6,7 @@
 Name: %{_cross_os}selinux-policy
 Version: 0.0
 Release: 0%{?dist}
+Epoch: 1
 Summary: SELinux policy
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket

--- a/packages/socat/socat.spec
+++ b/packages/socat/socat.spec
@@ -1,6 +1,7 @@
 Name: %{_cross_os}socat
 Version: 1.8.0.0
 Release: 1%{?dist}
+Epoch: 1
 Summary: Transfer data between two channels
 License: GPL-2.0-only
 URL: http://www.dest-unreach.org/socat/

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -5,6 +5,7 @@
 Name: %{_cross_os}soci-snapshotter
 Version: %{gover}
 Release: 1%{?dist}
+Epoch: 1
 Summary: A containerd snapshotter plugin which enables lazy loading for OCI images.
 License: Apache-2.0
 URL: https://github.com/awslabs/soci-snapshotter

--- a/packages/static-pods/static-pods.spec
+++ b/packages/static-pods/static-pods.spec
@@ -3,7 +3,7 @@
 
 Name: %{_cross_os}static-pods
 Version: 0.1
-Release: 0%{?dist}
+Release: 1%{?dist}
 Summary: Manages user-defined K*S static pods
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -4,6 +4,7 @@
 Name: %{_cross_os}util-linux
 Version: %{version}
 Release: 1%{?dist}
+Epoch: 1
 Summary: A collection of basic system utilities
 License: BSD-3-Clause AND BSD-4-Clause-UC AND GPL-1.0-or-later AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
 URL: http://en.wikipedia.org/wiki/Util-linux

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -13,6 +13,7 @@
 Name: %{_cross_os}wicked
 Version: 0.6.68
 Release: 1%{?dist}
+Epoch: 1
 Summary: Network configuration infrastructure
 License: GPL-2.0-or-later AND (GPL-2.0-only OR BSD-3-Clause)
 URL: https://github.com/openSUSE/wicked


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**


Related: 

* https://github.com/bottlerocket-os/twoliter/issues/364
* https://github.com/bottlerocket-os/bottlerocket/discussions/4063

**Description of changes:**

For all packages whose version is < 3.0.0, set an Epoch of 1 in the package spec. This is to appease new app inventory requirements for building Bottlerocket variants such that package version comparisons using rpmvercmp are not broken.

See https://github.com/bottlerocket-os/bottlerocket/discussions/4063 for full details

1. Get App Inventory for aws-dev, metal-dev, vmware-dev and combine

Build with Twoliter from https://github.com/bottlerocket-os/twoliter/pull/384

```
for variant in aws-dev metal-dev vmware-dev; do
        cargo make \
                   -e BUILDSYS_ARCH=x86_64 \
                   -e=TWOLITER_REPO=https://github.com/ginglis13/twoliter \
                  -e=TWOLITER_VERSION=44a2623a6419dc7b07e346175a425bcad2f88aa6 \
                  -e=TWOLITER_ALLOW_SOURCE_INSTALL=true \
                  -e=TWOLITER_ALLOW_BINARY_INSTALL=false \
                  -e=TWOLITER_SKIP_VERSION_CHECK=true \
                  -e BUILDSYS_VARIANT=$variant
done
 
# jq for just package name, version, epoch
cat build/images/x86_64-aws-dev/latest/application-inventory.json | jq -r '.Content[] | [.Name, .Version, .Epoch] | @csv' \
    > aws-dev-latest.csv
    
cat build/images/x86_64-metal-dev/latest/application-inventory.json | jq -r '.Content[] | [.Name, .Version, .Epoch] | @csv' \
    > metal-dev-latest.csv
    
cat build/images/x86_64-vmware-dev/latest/application-inventory.json | jq -r '.Content[] | [.Name, .Version, .Epoch] | @csv' \
    > vmware-dev-latest.csv
    
# combine unique to one csv
sort -u *.csv -o bottlerocket-packages.csv

# strip quotes
  sed -i 's/\"//g' bottlerocket-packages.csv
```


3. Search the CSV for package,version for < 1.24.1

```
#!/usr/bin/env bash
# find_packages_requiring_epoch.sh

BOTTLEROCKET_VERSION=1.24.1

declare i_need_epoch=()

while IFS=, read -r name version epoch
do
        rpmdev-vercmp $epoch:$version:0 0:$BOTTLEROCKET_VERSION:0 > /dev/null
        if [ $? == 12 ]; then
                i_need_epoch+=("$name $version")
        fi

done < bottlerocket-packages.csv

printf '%s\n' "${i_need_epoch[@]}"
```

```
apiclient 0.0
apiserver 0.0
bloodhound 0.0
bootstrap-commands 0.0
bootstrap-containers 0.0
bork 0.0
bottlerocket-metadata 1.0
bottlerocket-settings-defaults 0.0
bottlerocket-settings-defaults-aws-dev 0.0
bottlerocket-settings-defaults-metal-dev 0.0
bottlerocket-settings-defaults-vmware-dev 0.0
bottlerocket-settings-plugins 0.0
bottlerocket-settings-plugins-aws-dev 0.0
bottlerocket-settings-plugins-metal-dev 0.0
bottlerocket-settings-plugins-vmware-dev 0.0
certdog 0.0                                                                                                                                                                                                                                                                                                         [0/589]
cfsignal 0.0
conntrack-tools 1.4.8
containerd 1.7.22
containerd-bin 1.7.22
corndog 0.0
early-boot-config 0.1
early-boot-config-aws 0.1
early-boot-config-local 0.1
early-boot-config-metal 0.1
early-boot-config-vmware 0.1
filesystem 1.0
ghostdog 0.0
host-containers 0.0
host-ctr 0.0
host-ctr-bin 0.0
hostname-imds 0.1.1
hostname-reverse-dns 0.1.1
iptables 1.8.10
keyutils 1.6.1
libelf 0.191
libgcc 0.0
libmnl 1.0.5
libnetfilter_conntrack 1.0.9
libnetfilter_cthelper 1.0.1
libnetfilter_cttimeout 1.0.1
libnetfilter_queue 1.0.5
libnfnetlink 1.0.2
libnftnl 1.2.7
libnvme 1.10
libstd-rust 0.0
libtirpc 1.3.5
liburcu 0.14.0
libz 1.3.1
libzstd 1.5.6
logdog 0.0
login 0.0.1
makedumpfile 1.7.5
metricdog 0.0
microcode-amd-license 0.0
microcode-intel-license 0.0
microcode-licenses 0.0
migration 0.0
netdog 0.1.1
netdog-systemd-networkd 0.1.1
oci-add-hooks 1.0.0
os 0.0
prairiedog 0.0
release 0.0
runc 1.1.14
runc-bin 1.1.14
schnauzer 0.0
selinux-policy 0.0
settings-committer 0.0
shibaken 0.0
shimpei 0.0
signpost 0.0
socat 1.8.0.0
soci-snapshotter 0.7.0
soci-snapshotter-bin 0.7.0
storewolf 0.0
sundog 0.0
thar-be-settings 0.0
thar-be-updates 0.0
updog 0.0
xfscli 0.0
```

Set `Epoch: 1` for all specs that build above packages

**Testing done:**

1. Publish core kit with these changes
2. Repeat (1) and (2) above, confirm Epoch is 1 for all packages with version < 1.24.1

The following packages are defined in the first party Bottlerocket AMI and are still showing as an Epoch of 0:

```
$ ./find_packages_requiring_epoch.sh
bottlerocket-metadata 1.0
bottlerocket-settings-defaults 0.0
bottlerocket-settings-defaults-aws-dev 0.0
bottlerocket-settings-defaults-metal-dev 0.0
bottlerocket-settings-defaults-vmware-dev 0.0
bottlerocket-settings-plugins 0.0
bottlerocket-settings-plugins-aws-dev 0.0
bottlerocket-settings-plugins-metal-dev 0.0
bottlerocket-settings-plugins-vmware-dev 0.0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
