### PR TITLE
advisories: add 2.9.0 release BRSAs

### DIFF
--- a/advisories/2.9.0/BRSA-glvb5gspjgq6.toml
+++ b/advisories/2.9.0/BRSA-glvb5gspjgq6.toml
@@ -13,6 +13,6 @@ patched-epoch = "0"
 
 [updateinfo]
 author = "kushupad"
-issue-date = 2024-10-07T18:35:49Z
+issue-date = 2024-10-09T22:16:25Z
 arches = ["x86_64", "aarch64"]
-version = "staging"
+version = "2.9.0"

--- a/advisories/2.9.0/BRSA-jsc9uatb4znj.toml
+++ b/advisories/2.9.0/BRSA-jsc9uatb4znj.toml
@@ -13,6 +13,6 @@ patched-epoch = "0"
 
 [updateinfo]
 author = "kushupad"
-issue-date = 2024-10-07T18:33:08Z
+issue-date = 2024-10-09T22:16:25Z
 arches = ["x86_64", "aarch64"]
-version = "staging"
+version = "2.9.0"


### PR DESCRIPTION
Add advisories for amazon-ssm-agent

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

Add BRSAs for CVEs fixed by patching amazon-ssm-agent in the 2.9.0 release of the core kit.

**Testing done:**

n/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
