### PR TITLE
Prepare 3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v3.1.4 (2024-11-01)
+
+## OS Changes
+* Update kernel 5.10.227 and kernel 5.15.168 ([#235])
+
+[#235]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/235
+
 # v3.1.3 (2024-10-31)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "3.1.3"
+release-version = "3.1.4"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"


### PR DESCRIPTION
**Description of changes:**

Prepare for version 3.1.4 of core kit:
* Update changelog
* Bump version in Twoliter.toml

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
