### PR TITLE
advisories: backfill kernel-6.1 BRSAs for 3.3.1

### DIFF
--- a/advisories/3.3.1/BRSA-plp2gkokhcuk.toml
+++ b/advisories/3.3.1/BRSA-plp2gkokhcuk.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-plp2gkokhcuk"
+title = "kernel CVE-2024-47685"
+cve = "CVE-2024-47685"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: Use skb_put_zero() to clear the whole TCP header, as done in nf_reject_ip_tcphdr_put()"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "6.1.115"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-11-15T00:57:17Z
+arches = ["x86_64", "aarch64"]
+version = "3.3.1"

--- a/advisories/3.3.1/BRSA-r1pp3ifrqlrj.toml
+++ b/advisories/3.3.1/BRSA-r1pp3ifrqlrj.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-r1pp3ifrqlrj"
+title = "kernel CVE-2024-35963"
+cve = "CVE-2024-35963"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: Bluetooth: hci_sock: Fix not validating setsockopt user input"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "6.1.115"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-11-15T00:57:17Z
+arches = ["x86_64", "aarch64"]
+version = "3.3.1"

--- a/advisories/3.3.1/BRSA-rmht97wx4535.toml
+++ b/advisories/3.3.1/BRSA-rmht97wx4535.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-rmht97wx4535"
+title = "kernel CVE-2024-46695"
+cve = "CVE-2024-46695"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: selinux,smack: don't bypass permissions check in inode_setsecctx hook"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "6.1.115"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-11-15T00:57:17Z
+arches = ["aarch64", "x86_64"]
+version = "3.3.1"

--- a/advisories/3.3.1/BRSA-rz4jhrkccvad.toml
+++ b/advisories/3.3.1/BRSA-rz4jhrkccvad.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "BRSA-rz4jhrkccvad"
+title = "kernel CVE-2024-38632"
+cve = "CVE-2024-38632"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: vfio/pci: fix potential memory leak in vfio_intx_enable()"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "6.1.115"
+patched-release = "0"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-11-15T00:57:17Z
+arches = ["aarch64", "x86_64"]
+version = "3.3.1"


### PR DESCRIPTION
**Description of changes:**

Add kernel-6.1 advisories for the 3.3.1 core kit release

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
