### PR TITLE
kernel-6.1: add patch for blkio with cgroupsv1 

### DIFF
--- a/packages/kernel-6.1/1100-blk-throttle-Fix-io-statistics-for-cgroup-v1.patch
+++ b/packages/kernel-6.1/1100-blk-throttle-Fix-io-statistics-for-cgroup-v1.patch
@@ -1,0 +1,95 @@
+From 4c5b35e202a3dd2c0d0bf0715c695ef3cc6d902e Mon Sep 17 00:00:00 2001
+From: Jinke Han <hanjinke.666@bytedance.com>
+Date: Mon, 8 May 2023 01:06:31 +0800
+Subject: [PATCH] blk-throttle: Fix io statistics for cgroup v1
+
+After commit f382fb0bcef4 ("block: remove legacy IO schedulers"),
+blkio.throttle.io_serviced and blkio.throttle.io_service_bytes become
+the only stable io stats interface of cgroup v1, and these statistics
+are done in the blk-throttle code. But the current code only counts the
+bios that are actually throttled. When the user does not add the throttle
+limit, the io stats for cgroup v1 has nothing. I fix it according to the
+statistical method of v2, and made it count all ios accurately.
+
+Fixes: a7b36ee6ba29 ("block: move blk-throtl fast path inline")
+Tested-by: Andrea Righi <andrea.righi@canonical.com>
+Signed-off-by: Jinke Han <hanjinke.666@bytedance.com>
+Acked-by: Muchun Song <songmuchun@bytedance.com>
+Acked-by: Tejun Heo <tj@kernel.org>
+Link: https://lore.kernel.org/r/20230507170631.89607-1-hanjinke.666@bytedance.com
+Signed-off-by: Jens Axboe <axboe@kernel.dk>
+[bcressey:
+  - backport to 6.1
+  - adjust context in blk_cgroup_bio_start
+  - avoid changes from 3b8cc629 ("blk-cgroup: Optimize blkcg_rstat_flush()")]
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ block/blk-cgroup.c   | 6 ++++--
+ block/blk-throttle.c | 6 ------
+ block/blk-throttle.h | 9 +++++++++
+ 3 files changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/block/blk-cgroup.c b/block/blk-cgroup.c
+index 1b7fd1fc2f33..435432c4a62e 100644
+--- a/block/blk-cgroup.c
++++ b/block/blk-cgroup.c
+@@ -1969,6 +1969,9 @@ void blk_cgroup_bio_start(struct bio *bio)
+ 	struct blkg_iostat_set *bis;
+ 	unsigned long flags;
+
++	if (!cgroup_subsys_on_dfl(io_cgrp_subsys))
++		return;
++
+ 	cpu = get_cpu();
+ 	bis = per_cpu_ptr(bio->bi_blkg->iostat_cpu, cpu);
+ 	flags = u64_stats_update_begin_irqsave(&bis->sync);
+@@ -1984,8 +1987,7 @@ void blk_cgroup_bio_start(struct bio *bio)
+ 	bis->cur.ios[rwd]++;
+
+ 	u64_stats_update_end_irqrestore(&bis->sync, flags);
+-	if (cgroup_subsys_on_dfl(io_cgrp_subsys))
+-		cgroup_rstat_updated(bio->bi_blkg->blkcg->css.cgroup, cpu);
++	cgroup_rstat_updated(bio->bi_blkg->blkcg->css.cgroup, cpu);
+ 	put_cpu();
+ }
+
+diff --git a/block/blk-throttle.c b/block/blk-throttle.c
+index 62a3f62316df..ab847abe30b0 100644
+--- a/block/blk-throttle.c
++++ b/block/blk-throttle.c
+@@ -2176,12 +2176,6 @@ bool __blk_throtl_bio(struct bio *bio)
+
+ 	rcu_read_lock();
+
+-	if (!cgroup_subsys_on_dfl(io_cgrp_subsys)) {
+-		blkg_rwstat_add(&tg->stat_bytes, bio->bi_opf,
+-				bio->bi_iter.bi_size);
+-		blkg_rwstat_add(&tg->stat_ios, bio->bi_opf, 1);
+-	}
+-
+ 	spin_lock_irq(&q->queue_lock);
+
+ 	throtl_update_latency_buckets(td);
+diff --git a/block/blk-throttle.h b/block/blk-throttle.h
+index ef4b7a4de987..d1ccbfe9f797 100644
+--- a/block/blk-throttle.h
++++ b/block/blk-throttle.h
+@@ -185,6 +185,15 @@ static inline bool blk_should_throtl(struct bio *bio)
+ 	struct throtl_grp *tg = blkg_to_tg(bio->bi_blkg);
+ 	int rw = bio_data_dir(bio);
+
++	if (!cgroup_subsys_on_dfl(io_cgrp_subsys)) {
++		if (!bio_flagged(bio, BIO_CGROUP_ACCT)) {
++			bio_set_flag(bio, BIO_CGROUP_ACCT);
++			blkg_rwstat_add(&tg->stat_bytes, bio->bi_opf,
++					bio->bi_iter.bi_size);
++		}
++		blkg_rwstat_add(&tg->stat_ios, bio->bi_opf, 1);
++	}
++
+ 	/* iops limit is always counted */
+ 	if (tg->has_rules_iops[rw])
+ 		return true;
+--
+2.45.1
+

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -36,6 +36,9 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 # options for nvidia are instead included through DRM_SIMPLE
 Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
 
+# Fix cgroup v1 I/O statistics in blk-throttle to count all I/Os, not just throttled ones, aligning with cgroup v2 methods.
+Patch1100: 1100-blk-throttle-Fix-io-statistics-for-cgroup-v1.patch
+
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**
kernel-6.1: add patch for blkio when using cgroupsv1

**Testing done:**

With commit:

```
cat /sys/fs/cgroup/blkio/ecs/25754cf932b94a15b80eedeb05f6d0ae/200927c37cb9ea0980b7be3b50ebebf7e06168d2799f3ad5d634c01f775ff3f2/blkio.throttle.io_service_bytes_recursive                                                                                                                                         Tue Oct 29 20:53:41 2024

259:0 Read 0
259:0 Write 939524096
259:0 Sync 939524096
259:0 Async 0
259:0 Discard 0
259:0 Total 939524096
259:2 Read 90112
259:2 Write 0
259:2 Sync 90112
259:2 Async 0
259:2 Discard 0
259:2 Total 90112
252:0 Read 90112
252:0 Write 0
252:0 Sync 90112
252:0 Async 0
252:0 Discard 0
252:0 Total 90112
Total 939704320
```

Without commit:

```
bash-5.1# cat /sys/fs/cgroup/blkio/ecs/ead1cd68007a4927b73d5df762abfdb0/ec134ec4291269aea86f4d7cd5f383cf4b72e9bd07756c0e794f4a3c31c58a95/blkio.throttle.io_service_bytes_recursive
259:1 Read 0
259:1 Write 0
259:1 Sync 0
259:1 Async 0
259:1 Discard 0
259:1 Total 0
252:0 Read 0
252:0 Write 0
252:0 Sync 0
252:0 Async 0
252:0 Discard 0
252:0 Total 0
Total 0
```





**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
