### PR TITLE
update libdbus and libexpat

### DIFF
--- a/packages/libdbus/Cargo.toml
+++ b/packages/libdbus/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://dbus.freedesktop.org/releases/dbus"
 
 [[package.metadata.build-package.external-files]]
-url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.15.6.tar.xz"
-sha512 = "8c2e207d98245d5f8d358e9824be9e8646af8147958e8bd56e18d478e8976e58a6645ee1aba62451fcc58443157e2a39c4a6ed9c2e440e7b6b05053d022f0113"
+url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.15.12.tar.xz"
+sha512 = "9af8ee28d61e1794eacd8cdecd6a68fa32ab5ea229df32f7112ed67f1aa8e57dd9a595ceaf42621891b50074e6f5a0cdd8c76f7d5882633446d0b81c40434cc0"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libdbus/libdbus.spec
+++ b/packages/libdbus/libdbus.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libdbus
-Version: 1.15.6
+Version: 1.15.12
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for a message bus
@@ -26,22 +26,40 @@ Requires: %{name}
 %autosetup -n dbus-%{version} -p1
 
 %build
-%cross_configure \
-  --disable-asserts \
-  --disable-doxygen-docs \
-  --disable-ducktype-docs \
-  --disable-tests \
-  --disable-xml-docs \
-  --disable-selinux \
-  --disable-systemd \
-  --with-xml=expat \
+CONFIGURE_OPTS=(
+ -Dasserts=false
+ -Dcontainers=false
+ -Dembedded_tests=false
+ -Dinstalled_tests=false
+ -Dmessage_bus=false
+ -Dstats=false
+ -Dtools=false
+ -Dtraditional_activation=false
+ -Duser_session=false
 
-%force_disable_rpath
+ -Dapparmor=disabled
+ -Ddoxygen_docs=disabled
+ -Dducktype_docs=disabled
+ -Dkqueue=disabled
+ -Dlaunchd=disabled
+ -Dlibaudit=disabled
+ -Dmodular_tests=disabled
+ -Dqt_help=disabled
+ -Drelocation=disabled
+ -Dselinux=disabled
+ -Dsystemd=disabled
+ -Dvalgrind=disabled
+ -Dx11_autolaunch=disabled
+ -Dxml_docs=disabled
 
-%make_build
+ -Dchecks=true
+)
+
+%cross_meson "${CONFIGURE_OPTS[@]}"
+%cross_meson_build
 
 %install
-%make_install
+%cross_meson_install
 
 rm -rf %{buildroot}%{_cross_docdir}/dbus/examples
 
@@ -49,15 +67,10 @@ rm -rf %{buildroot}%{_cross_docdir}/dbus/examples
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
-%exclude %{_cross_bindir}
-%exclude %{_cross_datadir}/dbus-1
 %exclude %{_cross_datadir}/doc
 %exclude %{_cross_datadir}/xml
-%exclude %{_cross_libexecdir}
-%exclude %{_cross_sysconfdir}
 
 %files devel
-%{_cross_libdir}/*.a
 %{_cross_libdir}/*.so
 %dir %{_cross_libdir}/dbus-1.0
 %{_cross_libdir}/dbus-1.0/*

--- a/packages/libexpat/Cargo.toml
+++ b/packages/libexpat/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/libexpat/libexpat/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/libexpat/libexpat/releases/download/R_2_6_3/expat-2.6.3.tar.xz"
-sha512 = "e02c4ad88f9d539258aa1c1db71ded7770a8f12c77b5535e5b34f040ae5b1361ef23132f16d96bdb7c096a83acd637a7c907916bdfcc6d5cfb9e35d04020ca0b"
+url = "https://github.com/libexpat/libexpat/releases/download/R_2_6_4/expat-2.6.4.tar.xz"
+sha512 = "620da34d98524478b445038bf1dd439790fe11169496516425fca922226797835c27549fc5fb825792b516563b24eb922d9ad8f27d20a0229e7ee8cd640dfb25"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libexpat/libexpat.spec
+++ b/packages/libexpat/libexpat.spec
@@ -1,4 +1,4 @@
-%global unversion 2_6_3
+%global unversion 2_6_4
 
 Name: %{_cross_os}libexpat
 Version: %(echo %{unversion} | sed 's/_/./g')


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Update libexpat to 2.6.4 to fix CVE-2024-50602.

Update libdbus to 1.15.12. Support for the autotools build system was removed, so switch over to the meson equivalent.


**Testing done:**
Verified that an aws-k8s-1.24 node - which depends on wicked, and therefore libexpat and libdbus - booted and joined the cluster.

```
# wicked ifstatus eth0
eth0            up
      link:     #2, state up, mtu 9001
      type:     ethernet, hwaddr 06:3f:fa:ea:1c:a1
      config:   wicked:xml:/etc/wicked/ifconfig/eth0.xml
      leases:   ipv4 dhcp granted
      leases:   ipv6 dhcp granted
      addr:     ipv4 10.0.87.167/20 [dhcp]
      addr:     ipv6 2600:1f14:ae2:f103:bf2e:d8f8:1902:2333/128 [dhcp]
      route:    ipv4 default via 10.0.80.1 proto dhcp
      route:    ipv6 default via fe80::496:20ff:fe36:bdbb metric 1024 proto ra

# busctl --acquired   
NAME                        PID PROCESS        USER CONNECTION UNIT                   SESSION DESCRIPTION
org.freedesktop.DBus          1 systemd        root -          init.scope             -       -          
org.freedesktop.login1     1109 systemd-logind root :1.4       systemd-logind.service -       -          
org.freedesktop.systemd1      1 systemd        root :1.0       init.scope             -       -          
org.opensuse.Network       1122 wickedd        root :1.5       wickedd.service        -       -          
org.opensuse.Network.DHCP4 1114 wickedd-dhcp4  root :1.2       wickedd-dhcp4.service  -       -          
org.opensuse.Network.DHCP6 1119 wickedd-dhcp6  root :1.3       wickedd-dhcp6.service  -       -          
org.opensuse.Network.Nanny 1161 wickedd-nanny  root :1.6       wickedd-nanny.service  -       - 
```

Also verified that an aws-k8s-1.31 node, which just uses libexpat via dbus-broker, booted and joined the cluster.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
