### PR TITLE
Update EKS 1.28-1.31 versions to latest. 

### DIFF
--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/33/artifacts/kubernetes/v1.28.13/kubernetes-src.tar.gz"
-sha512 = "7664cb9c178840e7499ceec22a198d8f6feb794423b533a632d4dd6294f6b4616313bb620473ba2a71171304b498d84d33a87038ae57482de03e040c8c1b3c18"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/35/artifacts/kubernetes/v1.28.14/kubernetes-src.tar.gz"
+sha512 = "171a3d8875706d43a753cb03039fa6cffc6e9f7422bad3dbc558e41bf997b6cbdb85859eadad13e31dbabac6e032024d6b697c96f8671bc7b8875b76cf193b81"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.28.13
+%global gover 1.28.14
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/33/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/35/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/22/artifacts/kubernetes/v1.29.8/kubernetes-src.tar.gz"
-sha512 = "89dbb4d282da817be9f61035383467339f1146809e3bbd8d848d72cef6ae6c6cc9fc19bcd7ff3d9da0fee6b7fef13e272a76839282a4092a183a55c64c1695fa"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/24/artifacts/kubernetes/v1.29.9/kubernetes-src.tar.gz"
+sha512 = "5b0d50c6779feb5f2b06a15cc5962e69d97d1554bcc456171ef3780699529c1a28357e82d22614fb48941dc450e6150d1a3c41dfe1be27d4c38894c99cc5e656"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.29.8
+%global gover 1.29.9
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/22/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/24/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/15/artifacts/kubernetes/v1.30.4/kubernetes-src.tar.gz"
-sha512 = "a068efe5ae458178c336478ed91ec268eba087d82b2fb5eddbcb07c9a948be0ed7a11470e69cecc3dd8faae7ae2fe56ff00e879be3c6dbf66b5c836afe2e29a5"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/17/artifacts/kubernetes/v1.30.5/kubernetes-src.tar.gz"
+sha512 = "6d574561603f72c1743333d87b560cd375d3f022206f8751dbd5370ab08096ec414a3c9be5f1e026b420974c786b2ced568e4c8508634c01f326615f7e4d40b2"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.30.1
+%global gover 1.30.5
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/15/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/17/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/4/artifacts/kubernetes/v1.31.0/kubernetes-src.tar.gz"
-sha512 = "c19a550d7e998f967a307abfde0d060f69a520f4000ef054e8652f05ae925792fa254ce9df3be15255684573c4b61c02eb722b480f6791648783dac6b0ed4c50"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/6/artifacts/kubernetes/v1.31.1/kubernetes-src.tar.gz"
+sha512 = "d776cf029babde78af7f88aad7b337f2b73a18617a098d61666f462f6af7f9628e1d99a2abb6d840a8fead38ef2561ec5a41f8087d7c6c4d714f23b78e8b8ca7"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.31.0
+%global gover 1.31.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-31/releases/4/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-31/releases/6/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
N/A

**Description of changes:**
* Updates kubernetes-1.28 through 1.31 to the latest upstream versions.


**Testing done:**

- [x] aarch64 and x86_64
```
aarch64-aws-k8s-128-conformance                                          Test                                    passed                                                                   384                                     0                                  7012  
 aarch64-aws-k8s-128-nvidia-quick                                         Test                                    passed                                                                     5                                     0                                  7391 
 aarch64-aws-k8s-128-quick                                                Test                                    passed                                                                     5                                     0                                  7391 
 aarch64-aws-k8s-129-conformance                                          Test                                    passed                                                                   392                                     0                                  7022 
 aarch64-aws-k8s-129-nvidia-quick                                         Test                                    passed                                                                     5                                     0                                  7409 
 aarch64-aws-k8s-129-quick                                                Test                                    passed                                                                     5                                     0                                  7409 
 aarch64-aws-k8s-130-conformance                                          Test                                    passed                                                                   406                                     0                                  6797 
 aarch64-aws-k8s-130-nvidia-quick                                         Test                                    passed                                                                     5                                     0                                  7198 
 aarch64-aws-k8s-130-quick                                                Test                                    passed                                                                     5                                     0                                  7198 
 aarch64-aws-k8s-131-conformance                                          Test                                    passed                                                                   408                                     0                                  6201 
 aarch64-aws-k8s-131-nvidia-quick                                         Test                                    passed                                                                     5                                     0                                  6604 
 aarch64-aws-k8s-131-quick                                                Test                                    passed                                                                     5                                     0                                  6604 
 x86-64-aws-k8s-128-conformance                                           Test                                    passed                                                                   384                                     0                                  7012 
 x86-64-aws-k8s-128-nvidia-quick                                          Test                                    passed                                                                     5                                     0                                  7391 
 x86-64-aws-k8s-128-quick                                                 Test                                    passed                                                                     5                                     0                                  7391 
 x86-64-aws-k8s-129-conformance                                           Test                                    passed                                                                   392                                     0                                  7022 
 x86-64-aws-k8s-129-nvidia-quick                                          Test                                    passed                                                                     5                                     0                                  7409 
 x86-64-aws-k8s-129-quick                                                 Test                                    passed                                                                     5                                     0                                  7409 
 x86-64-aws-k8s-130-conformance                                           Test                                    passed                                                                   406                                     0                                  6797 
 x86-64-aws-k8s-130-nvidia-quick                                          Test                                    passed                                                                     5                                     0                                  7198 
 x86-64-aws-k8s-130-quick                                                 Test                                    passed                                                                     5                                     0                                  7198 
 x86-64-aws-k8s-131-conformance                                           Test                                    passed                                                                   408                                     0                                  6201 
 x86-64-aws-k8s-131-nvidia-quick                                          Test                                    passed                                                                     5                                     0                                  6604 
 x86-64-aws-k8s-131-quick                                                 Test                                    passed                                                                     5             
```
- [x] Verified NVIDIA pod with GPU access



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
