### PR TITLE
set LoaderTimeInitUSec and LoaderTimeExecUSec in GRUB

### DIFF
--- a/packages/grub/0049-efi-Add-grub_efi_set_variable_with_attributes.patch
+++ b/packages/grub/0049-efi-Add-grub_efi_set_variable_with_attributes.patch
@@ -1,0 +1,88 @@
+From 37cd5dfd522882e1d95c4205635f9b2763256707 Mon Sep 17 00:00:00 2001
+From: Oliver Steffen <osteffen@redhat.com>
+Date: Fri, 26 May 2023 13:35:42 +0200
+Subject: [PATCH] efi: Add grub_efi_set_variable_with_attributes()
+
+Add a function to the EFI module that allows setting EFI variables
+with specific attributes.
+
+This is useful for marking variables as volatile, for example.
+
+Signed-off-by: Oliver Steffen <osteffen@redhat.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+[bcressey:
+  - backport to 2.06
+  - avoid changes from bb4aa6e0 ("efi: Drop all uses of efi_call_XX() wrappers")]
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+
+(cherry picked from commit 7e4da6fb2d03ea20f7e11efc496e2e6cf360048b)
+---
+ grub-core/kern/efi/efi.c | 20 +++++++++++++-------
+ include/grub/efi/efi.h   |  6 ++++++
+ 2 files changed, 19 insertions(+), 7 deletions(-)
+
+diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
+index 3a4475c5c..ab9a53966 100644
+--- a/grub-core/kern/efi/efi.c
++++ b/grub-core/kern/efi/efi.c
+@@ -211,8 +211,8 @@ grub_efi_set_virtual_address_map (grub_efi_uintn_t memory_map_size,
+ }
+ 
+ grub_err_t
+-grub_efi_set_variable(const char *var, const grub_efi_guid_t *guid,
+-		      void *data, grub_size_t datasize)
++grub_efi_set_variable_with_attributes (const char *var, const grub_efi_guid_t *guid,
++		      void *data, grub_size_t datasize, grub_efi_uint32_t attributes)
+ {
+   grub_efi_status_t status;
+   grub_efi_runtime_services_t *r;
+@@ -229,11 +229,7 @@ grub_efi_set_variable(const char *var, const grub_efi_guid_t *guid,
+ 
+   r = grub_efi_system_table->runtime_services;
+ 
+-  status = efi_call_5 (r->set_variable, var16, guid, 
+-		       (GRUB_EFI_VARIABLE_NON_VOLATILE
+-			| GRUB_EFI_VARIABLE_BOOTSERVICE_ACCESS
+-			| GRUB_EFI_VARIABLE_RUNTIME_ACCESS),
+-		       datasize, data);
++  status = efi_call_5 (r->set_variable, var16, guid, attributes, datasize, data);
+   grub_free (var16);
+   if (status == GRUB_EFI_SUCCESS)
+     return GRUB_ERR_NONE;
+@@ -244,6 +240,16 @@ grub_efi_set_variable(const char *var, const grub_efi_guid_t *guid,
+   return grub_error (GRUB_ERR_IO, "could not set EFI variable `%s'", var);
+ }
+ 
++grub_err_t
++grub_efi_set_variable (const char *var, const grub_efi_guid_t *guid,
++		      void *data, grub_size_t datasize)
++{
++  return grub_efi_set_variable_with_attributes (var, guid, data, datasize,
++			GRUB_EFI_VARIABLE_NON_VOLATILE
++			| GRUB_EFI_VARIABLE_BOOTSERVICE_ACCESS
++			| GRUB_EFI_VARIABLE_RUNTIME_ACCESS);
++}
++
+ grub_efi_status_t
+ grub_efi_get_variable_with_attributes (const char *var,
+ 				       const grub_efi_guid_t *guid,
+diff --git a/include/grub/efi/efi.h b/include/grub/efi/efi.h
+index d580b6bd9..a08f9474d 100644
+--- a/include/grub/efi/efi.h
++++ b/include/grub/efi/efi.h
+@@ -128,6 +128,12 @@ grub_efi_status_t EXPORT_FUNC (grub_efi_get_variable) (const char *variable,
+ 						       grub_size_t *datasize_out,
+ 						       void **data_out);
+ grub_err_t
++EXPORT_FUNC (grub_efi_set_variable_with_attributes) (const char *var,
++				     const grub_efi_guid_t *guid,
++				     void *data,
++				     grub_size_t datasize,
++				     grub_efi_uint32_t attributes);
++grub_err_t
+ EXPORT_FUNC (grub_efi_set_variable) (const char *var,
+ 				     const grub_efi_guid_t *guid,
+ 				     void *data,
+-- 
+2.47.0
+

--- a/packages/grub/0050-include-grub-types.h-Add-GRUB_SSIZE_MAX.patch
+++ b/packages/grub/0050-include-grub-types.h-Add-GRUB_SSIZE_MAX.patch
@@ -1,0 +1,40 @@
+From abacbb46f1a73e33a6b7644a8a8081244c43c28f Mon Sep 17 00:00:00 2001
+From: Oliver Steffen <osteffen@redhat.com>
+Date: Fri, 26 May 2023 13:35:46 +0200
+Subject: [PATCH] include/grub/types.h: Add GRUB_SSIZE_MAX
+
+In the same way as GRUB_SIZE_MAX, add GRUB_SSIZE_MAX.
+
+Signed-off-by: Oliver Steffen <osteffen@redhat.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+[bcressey: backport to 2.06]
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+
+(cherry picked from commit 389d3dc835a37c42184d2fab978ccd902a2399f7)
+---
+ include/grub/types.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/grub/types.h b/include/grub/types.h
+index ba446d990..ebf672b46 100644
+--- a/include/grub/types.h
++++ b/include/grub/types.h
+@@ -122,6 +122,7 @@ typedef grub_uint64_t	grub_size_t;
+ typedef grub_int64_t	grub_ssize_t;
+ 
+ # define GRUB_SIZE_MAX 18446744073709551615UL
++# define GRUB_SSIZE_MAX 9223372036854775807L
+ 
+ # if GRUB_CPU_SIZEOF_LONG == 8
+ #  define PRIxGRUB_SIZE	 "lx"
+@@ -140,6 +141,7 @@ typedef grub_uint32_t	grub_size_t;
+ typedef grub_int32_t	grub_ssize_t;
+ 
+ # define GRUB_SIZE_MAX 4294967295UL
++# define GRUB_SSIZE_MAX 2147483647L
+ 
+ # define PRIxGRUB_SIZE	"x"
+ # define PRIxGRUB_ADDR	"x"
+-- 
+2.47.0
+

--- a/packages/grub/0051-kern-misc-kern-efi-Extract-UTF-8-to-UTF-16-code.patch
+++ b/packages/grub/0051-kern-misc-kern-efi-Extract-UTF-8-to-UTF-16-code.patch
@@ -1,0 +1,136 @@
+From 55011a89968539f9d54d3425dc7ab73a0812851e Mon Sep 17 00:00:00 2001
+From: Oliver Steffen <osteffen@redhat.com>
+Date: Fri, 26 May 2023 13:35:47 +0200
+Subject: [PATCH] kern/misc, kern/efi: Extract UTF-8 to UTF-16 code
+
+Create a new function for UTF-8 to UTF-16 conversion called
+grub_utf8_to_utf16_alloc() in the grub-code/kern/misc.c and replace
+charset conversion code used in some places in the EFI code. It is
+modeled after the grub_utf8_to_ucs4_alloc() like functions in
+include/grub/charset.h. It can't live in include/grub/charset.h,
+because it needs to be reachable from the kern/efi code.
+
+Add a check for integer overflow and remove redundant NUL-termination.
+
+Signed-off-by: Oliver Steffen <osteffen@redhat.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+[bcressey: backport to 2.06]
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+
+(cherry picked from commit a0b16564ee2e8eb7f597926bf60c4de2d696cd66)
+---
+ grub-core/kern/efi/efi.c | 21 ++++++---------------
+ grub-core/kern/misc.c    | 32 ++++++++++++++++++++++++++++++++
+ include/grub/misc.h      |  3 +++
+ 3 files changed, 41 insertions(+), 15 deletions(-)
+
+diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
+index ab9a53966..354343935 100644
+--- a/grub-core/kern/efi/efi.c
++++ b/grub-core/kern/efi/efi.c
+@@ -217,15 +217,11 @@ grub_efi_set_variable_with_attributes (const char *var, const grub_efi_guid_t *g
+   grub_efi_status_t status;
+   grub_efi_runtime_services_t *r;
+   grub_efi_char16_t *var16;
+-  grub_size_t len, len16;
+ 
+-  len = grub_strlen (var);
+-  len16 = len * GRUB_MAX_UTF16_PER_UTF8;
+-  var16 = grub_calloc (len16 + 1, sizeof (var16[0]));
+-  if (!var16)
++  grub_utf8_to_utf16_alloc (var, &var16, NULL);
++
++  if (var16 == NULL)
+     return grub_errno;
+-  len16 = grub_utf8_to_utf16 (var16, len16, (grub_uint8_t *) var, len, NULL);
+-  var16[len16] = 0;
+ 
+   r = grub_efi_system_table->runtime_services;
+ 
+@@ -262,18 +258,13 @@ grub_efi_get_variable_with_attributes (const char *var,
+   grub_efi_runtime_services_t *r;
+   grub_efi_char16_t *var16;
+   void *data;
+-  grub_size_t len, len16;
+ 
+   *data_out = NULL;
+   *datasize_out = 0;
+ 
+-  len = grub_strlen (var);
+-  len16 = len * GRUB_MAX_UTF16_PER_UTF8;
+-  var16 = grub_calloc (len16 + 1, sizeof (var16[0]));
+-  if (!var16)
+-    return GRUB_EFI_OUT_OF_RESOURCES;
+-  len16 = grub_utf8_to_utf16 (var16, len16, (grub_uint8_t *) var, len, NULL);
+-  var16[len16] = 0;
++  grub_utf8_to_utf16_alloc (var, &var16, NULL);
++  if (var16 == NULL)
++    return grub_errno;
+ 
+   r = grub_efi_system_table->runtime_services;
+ 
+diff --git a/grub-core/kern/misc.c b/grub-core/kern/misc.c
+index a95d182ba..f9be124d9 100644
+--- a/grub-core/kern/misc.c
++++ b/grub-core/kern/misc.c
+@@ -28,6 +28,8 @@
+ #if DEBUG_WITH_TIMESTAMPS
+ #include <grub/time.h>
+ #endif
++#include <grub/types.h>
++#include <grub/charset.h>
+ 
+ static void
+ parse_printf_args (const char *fmt0, struct grub_printf_args *args,
+@@ -1280,6 +1282,36 @@ grub_fatal (const char *fmt, ...)
+   grub_abort ();
+ }
+ 
++grub_ssize_t
++grub_utf8_to_utf16_alloc (const char *str8, grub_uint16_t **utf16_msg, grub_uint16_t **last_position)
++{
++  grub_size_t len;
++  grub_size_t len16;
++
++  len = grub_strlen (str8);
++
++  /* Check for integer overflow */
++  if (len > GRUB_SSIZE_MAX / GRUB_MAX_UTF16_PER_UTF8 - 1)
++    {
++      grub_error (GRUB_ERR_BAD_ARGUMENT, N_("string too long"));
++      *utf16_msg = NULL;
++      return -1;
++    }
++
++  len16 = len * GRUB_MAX_UTF16_PER_UTF8;
++
++  *utf16_msg = grub_calloc (len16 + 1, sizeof (*utf16_msg[0]));
++  if (*utf16_msg == NULL)
++    return -1;
++
++  len16 = grub_utf8_to_utf16 (*utf16_msg, len16, (grub_uint8_t *) str8, len, NULL);
++
++  if (last_position != NULL)
++    *last_position = *utf16_msg + len16;
++
++  return len16;
++}
++
+ #if BOOT_TIME_STATS
+ 
+ #include <grub/time.h>
+diff --git a/include/grub/misc.h b/include/grub/misc.h
+index a359b0dee..8716e486d 100644
+--- a/include/grub/misc.h
++++ b/include/grub/misc.h
+@@ -536,4 +536,7 @@ void EXPORT_FUNC(grub_real_boot_time) (const char *file,
+ 
+ #define grub_log2ull(n) (GRUB_TYPE_BITS (grub_uint64_t) - __builtin_clzll (n) - 1)
+ 
++grub_ssize_t
++EXPORT_FUNC(grub_utf8_to_utf16_alloc) (const char *str8, grub_uint16_t **utf16_msg, grub_uint16_t **last_position);
++
+ #endif /* ! GRUB_MISC_HEADER */
+-- 
+2.47.0
+

--- a/packages/grub/0052-efi-Add-grub_efi_set_variable_to_string.patch
+++ b/packages/grub/0052-efi-Add-grub_efi_set_variable_to_string.patch
@@ -1,0 +1,71 @@
+From 28bf9df5e7146610fd1890ea5856c0c0a86dac1c Mon Sep 17 00:00:00 2001
+From: Oliver Steffen <osteffen@redhat.com>
+Date: Fri, 26 May 2023 13:35:48 +0200
+Subject: [PATCH] efi: Add grub_efi_set_variable_to_string()
+
+Add a function that sets an EFI variable to a string value.
+The string is converted from UTF-8 to UTF-16.
+
+Signed-off-by: Oliver Steffen <osteffen@redhat.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+[bcressey:
+  - backport to 2.06
+  - avoid changes from 06edd40d ("guid: Unify GUID types")]
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+
+(cherry picked from commit e83a88f6ea7f97d643387681fe044f45dcd732b9)
+---
+ grub-core/kern/efi/efi.c | 22 ++++++++++++++++++++++
+ include/grub/efi/efi.h   |  3 +++
+ 2 files changed, 25 insertions(+)
+
+diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
+index 354343935..a65ef27bd 100644
+--- a/grub-core/kern/efi/efi.c
++++ b/grub-core/kern/efi/efi.c
+@@ -297,6 +297,28 @@ grub_efi_get_variable_with_attributes (const char *var,
+   return status;
+ }
+ 
++grub_err_t
++grub_efi_set_variable_to_string (const char *name, const grub_efi_guid_t *guid,
++			         const char *value, grub_efi_uint32_t attributes)
++{
++  grub_efi_char16_t *value_16;
++  grub_ssize_t len16;
++  grub_err_t status;
++
++  len16 = grub_utf8_to_utf16_alloc (value, &value_16, NULL);
++
++  if (len16 < 0)
++    return grub_errno;
++
++  status = grub_efi_set_variable_with_attributes (name, guid,
++			(void *) value_16, (len16 + 1) * sizeof (value_16[0]),
++			attributes);
++
++  grub_free (value_16);
++
++  return status;
++}
++
+ grub_efi_status_t
+ grub_efi_get_variable (const char *var, const grub_efi_guid_t *guid,
+ 		       grub_size_t *datasize_out, void **data_out)
+diff --git a/include/grub/efi/efi.h b/include/grub/efi/efi.h
+index a08f9474d..a82741ef2 100644
+--- a/include/grub/efi/efi.h
++++ b/include/grub/efi/efi.h
+@@ -138,6 +138,9 @@ EXPORT_FUNC (grub_efi_set_variable) (const char *var,
+ 				     const grub_efi_guid_t *guid,
+ 				     void *data,
+ 				     grub_size_t datasize);
++grub_err_t
++EXPORT_FUNC (grub_efi_set_variable_to_string) (const char *name, const grub_efi_guid_t *guid,
++					       const char *value, grub_efi_uint32_t attributes);
+ int
+ EXPORT_FUNC (grub_efi_compare_device_paths) (const grub_efi_device_path_t *dp1,
+ 					     const grub_efi_device_path_t *dp2);
+-- 
+2.47.0
+

--- a/packages/grub/0053-efi-add-vendor-GUID-for-Boot-Loader-Interface.patch
+++ b/packages/grub/0053-efi-add-vendor-GUID-for-Boot-Loader-Interface.patch
@@ -1,0 +1,32 @@
+From ec2bbc9d87079cd080feaad6b7512624a52ee555 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 14 Nov 2024 19:24:42 +0000
+Subject: [PATCH] efi: add vendor GUID for Boot Loader Interface
+
+Backports the relevant part of upstream commit e0fa7dc8 ("bli: Add a
+module for the Boot Loader Interface").
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ include/grub/efi/api.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
+index 464842ba3..f301913e6 100644
+--- a/include/grub/efi/api.h
++++ b/include/grub/efi/api.h
+@@ -368,6 +368,11 @@
+     { 0xa1, 0x92, 0xbf, 0x1d, 0x57, 0xd0, 0xb1, 0x89 } \
+   }
+ 
++#define GRUB_EFI_VENDOR_BOOT_LOADER_INTERFACE_GUID \
++  { 0x4a67b082, 0x0a4c, 0x41cf, \
++    { 0xb6, 0xc7, 0x44, 0x0b, 0x29, 0xbb, 0x8c, 0x4f } \
++  }
++
+ struct grub_efi_sal_system_table
+ {
+   grub_uint32_t signature;
+-- 
+2.47.0
+

--- a/packages/grub/0054-efi-set-LoaderTimeInitUSec-and-LoaderTimeExecUSec.patch
+++ b/packages/grub/0054-efi-set-LoaderTimeInitUSec-and-LoaderTimeExecUSec.patch
@@ -1,0 +1,129 @@
+From a76d5d1d5f425eb6128cadee06d9aaeff1b24b83 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 14 Nov 2024 20:29:13 +0000
+Subject: [PATCH] efi: set LoaderTimeInitUSec and LoaderTimeExecUSec
+
+This implements the part of the Boot Loader Interface [0] that's used
+by `systemd-analyze` to calculate the time spent in the firmware and
+bootloader, prior to kernel execution.
+
+[0] https://systemd.io/BOOT_LOADER_INTERFACE/
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ grub-core/kern/arm64/efi/init.c | 23 +++++++++++++++++++++++
+ grub-core/kern/i386/efi/init.c  | 26 ++++++++++++++++++++++++++
+ 2 files changed, 49 insertions(+)
+
+diff --git a/grub-core/kern/arm64/efi/init.c b/grub-core/kern/arm64/efi/init.c
+index 5010caefd..52e87d582 100644
+--- a/grub-core/kern/arm64/efi/init.c
++++ b/grub-core/kern/arm64/efi/init.c
+@@ -22,6 +22,7 @@
+ #include <grub/misc.h>
+ #include <grub/mm.h>
+ #include <grub/time.h>
++#include <grub/efi/api.h>
+ #include <grub/efi/efi.h>
+ #include <grub/loader.h>
+ 
+@@ -36,11 +37,16 @@ grub_efi_get_time_ms (void)
+   return tmr / timer_frequency_in_khz;
+ }
+ 
++static const grub_efi_guid_t bli_vendor_guid = GRUB_EFI_VENDOR_BOOT_LOADER_INTERFACE_GUID;
++static const grub_efi_uint32_t bli_efivar_attr =
++  GRUB_EFI_VARIABLE_BOOTSERVICE_ACCESS | GRUB_EFI_VARIABLE_RUNTIME_ACCESS;
+ 
+ void
+ grub_machine_init (void)
+ {
+   grub_uint64_t timer_frequency;
++  grub_efi_uint64_t init_ms;
++  char *init_usec;
+ 
+   grub_efi_init ();
+ 
+@@ -48,11 +54,28 @@ grub_machine_init (void)
+   timer_frequency_in_khz = timer_frequency / 1000;
+ 
+   grub_install_get_time_ms (grub_efi_get_time_ms);
++
++  init_ms = grub_get_time_ms ();
++  init_usec = grub_xasprintf ("%lu000", init_ms);
++  grub_efi_set_variable_to_string ("LoaderTimeInitUSec",
++				   &bli_vendor_guid,
++				   init_usec,
++				   bli_efivar_attr);
+ }
+ 
+ void
+ grub_machine_fini (int flags)
+ {
++  grub_efi_uint64_t exec_ms;
++  char *exec_usec;
++
++  exec_ms = grub_get_time_ms ();
++  exec_usec = grub_xasprintf ("%lu000", exec_ms);
++  grub_efi_set_variable_to_string ("LoaderTimeExecUSec",
++				   &bli_vendor_guid,
++				   exec_usec,
++				   bli_efivar_attr);
++
+   if (!(flags & GRUB_LOADER_FLAG_NORETURN))
+     return;
+ 
+diff --git a/grub-core/kern/i386/efi/init.c b/grub-core/kern/i386/efi/init.c
+index 46476e27e..1e237cfcb 100644
+--- a/grub-core/kern/i386/efi/init.c
++++ b/grub-core/kern/i386/efi/init.c
+@@ -24,20 +24,46 @@
+ #include <grub/dl.h>
+ #include <grub/cache.h>
+ #include <grub/kernel.h>
++#include <grub/efi/api.h>
+ #include <grub/efi/efi.h>
+ #include <grub/i386/tsc.h>
+ #include <grub/loader.h>
++#include <grub/time.h>
++
++static const grub_efi_guid_t bli_vendor_guid = GRUB_EFI_VENDOR_BOOT_LOADER_INTERFACE_GUID;
++static const grub_efi_uint32_t bli_efivar_attr =
++  GRUB_EFI_VARIABLE_BOOTSERVICE_ACCESS | GRUB_EFI_VARIABLE_RUNTIME_ACCESS;
+ 
+ void
+ grub_machine_init (void)
+ {
++  grub_efi_uint64_t init_ms;
++  char *init_usec;
++
+   grub_efi_init ();
+   grub_tsc_init ();
++
++  init_ms = grub_get_time_ms ();
++  init_usec = grub_xasprintf ("%lu000", init_ms);
++  grub_efi_set_variable_to_string ("LoaderTimeInitUSec",
++				   &bli_vendor_guid,
++				   init_usec,
++				   bli_efivar_attr);
+ }
+ 
+ void
+ grub_machine_fini (int flags)
+ {
++  grub_efi_uint64_t exec_ms;
++  char *exec_usec;
++
++  exec_ms = grub_get_time_ms ();
++  exec_usec = grub_xasprintf ("%lu000", exec_ms);
++  grub_efi_set_variable_to_string ("LoaderTimeExecUSec",
++				   &bli_vendor_guid,
++				   exec_usec,
++				   bli_efivar_attr);
++
+   if (!(flags & GRUB_LOADER_FLAG_NORETURN))
+     return;
+ 
+-- 
+2.47.0
+

--- a/packages/grub/0055-tsc-drop-tsc_boot_time-offset.patch
+++ b/packages/grub/0055-tsc-drop-tsc_boot_time-offset.patch
@@ -1,0 +1,66 @@
+From 1a31957af68baeba1065a250382e4744709b80a6 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 14 Nov 2024 19:55:38 +0000
+Subject: [PATCH] tsc: drop tsc_boot_time offset
+
+To implement the Boot Loader Interface, we need to store the time at
+which GRUB was started in the `LoaderTimeInitUSec` variable.
+
+On the i386 architecture, GRUB stores the TSC value at the time that
+TSC calibration took place, and subtracts it before returning a value
+from grub_tsc_get_time_ms(), which is called by grub_get_time_ms() -
+the architecture-independent function for retrieving timestamps.
+
+Storing the TSC value at the time of initialization, and subtracting
+it from subsequent calculations, prevents callers from determining
+the system time elapsed before GRUB was loaded.
+
+The equivalent offset is not done for arm64, and does not appear to
+serve a purpose. Callers of grub_get_time_ms() all follow a pattern
+where they first record a "start" time and then compute a delta in a
+loop, which works the same way whether the "start" time is close to
+zero or not.
+
+Rather than exposing another function to provide the "raw" timestamp
+without the offset, just drop `tsc_boot_time` from the calculation.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ grub-core/kern/i386/tsc.c | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/grub-core/kern/i386/tsc.c b/grub-core/kern/i386/tsc.c
+index 9293b161d..ec6899812 100644
+--- a/grub-core/kern/i386/tsc.c
++++ b/grub-core/kern/i386/tsc.c
+@@ -25,9 +25,6 @@
+ #include <grub/i386/tsc.h>
+ #include <grub/i386/cpuid.h>
+ 
+-/* This defines the value TSC had at the epoch (that is, when we calibrated it). */
+-static grub_uint64_t tsc_boot_time;
+-
+ /* Calibrated TSC rate.  (In ms per 2^32 ticks) */
+ /* We assume that the tick is less than 1 ms and hence this value fits
+    in 32-bit.  */
+@@ -36,7 +33,7 @@ grub_uint32_t grub_tsc_rate;
+ static grub_uint64_t
+ grub_tsc_get_time_ms (void)
+ {
+-  grub_uint64_t a = grub_get_tsc () - tsc_boot_time;
++  grub_uint64_t a = grub_get_tsc ();
+   grub_uint64_t ah = a >> 32;
+   grub_uint64_t al = a & 0xffffffff;
+ 
+@@ -63,8 +60,6 @@ grub_tsc_init (void)
+       return;
+     }
+ 
+-  tsc_boot_time = grub_get_tsc ();
+-
+ #if defined (GRUB_MACHINE_XEN) || defined (GRUB_MACHINE_XEN_PVH)
+   (void) (grub_tsc_calibrate_from_xen () || calibrate_tsc_hardcode());
+ #elif defined (GRUB_MACHINE_EFI)
+-- 
+2.47.0
+

--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -68,6 +68,13 @@ Patch0045: 0045-mkimage-pgp-move-single-public-key-into-its-own-sect.patch
 Patch0046: 0046-Revert-sb-Add-fallback-to-EFI-LoadImage-if-shim_lock.patch
 Patch0047: 0047-Revert-UBUNTU-Move-verifiers-after-decompressors.patch
 Patch0048: 0048-add-flag-to-only-search-root-dev.patch
+Patch0049: 0049-efi-Add-grub_efi_set_variable_with_attributes.patch
+Patch0050: 0050-include-grub-types.h-Add-GRUB_SSIZE_MAX.patch
+Patch0051: 0051-kern-misc-kern-efi-Extract-UTF-8-to-UTF-16-code.patch
+Patch0052: 0052-efi-Add-grub_efi_set_variable_to_string.patch
+Patch0053: 0053-efi-add-vendor-GUID-for-Boot-Loader-Interface.patch
+Patch0054: 0054-efi-set-LoaderTimeInitUSec-and-LoaderTimeExecUSec.patch
+Patch0055: 0055-tsc-drop-tsc_boot_time-offset.patch
 
 BuildRequires: automake
 BuildRequires: bison


### PR DESCRIPTION
**Issue number:**
Fixes #272 

**Description of changes:**
For `systemd-analyze` to report the time spent in firmware and in the boot loader, we need to set `LoaderTimeInitUSec` and `LoaderTimeExecUSec`, so the values can be read by [efi_loader_get_boot_usec()](https://github.com/systemd/systemd/blob/248eeec612d50e75c9da541721eeea8ac72e27ea/src/shared/efi-loader.c#L36) and set by [boot_timestamps()](https://github.com/systemd/systemd/blob/248eeec612d50e75c9da541721eeea8ac72e27ea/src/shared/boot-timestamps.c#L9).

This patch series teaches GRUB to do this for x86 and aarch64. It relies on backported [upstream patches](https://mail.gnu.org/archive/html/grub-devel/2023-05/msg00147.html) from the series that added the Boot Loader Interface module]. That series implemented support for a different part of BLI: the `LoaderInfo` and `LoaderDevicePartUUID` variables.

**Testing done:**
Tested this under the different EFI implementations I have access to - edk2 via QEMU/KVM, EC2 Nitro instances, and VMware ESXi VMs.

Verified that `systemd-analyze` reports firmware and loader time:
```
# systemd-analyze
Startup finished in 4.392s (firmware) + 833ms (loader) + 776ms (kernel) + 3.728s (userspace) = 9.729s
multi-user.target reached after 3.727s in userspace.
```

Confirmed that the variables aren't marked as non-volatile:
```
[fedora@admin]$ efivar -p --name 4a67b082-0a4c-41cf-b6c7-440b29bb8c4f-LoaderTimeExecUSec
GUID: 4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
Name: "LoaderTimeExecUSec"
Attributes:
	Boot Service Access
	Runtime Service Access
Value:
00000000  36 00 36 00 31 00 36 00  30 00 30 00 30 00 00 00  |6.6.1.6.0.0.0...|

[fedora@admin]$ efivar -p --name 4a67b082-0a4c-41cf-b6c7-440b29bb8c4f-LoaderTimeInitUSec
GUID: 4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
Name: "LoaderTimeInitUSec"
Attributes:
	Boot Service Access
	Runtime Service Access
Value:
00000000  31 00 37 00 30 00 34 00  30 00 30 00 30 00 00 00  |1.7.0.4.0.0.0...|
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
