### PR TITLE
package: add rdma-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "pigz",
  "policycoreutils",
  "procps",
+ "rdma-core",
  "readline",
  "release",
  "runc",
@@ -963,6 +964,14 @@ version = "0.1.0"
 dependencies = [
  "glibc",
  "libselinux",
+]
+
+[[package]]
+name = "rdma-core"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "libnl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ members = [
   "packages/pigz",
   "packages/policycoreutils",
   "packages/procps",
+  "packages/rdma-core",
   "packages/readline",
   "packages/release",
   "packages/runc",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -119,6 +119,7 @@ pciutils = { path = "../../packages/pciutils" }
 pigz = { path = "../../packages/pigz" }
 policycoreutils = { path = "../../packages/policycoreutils" }
 procps = { path = "../../packages/procps" }
+rdma-core = { path = "../../packages/rdma-core" }
 readline = { path = "../../packages/readline" }
 release = { path = "../../packages/release" }
 runc = { path = "../../packages/runc" }

--- a/packages/rdma-core/Cargo.toml
+++ b/packages/rdma-core/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rdma-core"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/linux-rdma/rdma-core/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/linux-rdma/rdma-core/releases/download/v54.0/rdma-core-54.0.tar.gz"
+sha512 = "efb98dec017e1eb71ed6f2b652d557d0444c672ff388927bdd724c81bb4baeb5617c81fff609f794c1ff128ab93ae26ed4502bd0ebf14e157737b1b08d0fb4b9"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+libnl = { path = "../libnl" }

--- a/packages/rdma-core/libibverbs-tmpfiles.conf
+++ b/packages/rdma-core/libibverbs-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/libibverbs.d - - - -

