### PR TITLE
mount binfmt_misc by default and restrict writes

### DIFF
--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -20,7 +20,7 @@
 ; Specify a context for filesystems that do not support other ways to label.
 (genfscon autofs / any)
 (genfscon bdev / any)
-(genfscon binfmt_misc / any)
+(genfscon binfmt_misc / binfmt_misc_fs)
 (genfscon bpf / any)
 (genfscon cgroup / any)
 (genfscon cgroup2 / any)

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -59,6 +59,11 @@
 (roletype object_r proc_t)
 (context proc (system_u object_r proc_t s0))
 
+; Files in the binfmt_misc filesystem
+(type binfmt_misc_fs_t)
+(roletype object_r binfmt_misc_fs_t)
+(context binfmt_misc_fs (system_u object_r binfmt_misc_fs_t s0))
+
 ; Files where we have no specific policy objectives, such as
 ; tmpfs mounts and various kernel filesystems.
 (type any_t)
@@ -135,7 +140,7 @@
 
 ; Dynamic objects are files on temporary storage with special rules.
 (typeattribute dynamic_o)
-(typeattributeset dynamic_o (etc_t))
+(typeattributeset dynamic_o (etc_t binfmt_misc_fs_t))
 
 ; Shared objects are files on local storage for containers.
 (typeattribute shared_o)
@@ -204,7 +209,7 @@
   os_t init_exec_t api_exec_t clock_exec_t
   network_exec_t bus_exec_t runtime_exec_t
   mount_exec_t cni_exec_t csi_exec_t
-  any_t etc_t proc_t
+  any_t etc_t proc_t binfmt_misc_fs_t
   local_t data_t private_t secret_t cache_t
   lease_t measure_t state_t
   api_socket_t))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -179,11 +179,15 @@
 (allow all_s ephemeral_o (files (mutate mount)))
 
 ; Trusted subjects are allowed to write to and manage mounts
-; for "dynamic" files in /etc.
-(allow trusted_s dynamic_o (files (mutate mount)))
+; for files in /etc.
+(allow trusted_s etc_t (files (mutate mount)))
 
 ; wicked calls netdog which writes /etc/resolv.conf.
 (allow network_t etc_t (files (mutate)))
+
+; Privileged subjects are allowed to write to and manage mounts for
+; the binfmt_misc filesystem.
+(allow privileged_s binfmt_misc_fs_t (files (mutate mount)))
 
 ; Other subjects cannot modify these "dynamic" files.
 (neverallow other_s dynamic_o (files (mutate mount)))

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -161,7 +161,7 @@ CONFIGURE_OPTS=(
  -Defi=true
  -Dtpm=false
  -Denvironment-d=false
- -Dbinfmt=false
+ -Dbinfmt=true
  -Drepart=true
  -Dcoredump=false
  -Dpstore=true
@@ -313,6 +313,11 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/default.target
 rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/multi-user.target
 rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/graphical.target
 
+# Ensure /proc/sys/fs/binfmt_misc mount is wanted by sysinit.target,
+# since we exclude the automount unit.
+ln -s  ../proc-sys-fs-binfmt_misc.mount \
+  %{buildroot}%{_cross_unitdir}/sysinit.target.wants/proc-sys-fs-binfmt_misc.mount
+
 # Add art to the console
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/issue
@@ -371,13 +376,18 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 
 %dir %{_cross_libdir}/systemd
 %{_cross_libdir}/systemd/*
+%exclude %{_cross_libdir}/systemd/systemd-binfmt
 %exclude %{_cross_libdir}/systemd/systemd-user-runtime-dir
 %exclude %{_cross_unitdir}/dbus-org.freedesktop.login1.service
+%exclude %{_cross_unitdir}/proc-sys-fs-binfmt_misc.automount
+%exclude %{_cross_unitdir}/systemd-binfmt.service
 %exclude %{_cross_unitdir}/systemd-repart.service
 %exclude %{_cross_unitdir}/user-runtime-dir@.service
 %exclude %{_cross_unitdir}/user@.service
 %exclude %{_cross_unitdir}/user@.service.d
 %exclude %{_cross_unitdir}/user@0.service.d
+%exclude %{_cross_unitdir}/sysinit.target.wants/proc-sys-fs-binfmt_misc.automount
+%exclude %{_cross_unitdir}/sysinit.target.wants/systemd-binfmt.service
 
 %dir %{_cross_libdir}/udev
 %{_cross_libdir}/udev/*


### PR DESCRIPTION
**Issue number:**
Fixes https://github.com/bottlerocket-os/bottlerocket/issues/4215

**Description of changes:**
This ensures that the binfmt_misc filesystem is mounted at boot, like other kernel filesystems.

Exclude the systemd-binfmt service and the automount unit, since the expectation is that privileged containers will register any handlers that the system requires.

Restrict writes to privileged containers, since `binfmt_misc` operations are not otherwise constrained by capabilities.


**Testing done:**
Verified that the binfmt_misc filesystem was mounted at boot.

```
bash-5.1# findmnt /proc/sys/fs/binfmt_misc/
TARGET                   SOURCE      FSTYPE      OPTIONS
/proc/sys/fs/binfmt_misc binfmt_misc binfmt_misc rw,nosuid,nodev,noexec,relatime
```

Added a test case to ensure that unprivileged containers running as UID with access to a mounted binfmt_misc filesystem could not write to it:
```
[ 1540.521904] audit: type=1400 audit(1729528847.657:148): avc:  denied  { write } for  pid=26856 comm="unprivileged-co" name="register" dev="binfmt_misc" ino=3 scontext=system_u:system_r:container_t:s0:c172,c178 tcontext=system_u:object_r:binfmt_misc_fs_t:s0 tclass=file permissive=0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
