### PR TITLE
Revert "add default security settings" due to bottlerocket-os/bottlerocket 1.26.0 release

### DIFF
--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -87,7 +87,6 @@ Source1100: systemd-tmpfiles-setup-service-debug.conf
 Source1101: systemd-resolved-service-env.conf
 Source1102: systemd-networkd-service-env.conf
 Source1103: systemd-logind-inhibit-maxdelay.conf
-Source1104: systemd-service-security.conf
 
 # network link rules
 Source1200: 80-release.link
@@ -208,9 +207,6 @@ install -d %{buildroot}%{_cross_unitdir}/systemd-networkd.service.d
 install -p -m 0644 %{S:1102} \
   %{buildroot}%{_cross_unitdir}/systemd-networkd.service.d/00-env.conf
 
-install -d %{buildroot}%{_cross_unitdir}/service.d/
-install -p -m 0644 %{S:1104} %{buildroot}%{_cross_unitdir}/service.d/10-security.conf
-
 # Empty (but packaged) directory. The FIPS packages for kernels will add drop-ins to
 # this directory to arrange for the right modules to be loaded before the check runs.
 install -d %{buildroot}%{_cross_unitdir}/check-fips-modules.service.d
@@ -316,7 +312,6 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/prepare-local-fs.service
 %{_cross_unitdir}/deprecation-warning@.service
 %{_cross_unitdir}/deprecation-warning@.timer
-%{_cross_unitdir}/service.d/10-security.conf
 %dir %{_cross_unitdir}/systemd-resolved.service.d
 %{_cross_unitdir}/systemd-resolved.service.d/00-env.conf
 %dir %{_cross_unitdir}/systemd-networkd.service.d

--- a/packages/release/systemd-service-security.conf
+++ b/packages/release/systemd-service-security.conf
@@ -1,2 +1,0 @@
-[Service]
-MemoryDenyWriteExecute=yes


### PR DESCRIPTION
This reverts commit 1395a0cbbe40fcb0f8d354d30cd4d3208044e956.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
bottlerocket-os/bottlerocket#4253
bottlerocket-os/bottlerocket#4260
bottlerocket-os/bottlerocket#4261
bottlerocket-os/bottlerocket#4262


**Description of changes:**


As a part of the Bottlerocket 1.26.0 release, this commit was identified as an issue.


**Testing done:**

With the commit:

```
=========================================================================

  JBoss Bootstrap Environment

  JBOSS_HOME: /opt/jboss/wildfly

  JAVA: /usr/lib/jvm/java/bin/java

  JAVA_OPTS:  -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true

=========================================================================

OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f6179700000, 2555904, 1) failed; error='Operation not permitted' (errno=1)
#
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (mmap) failed to map 2555904 bytes for committing reserved memory.
# An error report file with more information is saved as:
# /opt/jboss/hs_err_pid61.log
```

Without the commit:

```
=========================================================================

  JBoss Bootstrap Environment

  JBOSS_HOME: /opt/jboss/wildfly

  JAVA: /usr/lib/jvm/java/bin/java

  JAVA_OPTS:  -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true  --add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED

=========================================================================

06:40:23,001 INFO  [org.jboss.modules] (main) JBoss Modules version 1.12.0.Final
06:40:23,488 INFO  [org.jboss.msc] (main) JBoss MSC version 1.4.13.Final
06:40:23,497 INFO  [org.jboss.threads] (main) JBoss Threads version 2.4.0.Final
...
06:40:26,484 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: WildFly Full 25.0.0.Final (WildFly Core 17.0.1.Final) started in 3855ms - Started 298 of 538 services (337 services are lazy, passive or on-demand)
06:40:26,486 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0060: Http management interface listening on http://127.0.0.1:9990/management
06:40:26,486 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0051: Admin console listening on http://127.0.0.1:9990
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
