### PR TITLE
Update kubernetes packages

### DIFF
--- a/advisories/staging/BRSA-drwh5tbpr8wv.toml
+++ b/advisories/staging/BRSA-drwh5tbpr8wv.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-drwh5tbpr8wv"
+title = "libcontainer CVE-2024-21626"
+cve = "CVE-2024-21626"
+severity = "high"
+description = "A flaw was found in libcontainer which could leak file descriptors and give a container access to a host filesystem."
+
+[[advisory.products]]
+package-name = "kubernetes-1.27"
+patched-version = "1.27.16"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-09T18:37:37Z
+arches = ["x86_64", "aarch64"]
+version = "staging"

--- a/advisories/staging/BRSA-dtrat1npvdre.toml
+++ b/advisories/staging/BRSA-dtrat1npvdre.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-dtrat1npvdre"
+title = "libcontainer CVE-2024-21626"
+cve = "CVE-2024-21626"
+severity = "high"
+description = "A flaw was found in libcontainer which could leak file descriptors and give a container access to a host filesystem."
+
+[[advisory.products]]
+package-name = "kubernetes-1.29"
+patched-version = "1.29.8"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-09T18:59:32Z
+arches = ["aarch64", "x86_64"]
+version = "staging"

--- a/advisories/staging/BRSA-emfpcl53wtfr.toml
+++ b/advisories/staging/BRSA-emfpcl53wtfr.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-emfpcl53wtfr"
+title = "libcontainer CVE-2024-45310"
+cve = "CVE-2024-45310"
+severity = "low"
+description = "A flaw was found in libcontainer which could create empty files or directories on the host."
+
+[[advisory.products]]
+package-name = "kubernetes-1.27"
+patched-version = "1.27.16"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-09T19:26:27Z
+arches = ["x86_64", "aarch64"]
+version = "staging"

--- a/advisories/staging/BRSA-fdnhjaspych2.toml
+++ b/advisories/staging/BRSA-fdnhjaspych2.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-fdnhjaspych2"
+title = "libcontainer CVE-2024-21626"
+cve = "CVE-2024-21626"
+severity = "high"
+description = "A flaw was found in libcontainer which could leak file descriptors and give a container access to a host filesystem."
+
+[[advisory.products]]
+package-name = "kubernetes-1.28"
+patched-version = "1.28.13"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-09T18:46:56Z
+arches = ["aarch64", "x86_64"]
+version = "staging"

--- a/advisories/staging/BRSA-lk2xqb8iclw8.toml
+++ b/advisories/staging/BRSA-lk2xqb8iclw8.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-lk2xqb8iclw8"
+title = "libcontainer CVE-2024-45310"
+cve = "CVE-2024-45310"
+severity = "low"
+description = "A flaw was found in libcontainer which could create empty files or directories on the host."
+
+[[advisory.products]]
+package-name = "kubernetes-1.28"
+patched-version = "1.28.13"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-09T19:25:01Z
+arches = ["x86_64", "aarch64"]
+version = "staging"

--- a/advisories/staging/BRSA-r4dkiuopvj2w.toml
+++ b/advisories/staging/BRSA-r4dkiuopvj2w.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-r4dkiuopvj2w"
+title = "libcontainer CVE-2024-45310"
+cve = "CVE-2024-45310"
+severity = "low"
+description = "A flaw was found in libcontainer which could create empty files or directories on the host."
+
+[[advisory.products]]
+package-name = "kubernetes-1.29"
+patched-version = "1.29.8"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-09T19:21:40Z
+arches = ["aarch64", "x86_64"]
+version = "staging"

--- a/packages/kubernetes-1.24/Cargo.toml
+++ b/packages/kubernetes-1.24/Cargo.toml
@@ -141,6 +141,10 @@ sha512 = "974790a848aac14b22bce4f9248ede33a6131f3a5ea8f881f31d42ea0e03dd4b770c90
 url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-24/patches/0036-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch"
 sha512 = "287f530b8372ffb4384799bc6f53ac373132c851c306a9217c982814404af3bde92901a8362bcf078b01584d975aef225dbd06c934b8b1da18b26ef33724d3a7"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-24/patches/0037-EKS-PATCH-Add-sourceARN-to-sts-headers.patch"
