### PR TITLE
packages: normalize amazon-ecs-cni-plugins version to 2020.09.0

### DIFF
--- a/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
+++ b/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
@@ -4,8 +4,10 @@
 %global ecscni_gitrev 53a8481891251e66e35847554d52a13fc7c4fd03
 
 Name: %{_cross_os}amazon-ecs-cni-plugins
-Version: %{ecscni_gitrev}
+# https://github.com/aws/amazon-ecs-cni-plugins/blob/53a8481891251e66e35847554d52a13fc7c4fd03/VERSION#L1
+Version: 2020.09.0
 Release: 1%{?dist}
+Epoch: 1
 Summary: Networking plugins for ECS task networking
 License: Apache-2.0
 URL: https://%{ecscni_goimport}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #249 

**Description of changes:**

Normalize the versioning of the amazon-ecs-cni-plugins package by using its VERSION provided in the upstream. Add an Epoch of 1 to account for past packages using a gitrev for Version.

**Testing done:**

Build a dev core kit, launch an `aws-ecs-2` variant:

```
bash-5.1# ls -l /usr/libexec/amazon-ecs-agent/
total 4
lrwxrwxrwx. 1 root root   22 Nov 13 22:52 aws-appmesh -> ../cni/vpc/aws-appmesh
lrwxrwxrwx. 1 root root   21 Nov 15 23:40 ecs-bridge -> ../cni/ecs/ecs-bridge
lrwxrwxrwx. 1 root root   18 Nov 15 23:40 ecs-eni -> ../cni/ecs/ecs-eni
lrwxrwxrwx. 1 root root   19 Nov 15 23:40 ecs-ipam -> ../cni/ecs/ecs-ipam
lrwxrwxrwx. 1 root root   29 Nov 13 22:52 ecs-serviceconnect -> ../cni/vpc/ecs-serviceconnect
drwxr-xr-x. 3 root root 4096 Nov 16 00:42 managed-agents
lrwxrwxrwx. 1 root root   25 Nov 13 22:52 vpc-branch-eni -> ../cni/vpc/vpc-branch-eni
lrwxrwxrwx. 1 root root   21 Nov 13 22:52 vpc-bridge -> ../cni/vpc/vpc-bridge
lrwxrwxrwx. 1 root root   18 Nov 13 22:52 vpc-eni -> ../cni/vpc/vpc-eni
lrwxrwxrwx. 1 root root   21 Nov 13 22:52 vpc-tunnel -> ../cni/vpc/vpc-tunnel

bash-5.1# systemctl status ecs
● ecs.service - Amazon Elastic Container Service - container agent
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/ecs.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/ecs.service.d
             └─00-defaults.conf
             /etc/systemd/system/ecs.service.d
             └─10-base.conf
     Active: active (running) since Sat 2024-11-16 00:46:23 UTC; 8min ago
       Docs: https://aws.amazon.com/documentation/ecs/
   Main PID: 1367 (amazon-ecs-agen)
      Tasks: 9 (limit: 2250)
     Memory: 80.7M
        CPU: 425ms
     CGroup: /system.slice/ecs.service
             └─1367 /usr/bin/amazon-ecs-agent
```


*  Internal testing for aws-ecs-2 variant succeeds.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
