### PR TITLE
cfsignal: add proxy support

### DIFF
--- a/packages/os/cfsignal.service
+++ b/packages/os/cfsignal.service
@@ -9,6 +9,7 @@ ConditionPathExists=!/var/lib/bottlerocket/cfsignal.ran
 
 [Service]
 Type=simple
+EnvironmentFile=/etc/network/proxy.env
 ExecStart=/usr/bin/cfsignal
 
 [Install]

--- a/sources/cfsignal/Cargo.toml
+++ b/sources/cfsignal/Cargo.toml
@@ -11,19 +11,19 @@ exclude = ["README.md"]
 fips = ["rustls/fips", "aws-lc-rs/fips", "aws-smithy-experimental/crypto-aws-lc-fips"]
 
 [dependencies]
-log.workspace = true
-serde = { workspace = true, features = ["derive"] }
-simplelog.workspace = true
-snafu.workspace = true
-toml.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 aws-config.workspace = true
 aws-lc-rs = { workspace = true, features = ["bindgen"] }
 aws-sdk-cloudformation.workspace = true
 aws-smithy-experimental = { workspace = true, features = ["crypto-aws-lc"] }
 aws-types.workspace = true
 imdsclient.workspace = true
+log.workspace = true
 rustls.workspace = true
+serde = { workspace = true, features = ["derive"] }
+simplelog.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+toml.workspace = true
 
 [build-dependencies]
 generate-readme.workspace = true


### PR DESCRIPTION
**Description of changes:**

Adds support for sending signals to CloudFormation through a set proxy.

**Testing done:**

Launched an `aws-ecs-2` node with the following userdata:

```toml
[settings.ecs]
cluster = "<MY_CLUSTER>"

[settings.network]
https-proxy = "<MY_PROXY>:8888"

[settings.cloudformation]
should-signal = true
stack-name = "<MY_STACK>"
logical-resource-id = "<MY_RESOURCE>"
```

Status of `cfsignal.service`:

```bash
bash-5.1# systemctl status cfsignal
○ cfsignal.service - Send signal to CloudFormation Stack
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/cfsignal.service; enabled; preset: enabled)
     Active: inactive (dead) since Fri 2024-11-01 00:19:10 UTC; 6min ago
   Duration: 2.483s
   Main PID: 1157 (code=exited, status=0/SUCCESS)
        CPU: 25ms

Nov 01 00:19:07 localhost systemd[1]: Started Send signal to CloudFormation Stack.
Nov 01 00:19:09 ip-XXX-XXX-XX-XX.us-west-2.compute.internal cfsignal[1157]: 00:19:09 [INFO] System status is: running [0]
Nov 01 00:19:09 ip-XXX-XXX-XX-XX.us-west-2.compute.internal cfsignal[1157]: 00:19:09 [INFO] Connecting to IMDS
Nov 01 00:19:10 ip-XXX-XXX-XX-XX.us-west-2.compute.internal cfsignal[1157]: 00:19:10 [INFO] Received meta-data/instance-id
Nov 01 00:19:10 ip-XXX-XXX-XX-XX.us-west-2.compute.internal cfsignal[1157]: 00:19:10 [INFO] Received dynamic/instance-identity/document
Nov 01 00:19:10 ip-XXX-XXX-XX-XX.us-west-2.compute.internal cfsignal[1157]: 00:19:10 [INFO] Region: "us-west-2" - InstanceID: "<MY_INSTANCE>" - Signal: "SUCCESS"
Nov 01 00:19:10 ip-XXX-XXX-XX-XX.us-west-2.compute.internal cfsignal[1157]: 00:19:10 [INFO] lazy_load_identity;
Nov 01 00:19:10 ip-XXX-XXX-XX-XX.us-west-2.compute.internal systemd[1]: cfsignal.service: Deactivated successfully.
```

Excerpts from CloudTrail:
```json
"eventName": "SignalResource",
"eventSource": "cloudformation.amazonaws.com",
"eventTime": "2024-11-01T00:19:10Z",
"eventType": "AwsApiCall",
"eventVersion": "1.08",
"managementEvent": true,
"readOnly": false,
```
...
```json
"requestParameters": {
    "logicalResourceId": "<MY_RESOURCE>",
    "stackName": "<MY_STACK>",
    "status": "SUCCESS",
    "uniqueId": "<MY_INSTANCE>"
},
```
...
```json
"sourceIPAddress": "<MY_PROXY>",
"userAgent": "aws-sdk-rust/1.3.3 os/linux lang/rust/1.81.0",
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
