### PR TITLE
drop dependency on glibc for nvidia kmods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,6 @@ dependencies = [
 name = "kmod-5_10-nvidia"
 version = "0.1.0"
 dependencies = [
- "glibc",
  "kernel-5_10",
 ]
 
@@ -481,7 +480,6 @@ dependencies = [
 name = "kmod-5_15-nvidia"
 version = "0.1.0"
 dependencies = [
- "glibc",
  "kernel-5_15",
 ]
 
@@ -496,7 +494,6 @@ dependencies = [
 name = "kmod-6_1-nvidia"
 version = "0.1.0"
 dependencies = [
- "glibc",
  "kernel-6_1",
 ]
 

--- a/packages/kmod-5.10-nvidia/Cargo.toml
+++ b/packages/kmod-5.10-nvidia/Cargo.toml
@@ -42,5 +42,4 @@ sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3
 force-upstream = true
 
 [build-dependencies]
-glibc = { path = "../glibc" }
 kernel-5_10 = { path = "../kernel-5.10" }

--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -55,7 +55,6 @@ Source307: load-tesla-kernel-modules.service.in
 Source308: copy-open-gpu-kernel-modules.service.in
 Source309: load-open-gpu-kernel-modules.service.in
 
-BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}kernel-5.10-archive
 
 %description

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -42,5 +42,4 @@ sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3
 force-upstream = true
 
 [build-dependencies]
-glibc = { path = "../glibc" }
 kernel-5_15 = { path = "../kernel-5.15" }

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -55,7 +55,6 @@ Source307: load-tesla-kernel-modules.service.in
 Source308: copy-open-gpu-kernel-modules.service.in
 Source309: load-open-gpu-kernel-modules.service.in
 
-BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}kernel-5.15-archive
 
 %description

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -42,5 +42,4 @@ sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3
 force-upstream = true
 
 [build-dependencies]
-glibc = { path = "../glibc" }
 kernel-6_1 = { path = "../kernel-6.1" }

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -55,7 +55,6 @@ Source307: load-tesla-kernel-modules.service.in
 Source308: copy-open-gpu-kernel-modules.service.in
 Source309: load-open-gpu-kernel-modules.service.in
 
-BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}kernel-6.1-archive
 
 %description


### PR DESCRIPTION
**Issue number:**
#193

**Description of changes:**
The NVIDIA kernel modules don't depend on the userspace C library. All of the userspace libraries are already compiled and don't need it either.


**Testing done:**
Builds!


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
