### PR TITLE
packages: update libaudit to 3.1.5

### DIFF
--- a/packages/libaudit/Cargo.toml
+++ b/packages/libaudit/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-audit/audit-userspace/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-audit/audit-userspace/archive/v3.1.4/audit-userspace-3.1.4.tar.gz"
-sha512 = "76cbc0bdde91adf8f8870784ea0741a01869c68dc0d3fb9c5815d5aa3e96ead2fd28ba06b98e5c70b8fe2113e7c43defd48af01ec82cba13f3907698067f964d"
+url = "https://github.com/linux-audit/audit-userspace/archive/v3.1.5/audit-userspace-3.1.5.tar.gz"
+sha512 = "9274a6addf20f306292e0a79f3432b7f4934b8134ed9cafdd2088ec676c03303e56f1c618b45fc922d4484306801dcbec420ea6533f68a1464960b979d40313a"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libaudit
-Version: 3.1.4
+Version: 3.1.5
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for the audit subsystem


### PR DESCRIPTION
**Description of changes:**

Update libaudit to upstream 3.1.5. Among other bug fixes, upstream commits include fixes for potential memory leaks.

**Testing done:**

Verified that an aws-k8s-1.31 AMI will join an EKS cluster.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
