### PR TITLE
packages: update aws-otel-collector

### DIFF
--- a/packages/aws-otel-collector/Cargo.toml
+++ b/packages/aws-otel-collector/Cargo.toml
@@ -9,8 +9,8 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.40.0/aws-otel-collector-v0.40.0.tar.gz"
-sha512 = "4dc90d798fc818f357c93424e3111697e6830a2dc9913fb71e754959ec4f6002be8f079220208cad93b3b6850d337174fa0e52f57d517364d004dd08bae97e14"
+url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.41.1/aws-otel-collector-v0.41.1.tar.gz"
+sha512 = "8e6436e4cec7d4f02468ad69fd6b26c97a9b592083da2725daa0b4c4777c34b2127dadc217c13be7c8de53bde021165aacbc1e5fecbd9ae0cae26d9fea8327e4"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/aws-otel-collector/aws-otel-collector.spec
+++ b/packages/aws-otel-collector/aws-otel-collector.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}aws-otel-collector
-Version: 0.40.0
+Version: 0.41.1
 Release: 1%{?dist}
 Epoch: 1
 Summary: AWS Distro for OpenTelemetry Collector


### PR DESCRIPTION


**Description of changes:**

Update aws-otel-collector to v0.41.1

**Testing done:**

Included the package in the `aws-dev` variant, verified that we create the config during boot, that the service starts, and that log and config are where we expect them to be.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
