### PR TITLE
Match EKS Optimized AMIs' TLS ciphers

### DIFF
--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -147,6 +147,13 @@ serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -148,6 +148,13 @@ serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -148,6 +148,13 @@ serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.27/kubelet-config
+++ b/packages/kubernetes-1.27/kubelet-config
@@ -149,6 +149,13 @@ serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -147,6 +147,13 @@ serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -147,6 +147,13 @@ serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -147,6 +147,13 @@ serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -147,6 +147,13 @@ serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
 {{/if}}
 tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_256_GCM_SHA384
+- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"


### PR DESCRIPTION
**Issue number:**

Related to https://github.com/bottlerocket-os/bottlerocket/issues/1667

**Description of changes:**

Match the TLS ciphers that the EKS Optimized AMIs use. This also helps with a problem observed in VMware variants, where the `kubelet` HTTPS server refused TLS connections in FIPS mode.

**Testing done:**

- [x] AWS k8s 1.24, `kubectl exec` and `kubectl logs` work
- [x] AWS k8s 1.25, `kubectl exec` and `kubectl logs` work
- [x] AWS k8s 1.26, `kubectl exec` and `kubectl logs` work
- [x] AWS k8s 1.27, `kubectl exec` and `kubectl logs` work
- [x] AWS k8s 1.28, `kubectl exec` and `kubectl logs` work
- [x] AWS k8s 1.29, `kubectl exec` and `kubectl logs` work
- [x] AWS k8s 1.30, `kubectl exec` and `kubectl logs` work
- [x] AWS k8s 1.31, `kubectl exec` and `kubectl logs` work
- [x] VMware k8s 1.28, `kubectl exec` and `kubectl logs` work
- [x] VMware k8s 1.29, `kubectl exec` and `kubectl logs` work
- [x] VMware k8s 1.30, `kubectl exec` and `kubectl logs` work
- [x] VMware k8s 1.31, `kubectl exec` and `kubectl logs` work

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
