### PR TITLE
add libstdc++ subpackage to libgcc

### DIFF
--- a/packages/libgcc/libgcc.spec
+++ b/packages/libgcc/libgcc.spec
@@ -1,5 +1,5 @@
-# This is a wrapper package that vends a pre-built shared library from
-# the SDK, allowing it to be loaded at runtime. It also lets us extract
+# This is a wrapper package that vends pre-built shared libraries from
+# the SDK, allowing them to be loaded at runtime. It also lets us extract
 # debuginfo in the usual way.
 %undefine _debugsource_packages
 
@@ -14,20 +14,37 @@ URL: https://gcc.gnu.org/
 %description
 %{summary}.
 
+%package -n %{_cross_os}libstdc++
+Summary: GCC C++ standard library
+License: GPL-3.0-or-later WITH GCC-exception-3.1
+Requires: %{_cross_os}libgcc
+
+%description -n %{_cross_os}libstdc++
+%{summary}.
+
 %prep
 %setup -T -c
 cp %{_cross_licensedir}/gcc/COPYING{3,.RUNTIME} .
 
 %build
 install -p -m0755 %{_cross_libdir}/libgcc_s.so.1 .
+install -p -m0755 %{_cross_libdir}/libstdc++.so.6.* .
 
 %install
 mkdir -p %{buildroot}%{_cross_libdir}
 install -p -m0755 libgcc_s.so.1 %{buildroot}%{_cross_libdir}
+install -p -m0755 libstdc++.so.6.* %{buildroot}%{_cross_libdir}
+for lib in $(find %{buildroot}%{_cross_libdir} -name 'libstdc++.so.6.*') ; do
+  ln -s "${lib##*/}" %{buildroot}%{_cross_libdir}/libstdc++.so.6
+done
 
 %files
 %license COPYING3 COPYING.RUNTIME
 %{_cross_attribution_file}
 %{_cross_libdir}/libgcc_s.so.1
+
+%files -n %{_cross_os}libstdc++
+%{_cross_libdir}/libstdc++.so.6
+%{_cross_libdir}/libstdc++.so.6.*
 
 %changelog


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/issues/215

**Description of changes:**
Add a `libstdc++` subpackage to the `libgcc` package, so that downstream packages that use C++ can arrange for the library to be installed at runtime without including it in their own files.


**Testing done:**
Extracted the packaged files and confirmed that the library and symlink were correct:
```
❯ ls -latr ./*-bottlerocket-linux-gnu/sys-root/usr/lib/
./aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/:
total 2176
lrwxrwxrwx. 1 fedora fedora      19 Nov 11 19:59 libstdc++.so.6 -> libstdc++.so.6.0.29
-rwxr-xr-x. 1 fedora fedora 2216376 Nov 11 19:59 libstdc++.so.6.0.29

./x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/:
total 2212
lrwxrwxrwx. 1 fedora fedora      19 Nov 11 18:53 libstdc++.so.6 -> libstdc++.so.6.0.29
-rwxr-xr-x. 1 fedora fedora 2256504 Nov 11 18:53 libstdc++.so.6.0.29
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
