### PR TITLE
kubelet: drop insecure ciphers

### DIFF
--- a/packages/kubernetes-1.24/kubelet-config
+++ b/packages/kubernetes-1.24/kubelet-config
@@ -152,8 +152,6 @@ tlsCipherSuites:
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -153,8 +153,6 @@ tlsCipherSuites:
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -153,8 +153,6 @@ tlsCipherSuites:
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.27/kubelet-config
+++ b/packages/kubernetes-1.27/kubelet-config
@@ -154,8 +154,6 @@ tlsCipherSuites:
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -152,8 +152,6 @@ tlsCipherSuites:
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -152,8 +152,6 @@ tlsCipherSuites:
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -152,8 +152,6 @@ tlsCipherSuites:
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -152,8 +152,6 @@ tlsCipherSuites:
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_256_GCM_SHA384
-- TLS_RSA_WITH_AES_128_GCM_SHA256
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
 staticPodPath: "/etc/kubernetes/static-pods/"


### PR DESCRIPTION

**Issue number:**

Closes #238

**Description of changes:**

Remove the ciphers marked by the kubelet as insecure:
- TLS_RSA_WITH_AES_256_GCM_SHA384
- TLS_RSA_WITH_AES_128_GCM_SHA256

**Testing done:**

In `vmware-k8s-1.31-fips`, I don't see the logs:

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "f375c033-dirty",
    "pretty_name": "Bottlerocket OS 1.27.0 (vmware-k8s-1.31-fips)",
    "variant_id": "vmware-k8s-1.31-fips",
    "version_id": "1.27.0"
  }
}
bash-5.1# journalctl -u kubectl.service | grep insecure
bash-5.1#
```

I still can `exec` to a running container:

```bash
$ k --kubeconfig br-eksa-131-fips-ng-eks-a-cluster.kubeconfig exec cilium-2lgcx -n kube-system -- cat /etc/os-release
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), clean-cilium-state (init), install-cni-binaries (init)
PRETTY_NAME="Ubuntu 22.04.4 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.4 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```

In `aws-k8s-1.30`, I no longer see the logs:

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "f375c033-dirty",
    "pretty_name": "Bottlerocket OS 1.27.0 (aws-k8s-1.30)",
    "variant_id": "aws-k8s-1.30",
    "version_id": "1.27.0"
  }
}
bash-5.1# journalctl -u kubelet.service | grep insecure
bash-5.1#
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
