### PR TITLE
kernel-5.15: Add patch to fix IPv6 typo

### DIFF
--- a/packages/kernel-5.15/1100-netfilter-xtables-fix-typo-causing-some-targets-not-.patch
+++ b/packages/kernel-5.15/1100-netfilter-xtables-fix-typo-causing-some-targets-not-.patch
@@ -1,0 +1,79 @@
+From 02d6d4a741619b0bc8f29705d0f59aac596a9bf6 Mon Sep 17 00:00:00 2001
+From: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Date: Mon, 28 Oct 2024 07:25:38 +0100
+Subject: [PATCH 49/79] netfilter: xtables: fix typo causing some targets not
+ to load on IPv6
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+5.15-stable review patch.  If anyone has any objections, please let me know.
+
+------------------
+
+From: Pablo Neira Ayuso <pablo@netfilter.org>
+
+[ Upstream commit 306ed1728e8438caed30332e1ab46b28c25fe3d8 ]
+
+- There is no NFPROTO_IPV6 family for mark and NFLOG.
+- TRACE is also missing module autoload with NFPROTO_IPV6.
+
+This results in ip6tables failing to restore a ruleset. This issue has been
+reported by several users providing incomplete patches.
+
+Very similar to Ilya Katsnelson's patch including a missing chunk in the
+TRACE extension.
+
+Fixes: 0bfcb7b71e73 ("netfilter: xtables: avoid NFPROTO_UNSPEC where needed")
+Reported-by: Ignat Korchagin <ignat@cloudflare.com>
+Reported-by: Ilya Katsnelson <me@0upti.me>
+Reported-by: Krzysztof Olędzki <ole@ans.pl>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ net/netfilter/xt_NFLOG.c | 2 +-
+ net/netfilter/xt_TRACE.c | 1 +
+ net/netfilter/xt_mark.c  | 2 +-
+ 3 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/net/netfilter/xt_NFLOG.c b/net/netfilter/xt_NFLOG.c
+index d80abd6cc..6dcf4bc7e 100644
+--- a/net/netfilter/xt_NFLOG.c
++++ b/net/netfilter/xt_NFLOG.c
+@@ -79,7 +79,7 @@ static struct xt_target nflog_tg_reg[] __read_mostly = {
+ 	{
+ 		.name       = "NFLOG",
+ 		.revision   = 0,
+-		.family     = NFPROTO_IPV4,
++		.family     = NFPROTO_IPV6,
+ 		.checkentry = nflog_tg_check,
+ 		.destroy    = nflog_tg_destroy,
+ 		.target     = nflog_tg,
+diff --git a/net/netfilter/xt_TRACE.c b/net/netfilter/xt_TRACE.c
+index f3fa4f113..a642ff09f 100644
+--- a/net/netfilter/xt_TRACE.c
++++ b/net/netfilter/xt_TRACE.c
+@@ -49,6 +49,7 @@ static struct xt_target trace_tg_reg[] __read_mostly = {
+ 		.target		= trace_tg,
+ 		.checkentry	= trace_tg_check,
+ 		.destroy	= trace_tg_destroy,
++		.me		= THIS_MODULE,
+ 	},
+ #endif
+ };
+diff --git a/net/netfilter/xt_mark.c b/net/netfilter/xt_mark.c
+index f76fe04fc..65b965ca4 100644
+--- a/net/netfilter/xt_mark.c
++++ b/net/netfilter/xt_mark.c
+@@ -62,7 +62,7 @@ static struct xt_target mark_tg_reg[] __read_mostly = {
+ 	{
+ 		.name           = "MARK",
+ 		.revision       = 2,
+-		.family         = NFPROTO_IPV4,
++		.family         = NFPROTO_IPV6,
+ 		.target         = mark_tg,
+ 		.targetsize     = sizeof(struct xt_mark_tginfo2),
+ 		.me             = THIS_MODULE,
+-- 
+2.45.0
+

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -25,6 +25,9 @@ Patch1003: 1003-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
 # Increase default of sysctl net.unix.max_dgram_qlen to 512.
 Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 
+# Fix typo that breaks IPv6 via ip6tables commands
+Patch1100: 1100-netfilter-xtables-fix-typo-causing-some-targets-not-.patch
+
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket/issues/4295

**Description of changes:**
This patch fixes issues with ip6tables commands that fail due to a typo.

This is the type of error that can come up:
```
exit status 2: ip6tables-restore v1.8.4 (legacy): unknown option "--xor-mark"
```


**Testing done:**
Nodes using the current 5.15 kernel fail to become ready when `ip6tables-restore` fails, but with this patch they come up fine and there is no longer the error.

Current 1.26.2 node when running in an IPv6 subnet:
```
bash-5.1# journalctl | grep ip6tables
Nov 15 02:19:43 ip-192-168-93-220.us-west-2.compute.internal kubelet[1387]:         ip6tables v1.8.10 (legacy): MARK target: kernel too old for --or-mark
Nov 15 02:19:43 ip-192-168-93-220.us-west-2.compute.internal kubelet[1387]:         Try `ip6tables -h' or 'ip6tables --help' for more information.
```

With the patch:

```
bash-5.1# journalctl | grep ip6tables
bash-5.1#
```

Also booted with IPv4 instead of IPv6 and the node worked as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
