### PR TITLE
switch to AL23 as upstream for libkcapi

### DIFF
--- a/packages/libkcapi/Cargo.toml
+++ b/packages/libkcapi/Cargo.toml
@@ -8,12 +8,9 @@ build = "../build.rs"
 [lib]
 path = "../packages.rs"
 
-[package.metadata.build-package]
-releases-url = "https://github.com/smuellerDD/libkcapi/releases"
-
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/smuellerDD/libkcapi/archive/v1.5.0/libkcapi-1.5.0.tar.gz"
-sha512 = "510d0606cdc9479a77ed07bd3ac59b07c3996402a85cee012e6836d0a31cb06f5b7f715cdb76f3745784aab3154595caec4537b4c774236a139ebfe6e1a8be9b"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/0eef74b3b4eb1ec321bab80f867aee89b94dc9fc95571da58ea5bba7a70e6224/libkcapi-1.4.0-105.amzn2023.0.1.src.rpm"
+sha512 = "6498147434059343f1ccdd7efadcd425ad7074e41b4e019fc995129d5df326b781e0a61a4324e1ce8d6771162d1612b754ce24625fb3b1458811f6bde8f638c9"
 
 [build-dependencies]
 glibc = { path = "../glibc" }


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/1667

**Description of changes:**
This aligns libkcapi with the version specified in [the FIPS 140-3 security policy](https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4808.pdf) for the Amazon Linux 2023 Kernel Cryptographic API.

Bump the epoch to ensure that the "older" 1.4.0 version is preferred over the "newer" 1.5.0 version from past core kit releases.

Trim the set of installed files down to just the ones referenced by the security policy: `sha512hmac` and `libkcapi.so.1.4.0`.


**Testing done:**
Enabled the FIPS feature for `aws-dev` and verified that the kernel integrity check still works:
```
bash-5.2# cd /boot
bash-5.2# sha512hmac -c .vmlinuz.hmac
vmlinuz: OK
```

This operation implicitly checks the SHA-512 HMAC of `/usr/bin/sha512hmac` and the SHA-256 HMAC of `/usr/lib64/libkcapi.so.1.4.0`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
