### PR TITLE
Set AWS_SDK_LOAD_CONFIG for system services

### DIFF
--- a/packages/release/aws-config.conf
+++ b/packages/release/aws-config.conf
@@ -1,0 +1,5 @@
+[Service]
+# Set the AWS_SDK_LOAD_CONFIG system-wide instead of at the individual service
+# level, to make sure new system services that use the AWS SDK for Go read the
+# shared AWS config
+Environment=AWS_SDK_LOAD_CONFIG=true

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -87,6 +87,7 @@ Source1100: systemd-tmpfiles-setup-service-debug.conf
 Source1101: systemd-resolved-service-env.conf
 Source1102: systemd-networkd-service-env.conf
 Source1103: systemd-logind-inhibit-maxdelay.conf
+Source1104: aws-config.conf
 
 # network link rules
 Source1200: 80-release.link
@@ -168,6 +169,9 @@ install -p -m 0644 %{S:96} %{buildroot}%{_cross_libdir}/repart.d/80-local.conf
 
 install -d %{buildroot}%{_cross_sysctldir}
 install -p -m 0644 %{S:97} %{buildroot}%{_cross_sysctldir}/80-release.conf
+
+install -d %{buildroot}%{_cross_unitdir}/service.d
+install -p -m 0644 %{S:1104} %{buildroot}%{_cross_unitdir}/service.d/00-aws-config.conf
 
 install -d %{buildroot}%{_cross_libdir}/systemd/system.conf.d
 install -p -m 0644 %{S:98} %{buildroot}%{_cross_libdir}/systemd/system.conf.d/80-release.conf
@@ -312,6 +316,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/prepare-local-fs.service
 %{_cross_unitdir}/deprecation-warning@.service
 %{_cross_unitdir}/deprecation-warning@.timer
+%{_cross_unitdir}/service.d/00-aws-config.conf
 %dir %{_cross_unitdir}/systemd-resolved.service.d
 %{_cross_unitdir}/systemd-resolved.service.d/00-env.conf
 %dir %{_cross_unitdir}/systemd-networkd.service.d


### PR DESCRIPTION
**Issue number:**

Related: https://github.com/bottlerocket-os/bottlerocket/issues/1667

**Description of changes:**

The AWS SDK for Go doesn't use the `${HOME}/.aws/config` file unless the `AWS_SDK_LOAD_CONFIG` env variable is set to a truthy value. This applies to both [v1](https://github.com/aws/aws-sdk-go/blob/7112c0a0c2d01713a9db2d57f0e5722225baf5b5/README.md?plain=1#L257) and [v2](https://github.com/aws/aws-sdk-go-v2/blob/061540b5a73ead172928c9c5aebc48c011bf4ee1/credentials/processcreds/doc.go#L22) versions of the AWS SDK for Go. The AWS SDK for Rust [doesn't require](https://github.com/smithy-lang/smithy-rs/blob/62caa4639497bc9b18f57e51a30265899d9b511e/aws/SDK_README.md.hb#L40) `AWS_SDK_LOAD_CONFIG` to be set to read `${HOME}/.aws/config`

**Testing done:**

In an `aws-ecs-2-fips` variant which defaults to have an AWS config as:

```
[default]
use_fips_endpoint=true
```

Without the environment variable set, the ECS agent used the default AWS endpoints. With the environment variable set and the same AWS confg as above, the ECS agent used the FIPS endpoints:

```
[root@admin]# sheltie journalctl -u systemd-resolved.service | grep fips
systemd-resolved[5806]: Looking up RR for ecs-fips.us-west-2.amazonaws.com IN AAAA.
systemd-resolved[5806]: Cache miss for ecs-fips.us-west-2.amazonaws.com IN AAAA
systemd-resolved[5806]: Firing regular transaction 38590 for <ecs-fips.us-west-2.amazonaws.com IN AAAA> scope dns on eth0/* (validate=yes).
systemd-resolved[5806]: Looking up RR for ecs-fips.us-west-2.amazonaws.com IN A.
systemd-resolved[5806]: Cache miss for ecs-fips.us-west-2.amazonaws.com IN A
systemd-resolved[5806]: Firing regular transaction 35110 for <ecs-fips.us-west-2.amazonaws.com IN A> scope dns on eth0/* (validate=yes).
systemd-resolved[5806]: Not caching negative entry for: ecs-fips.us-west-2.amazonaws.com IN AAAA, cache mode set to no-negative
systemd-resolved[5806]: Regular transaction 38590 for <ecs-fips.us-west-2.amazonaws.com IN AAAA> on scope dns on eth0/* now complete with <success> from network (unsigned; non-confidential).
systemd-resolved[5806]: Added positive unauthenticated non-confidential cache entry for ecs-fips.us-west-2.amazonaws.com IN A 60s on eth0/INET/172.31.0.2
systemd-resolved[5806]: Regular transaction 35110 for <ecs-fips.us-west-2.amazonaws.com IN A> on scope dns on eth0/* now complete with <success> from network (unsigned; non-confidential).
systemd-resolved[5806]: Looking up RR for ecs-fips.us-west-2.amazonaws.com IN AAAA.
systemd-resolved[5806]: Cache miss for ecs-fips.us-west-2.amazonaws.com IN AAAA
systemd-resolved[5806]: Firing regular transaction 26730 for <ecs-fips.us-west-2.amazonaws.com IN AAAA> scope dns on eth0/* (validate=yes).
systemd-resolved[5806]: Looking up RR for ecs-fips.us-west-2.amazonaws.com IN A.
systemd-resolved[5806]: Positive cache hit for ecs-fips.us-west-2.amazonaws.com IN A
systemd-resolved[5806]: Regular transaction 25613 for <ecs-fips.us-west-2.amazonaws.com IN A> on scope dns on eth0/* now complete with <success> from cache (unsigned; non-confidential).
systemd-resolved[5806]: Not caching negative entry for: ecs-fips.us-west-2.amazonaws.com IN AAAA, cache mode set to no-negative
systemd-resolved[5806]: Regular transaction 26730 for <ecs-fips.us-west-2.amazonaws.com IN AAAA> on scope dns on eth0/* now complete with <success> from network (unsigned; non-confidential).
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
