### PR TITLE
Enable rdma core in release

### DIFF
--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -67,7 +67,7 @@ Requires: %{name}-devel = %{version}-%{release}
 # Pull in platform-dependent boot config snippets.
 Requires: (%{name}-bootconfig-aws if %{_cross_os}variant-platform(aws))
 Requires: (%{name}-bootconfig-vmware if %{_cross_os}variant-platform(vmware))
-Requires: (%{name}-bootconfig-metal if %{_cross_os}variant-platform(vmware))
+Requires: (%{name}-bootconfig-metal if %{_cross_os}variant-platform(metal))
 
 # Pull in platform-dependent modules.
 Requires: (%{name}-modules-metal if %{_cross_os}variant-platform(metal))

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -129,6 +129,7 @@ Requires: %{_cross_os}os
 Requires: %{_cross_os}pciutils
 Requires: %{_cross_os}policycoreutils
 Requires: %{_cross_os}procps
+Requires: (%{_cross_os}rdma-core if %{_cross_os}variant-platform(aws))
 Requires: %{_cross_os}selinux-policy
 Requires: %{_cross_os}shim
 Requires: %{_cross_os}systemd


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

**Description of changes:**
- Add `rdma-core` to all "aws-*" variants.
- Fixed a typo in kernel-6.1 where the `%{name}-bootconfig-vmware` was loaded for metal variant.


**Testing done:**
Test building an (aws-k8s-1.27-nvidia) variant with this change in [BoB repo](https://github.com/bottlerocket-os/bottlerocket/pull/4290), consuming from a personal kit.

Also verified that the EFA drivers are available in the 5.15 and 5.10 kernels, so it checks the compatibility box of the rdma-core package.

RDMA helpers are working as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
