### PR TITLE
advisories: backfill for core kit release 2.8.4

### DIFF
--- a/advisories/2.8.4/BRSA-47umod34pbhi.toml
+++ b/advisories/2.8.4/BRSA-47umod34pbhi.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-47umod34pbhi"
+title = "kernel CVE-2024-46745"
+cve = "CVE-2024-46745"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: Input: uinput - reject requests with unreasonable number of slots"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-7o3evqkj6dxz.toml
+++ b/advisories/2.8.4/BRSA-7o3evqkj6dxz.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-7o3evqkj6dxz"
+title = "kernel CVE-2024-46719"
+cve = "CVE-2024-46719"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: usb: typec: ucsi: Fix null pointer dereference in trace"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-b13xkctvgeap.toml
+++ b/advisories/2.8.4/BRSA-b13xkctvgeap.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-b13xkctvgeap"
+title = "kernel CVE-2024-46798"
+cve = "CVE-2024-46798"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: -  - ASoC: dapm: Fix UAF for snd_soc_pcm_runtime object"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-biwzawbqkkck.toml
+++ b/advisories/2.8.4/BRSA-biwzawbqkkck.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-biwzawbqkkck"
+title = "kernel CVE-2024-46714"
+cve = "CVE-2024-46714"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: drm/amd/display: Skip wbscl_set_scaler_filter if filter is null"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-djvbmhotwvlh.toml
+++ b/advisories/2.8.4/BRSA-djvbmhotwvlh.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-djvbmhotwvlh"
+title = "kernel CVE-2024-46743"
+cve = "CVE-2024-46743"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: of/irq: Prevent device address out-of-bounds read in interrupt map walk"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-etjtxb1xuryc.toml
+++ b/advisories/2.8.4/BRSA-etjtxb1xuryc.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-etjtxb1xuryc"
+title = "kernel CVE-2024-46759"
+cve = "CVE-2024-46759"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: hwmon: (adc128d818) Fix underflows seen when writing limit attributes"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-fazhlws8ujwv.toml
+++ b/advisories/2.8.4/BRSA-fazhlws8ujwv.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-fazhlws8ujwv"
+title = "kernel CVE-2024-46734"
+cve = "CVE-2024-46734"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: btrfs: fix race between direct IO write and fsync when using same fd"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-finkwdny1frl.toml
+++ b/advisories/2.8.4/BRSA-finkwdny1frl.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-finkwdny1frl"
+title = "kernel CVE-2024-46777"
+cve = "CVE-2024-46777"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: udf: Avoid excessive partition lengths"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-iz6ir36tl3zj.toml
+++ b/advisories/2.8.4/BRSA-iz6ir36tl3zj.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-iz6ir36tl3zj"
+title = "kernel CVE-2024-46755"
+cve = "CVE-2024-46755"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: wifi: mwifiex: Do not return unused priv in mwifiex_get_priv_by_id()"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-jrhcxqii4w7z.toml
+++ b/advisories/2.8.4/BRSA-jrhcxqii4w7z.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-jrhcxqii4w7z"
+title = "kernel CVE-2024-46771"
+cve = "CVE-2024-46771"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: can: bcm: Remove proc entry when dev is unregistered."
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-kdtc28cpjbao.toml
+++ b/advisories/2.8.4/BRSA-kdtc28cpjbao.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-kdtc28cpjbao"
+title = "kernel CVE-2024-46725"
+cve = "CVE-2024-46725"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: -  - drm/amdgpu: Fix out-of-bounds write warning"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-kov02uiwkgvt.toml
+++ b/advisories/2.8.4/BRSA-kov02uiwkgvt.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-kov02uiwkgvt"
+title = "kernel CVE-2024-46738"
+cve = "CVE-2024-46738"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: VMCI: Fix use-after-free when removing resource in vmci_resource_remove()"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-kptn1dbzazgp.toml
+++ b/advisories/2.8.4/BRSA-kptn1dbzazgp.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-kptn1dbzazgp"
+title = "kernel CVE-2024-46750"
+cve = "CVE-2024-46750"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: PCI: Add missing bridge lock to pci_bus_lock()"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-kzwthwuxdl5z.toml
+++ b/advisories/2.8.4/BRSA-kzwthwuxdl5z.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-kzwthwuxdl5z"
+title = "kernel CVE-2024-46781"
+cve = "CVE-2024-46781"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: nilfs2: fix missing cleanup on rollforward recovery error"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-lhyjbjjsipyj.toml
+++ b/advisories/2.8.4/BRSA-lhyjbjjsipyj.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-lhyjbjjsipyj"
+title = "kernel CVE-2024-46713"
+cve = "CVE-2024-46713"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: perf/aux: Fix AUX buffer serialization"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-lvthulwc1dyg.toml
+++ b/advisories/2.8.4/BRSA-lvthulwc1dyg.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-lvthulwc1dyg"
+title = "kernel CVE-2022-48733"
+cve = "CVE-2022-48733"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: btrfs: fix use-after-free after failure to create a snapshot"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-m7wpxfdhmde5.toml
+++ b/advisories/2.8.4/BRSA-m7wpxfdhmde5.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-m7wpxfdhmde5"
+title = "kernel CVE-2024-46744"
+cve = "CVE-2024-46744"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: Squashfs: sanity check symbolic link size"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-m8wrxk9jxoup.toml
+++ b/advisories/2.8.4/BRSA-m8wrxk9jxoup.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-m8wrxk9jxoup"
+title = "kernel CVE-2024-39494"
+cve = "CVE-2024-39494"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: ima: Fix use-after-free on a dentry's dname.name"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-nakgsv7gyxl7.toml
+++ b/advisories/2.8.4/BRSA-nakgsv7gyxl7.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-nakgsv7gyxl7"
+title = "kernel CVE-2024-46757"
+cve = "CVE-2024-46757"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: hwmon: (nct6775-core) Fix underflows seen when writing limit attributes"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-niamajznm3gq.toml
+++ b/advisories/2.8.4/BRSA-niamajznm3gq.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-niamajznm3gq"
+title = "kernel CVE-2024-46800"
+cve = "CVE-2024-46800"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: sch/netem: fix use after free in netem_dequeue"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-njyzcxeuofrb.toml
+++ b/advisories/2.8.4/BRSA-njyzcxeuofrb.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-njyzcxeuofrb"
+title = "kernel CVE-2024-46722"
+cve = "CVE-2024-46722"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: drm/amdgpu: fix mc_data out-of-bounds read warning"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-o6qzbzn0nfnb.toml
+++ b/advisories/2.8.4/BRSA-o6qzbzn0nfnb.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-o6qzbzn0nfnb"
+title = "kernel CVE-2024-46739"
+cve = "CVE-2024-46739"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: uio_hv_generic: Fix kernel NULL pointer dereference in hv_uio_rescind"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-peohfuz1njqw.toml
+++ b/advisories/2.8.4/BRSA-peohfuz1njqw.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-peohfuz1njqw"
+title = "kernel CVE-2024-46723"
+cve = "CVE-2024-46723"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: drm/amdgpu: fix ucode out-of-bounds read warning"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-psp4lwvbepfo.toml
+++ b/advisories/2.8.4/BRSA-psp4lwvbepfo.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-psp4lwvbepfo"
+title = "kernel CVE-2024-46780"
+cve = "CVE-2024-46780"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: nilfs2: protect references to superblock parameters exposed in sysfs"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-qi81n37bsk6z.toml
+++ b/advisories/2.8.4/BRSA-qi81n37bsk6z.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-qi81n37bsk6z"
+title = "kernel CVE-2024-46782"
+cve = "CVE-2024-46782"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: ila: call nf_unregister_net_hooks() sooner"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-qinbkyilzhys.toml
+++ b/advisories/2.8.4/BRSA-qinbkyilzhys.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-qinbkyilzhys"
+title = "kernel CVE-2024-46721"
+cve = "CVE-2024-46721"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved:  apparmor: fix possible NULL pointer dereference"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-qq3ohsmcsrgm.toml
+++ b/advisories/2.8.4/BRSA-qq3ohsmcsrgm.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-qq3ohsmcsrgm"
+title = "kernel CVE-2024-44974"
+cve = "CVE-2024-44974"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: mptcp: pm: avoid possible UaF when selecting endp"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-qywi0dd3kooh.toml
+++ b/advisories/2.8.4/BRSA-qywi0dd3kooh.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-qywi0dd3kooh"
+title = "kernel CVE-2024-46737"
+cve = "CVE-2024-46737"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: nvmet-tcp: fix kernel crash if commands allocation fails"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-rw5rhjfggf5d.toml
+++ b/advisories/2.8.4/BRSA-rw5rhjfggf5d.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-rw5rhjfggf5d"
+title = "kernel CVE-2024-46795"
+cve = "CVE-2024-46795"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: ksmbd: unset the binding mark of a reused connection"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-s847umvzzi9c.toml
+++ b/advisories/2.8.4/BRSA-s847umvzzi9c.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-s847umvzzi9c"
+title = "kernel CVE-2024-46752"
+cve = "CVE-2024-46752"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: btrfs: replace BUG_ON() with error handling at update_ref_for_cow()"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-syvaiycl6jfg.toml
+++ b/advisories/2.8.4/BRSA-syvaiycl6jfg.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-syvaiycl6jfg"
+title = "kernel CVE-2024-46758"
+cve = "CVE-2024-46758"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: hwmon: (lm95234) Fix underflows seen when writing limit attributes"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-szd9r9wep4yw.toml
+++ b/advisories/2.8.4/BRSA-szd9r9wep4yw.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-szd9r9wep4yw"
+title = "kernel CVE-2024-46732"
+cve = "CVE-2024-46732"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: drm/amd/display: Assign linear_pitch_alignment even for VM"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-ufrj5ajwrrgz.toml
+++ b/advisories/2.8.4/BRSA-ufrj5ajwrrgz.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-ufrj5ajwrrgz"
+title = "kernel CVE-2024-46747"
+cve = "CVE-2024-46747"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: HID: cougar: fix slab-out-of-bounds Read in cougar_report_fixup"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-v2zqg3zefpai.toml
+++ b/advisories/2.8.4/BRSA-v2zqg3zefpai.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-v2zqg3zefpai"
+title = "kernel CVE-2024-46724"
+cve = "CVE-2024-46724"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: drm/amdgpu: Fix out-of-bounds read of df_v1_7_channel_number"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-v678mophia4z.toml
+++ b/advisories/2.8.4/BRSA-v678mophia4z.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-v678mophia4z"
+title = "kernel CVE-2024-46756"
+cve = "CVE-2024-46756"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: hwmon: (w83627ehf) Fix underflows seen when writing limit attributes"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-xpdpuokmljqv.toml
+++ b/advisories/2.8.4/BRSA-xpdpuokmljqv.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-xpdpuokmljqv"
+title = "kernel CVE-2024-46783"
+cve = "CVE-2024-46783"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: tcp_bpf: fix return value of tcp_bpf_sendmsg()"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["aarch64", "x86_64"]
+version = "2.8.4"

--- a/advisories/2.8.4/BRSA-zznorreu8hsx.toml
+++ b/advisories/2.8.4/BRSA-zznorreu8hsx.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-zznorreu8hsx"
+title = "kernel CVE-2024-46731"
+cve = "CVE-2024-46731"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: drm/amd/pm: fix the Out-of-bounds read warning"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.226-214.879.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.167-112.165.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-10-03T22:20:35Z
+arches = ["x86_64", "aarch64"]
+version = "2.8.4"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

bottlerocket-core-kit 2.8.4 was released `2024-10-03T22:20:35Z` and includes patches for CVEs in kernels:
* kernel-5.10.226-214.879.amzn2
* kernel-5.15.167-112.165.amzn2

**Testing done:**

n/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