--- a/packages/rdma-core/logdog.rdma.conf
+++ b/packages/rdma-core/logdog.rdma.conf
@@ -1,0 +1,3 @@
+exec ibv_devinfo.log ibv_devinfo
+glob /sys/class/infiniband/*/device/p2p
+glob /sys/class/infiniband/*/ports/*/hw_counters/*

--- a/packages/rdma-core/rdma-core.spec
+++ b/packages/rdma-core/rdma-core.spec
@@ -8,6 +8,9 @@ License: Linux-OpenIB AND MIT
 Source0: https://github.com/linux-rdma/rdma-core/releases/download/v%{version}/rdma-core-%{version}.tar.gz
 Source100: libibverbs-tmpfiles.conf
 
+# RDMA logdog configuration
+Source200: logdog.rdma.conf
+
 BuildRequires: cmake
 BuildRequires: %{_cross_os}libnl-devel
 BuildRequires: %{_cross_os}glibc-devel
@@ -45,9 +48,13 @@ install -p -m 0644 %{S:100} %{buildroot}%{_cross_tmpfilesdir}/rdma-core.conf
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/libibverbs.d
 install -p %{buildroot}%{_cross_sysconfdir}/libibverbs.d/efa.driver %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/libibverbs.d
 
+install -d %{buildroot}%{_cross_datadir}/logdog.d
+install -p -m 0644 %{S:200} %{buildroot}%{_cross_datadir}/logdog.d
+
 %files
 %license COPYING.md COPYING.BSD_MIT ccan/LICENSE.MIT
 %{_cross_attribution_file}
+%{_cross_datadir}/logdog.d/logdog.rdma.conf
 %{_cross_tmpfilesdir}/rdma-core.conf
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/libibverbs.d
 %{_cross_factorydir}%{_cross_sysconfdir}/libibverbs.d/efa.driver
@@ -64,7 +71,6 @@ install -p %{buildroot}%{_cross_sysconfdir}/libibverbs.d/efa.driver %{buildroot}
 # Verification tools
 %{_cross_bindir}/ibv_devices
 %{_cross_bindir}/ibv_devinfo
-
 
 # Exclude the bits that are not needed
 %exclude %{_cross_datadir}/perl5

--- a/packages/rdma-core/rdma-core.spec
+++ b/packages/rdma-core/rdma-core.spec
@@ -1,0 +1,151 @@
+%global abiver rdmav34
+
+Name: %{_cross_os}rdma-core
+Version: 54.0
+Release: 1%{?dist}
+Summary: RDMA core userspace infrastructure, including core libraries and util programs.
+License: Linux-OpenIB AND MIT
+Source0: https://github.com/linux-rdma/rdma-core/releases/download/v%{version}/rdma-core-%{version}.tar.gz
+Source100: libibverbs-tmpfiles.conf
+
+BuildRequires: cmake
+BuildRequires: %{_cross_os}libnl-devel
+BuildRequires: %{_cross_os}glibc-devel
+Requires: %{_cross_os}libnl
+
+%description
+%{summary}.
+
+%package devel
+Summary: RDMA core development libraries and headers
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n rdma-core-%{version} -p1
+
+%build
+%{cross_cmake} . \
+  -DNO_PYVERBS=1 \
+  -DNO_MAN_PAGES=1 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX:PATH=%{_cross_prefix} \
+  -DCMAKE_INSTALL_BINDIR:PATH=%{_cross_bindir} \
+  -DCMAKE_INSTALL_SBINDIR:PATH=%{_cross_sbindir} \
+  -DCMAKE_INSTALL_SYSCONFDIR:PATH=%{_cross_sysconfdir} \
+
+%make_build
+
+%install
+%make_install
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:100} %{buildroot}%{_cross_tmpfilesdir}/rdma-core.conf
+
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/libibverbs.d
+install -p %{buildroot}%{_cross_sysconfdir}/libibverbs.d/efa.driver %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/libibverbs.d
+
+%files
+%license COPYING.md COPYING.BSD_MIT ccan/LICENSE.MIT
+%{_cross_attribution_file}
+%{_cross_tmpfilesdir}/rdma-core.conf
+%dir %{_cross_factorydir}%{_cross_sysconfdir}/libibverbs.d
+%{_cross_factorydir}%{_cross_sysconfdir}/libibverbs.d/efa.driver
+
+# Core RDMA libraries
+%{_cross_libdir}/libibverbs.so.*
+%{_cross_libdir}/librdmacm.so.*
+%dir %{_cross_libdir}/libibverbs
+
+# EFA libraries
+%{_cross_libdir}/libefa.so.*
+%{_cross_libdir}/libibverbs/libefa-%{abiver}.so
+
+# Verification tools
+%{_cross_bindir}/ibv_devices
+%{_cross_bindir}/ibv_devinfo
+
+
+# Exclude the bits that are not needed
+%exclude %{_cross_datadir}/perl5
+%exclude %{_cross_docdir}
+%exclude %{_cross_libdir}/udev
+%exclude %{_cross_libexecdir}
+%exclude %{_cross_pkgconfigdir}
+%exclude %{_cross_sbindir}
+%exclude %{_cross_sysconfdir}
+%exclude %{_cross_unitdir}
+
+# Exclude all the unused libs
+%exclude %{_cross_libdir}/ibacm*
+%exclude %{_cross_libdir}/libbnxt*
+%exclude %{_cross_libdir}/libcxgb4*
+%exclude %{_cross_libdir}/liberdma*
+%exclude %{_cross_libdir}/libhfi1*
+%exclude %{_cross_libdir}/libhns*
+%exclude %{_cross_libdir}/libibmad*
+%exclude %{_cross_libdir}/libibnetdisc*
+%exclude %{_cross_libdir}/libibumad*
+%exclude %{_cross_libdir}/libmana*
+%exclude %{_cross_libdir}/libmlx*
+%exclude %{_cross_libdir}/libmthca*
+%exclude %{_cross_libdir}/libocrdma*
+%exclude %{_cross_libdir}/libqedr*
+%exclude %{_cross_libdir}/librxe*
+%exclude %{_cross_libdir}/libsiw*
+%exclude %{_cross_libdir}/libvmw*
+%exclude %{_cross_libdir}/rsocket
+
+# Exclude specific RDMA providers (keeping only libefa)
+%exclude %{_cross_libdir}/libibverbs/libbnxt_re-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libcxgb4-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/liberdma-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libhfi1verbs-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libhns-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libipathverbs-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libirdma-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libmana-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libmlx4-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libmlx5-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libmthca-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libocrdma-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libqedr-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/librxe-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libsiw-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libvmw_pvrdma-%{abiver}.so
+
+# Exclude udev rules
+%exclude %{_cross_udevrulesdir}
+
+# Exclude all the unused binaries
+%exclude %{_cross_bindir}/cmtime
+%exclude %{_cross_bindir}/ib_acme
+%exclude %{_cross_bindir}/ibv_asyncwatch
+%exclude %{_cross_bindir}/ibv_rc_pingpong
+%exclude %{_cross_bindir}/ibv_srq_pingpong
+%exclude %{_cross_bindir}/ibv_uc_pingpong
+%exclude %{_cross_bindir}/ibv_ud_pingpong
+%exclude %{_cross_bindir}/ibv_xsrq_pingpong
+%exclude %{_cross_bindir}/mckey
+%exclude %{_cross_bindir}/rcopy
+%exclude %{_cross_bindir}/rdma_client
+%exclude %{_cross_bindir}/rdma_server
+%exclude %{_cross_bindir}/rdma_xclient
+%exclude %{_cross_bindir}/rdma_xserver
+%exclude %{_cross_bindir}/riostream
+%exclude %{_cross_bindir}/rping
+%exclude %{_cross_bindir}/rstream
+%exclude %{_cross_bindir}/ucmatose
+%exclude %{_cross_bindir}/udaddy
+%exclude %{_cross_bindir}/udpong
+
+%files devel
+%dir %{_cross_includedir}/infiniband
+%dir %{_cross_includedir}/rdma
+%{_cross_includedir}/infiniband/*
+%{_cross_includedir}/rdma/*
+%{_cross_libdir}/libefa*
+%{_cross_libdir}/libibverbs*
+%{_cross_libdir}/librdmacm*
+
+%changelog


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to https://github.com/bottlerocket-os/bottlerocket/issues/1031

**Description of changes:**
Add `rdma-core` package to core-kit. This is part of the effort to fully support EFA in Bottlerocket first party AMI. We will use the helper programs provided by rdma-core for better troubleshoot and logging experience (will be added in follow up PR).

- Add helper program `ibv_devices` and `ibv_devinfo`
- Add minimum required libraries and drivers in `libibverbs`.
- Add logdog entries for rdma-core.



**Testing done:**

- [x] Built `aws-k8s-1.28-nvidia` and tested the helper binary.

```
bash-5.1# ibv_devinfo
hca_id: efa_0
        transport:                      unspecified (4)
        fw_ver:                         0.0.0.0
        node_guid:                      0000:0000:0000:0000
        sys_image_guid:                 0000:0000:0000:0000
        vendor_id:                      0x1d0f
        vendor_part_id:                 61344
        hw_ver:                         0xEFA0
        phys_port_cnt:                  1
                port:   1
                        state:                  PORT_ACTIVE (4)
                        max_mtu:                4096 (5)
                        active_mtu:             4096 (5)
                        sm_lid:                 0
                        port_lid:               0
                        port_lmc:               0x01
                        link_layer:             Unspecified


bash-5.1# ibv_devices
    device                 node GUID
    ------              ----------------
    efa_0               0000000000000000
```

- [x] Test logdog entries.
`logdog` command indicates the rdma-core related logs are produced
```
[root@admin]# sheltie logdog
....
Checking: /usr/share/logdog.d/logdog.rdma.conf
....
Running: exec ibv_devinfo.log ibv_devinfo
Running: glob /sys/class/infiniband/*/device/p2p
Running: glob /sys/class/infiniband/*/ports/1/hw_counters/*
logs are at: /var/log/support/bottlerocket-logs.tar.gz
```
Unzipped the log file and verified the contents:
```
[root@admin]# tar xzf /.bottlerocket/rootfs/var/log/support/bottlerocket-logs.tar.gz
[root@admin]# cd bottlerocket-logs/

[root@admin]# cat ibv_devinfo.log
hca_id: efa_0
        transport:                      unspecified (4)
        fw_ver:                         0.0.0.0
        node_guid:                      0000:0000:0000:0000
        sys_image_guid:                 0000:0000:0000:0000
        vendor_id:                      0x1d0f
        vendor_part_id:                 61344
        hw_ver:                         0xEFA0
        phys_port_cnt:                  1
                port:   1
                        state:                  PORT_ACTIVE (4)
                        max_mtu:                4096 (5)
                        active_mtu:             4096 (5)
                        sm_lid:                 0
                        port_lid:               0
                        port_lmc:               0x01
                        link_layer:             Unspecified

[root@admin]# cat sys/class/infiniband/efa_0/device/p2p

[root@admin]# cat sys/class/infiniband/efa_0/ports/1/hw_counters/
lifespan               rdma_read_resp_bytes   rdma_read_wrs          rdma_write_recv_bytes  rdma_write_wrs         recv_wrs               rx_drops               send_bytes             tx_bytes
rdma_read_bytes        rdma_read_wr_err       rdma_write_bytes       rdma_write_wr_err      recv_bytes             rx_bytes               rx_pkts                send_wrs               tx_pkts
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
