### PR TITLE
advisories: backfill kernels BRSAs for 3.1.4

### DIFF
--- a/advisories/3.1.4/BRSA-0hz1ashhuthf.toml
+++ b/advisories/3.1.4/BRSA-0hz1ashhuthf.toml
@@ -1,0 +1,25 @@
+[advisory]
+id = "BRSA-0hz1ashhuthf"
+title = "kernel CVE-2024-46865"
+cve = "CVE-2024-46865"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: fou: fix initialization of grc"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "5.10.227"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "5.15.168"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "kssessio"
+issue-date = 2024-11-01T22:39:19Z
+arches = ["x86_64", "aarch64"]
+version = "3.1.4"
+

--- a/advisories/3.1.4/BRSA-a8saejq9c4ul.toml
+++ b/advisories/3.1.4/BRSA-a8saejq9c4ul.toml
@@ -1,0 +1,25 @@
+[advisory]
+id = "BRSA-a8saejq9c4ul"
+title = "kernel CVE-2024-46695"
+cve = "CVE-2024-46695"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: selinux,smack: don't bypass permissions check in inode_setsecctx hook"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "5.10.227"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "5.15.168"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "kssessio"
+issue-date = 2024-11-01T22:39:19Z
+arches = ["x86_64", "aarch64"]
+version = "3.1.4"
+

--- a/advisories/3.1.4/BRSA-jr1scivexljd.toml
+++ b/advisories/3.1.4/BRSA-jr1scivexljd.toml
@@ -1,0 +1,19 @@
+[advisory]
+id = "BRSA-jr1scivexljd"
+title = "kernel CVE-2024-46855"
+cve = "CVE-2024-46855"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: netfilter: nft_socket: fix sk refcount leaks"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "5.15.168"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "kssessio"
+issue-date = 2024-11-01T22:39:19Z
+arches = ["x86_64", "aarch64"]
+version = "3.1.4"
+

--- a/advisories/3.1.4/BRSA-khvn4nh2ukbb.toml
+++ b/advisories/3.1.4/BRSA-khvn4nh2ukbb.toml
@@ -1,0 +1,19 @@
+[advisory]
+id = "BRSA-khvn4nh2ukbb"
+title = "kernel CVE-2024-38632"
+cve = "CVE-2024-38632"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: vfio/pci: fix potential memory leak in vfio_intx_enable()"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "5.15.168"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "kssessio"
+issue-date = 2024-11-01T22:39:19Z
+arches = ["aarch64", "x86_64"]
+version = "3.1.4"
+

--- a/advisories/3.1.4/BRSA-w7yqxdlauzyr.toml
+++ b/advisories/3.1.4/BRSA-w7yqxdlauzyr.toml
@@ -1,0 +1,25 @@
+[advisory]
+id = "BRSA-w7yqxdlauzyr"
+title = "kernel CVE-2024-46858"
+cve = "CVE-2024-46858"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: mptcp: pm: Fix uaf in __timer_delete_sync"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "5.10.227"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "5.15.168"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "kssessio"
+issue-date = 2024-11-01T22:39:19Z
+arches = ["x86_64", "aarch64"]
+version = "3.1.4"
+

--- a/advisories/3.1.4/BRSA-yhcguys2vixo.toml
+++ b/advisories/3.1.4/BRSA-yhcguys2vixo.toml
@@ -1,0 +1,25 @@
+[advisory]
+id = "BRSA-yhcguys2vixo"
+title = "kernel CVE-2024-26921"
+cve = "CVE-2024-26921"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: inet: inet_defrag: prevent sk release while still in use"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "5.10.227"
+patched-release = "0"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "5.15.168"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "kssessio"
+issue-date = 2024-11-01T22:39:19Z
+arches = ["x86_64", "aarch64"]
+version = "3.1.4"
+


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**
* Backfill advisories for 5.10/5.15 kernel



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
