### PR TITLE
Label additional FIPS binaries

### DIFF
--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -44,9 +44,9 @@
 (filecon "/.*/usr/bin/mount" file mount_exec)
 (filecon "/.*/usr/bin/apiserver" file api_exec)
 (filecon "/.*/usr/bin/early-boot-config" file api_exec)
-(filecon "/.*/usr/bin/migrator" file api_exec)
+(filecon "/.*/usr(/fips)?/bin/migrator" file api_exec)
 (filecon "/.*/usr/bin/storewolf" file api_exec)
-(filecon "/.*/usr/bin/cfsignal" file api_exec)
+(filecon "/.*/usr(/fips)?/bin/cfsignal" file api_exec)
 (filecon "/.*/usr/bin/thar-be-settings" file api_exec)
 (filecon "/.*/usr/bin/dbus-broker.*" file bus_exec)
 (filecon "/.*/usr/sbin/chronyd" file clock_exec)
@@ -57,7 +57,7 @@
 (filecon "/.*/usr(/fips)?/bin/docker.*" file runtime_exec)
 (filecon "/.*/usr(/fips)?/bin/host-ctr" file runtime_exec)
 (filecon "/.*/usr(/fips)?/bin/runc.*" file runtime_exec)
-(filecon "/.*/usr/bin/shibaken" file api_exec)
+(filecon "/.*/usr(/fips)?/bin/shibaken" file api_exec)
 
 ; Label local storage mounts.
 (filecon "/local" any local)


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/1667

**Description of changes:**

The FIPS binaries created for `migrator`, `cfsignal` and `shibaken` received the wrong label. For `migrator`, upgrades failed with an SELinux denial:

```
AVC avc:  denied  { execute } for  pid=1410 comm="tokio-runtime-w" dev="tmpfs" ino=3072 scontext=system_u:system_r:system_t:s0 tcontext=system_u:object_r:any_t:s0 tclass=file permissive=0
```

**Testing done:**

- `aws-k8s-1.30-fips` (defined in my local BoB repo) boots and joins a cluster
- `aws-k8s-1.30-fips` successfully performs in-place upgrades

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
