### PR TITLE
fix: use inspect_err on exec result

### DIFF
--- a/sources/api/apiserver/src/server/exec/child.rs
+++ b/sources/api/apiserver/src/server/exec/child.rs
@@ -194,7 +194,7 @@ impl ChildHandles {
         })()
         // If anything went wrong when configuring the child process, kill it and return the
         // original error.
-        .inspect(|_| Self::stop_impl(pid))
+        .inspect_err(|_| Self::stop_impl(pid))
     }
 
     /// Terminates the child process.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Lint fixes to address map_err issue in #191 erroneously moved to use inspect rather than inspect_err, resulting in a breaking change to apiclient exec. 🤦 


**Testing done:**

build and launch variant from #191, attempt to `apiclient exec`:
```
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [INFO] Received exec request to localhost:/exec
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (2) apiserver::server::exec: Starting heartbeat and sending initial capacity update
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (2) apiserver::server::exec: Sending capacity update; 1024 max outstanding, 0 written
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (2) apiserver::server::exec: Client initialized for target container 'control' and command ["bash"] with tty: true
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (2) apiserver::server::exec::child: Creating PTY for exec request
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (2) apiserver::server::exec::child: Spawning command for exec request: env -i TERM="screen" "/usr/bin/ctr" "-a" "/run/host-containerd/containerd.sock" "task" "exec" "--exec-id" "apiexec-iJQsRQyLuiYA2NBF" "--tty" "control" "bash"
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (2) apiserver::server::exec::child: Spawned child has pid 1362349
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (2) apiserver::server::exec::child: Spawning thread to read from child
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (2) apiserver::server::exec::child: Spawning thread to write to child
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (2) apiserver::server::exec::child: Spawning thread to wait for child exit
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (7) apiserver::server::exec::child: Child process exited
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [DEBUG] (5) apiserver::server::exec::child: Child closed output
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [INFO] exec process returned 143
Oct 14 18:38:17 ip-192-168-49-20.us-west-2.compute.internal apiserver[1361725]: 18:38:17 [INFO] Closing exec connection; message: "143"
```

After changes:

```
bash-5.1# apiclient exec admin ls
bin   dev  home  lib64  media  opt   root  sbin  sys  usr
boot  etc  lib   local  mnt    proc  run   srv   tmp  var
bash-5.1# apiclient exec control ls
amazon-ssm-agent.gpg  boot  etc   lib    local  mnt  proc  run   srv  tmp  var
bin                   dev   home  lib64  media  opt  root  sbin  sys  usr
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
