### PR TITLE
selinux-policy: adjust kernel permissions for NFS

### DIFF
--- a/packages/selinux-policy/mcs.cil
+++ b/packages/selinux-policy/mcs.cil
@@ -86,9 +86,11 @@
 ; Restrict process transitions unless one of these conditions is met:
 ; * the new label exactly matches the old label
 ; * the source context is for a trusted subject
+; * the target context is not forbidden
 
 (mlsconstrain (processes (transform))
-  (or (eq t1 trusted_s)
+  (or (and (eq t1 trusted_s)
+           (neq t2 forbidden_t))
       (and (and (and (and
            (eq u1 u2)
            (eq r1 r2))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -166,9 +166,27 @@
 ; Subjects that must run verified code can execute immutable objects, since
 ; those are all protected by dm-verity.
 (allow verified_s immutable_o (files (execute)))
+(allow kernel_t immutable_o (files (execute)))
 
 ; Subjects that must run verified code cannot execute mutable objects.
 (neverallow verified_s mutable_o (files (execute)))
+
+; Ideally the kernel would also be denied permission to execute mutable
+; objects. However, this breaks certain scenarios such as serving files
+; over NFS, where the kernel's permissions are checked.
+(allow kernel_t mutable_o (file (execute)))
+
+; Prevent the kernel from executing mutable objects by blocking execution
+; unless there's a defined transition.
+(neverallow kernel_t mutable_o (file (execute_no_trans)))
+
+; Backstop against kernel execution of mutable objects by defining a type
+; transition, which is then explicitly disallowed.
+(typetransition kernel_t mutable_o process forbidden_t)
+(neverallow kernel_t forbidden_t (processes (transform)))
+
+; Block the use of any object as an entry point to the forbidden type.
+(neverallow forbidden_t all_o (files (enter)))
 
 ; All subjects are allowed to write to objects with their own label.
 ; This includes files like the ones under /proc/self.

--- a/packages/selinux-policy/subject.cil
+++ b/packages/selinux-policy/subject.cil
@@ -68,12 +68,18 @@
 (roletype system_r super_t)
 (context admin (system_u system_r super_t s0))
 
+; Processes that should never exist.
+(type forbidden_t)
+(roletype system_r forbidden_t)
+(context forbidden (system_u system_r forbidden_t s0))
+
 ; The set of all subjects.
 (typeattribute all_s)
 (typeattributeset all_s (
   kernel_t init_t system_t mount_t api_t
   network_t clock_t bus_t runtime_t
-  container_t control_t super_t))
+  container_t control_t super_t
+  forbidden_t))
 
 ; Subjects that are treated as a privileged part of the OS.
 (typeattribute privileged_s)
@@ -121,7 +127,8 @@
 
 ; Subjects shipped with the OS that should only execute verified code.
 (typeattribute verified_s)
-(typeattributeset verified_s (xor (host_s) (runtime_t mount_t api_t init_t)))
+(typeattributeset verified_s (xor (host_s) (
+  runtime_t mount_t api_t init_t kernel_t)))
 
 ; Subjects that are allowed to manage the system clock.
 (typeattribute clock_s)


### PR DESCRIPTION
**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/4116

**Description of changes:**
When serving files over NFS, the kernel's permissions to access the inode are checked when determining whether the file can be executed by clients. If the kernel lacks permission, then the client will see a permission error and won't be able to execute the program.

Work around this by allowing the kernel access to execute mutable files, while denying it permission to execute a new program without transitioning to a new SELinux context.

To close off other potential paths to execution, define a transition to a "forbidden" type that is explicitly denied, and deny the use of any object as an entry point to that domain.


**Testing done:**
Verified that the test case in the related issue now passes.

Added a test case to attempt to trigger kernel execution of untrusted code via one of the well-known forms of container escape - installing a new core pattern handler. Confirmed that execution was blocked:
```
[ 1535.724944] audit: type=1400 audit(1729528842.857:147): avc:  denied  { execute_no_trans } for  pid=26787 comm="kworker/u8:4" path="/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/172/fs/tmp/core-pattern-escape.sh" dev="nvme1n1p1" ino=54842222 scontext=system_u:system_r:kernel_t:s0 tcontext=system_u:object_r:data_t:s0:c346,c677 tclass=file permissive=0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
