### PR TITLE
vscode: Add insertFinalNewline to workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "rust-analyzer.linkedProjects": [
         "sources/Cargo.toml"
-    ]
+    ],
+    "files.insertFinalNewline": true
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Github will show a red symbol warning about no newline at end of file.

Adding `insertFinalNewline` to enforce that final newline will be present upon saving any code change within the workspace.




**Testing done:**
N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
