### PR TITLE
Update kernel 6.1 and 5.10 and 5.15

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/11c2c91624bd7d42460b998b80573fa17717ab1fe853099730a373452bde11a2/kernel-5.10.226-214.879.amzn2.src.rpm"
-sha512 = "2609956c60e622c8f6eefcc0279fe2d67958f27ef12e64f3b3515a4c51b3a224160eeeffcc219314b7aa3172c52f41dc6504aba46449eba10cae34846af66101"
+url = "https://cdn.amazonlinux.com/blobstore/c7942aadb77fa921637155fdd357a91a8deaf85f3d024fb5b5371052c8309426/kernel-5.10.226-214.880.amzn2.src.rpm"
+sha512 = "2992e8cb9662a8e53ca5f9cfb56dad8706fc95147cef4bb15c312406eb55cdbbc19f7584808c1b641c0b094428a3e701e15d83e545d6b9e61d107fc95b7e98f4"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/11c2c91624bd7d42460b998b80573fa17717ab1fe853099730a373452bde11a2/kernel-5.10.226-214.879.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/c7942aadb77fa921637155fdd357a91a8deaf85f3d024fb5b5371052c8309426/kernel-5.10.226-214.880.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/7d9322ae0af16962b5b12f984ec34e1644fe111beb5933bf6d75a1cf7f267201/kernel-5.15.167-112.165.amzn2.src.rpm"
-sha512 = "0d39cdc4a4bdcb66aa3f950af2f41ccb9d9f267524b3e5af7def532db68920321081684d2b37f1b0a1e24195b6d77a68f88dc92f5a47bccd3d12b665d2c36e7b"
+url = "https://cdn.amazonlinux.com/blobstore/6e5bde865f2f534b3e5c1ae2c3065e711f6c55b7fa5e4f91f0dc55894b1ad844/kernel-5.15.167-112.166.amzn2.src.rpm"
+sha512 = "90ca9a2ee14e34a34ddcd6d8d24904bccc5d9ce8560c211fad1a01ed451996aecc3d6bb5b0982fddcbb426b552701d809cfc68506bf3123f77c16a72b844a8dc"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/7d9322ae0af16962b5b12f984ec34e1644fe111beb5933bf6d75a1cf7f267201/kernel-5.15.167-112.165.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/6e5bde865f2f534b3e5c1ae2c3065e711f6c55b7fa5e4f91f0dc55894b1ad844/kernel-5.15.167-112.166.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/60b1be96cb0d00c8998e26b855b51b54e1cc82a655bb47a1d4f51c5ffbdd3148/kernel-6.1.109-118.189.amzn2023.src.rpm"
-sha512 = "2a40b73e7fbc28f48b01e3d0f463e6c72660662ce498fc91c4727617201ed1714480d731c9e59e8de632cb829ba1dc6cf0a07838eb9b90e61a2b422cb17aae8b"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/b88530d26f68ef4d2080a189cb3ff1b722a7298e63a286d4bbb86116075ba469/kernel-6.1.112-122.189.amzn2023.src.rpm"
+sha512 = "77c1bea98a14f611bd59e2058495e7d6a8a117f3a378087c19ef5bbf8379d0f4e775490052578a625347f255a364a878357b3ddcea962063f0802aab09dd40b6"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.109
+Version: 6.1.112
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/60b1be96cb0d00c8998e26b855b51b54e1cc82a655bb47a1d4f51c5ffbdd3148/kernel-6.1.109-118.189.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/b88530d26f68ef4d2080a189cb3ff1b722a7298e63a286d4bbb86116075ba469/kernel-6.1.112-122.189.amzn2023.src.rpm
 Source100: config-bottlerocket
 
 # This list of FIPS modules is extracted from /etc/fipsmodules in the initramfs


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Update kernel 5.10 to 5.10.226-214.880.amzn2
Update kernel 5.15 to 5.15.167-112.166.amzn2
Update kernel 6.1 to 6.1.112-122.189.amzn2023

**Config diff**
```
diff '--color=auto' directory-for-base-configs/config-6.1-x86_64.config directory-for-updated-configs/config-6.1-x86_64.config
3c3
< # Linux/x86 6.1.109 Kernel Configuration
---
> # Linux/x86 6.1.112 Kernel Configuration
1117c1117
< # CONFIG_TLS_DEVICE is not set
---
> CONFIG_TLS_DEVICE=y
1769a1770
> CONFIG_SOCK_VALIDATE_XMIT=y
2504a2506
> CONFIG_MLX5_EN_TLS=y
```

**File: packages/kernel-5.10/patch_changes/summary**
```
Patches that changed:
Patches that were dropped:
Patches that were added:
0879-AL2-5.10-Update-ena-driver-to-2.13.0g.patch
```

**File: packages/kernel-5.15/patch_changes/summary**
```
Patches that changed:
Patches that were dropped:
Patches that were added:
0165-AL2-5.15-Update-ena-driver-to-2.13.0g.patch
```

**File: packages/kernel-6.1/patch_changes/summary**
```
Patches that changed:
Patches that were dropped:
0186-x86-kaslr-Expose-and-use-the-end-of-the-physical-mem.patch
0188-fou-Fix-null-ptr-deref-in-GRO.patch
Patches that were added:
0187-smb-client-fix-UAF-in-smb2_reconnect_server.patch
0188-AL2023-6.1-Update-ena-driver-to-2.13.0g.patch
```

**Testing done:**
- [x] Kernel build
- [x] Variant aws-k8s-1.28 boot
- [x] Variant aws-k8s-1.24 boot



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
