### PR TITLE
Update kernels 5.10 and 5.15

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/c7942aadb77fa921637155fdd357a91a8deaf85f3d024fb5b5371052c8309426/kernel-5.10.226-214.880.amzn2.src.rpm"
-sha512 = "2992e8cb9662a8e53ca5f9cfb56dad8706fc95147cef4bb15c312406eb55cdbbc19f7584808c1b641c0b094428a3e701e15d83e545d6b9e61d107fc95b7e98f4"
+url = "https://cdn.amazonlinux.com/blobstore/a9b5c6b9ca0d2a84e4dc3b963a73017a055d602139d2293ff394d33b08111be7/kernel-5.10.227-219.884.amzn2.src.rpm"
+sha512 = "6729b3ef34c451685d29b736a1a98a6487d158707f503ae35cb0427daf034a442d8768e3cc0db3781bb4b17f316fd53811a211892be52c7f8d2feadf7773611c"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.226
+Version: 5.10.227
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/c7942aadb77fa921637155fdd357a91a8deaf85f3d024fb5b5371052c8309426/kernel-5.10.226-214.880.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/a9b5c6b9ca0d2a84e4dc3b963a73017a055d602139d2293ff394d33b08111be7/kernel-5.10.227-219.884.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/6e5bde865f2f534b3e5c1ae2c3065e711f6c55b7fa5e4f91f0dc55894b1ad844/kernel-5.15.167-112.166.amzn2.src.rpm"
-sha512 = "90ca9a2ee14e34a34ddcd6d8d24904bccc5d9ce8560c211fad1a01ed451996aecc3d6bb5b0982fddcbb426b552701d809cfc68506bf3123f77c16a72b844a8dc"
+url = "https://cdn.amazonlinux.com/blobstore/9cea3dae03703f3c4c78fcb1302eeee5fe4c07ebf53d783cf3aaf7e4f30a6d39/kernel-5.15.168-114.166.amzn2.src.rpm"
+sha512 = "5b0b0e2640bb04d4868b8820781029d8148c7939802c1b4edcf580533848afe70f7c6372e6e2306dfc017d2b32120a446ada15b105f7b2fe766b9382f83937d3"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.167
+Version: 5.15.168
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/6e5bde865f2f534b3e5c1ae2c3065e711f6c55b7fa5e4f91f0dc55894b1ad844/kernel-5.15.167-112.166.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/9cea3dae03703f3c4c78fcb1302eeee5fe4c07ebf53d783cf3aaf7e4f30a6d39/kernel-5.15.168-114.166.amzn2.src.rpm
 Source100: config-bottlerocket
 
 # Help out-of-tree module builds run `make prepare` automatically.


### PR DESCRIPTION
**Description of changes:**
Update kernel-5.10 to upstream 5.10.227 and kernel-5.15 to 5.15.168.

Patch changes: 
* In 5.10, improve nvme-passthrough handling of metadata.
* In both kernels, revert earlier patches to ext4 filesystem code.

Configuration changes:
* 5.10, aarch64: disable AMD GPU
* enable CONFIG_PROC_MEM_ALWAYS_FORCE

**Testing done:**

aws-ecs-1 (kernel 5.10) and aws-k8s-1.25 (kernel 5.15) AMIs boot on both architectures.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
