### PR TITLE
packages: update libnvidia-container and nvidia-container-toolkit to v1.17.0

### DIFF
--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "3.1.5"
+release-version = "3.1.6"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.16.2/libnvidia-container-1.16.2.tar.gz"
-sha512 = "fd24a7eb12b861e5e5712ea5bc3f70c44e19d84c57431ed992d1cbb41d6a057b219886bb6d60d166556ad9843ca142b91cca5de956d0558fffd6a0931f3ad654"
+url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.17.0/libnvidia-container-1.17.0.tar.gz"
+sha512 = "cdb3dba9033414211d5d41c623ef71cd7296be4e8f87a03afcb557fb27c3fa2212c55479cd3235f935426ca7b48e9d616753cbd9b85d38f7e8d1fa5208cc9419"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/NVIDIA/nvidia-modprobe/archive/550.54.14/nvidia-modprobe-550.54.14.tar.gz"

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -1,7 +1,7 @@
 %global nvidia_modprobe_version 550.54.14
 
 Name: %{_cross_os}libnvidia-container
-Version: 1.16.2
+Version: 1.17.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: NVIDIA container runtime library

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.16.2/nvidia-container-toolkit-1.16.2.tar.gz"
-sha512 = "529baa5335232bd7d3eb13cbe92a81c2e22459445fa2476e10d5199f1b2be342d57db0545b8834ea47aeac51e8abf2ae9eb54c001bdbb22fb4da7ea55f89078e"
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.17.0/nvidia-container-toolkit-1.17.0.tar.gz"
+sha512 = "339e823ccd231cf7f140fceb036cc06b88b8e3af3acd90c5e0dc1edc8c7479e6e7122d7a10054005e42f88201701dad2501edd4b8016b05b6d343cd0f1132f22"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 %global gorepo nvidia-container-toolkit
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.16.2
+%global gover 1.17.0
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-container-toolkit


### PR DESCRIPTION
**Testing done:**
* Ensured that GPU resources were exposed to k8s pods

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
