### PR TITLE
Update amazon-ssm-agent to v3.3.987.0

### DIFF
--- a/advisories/staging/BRSA-glvb5gspjgq6.toml
+++ b/advisories/staging/BRSA-glvb5gspjgq6.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-glvb5gspjgq6"
+title = "amazon-ssm-agent CVE-2024-24790"
+cve = "CVE-2024-24790"
+severity = "moderate"
+description = "A flaw was found in amazon-ssm-agent in which the various Is methods (IsPrivate, IsLoopback, etc) did not work as expected for IPv4-mapped IPv6 addresses, returning false for addresses which would return true in their traditional IPv4 forms."
+
+[[advisory.products]]
+package-name = "amazon-ssm-agent"
+patched-version = "3.3.987.0"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-10-07T18:35:49Z
+arches = ["x86_64", "aarch64"]
+version = "staging"

--- a/advisories/staging/BRSA-jsc9uatb4znj.toml
+++ b/advisories/staging/BRSA-jsc9uatb4znj.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-jsc9uatb4znj"
+title = "amazon-ssm-agent CVE-2023-45288"
+cve = "CVE-2023-45288"
+severity = "moderate"
+description = "A flaw was found in amazon-ssm-agent that could cause an HTTP/2 endpoint to read arbitrary amounts of header data by sending an excessive number of CONTINUATION frames. When a request's headers exceed MaxHeaderBytes, no memory is allocated to store the excess headers, but they are still parsed. This could cause an HTTP/2 endpoint to read arbitrary amounts of header data, all associated with a request which is going to be rejected."
+
+[[advisory.products]]
+package-name = "amazon-ssm-agent"
+patched-version = "3.3.987.0"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-10-07T18:33:08Z
+arches = ["x86_64", "aarch64"]
+version = "staging"

--- a/packages/amazon-ssm-agent/0001-agent-Add-config-to-make-shell-optional.patch
+++ b/packages/amazon-ssm-agent/0001-agent-Add-config-to-make-shell-optional.patch
@@ -1,6 +1,6 @@
-From c835d2ddc855439173a8a59828c335d169c03d15 Mon Sep 17 00:00:00 2001
+From af0299d3f9ffb36b1f10b3c608b68301af664b1e Mon Sep 17 00:00:00 2001
 From: Kush Upadhyay <kushupad@amazon.com>
-Date: Tue, 2 Jul 2024 20:54:29 +0000
+Date: Mon, 7 Oct 2024 09:13:38 +0000
 Subject: [PATCH] agent: Add config to make shell optional
 
 Signed-off-by: Kush Upadhyay <kushupad@amazon.com>
@@ -11,11 +11,11 @@ Signed-off-by: Kush Upadhyay <kushupad@amazon.com>
  3 files changed, 28 insertions(+), 11 deletions(-)
 
 diff --git a/agent/appconfig/appconfig.go b/agent/appconfig/appconfig.go
-index b6abcf1..e214cd5 100644
+index 021d9f2..867f9e0 100644
 --- a/agent/appconfig/appconfig.go
 +++ b/agent/appconfig/appconfig.go
-@@ -118,6 +118,7 @@ func DefaultConfig() SsmagentConfig {
- 		SessionLogsRetentionDurationHours:     DefaultSessionLogsRetentionDurationHours,
+@@ -119,6 +119,7 @@ func DefaultConfig() SsmagentConfig {
+ 		SessionLogsDestination:                SessionLogsDestinationNone,
  		PluginLocalOutputCleanup:              DefaultPluginOutputRetention,
  		OrchestrationDirectoryCleanup:         DefaultOrchestrationDirCleanup,
 +		UseShell:                              false,
@@ -23,7 +23,7 @@ index b6abcf1..e214cd5 100644
  	var agent = AgentInfo{
  		Name:                                    "amazon-ssm-agent",
 diff --git a/agent/appconfig/contracts.go b/agent/appconfig/contracts.go
-index 1337398..0a66441 100644
+index 687aed2..dcb8412 100644
 --- a/agent/appconfig/contracts.go
 +++ b/agent/appconfig/contracts.go
 @@ -50,6 +50,8 @@ type SsmCfg struct {

--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -9,8 +9,8 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.808.0/amazon-ssm-agent-3.3.808.0.tar.gz"
-sha512 = "d8c8fe3aaa1362bde3c449e5eebfa0f0e728c514c8671e3990bfa4351d343a0000542d26f67c019ba8783d26e28e88417a4de4fd83706bd494f14ef7c4da7b86"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.987.0/amazon-ssm-agent-3.3.987.0.tar.gz"
+sha512 = "d0eaa116fc38a4c89e91fffdd3691500f9084aa0f8c6ca6edf755f126deadbd76f025eea7a72a4ebb234bfd54f1632e4e5d1c2c6fbcd9cde3e446da7e93a9f11"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.3.808.0
+Version: 3.3.987.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0
@@ -65,7 +65,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-plugin-bin)
 %{summary}.
 
 %prep
-%autosetup -n %{gorepo}-%{version} -p0001
+%autosetup -n %{gorepo}-%{version} -p1
 
 %build
 %set_cross_go_flags


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Update `amazon-ssm-agent` package to version `3.3.987.0`, the latest available release: https://github.com/aws/amazon-ssm-agent/releases/tag/3.3.987.0

This new agent release altered `appconfig.go`, a file we patch, so also updating the patch.

**Testing done:**

Launched an `aws-dev` instance with the `amazon-ssm-agent` package added. Verified `amazon-ssm-agent` service is still running successfully on the host:
```bash
bash-5.1# systemctl status amazon-ssm-agent
● amazon-ssm-agent.service - Amazon SSM agent
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/amazon-ssm-agent.service; enabled; preset: enabled)
     Active: active (running) since Mon 2024-10-07 09:06:15 UTC; 2min 18s ago
   Main PID: 1378 (amazon-ssm-agen)
      Tasks: 20 (limit: 18596)
     Memory: 58.1M
        CPU: 615ms
     CGroup: /system.slice/amazon-ssm-agent.service
             ├─1378 /usr/bin/amazon-ssm-agent
             └─1429 /usr/bin/ssm-agent-worker
```

Verified ECS Exec still works on `aws-ecs-2` variant:
```
$ aws ecs run-task --cluster bottlerocket-test --task-definition nginx:3 --enable-execute-command 

$ aws ecs execute-command --cluster bottlerocket-test --task dff5515d0d00419d9c7b05bf7d867174 --interactive --command "/bin/sh"

The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.


Starting session with SessionId: ecs-execute-command-5yddxxg93r3b3b653otcagd7au
# uname -a
Linux 7d259dbfa30f 6.1.109 #1 SMP PREEMPT_DYNAMIC Sat Oct  5 01:21:13 UTC 2024 x86_64 GNU/Linux
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
