### PR TITLE
host-ctr: support FIPS ECR service endpoints

### DIFF
--- a/sources/api/schnauzer/src/helpers/mod.rs
+++ b/sources/api/schnauzer/src/helpers/mod.rs
@@ -16,7 +16,7 @@ use serde_plain::derive_fromstr_from_deserialize;
 use settings_extension_oci_defaults::OciDefaultsResourceLimitV1;
 use snafu::{OptionExt, ResultExt};
 use std::borrow::Borrow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
@@ -70,6 +70,19 @@ lazy_static! {
         m.insert("us-west-2", "328549459982");
         m
     };
+
+    /// A set to tell us which regions have FIPS ECR endpoints.
+    /// https://docs.aws.amazon.com/general/latest/gr/ecr.html
+    static ref ECR_FIPS_REGIONS: HashSet<&'static str> = {
+        let mut h = HashSet::new();
+        h.insert("us-east-1");
+        h.insert("us-east-2");
+        h.insert("us-gov-east-1");
+        h.insert("us-gov-west-1");
+        h.insert("us-west-1");
+        h.insert("us-west-2");
+        h
+    };
 }
 
 /// But if there is a region that does not exist in our map (for example a new
@@ -77,6 +90,9 @@ lazy_static! {
 /// containers from here.
 const ECR_FALLBACK_REGION: &str = "us-east-1";
 const ECR_FALLBACK_REGISTRY: &str = "328549459982";
+
+/// Path to FIPS sysctl file.
+const FIPS_ENABLED_SYSCTL_PATH: &str = "/proc/sys/crypto/fips_enabled";
 
 lazy_static! {
     /// A map to tell us which endpoint to pull updates from for a given region.
@@ -517,6 +533,14 @@ pub fn tuf_prefix(
         })?;
 
     Ok(())
+}
+
+/// Utility function to determine if a variant is in FIPS mode based
+/// on /proc/sys/crypto/fips_enabled.
+fn fips_enabled() -> bool {
+    std::fs::read_to_string(FIPS_ENABLED_SYSCTL_PATH)
+        .map(|s| s.trim() == "1")
+        .unwrap_or(false)
 }
 
 /// The `metadata-prefix` helper is used to map an AWS region to the correct
@@ -1426,7 +1450,16 @@ fn ecr_registry<S: AsRef<str>>(region: S) -> String {
     match partition {
         "aws-cn" => format!("{}.dkr.ecr.{}.amazonaws.com.cn", registry_id, region),
         "aws-iso-e" => format!("{}.dkr.ecr.{}.cloud.adc-e.uk", registry_id, region),
-        _ => format!("{}.dkr.ecr.{}.amazonaws.com", registry_id, region),
+        _ => {
+            // Only inject the FIPS service endpoint if the variant is in FIPS mode and the
+            // region supports FIPS.
+            let suffix = if fips_enabled() && ECR_FIPS_REGIONS.contains(region) {
+                "-fips"
+            } else {
+                ""
+            };
+            format!("{}.dkr.ecr{}.{}.amazonaws.com", registry_id, suffix, region)
+        }
     }
 }
 

--- a/sources/host-ctr/cmd/host-ctr/main_test.go
+++ b/sources/host-ctr/cmd/host-ctr/main_test.go
@@ -194,6 +194,18 @@ func TestFetchECRRef(t *testing.T) {
 			"ecr.aws/arn:aws-us-gov:ecr:us-gov-west-1:111111111111:repository/bottlerocket/container:1.2.3",
 		},
 		{
+			"Parse FIPS region for normal use-cases",
+			"111111111111.dkr.ecr-fips.us-west-2.amazonaws.com/bottlerocket/container:1.2.3",
+			false,
+			"ecr.aws/arn:aws:ecr-fips:us-west-2:111111111111:repository/bottlerocket/container:1.2.3",
+		},
+		{
+			"Fail for region that does not have FIPS support",
+			"111111111111.dkr.ecr-fips.ca-central-1.amazonaws.com/bottlerocket/container:1.2.3",
+			true,
+			"",
+		},
+		{
 			"Fail for invalid region",
 			"111111111111.dkr.ecr.outer-space.amazonaws.com/bottlerocket/container:1.2.3",
 			true,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: https://github.com/bottlerocket-os/bottlerocket/issues/1667

**Description of changes:**

Add support to host-ctr for FIPS ECR endpoints.

* add support for `-fips` service endpoints in host-ctr
* modify `ecr-prefix` to set the `fips` service endpoint if the variant is in FIPS mode and the region is FIPS supported


**Testing done:**

On an `aws-dev` instance in `us-west-2` with FIPS mode enabled:
```
[ssm-user@control]$ apiclient get settings.host-containers.control.source
{
  "settings": {
    "host-containers": {
      "control": {
        "source": "328549459982.dkr.ecr-fips.us-west-2.amazonaws.com/bottlerocket-control:v0.7.17"
      }
    }
  }
}
[ssm-user@control]$ cat /proc/sys/crypto/fips_enabled
1
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
