### PR TITLE
advisories: add BRSAs for core kit 2.6.0 and 2.7.0

### DIFF
--- a/advisories/2.6.0/BRSA-1cqkuf5yftei.toml
+++ b/advisories/2.6.0/BRSA-1cqkuf5yftei.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-1cqkuf5yftei"
+title = "kernel CVE-2024-44946"
+cve = "CVE-2024-44946"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: kcm: Serialise kcm_sendmsg() for the same socket."
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.109-118.189.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-17T22:23:44Z
+arches = ["x86_64", "aarch64"]
+version = "2.6.0"

--- a/advisories/2.6.0/BRSA-8uhc2lthzlak.toml
+++ b/advisories/2.6.0/BRSA-8uhc2lthzlak.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-8uhc2lthzlak"
+title = "kernel CVE-2024-44974"
+cve = "CVE-2024-44974"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: mptcp: pm: avoid possible UaF when selecting endp"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.109-118.189.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-17T22:23:44Z
+arches = ["x86_64", "aarch64"]
+version = "2.6.0"

--- a/advisories/2.6.0/BRSA-acmimk6cg5ii.toml
+++ b/advisories/2.6.0/BRSA-acmimk6cg5ii.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-acmimk6cg5ii"
+title = "kernel CVE-2024-41098"
+cve = "CVE-2024-41098"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: ata: libata-core: Fix null pointer dereference on error"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.109-118.189.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-17T22:23:44Z
+arches = ["aarch64", "x86_64"]
+version = "2.6.0"

--- a/advisories/2.6.0/BRSA-cqwuhssclfvu.toml
+++ b/advisories/2.6.0/BRSA-cqwuhssclfvu.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-cqwuhssclfvu"
+title = "kernel CVE-2024-46763"
+cve = "CVE-2024-46763"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: fou: Fix null-ptr-deref in GRO."
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.109-118.189.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-17T22:23:44Z
+arches = ["aarch64", "x86_64"]
+version = "2.6.0"

--- a/advisories/2.6.0/BRSA-dufxuzcdkftf.toml
+++ b/advisories/2.6.0/BRSA-dufxuzcdkftf.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-dufxuzcdkftf"
+title = "kernel CVE-2024-46707"
+cve = "CVE-2024-46707"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: KVM: arm64: Make ICC_*SGI*_EL1 undef in the absence of a vGICv3"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.109-118.189.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-17T22:23:44Z
+arches = ["aarch64", "x86_64"]
+version = "2.6.0"

--- a/advisories/2.6.0/BRSA-icxrcaupotbs.toml
+++ b/advisories/2.6.0/BRSA-icxrcaupotbs.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-icxrcaupotbs"
+title = "kernel CVE-2024-46689"
+cve = "CVE-2024-46689"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: soc: qcom: cmd-db: Map shared memory as WC, not WB"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.109-118.189.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-17T22:23:44Z
+arches = ["x86_64", "aarch64"]
+version = "2.6.0"

--- a/advisories/2.6.0/BRSA-khn9m6isqcsk.toml
+++ b/advisories/2.6.0/BRSA-khn9m6isqcsk.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-khn9m6isqcsk"
+title = "kernel CVE-2024-46711"
+cve = "CVE-2024-46711"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: mptcp: pm: fix ID 0 endp usage after multiple re-creations"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.109-118.189.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-17T22:23:44Z
+arches = ["x86_64", "aarch64"]
+version = "2.6.0"

--- a/advisories/2.6.0/BRSA-r1rx21n1lllx.toml
+++ b/advisories/2.6.0/BRSA-r1rx21n1lllx.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-r1rx21n1lllx"
+title = "kernel CVE-2024-46679"
+cve = "CVE-2024-46679"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: ethtool: check device is present when getting link settings"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.109-118.189.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-17T22:23:44Z
+arches = ["aarch64", "x86_64"]
+version = "2.6.0"

--- a/advisories/2.7.0/BRSA-e1kreztluzpr.toml
+++ b/advisories/2.7.0/BRSA-e1kreztluzpr.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-e1kreztluzpr"
+title = "kernel CVE-2024-46689"
+cve = "CVE-2024-46689"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: soc: qcom: cmd-db: Map shared memory as WC, not WB"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.225-213.878.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.166-111.163.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-20T01:39:55Z
+arches = ["aarch64", "x86_64"]
+version = "2.7.0"

--- a/advisories/2.7.0/BRSA-sweufcv6vbzw.toml
+++ b/advisories/2.7.0/BRSA-sweufcv6vbzw.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-sweufcv6vbzw"
+title = "kernel CVE-2024-46763"
+cve = "CVE-2024-46763"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: fou: Fix null-ptr-deref in GRO."
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.225-213.878.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.166-111.163.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-20T01:39:55Z
+arches = ["x86_64", "aarch64"]
+version = "2.7.0"

--- a/advisories/2.7.0/BRSA-tpjxdtyuwdkx.toml
+++ b/advisories/2.7.0/BRSA-tpjxdtyuwdkx.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-tpjxdtyuwdkx"
+title = "kernel CVE-2024-46679"
+cve = "CVE-2024-46679"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: ethtool: check device is present when getting link settings"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.225-213.878.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.166-111.163.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-20T01:39:55Z
+arches = ["aarch64", "x86_64"]
+version = "2.7.0"

--- a/advisories/2.7.0/BRSA-u8cl6fuffykz.toml
+++ b/advisories/2.7.0/BRSA-u8cl6fuffykz.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "BRSA-u8cl6fuffykz"
+title = "kernel CVE-2024-46707"
+cve = "CVE-2024-46707"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: KVM: arm64: Make ICC_*SGI*_EL1 undef in the absence of a vGICv3"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "kernel-5.10.225-213.878.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.166-111.163.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-20T01:39:55Z
+arches = ["aarch64", "x86_64"]
+version = "2.7.0"

--- a/advisories/2.7.0/BRSA-wpmrgfv8swv7.toml
+++ b/advisories/2.7.0/BRSA-wpmrgfv8swv7.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-wpmrgfv8swv7"
+title = "kernel CVE-2024-41098"
+cve = "CVE-2024-41098"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: ata: libata-core: Fix null pointer dereference on error"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "kernel-5.15.166-111.163.amzn2"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-09-20T01:39:55Z
+arches = ["x86_64", "aarch64"]
+version = "2.7.0"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

Backfill kernel BRSAs for core kit 2.6.0 and 2.7.0

**Testing done:**

n/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
