### PR TITLE
Use upstream sources for packages sourced from Amazon Linux

### DIFF
--- a/packages/grub/Cargo.toml
+++ b/packages/grub/Cargo.toml
@@ -11,3 +11,4 @@ path = "../packages.rs"
 [[package.metadata.build-package.external-files]]
 url = "https://cdn.amazonlinux.com/al2023/blobstore/f4fa28cb4e1586d622925449b1e24748c6ab09ccebe0fd8ddfa20cf5e7ce182a/grub2-2.06-61.amzn2023.0.9.src.rpm"
 sha512 = "57886df0580f166bd741126f19109a0e464bc2408aafca38e68def077a2ab1f64c239d85015c44162b88d787da7ec55a623f4e7d2601942391f0996038393f99"
+force-upstream = true

--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -15,11 +15,13 @@ path = "../packages.rs"
 # Use latest-kernel-srpm-url.sh to get this.
 url = "https://cdn.amazonlinux.com/blobstore/0af5f80d00a3d5a867d4959d74751bc7d24b1bcb0ab8a5de558ae301ae0fa52e/kernel-5.10.228-219.884.amzn2.src.rpm"
 sha512 = "124c6d662c48dc4cb8caf035e9ee44c9c47bc5e19141c319b94abc441dce4e2afa24e30b9c0196665aa267b6ef85004153b3f5cddfe9191c2c8927ddb4175fbd"
+force-upstream = true
 
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm-url.sh to get this.
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.18.12.0.noarch.rpm"
 sha512 = "4ed92e661d0ba368eaf8f60e1a68c202062a26819231fcfd42a5ff05d20ad2f34b82b23359a88e80eea22ee5d0056ad769b6febd5d7e7b161da0e36434ba2579"
+force-upstream = true
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -15,11 +15,13 @@ path = "../packages.rs"
 # Use latest-kernel-srpm-url.sh to get this.
 url = "https://cdn.amazonlinux.com/blobstore/9cea3dae03703f3c4c78fcb1302eeee5fe4c07ebf53d783cf3aaf7e4f30a6d39/kernel-5.15.168-114.166.amzn2.src.rpm"
 sha512 = "5b0b0e2640bb04d4868b8820781029d8148c7939802c1b4edcf580533848afe70f7c6372e6e2306dfc017d2b32120a446ada15b105f7b2fe766b9382f83937d3"
+force-upstream = true
 
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm-url.sh to get this.
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.18.12.0.noarch.rpm"
 sha512 = "4ed92e661d0ba368eaf8f60e1a68c202062a26819231fcfd42a5ff05d20ad2f34b82b23359a88e80eea22ee5d0056ad769b6febd5d7e7b161da0e36434ba2579"
+force-upstream = true
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -15,11 +15,13 @@ path = "../packages.rs"
 # Use latest-kernel-srpm-url.sh to get this.
 url = "https://cdn.amazonlinux.com/al2023/blobstore/d6984bd6e9f17839ebf3e0b0c4d7dd72aeb4db5911bf697ed299caea93c83327/kernel-6.1.115-126.197.amzn2023.src.rpm"
 sha512 = "eb1e9bdbbcc4b74cc678c894b19279437e1396c56e9db0904d1dd6898e6babf4fa3c4c53908ca189ee8558c5d249314a819b255f183fe100e4a3ed068ce2e6cf"
+force-upstream = true
 
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm-url.sh to get this.
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.18.12.0.noarch.rpm"
 sha512 = "4ed92e661d0ba368eaf8f60e1a68c202062a26819231fcfd42a5ff05d20ad2f34b82b23359a88e80eea22ee5d0056ad769b6febd5d7e7b161da0e36434ba2579"
+force-upstream = true
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/libkcapi/Cargo.toml
+++ b/packages/libkcapi/Cargo.toml
@@ -11,6 +11,7 @@ path = "../packages.rs"
 [[package.metadata.build-package.external-files]]
 url = "https://cdn.amazonlinux.com/al2023/blobstore/0eef74b3b4eb1ec321bab80f867aee89b94dc9fc95571da58ea5bba7a70e6224/libkcapi-1.4.0-105.amzn2023.0.1.src.rpm"
 sha512 = "6498147434059343f1ccdd7efadcd425ad7074e41b4e019fc995129d5df326b781e0a61a4324e1ce8d6771162d1612b754ce24625fb3b1458811f6bde8f638c9"
+force-upstream = true
 
 [build-dependencies]
 glibc = { path = "../glibc" }


### PR DESCRIPTION
**Issue number:**

n/a

**Description of changes:**

Build packages derived from Amazon Linux sources from upstream sources directly rather than relying on their existence in the Bottlerocket lookaside cache.

**Testing done:**

Build core kit for aarch64 and x86_64

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
