### PR TITLE
advisories: backfill kernel advisories for 2.9.1

### DIFF
--- a/advisories/2.9.1/BRSA-7sexrepdimua.toml
+++ b/advisories/2.9.1/BRSA-7sexrepdimua.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-7sexrepdimua"
+title = "kernel CVE-2024-46744"
+cve = "CVE-2024-46744"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: Squashfs: sanity check symbolic link size"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["x86_64", "aarch64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-8qqipj1mkjrt.toml
+++ b/advisories/2.9.1/BRSA-8qqipj1mkjrt.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-8qqipj1mkjrt"
+title = "kernel CVE-2024-46713"
+cve = "CVE-2024-46713"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: perf/aux: Fix AUX buffer serialization"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["aarch64", "x86_64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-ay1hf5po4u1z.toml
+++ b/advisories/2.9.1/BRSA-ay1hf5po4u1z.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-ay1hf5po4u1z"
+title = "kernel CVE-2024-46777"
+cve = "CVE-2024-46777"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: udf: Avoid excessive partition lengths"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["x86_64", "aarch64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-fpqyqlfgwry4.toml
+++ b/advisories/2.9.1/BRSA-fpqyqlfgwry4.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-fpqyqlfgwry4"
+title = "kernel CVE-2024-46782"
+cve = "CVE-2024-46782"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: ila: call nf_unregister_net_hooks() sooner"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["aarch64", "x86_64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-gn7endd6fnto.toml
+++ b/advisories/2.9.1/BRSA-gn7endd6fnto.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-gn7endd6fnto"
+title = "kernel CVE-2024-46783"
+cve = "CVE-2024-46783"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: tcp_bpf: fix return value of tcp_bpf_sendmsg()"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["aarch64", "x86_64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-jvkqxgliiw2o.toml
+++ b/advisories/2.9.1/BRSA-jvkqxgliiw2o.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-jvkqxgliiw2o"
+title = "kernel CVE-2024-46738"
+cve = "CVE-2024-46738"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: VMCI: Fix use-after-free when removing resource in vmci_resource_remove()"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["aarch64", "x86_64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-kbs5hlc0h4cl.toml
+++ b/advisories/2.9.1/BRSA-kbs5hlc0h4cl.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-kbs5hlc0h4cl"
+title = "kernel CVE-2024-46752"
+cve = "CVE-2024-46752"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: btrfs: replace BUG_ON() with error handling at update_ref_for_cow()"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["aarch64", "x86_64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-rssoacmi1zu1.toml
+++ b/advisories/2.9.1/BRSA-rssoacmi1zu1.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-rssoacmi1zu1"
+title = "kernel CVE-2024-46745"
+cve = "CVE-2024-46745"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: Input: uinput - reject requests with unreasonable number of slots"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["x86_64", "aarch64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-thajs1gugm3m.toml
+++ b/advisories/2.9.1/BRSA-thajs1gugm3m.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-thajs1gugm3m"
+title = "kernel CVE-2024-46734"
+cve = "CVE-2024-46734"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: btrfs: fix race between direct IO write and fsync when using same fd"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["x86_64", "aarch64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-tzwpiotgbfby.toml
+++ b/advisories/2.9.1/BRSA-tzwpiotgbfby.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-tzwpiotgbfby"
+title = "kernel CVE-2024-46750"
+cve = "CVE-2024-46750"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: PCI: Add missing bridge lock to pci_bus_lock()"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["aarch64", "x86_64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-wxp97oetaoy7.toml
+++ b/advisories/2.9.1/BRSA-wxp97oetaoy7.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-wxp97oetaoy7"
+title = "kernel CVE-2024-46743"
+cve = "CVE-2024-46743"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: of/irq: Prevent device address out-of-bounds read in interrupt map walk"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["x86_64", "aarch64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-xdf7dlwotmgr.toml
+++ b/advisories/2.9.1/BRSA-xdf7dlwotmgr.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-xdf7dlwotmgr"
+title = "kernel CVE-2024-46739"
+cve = "CVE-2024-46739"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: uio_hv_generic: Fix kernel NULL pointer dereference in hv_uio_rescind"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["aarch64", "x86_64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-y9biy8nyde0m.toml
+++ b/advisories/2.9.1/BRSA-y9biy8nyde0m.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-y9biy8nyde0m"
+title = "kernel CVE-2024-46800"
+cve = "CVE-2024-46800"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: sch/netem: fix use after free in netem_dequeue"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.111-120.187.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["x86_64", "aarch64"]
+version = "2.9.1"

--- a/advisories/2.9.1/BRSA-ye9ba4g7971j.toml
+++ b/advisories/2.9.1/BRSA-ye9ba4g7971j.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-ye9ba4g7971j"
+title = "kernel CVE-2024-35870"
+cve = "CVE-2024-35870"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: smb: client: fix UAF in smb2_reconnect_server()"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "kernel-6.1.112-122.189.amzn2023"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mharrimn"
+issue-date = 2024-10-17T00:33:43Z
+arches = ["x86_64", "aarch64"]
+version = "2.9.1"


### PR DESCRIPTION

**Description of changes:**

Backfill advisories for package kernel-6.1.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
