### PR TITLE
Fix source groups

### DIFF
--- a/packages/early-boot-config/Cargo.toml
+++ b/packages/early-boot-config/Cargo.toml
@@ -10,6 +10,8 @@ path = "../packages.rs"
 
 [package.metadata.build-package]
 source-groups = [
+    "api",
+    "constants",
     "early-boot-config/early-boot-config",
     "early-boot-config/early-boot-config-provider",
 
@@ -20,6 +22,8 @@ source-groups = [
     "early-boot-config/user-data-providers/local-overrides",
     "early-boot-config/user-data-providers/vmware-cd-rom",
     "early-boot-config/user-data-providers/vmware-guestinfo",
+    "generate-readme",
+    "imdsclient",
 ]
 
 # RPM BuildRequires

--- a/packages/netdog/Cargo.toml
+++ b/packages/netdog/Cargo.toml
@@ -10,8 +10,9 @@ path = "../packages.rs"
 
 [package.metadata.build-package]
 source-groups = [
-    "netdog",
     "dogtag",
+    "generate-readme",
+    "netdog",
 ]
 
 # RPM BuildRequires

--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -8,6 +8,8 @@ build = "../build.rs"
 [package.metadata.build-package]
 source-groups = [
     "api",
+    "constants",
+    "generate-readme",
     "aws-smithy-experimental",
     "bottlerocket-release",
     "metricdog",

--- a/packages/static-pods/Cargo.toml
+++ b/packages/static-pods/Cargo.toml
@@ -7,7 +7,8 @@ build = "../build.rs"
 
 [package.metadata.build-package]
 source-groups = [
-    "static-pods"
+    "static-pods",
+    "generate-readme"
 ]
 
 [lib]

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -12,9 +12,6 @@ exclude = ["README.md"]
 [features]
 fips = ["aws-lc-rs/fips", "aws-smithy-experimental/crypto-aws-lc-fips", "rustls/fips"]
 
-[package.metadata.build-package]
-source-groups = ["aws-smithy-experimental"]
-
 [dependencies]
 aws-config.workspace = true
 aws-lc-rs = { workspace = true, features = ["bindgen"] }


### PR DESCRIPTION
**Description of changes:**

`early-boot-config` was missing `api` and `imdsclient` from its `source-group` dependencies, so changes to either `apiclient` or `imdsclient` didn't trigger a rebuild of `early-boot-config`.

`pluto` 's `Cargo.toml` included `source-groups` by mistake, and it doesn't have any effect.

**Testing done:**

After this change, I confirmed that `early-boot-config` was re-compiled whenever I changed `apiclient` or `imdsclient` (even by just `touch`ing the files). Before this change, `touch`ing didn't trigger a rebuild.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