+sha512 = "cc1e82230d011082aea78bffa921dda41d5004f1cec13ec3f667b6f7067be5a7394be8299decc1d1ca7a70ccfb8e5531ba20be36da7557975c0332091f85e6fc"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.24/kubernetes-1.24.spec
+++ b/packages/kubernetes-1.24/kubernetes-1.24.spec
@@ -98,6 +98,7 @@ Patch0033: 0033-EKS-PATCH-GO-UPDATE-go-Bump-images-dependencies-and-.patch
 Patch0034: 0034-EKS-PATCH-CVE-2023-45288-Bumps-1.24-dependency-for-C.patch
 Patch0035: 0035-EKS-PATCH-Fix-CVE-2024-5321.patch
 Patch0036: 0036-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch
+Patch0037: 0037-EKS-PATCH-Add-sourceARN-to-sts-headers.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -109,6 +109,10 @@ sha512 = "f74d550646b0bf0f4c0596c78337037034c29ada7f3683ad3f3dbbac0011f935185486
 url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-25/patches/0024-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch"
 sha512 = "3b6cd81edaf9758fa6ef8d2843c96f075a47b13dd97f37a3ef01c7584e47c877cdce3dbb8e57c3869da83935a15374512c62600b5720b9415011d0d30001e936"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-25/patches/0025-EKS-PATCH-Add-sourceARN-to-sts-headers.patch"
+sha512 = "521976beffc6b26dc837c767280100188f4be55583cb9d4001206dd028ef044cf98eef86f77bfecd3d4297dbfd5d1949af33d6990ab4f353f28e2dedf6a01ca8"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -90,6 +90,7 @@ Patch0021: 0021-EKS-PATCH-Bumps-dependencies-for-fixing-CVE-2023-452.patch
 Patch0022: 0022-EKS-PATCH-Update-aws-sdk-go-to-include-new-regions.patch
 Patch0023: 0023-EKS-PATCH-Fix-CVE-2024-5321.patch
 Patch0024: 0024-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch
+Patch0025: 0025-EKS-PATCH-Add-sourceARN-to-sts-headers.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -69,6 +69,10 @@ sha512 = "6267486606741f25e12b2d0bd19d3243c485b21cce4ae992258a64db714c42ea3542c0
 url = "https://raw.githubusercontent.com/aws/eks-distro/main/projects/kubernetes/kubernetes/1-26/patches/0015-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch"
 sha512 = "7b65bb30ee2863ea19dbcb74a855c2a898b85e99e43d772228eec81859017cad0949dd0758461a2c6f7c496907718153ddbd2c30eb578c6b5c11599d593ac72d"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-26/patches/0016-EKS-PATCH-Add-sourceARN-to-sts-headers.patch"
+sha512 = "6a916a0644e98ab8f1bd00c1ac8fc408667ad1d7e0cbb179d2c6fd8d9d9db04fcd0ec8528464b08e5cb5a1718d8e926052138e7dd42301e4acc6f692c4cdbd38"
+
 # RPM BuildRequires
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -80,6 +80,7 @@ Patch0012: 0012-EKS-PATCH-Bumps-dependency-for-CVE-2023-45288.patch
 Patch0013: 0013-EKS-PATCH-Update-aws-sdk-go-for-new-regions.patch
 Patch0014: 0014-EKS-PATCH-Fix-CVE-2024-5321.patch
 Patch0015: 0015-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch
+Patch0016: 0016-EKS-PATCH-Add-sourceARN-to-sts-headers.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.27/.gitignore
+++ b/packages/kubernetes-1.27/.gitignore
@@ -1,0 +1,1 @@
+/*-EKS-PATCH-*.patch

--- a/packages/kubernetes-1.27/Cargo.toml
+++ b/packages/kubernetes-1.27/Cargo.toml
@@ -14,8 +14,60 @@ path = "../packages.rs"
 package-name = "kubernetes-1.27"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/34/artifacts/kubernetes/v1.27.14/kubernetes-src.tar.gz"
-sha512 = "c7a6acb127cfc510194b44a36d2f56883c89e363007312906e2aea5b21c53fd83b826f8661762e6b7afcab8027079c9d9bc1ba9f6848304845d16248698355b4"
+url = "https://dl.k8s.io/v1.27.16/kubernetes-src.tar.gz"
+sha512 = "fba641f745b5eef6f17e16501025959e570ae88912d79e2e08b4c79d18475430b879f98947d516871407feb297d5dac9b2fbc4ca565d3770c600d9550f3cffac"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0001-EKS-PATCH-admission-webhook-exclusion-from-file.patch"
+sha512 = "ef176d578e1239f5ab6dea1970193e7d6cf1ba570fe062334858c2b02eb7d0a5698d66c223192de4c4b8c6301fb35c73baa637884a5bbf94018c8d43da718c70"
+
+# There is no patch 0002-xxxx
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0003-EKS-PATCH-add-Authentication-tracking-request-error-.patch"
+sha512 = "047845b5bb3fe309923e1c3a4a9a388c76e55c305bdb3f9bab3efaa49a297f062936f8eff8173e1f9791f75085c0d6409eb2f5e740416aad745760627c9bdd53"
+
+# There is no patch 0004-xxxx
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0005-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.27.3.patch"
+sha512 = "f628ee49ac6bafb85767729443d267043ea63237b43c1f083267a05f11e667856c67026b0353467a703b0367c11c9ec6868d8f975b8924ea8da1a83831524c72"
+
+# There is no patch 0006-xxxx
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0007-EKS-PATCH-Support-tracking-executing-requests.patch"
+sha512 = "06ba5a31e31468a67df4f2ed41e126ac2e656aa2dd81e29dff42bfec3b5802ebe76d1d4be26ba2dca173f6dfd774cffa81323c58e1f7b60468abccae20846947"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0008-EKS-PATCH-Fix-etcd-storage_events_received_total-met.patch"
+sha512 = "08dce9f94f345638a8f81176e8aeb5bd8458e9332e7a4227a4a700d3003cfd3030f347312f53be14b9b641f93dc78d38a299038a6a4866ec09bb0a0c360d0cc9"
+
+# There is no patch 0009-xxxx
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0010-EKS-PATCH-Update-log-verbosity-for-node-health-and-t.patch"
+sha512 = "887fc5648a698297f331af0c0d0674b415ec1a1317f1981096359799a1c39198375421f4c0e963683a31887f2a776e2d2cd5a83a343ca52286dc16383f5200cb"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0011-EKS-PATCH-apiserver-fix-watch-namespace.patch"
+sha512 = "c9f46dda047957e331fc1ff50f870b1c72db4052b56be7eaf31b15de219c28bf7ce8c49f5525f96d824f72ca737d671fd6690a284c8f05c01ab24abc8f03ee79"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0012-EKS-PATCH-add-resource-to-the-transformation-metrics.patch"
+sha512 = "4f3de6d1e5f71cc9bd44fb0433255c6e31a8b014c76ec84634699c1764d08a2148753bb491fdd648c70ac11f17c1c6195172d13f2b70f3f06c53ab54a3ad2fc7"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0013-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch"
+sha512 = "c6fbd4167fb1fcc86f1f1c32f01f4c3cc871800d50f6771adee5852c67d2774f1486e1e92734c72cc1faf70cc67921a21ed01338111cb28187201235874cfe75"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0014-EKS-PATCH-Bumps-runc-version-to-fix-CVE-2024-45310.patch"
+sha512 = "e36830d54594aa9ccca4b2ff3b44105b69522beceee8455846338292b7ab5127c6f4ed6233c775fa0b1f6bea48e6c8ee26db791621dedde95ebe5b9be328b3fc"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/refs/heads/main/projects/kubernetes/kubernetes/1-27/patches/0015-EKS-PATCH-Add-apf-queue-wait-audit-log-latency-annot.patch"
+sha512 = "489e9baba81a3683e7be5de260e82c56628c0546f7032695e2107d3bc42dfbaf059f424f8d423d15ded5d7845ebb21966a886af9eefed132b8c361b8393efe44"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.27.14
+%global gover 1.27.16
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/34/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://dl.k8s.io/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config
@@ -66,6 +66,18 @@ Source101: pause-manifest.json
 Source102: pod-infra-container-image
 
 Source1000: clarify.toml
+
+Patch0001: 0001-EKS-PATCH-admission-webhook-exclusion-from-file.patch
+Patch0003: 0003-EKS-PATCH-add-Authentication-tracking-request-error-.patch
+Patch0005: 0005-EKS-PATCH-Fix-CVE-for-kube-proxy-v1.27.3.patch
+Patch0007: 0007-EKS-PATCH-Support-tracking-executing-requests.patch
+Patch0008: 0008-EKS-PATCH-Fix-etcd-storage_events_received_total-met.patch
+Patch0010: 0010-EKS-PATCH-Update-log-verbosity-for-node-health-and-t.patch
+Patch0011: 0011-EKS-PATCH-apiserver-fix-watch-namespace.patch
+Patch0012: 0012-EKS-PATCH-add-resource-to-the-transformation-metrics.patch
+Patch0013: 0013-EKS-PATCH-Check-git-directory-to-be-max-1-level-deep.patch
+Patch0014: 0014-EKS-PATCH-Bumps-runc-version-to-fix-CVE-2024-45310.patch
+Patch0015: 0015-EKS-PATCH-Add-apf-queue-wait-audit-log-latency-annot.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.28/.gitignore
+++ b/packages/kubernetes-1.28/.gitignore
@@ -1,0 +1,1 @@
+/*-EKS-PATCH-*.patch

--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/27/artifacts/kubernetes/v1.28.10/kubernetes-src.tar.gz"
-sha512 = "a7c00d5fd6bca4c6a17c4d57f1b16e30eed6f55ac0c84b01b10c85042f6fa71ed7624f075698da90b873e2dc9a26e22df2de4d0821ee4567bf0d08043343c3f6"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/33/artifacts/kubernetes/v1.28.13/kubernetes-src.tar.gz"
+sha512 = "7664cb9c178840e7499ceec22a198d8f6feb794423b533a632d4dd6294f6b4616313bb620473ba2a71171304b498d84d33a87038ae57482de03e040c8c1b3c18"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.28.10
+%global gover 1.28.13
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/27/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/33/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.29/.gitignore
+++ b/packages/kubernetes-1.29/.gitignore
@@ -1,0 +1,1 @@
+/*-EKS-PATCH-*.patch

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/16/artifacts/kubernetes/v1.29.5/kubernetes-src.tar.gz"
-sha512 = "a79145490ec242d22a079c22c882fedfc283014ee493fb99bd55939b02c94397b3b190d5a994cdeff183a456523782a422834f0201b579179a8e65cba4c67422"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/22/artifacts/kubernetes/v1.29.8/kubernetes-src.tar.gz"
+sha512 = "89dbb4d282da817be9f61035383467339f1146809e3bbd8d848d72cef6ae6c6cc9fc19bcd7ff3d9da0fee6b7fef13e272a76839282a4092a183a55c64c1695fa"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.29.5
+%global gover 1.29.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/16/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/22/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.30/.gitignore
+++ b/packages/kubernetes-1.30/.gitignore
@@ -1,0 +1,1 @@
+/*-EKS-PATCH-*.patch

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/9/artifacts/kubernetes/v1.30.1/kubernetes-src.tar.gz"
-sha512 = "314c4cdc3705fa6ded932bb2780e63b78040e75fe7e284aa2cbff93eac177d40eae5dfbe90b7482b682ed97b9d4723b55e4a1d598ec6424df77543e00e7fd6a2"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/15/artifacts/kubernetes/v1.30.4/kubernetes-src.tar.gz"
+sha512 = "a068efe5ae458178c336478ed91ec268eba087d82b2fb5eddbcb07c9a948be0ed7a11470e69cecc3dd8faae7ae2fe56ff00e879be3c6dbf66b5c836afe2e29a5"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/9/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/15/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.31/.gitignore
+++ b/packages/kubernetes-1.31/.gitignore
@@ -1,0 +1,1 @@
+/*-EKS-PATCH-*.patch

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/2/artifacts/kubernetes/v1.31.0/kubernetes-src.tar.gz"
-sha512 = "d27f975200294a24b902ed7bf64fb3cb93d67ed5edb03e47929fe08cb851d90404102d369671f7be268212978f78d317d6954c4938603993d464182ebcf1891c"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/4/artifacts/kubernetes/v1.31.0/kubernetes-src.tar.gz"
+sha512 = "c19a550d7e998f967a307abfde0d060f69a520f4000ef054e8652f05ae925792fa254ce9df3be15255684573c4b61c02eb722b480f6791648783dac6b0ed4c50"
 
 # RPM BuildRequires
 [build-dependencies]

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-31/releases/2/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-31/releases/4/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION

**Description of changes:**

Updates kubernetes-1.24 through 1.31 to the latest upstream versions. Moves kubernetes-1.27 from standard support to extended.

**Testing done:**

Built AMIs, created nodegroups with eksctl, verified that they would each join the cluster and run busybox. Accidentally verified that an aws-k8s-1.31 node will not join a v1.30 cluster, but will join a v1.31 cluster.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
