### PR TITLE
Clarify license for open gpu driver

### DIFF
--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -71,7 +71,7 @@ Requires: %{name}-tesla(fabricmanager)
 %package open-gpu-%{tesla_major}
 Summary: NVIDIA %{tesla_major} Open GPU driver
 Version: %{tesla_ver}
-License: MIT OR GPL-2.0-only
+License: MIT AND GPL-2.0-only
 Requires: %{_cross_os}variant-platform(aws)
 
 %description open-gpu-%{tesla_major}

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -71,7 +71,7 @@ Requires: %{name}-tesla(fabricmanager)
 %package open-gpu-%{tesla_major}
 Summary: NVIDIA %{tesla_major} Open GPU driver
 Version: %{tesla_ver}
-License: MIT OR GPL-2.0-only
+License: MIT AND GPL-2.0-only
 Requires: %{_cross_os}variant-platform(aws)
 
 %description open-gpu-%{tesla_major}

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -71,7 +71,7 @@ Requires: %{name}-tesla(fabricmanager)
 %package open-gpu-%{tesla_major}
 Summary: NVIDIA %{tesla_major} Open GPU driver
 Version: %{tesla_ver}
-License: MIT OR GPL-2.0-only
+License: MIT AND GPL-2.0-only
 Requires: %{_cross_os}variant-platform(aws)
 
 %description open-gpu-%{tesla_major}


### PR DESCRIPTION
**Description of changes:**

The license was slight vague for the Open GPU driver in the kmod-*-nvidia packages. This adds punctuation to clarify the order.

**Testing done:**
Built the kit. No functional change.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
