### PR TITLE
kernel: disable BPF preload and bpfilter helpers

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -119,6 +119,12 @@ CONFIG_BOOT_CONFIG=y
 # Enables support for checkpoint/restore
 CONFIG_CHECKPOINT_RESTORE=y
 
+# Disable user-mode helpers for BPF preload and bpfilter, since they rely on a
+# more complete set of userspace libraries for the target than we want to
+# depend on at kernel build time.
+# CONFIG_BPF_PRELOAD_UMD is not set
+# CONFIG_BPFILTER_UMH is not set
+
 # Disable unused filesystems.
 # CONFIG_AFS_FS is not set
 # CONFIG_CRAMFS is not set

--- a/packages/kernel-5.15/config-bottlerocket
+++ b/packages/kernel-5.15/config-bottlerocket
@@ -132,6 +132,12 @@ CONFIG_BOOT_CONFIG=y
 # Enables support for checkpoint/restore
 CONFIG_CHECKPOINT_RESTORE=y
 
+# Disable user-mode helpers for BPF preload and bpfilter, since they rely on a
+# more complete set of userspace libraries for the target than we want to
+# depend on at kernel build time.
+# CONFIG_BPF_PRELOAD_UMD is not set
+# CONFIG_BPFILTER_UMH is not set
+
 # Disable unused filesystems.
 # CONFIG_AFS_FS is not set
 # CONFIG_CRAMFS is not set

--- a/packages/kernel-6.1/config-bottlerocket
+++ b/packages/kernel-6.1/config-bottlerocket
@@ -162,6 +162,11 @@ CONFIG_BOOT_CONFIG=y
 # Enables support for checkpoint/restore
 CONFIG_CHECKPOINT_RESTORE=y
 
+# Disable user-mode helper for bpfilter, since it relies on a more complete set
+# of userspace libraries for the target than we want to depend on at kernel
+# build time.
+# CONFIG_BPFILTER_UMH is not set
+
 # Disable unused filesystems.
 # CONFIG_AFS_FS is not set
 # CONFIG_CRAMFS is not set


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/222

**Description of changes:**
The kernel build will automatically enable these helpers if it finds that the target C compiler can build a userspace program that depends on the C library. However, the helpers require additional libraries such as libelf which are not guaranteed to be present.

Since we don't make use of precompiled BPF programs, disable these config options rather than leaving it up to auto-detect.


**Testing done:**
With the current SDK that **does not** include glibc, `diff-kernel-config` reports no differences in the config files.

With a custom SDK that **does** include glibc, `diff-kernel-config` reports these changes:
```
==> configs-4/config-aarch64-5.10-diff <==
+BPFILTER_UMH n
+BPF_PRELOAD_UMD n
+CC_CAN_LINK y
+CC_CAN_LINK_STATIC y

==> configs-4/config-aarch64-5.15-diff <==
+BPFILTER_UMH n
+BPF_PRELOAD_UMD n
+CC_CAN_LINK y
+CC_CAN_LINK_STATIC y

==> configs-4/config-aarch64-6.1-diff <==
+BPFILTER_UMH n
+CC_CAN_LINK y
+CC_CAN_LINK_STATIC y

==> configs-4/config-x86_64-5.10-diff <==
+BPFILTER_UMH n
+BPF_PRELOAD_UMD n
+CC_CAN_LINK y
+CC_CAN_LINK_STATIC y

==> configs-4/config-x86_64-5.15-diff <==
+BPFILTER_UMH n
+BPF_PRELOAD_UMD n
+CC_CAN_LINK y
+CC_CAN_LINK_STATIC y

==> configs-4/config-x86_64-6.1-diff <==
+BPFILTER_UMH n
+CC_CAN_LINK y
+CC_CAN_LINK_STATIC y
```

Note that `CC_CAN_LINK` and `CC_CAN_LINK_STATIC` will be set automatically because the more complete sys-roots allow the target C compiler to compile a test program.

The other values are newly added and are set to "no" to prevent the kernel build from failing when `libelf` is not found, since that library is not present in the SDK's sys-roots.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
