### PR TITLE
feat: add nvidia MIG

### DIFF
--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -5,7 +5,11 @@ std = { version = "v1", helpers = ["default"] }
 +++
 version: v1
 flags:
+  {{#if (eq settings.kubelet-device-plugins.nvidia.device-partitioning-strategy "mig")}}
+  migStrategy: "single"
+  {{else}}
   migStrategy: "none"
+  {{/if}}
   failOnInitError: true
   plugin:
     passDeviceSpecs: {{default true settings.kubelet-device-plugins.nvidia.pass-device-specs}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-mig-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-mig-conf
@@ -1,0 +1,10 @@
+[required-extensions]
+kubelet-device-plugins = "v1"
+std = { version = "v1", helpers = ["if_not_null", "toml_encode"]}
++++
+{{#if_not_null settings.kubelet-device-plugins.nvidia.device-partitioning-strategy}}
+device-partitioning-strategy = "{{{settings.kubelet-device-plugins.nvidia.device-partitioning-strategy}}}"
+{{/if_not_null}}
+{{#if_not_null settings.kubelet-device-plugins.nvidia.mig.profile}}
+profile = {{ toml_encode settings.kubelet-device-plugins.nvidia.mig.profile }}
+{{/if_not_null}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -16,6 +16,7 @@ Source0: https://%{goimport}/archive/v%{gover}/v%{gover}.tar.gz#/k8s-device-plug
 Source1: nvidia-k8s-device-plugin.service
 Source2: nvidia-k8s-device-plugin-conf
 Source3: nvidia-k8s-device-plugin-exec-start-conf
+Source4: nvidia-k8s-device-plugin-mig-conf
 
 
 BuildRequires: %{_cross_os}glibc-devel
@@ -69,6 +70,7 @@ install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
 install -D -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-conf
 install -D -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-exec-start-conf
+install -D -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-mig-conf
 
 
 %files
@@ -78,6 +80,7 @@ install -D -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-pl
 %dir %{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
 %{_cross_templatedir}/nvidia-k8s-device-plugin-conf
 %{_cross_templatedir}/nvidia-k8s-device-plugin-exec-start-conf
+%{_cross_templatedir}/nvidia-k8s-device-plugin-mig-conf
 
 %files bin
 %{_cross_bindir}/nvidia-device-plugin

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1255,8 +1255,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.7.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+version = "0.8.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -1291,7 +1291,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1324,8 +1324,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.7.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+version = "0.8.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1388,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "serde",
 ]
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -4559,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4572,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4585,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4625,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4638,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4651,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4664,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4677,7 +4677,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4702,8 +4702,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4730,7 +4730,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4834,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.7.0#2a7c0986846eb98122e6812634d0526988a72c64"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -211,13 +211,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
-version = "0.7.0"
+tag = "bottlerocket-settings-models-v0.8.0"
+version = "0.8.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
-version = "0.7.0"
+tag = "bottlerocket-settings-models-v0.8.0"
+version = "0.8.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -226,7 +226,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.7.0"
+tag = "bottlerocket-settings-models-v0.8.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: 
* https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/63
* https://github.com/bottlerocket-os/bottlerocket/issues/4252


**Description of changes:**
Adding nvidia-migmanager service and binary that configures the instance with nvidia mig.  

**Testing done:**

1. Instance joined the cluster

```
NAME                                           STATUS   ROLES    AGE   VERSION
ip-XXXX.us-west-2.compute.internal   Ready    <none>   15h   v1.29.5-eks-1109419
```

2. Model Default:

```
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-partitioning-strategy": "none",
        "device-sharing-strategy": "none",
        "pass-device-specs": true
      }
    }
  }
}
```

3. Model Updates:
```
bash-5.1#: apiclient set settings.kubelet-device-plugins.nvidia.device-partitioning-strategy="mig"
bash-5.1#: apiclient set settings.kubelet-device-plugins.nvidia.mig.profile."a100-40gb"="1g.5gb"
bash-5.1# apiclient get settings.kubelet-device-plugin
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-partitioning-strategy": "mig",
        "device-sharing-strategy": "none",
        "mig": {
          "profile": {
            "a100-40gb": "1g.5gb"
          }
        },
        "pass-device-specs": true
      }
    }
  }
}
```

`kubectl describe node` shows 56 gpus post instance reboot.

4. Bounded check:

```
bash-5.1# apiclient apply <<EOF
> [settings.kubelet-device-plugins.nvidia.mig.profile]
> "hello"="1g.5gb"
> EOF
Failed to apply settings: Failed to PATCH settings from '-' to '/settings?tx=apiclient-apply-7NsnlaurtHEacSYL': Status 400 when PATCHing /settings?tx=apiclient-apply-7NsnlaurtHEacSYL: Json deserialize error: Unable to deserialize into NvidiaGPUModel: NVIDIA GPU Model must match '^([a-z])(\d+)\.(\d+)gb$', given: hello at line 1 column 62
bash-5.1# apiclient apply <<EOF
> [settings.kubelet-device-plugins.nvidia.mig.profile]
> "a100.40gb"="2"
> EOF
bash-5.1# apiclient apply <<EOF
> [settings.kubelet-device-plugins.nvidia.mig.profile]
> "a100.40gb"="5"
> EOF
Failed to apply settings: Failed to PATCH settings from '-' to '/settings?tx=apiclient-apply-GzUHB0axGlWNPzGw': Status 400 when PATCHing /settings?tx=apiclient-apply-GzUHB0axGlWNPzGw: Json deserialize error: Unable to deserialize into MIGProfile: MIG Profile must match '^[0-9]g\.\d+gb$', given: 5 at line 1 column 71
```

5. Files generated:


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
