### PR TITLE
Prevent io_uring calls from hanging

### DIFF
--- a/packages/kernel-6.1/1100-io_uring-always-lock-__io_cqring_overflow_flush.patch
+++ b/packages/kernel-6.1/1100-io_uring-always-lock-__io_cqring_overflow_flush.patch
@@ -1,0 +1,60 @@
+From 1863335f591d6a708fb5321fe10504174fddc9ee Mon Sep 17 00:00:00 2001
+From: Pavel Begunkov <asml.silence@gmail.com>
+Date: Wed, 10 Apr 2024 02:26:54 +0100
+Subject: [PATCH] io_uring: always lock __io_cqring_overflow_flush
+
+Commit 8d09a88ef9d3cb7d21d45c39b7b7c31298d23998 upstream.
+
+Conditional locking is never great, in case of
+__io_cqring_overflow_flush(), which is a slow path, it's not justified.
+Don't handle IOPOLL separately, always grab uring_lock for overflow
+flushing.
+
+Signed-off-by: Pavel Begunkov <asml.silence@gmail.com>
+Link: https://lore.kernel.org/r/162947df299aa12693ac4b305dacedab32ec7976.1712708261.git.asml.silence@gmail.com
+Signed-off-by: Jens Axboe <axboe@kernel.dk>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ io_uring/io_uring.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/io_uring/io_uring.c b/io_uring/io_uring.c
+index f902b161f02c..92c1aa8f3501 100644
+--- a/io_uring/io_uring.c
++++ b/io_uring/io_uring.c
+@@ -593,6 +593,8 @@ static bool __io_cqring_overflow_flush(struct io_ring_ctx *ctx, bool force)
+ 	bool all_flushed;
+ 	size_t cqe_size = sizeof(struct io_uring_cqe);
+ 
++	lockdep_assert_held(&ctx->uring_lock);
++
+ 	if (!force && __io_cqring_events(ctx) == ctx->cq_entries)
+ 		return false;
+ 
+@@ -647,12 +649,9 @@ static bool io_cqring_overflow_flush(struct io_ring_ctx *ctx)
+ 	bool ret = true;
+ 
+ 	if (test_bit(IO_CHECK_CQ_OVERFLOW_BIT, &ctx->check_cq)) {
+-		/* iopoll syncs against uring_lock, not completion_lock */
+-		if (ctx->flags & IORING_SETUP_IOPOLL)
+-			mutex_lock(&ctx->uring_lock);
++		mutex_lock(&ctx->uring_lock);
+ 		ret = __io_cqring_overflow_flush(ctx, false);
+-		if (ctx->flags & IORING_SETUP_IOPOLL)
+-			mutex_unlock(&ctx->uring_lock);
++		mutex_unlock(&ctx->uring_lock);
+ 	}
+ 
+ 	return ret;
+@@ -1405,6 +1404,8 @@ static int io_iopoll_check(struct io_ring_ctx *ctx, long min)
+ 	int ret = 0;
+ 	unsigned long check_cq;
+ 
++	lockdep_assert_held(&ctx->uring_lock);
++
+ 	if (!io_allowed_run_tw(ctx))
+ 		return -EEXIST;
+ 
+-- 
+2.47.0
+

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -42,6 +42,8 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 # Drop AL revert of upstream patch to minimize delta. The necessary dependency
 # options for nvidia are instead included through DRM_SIMPLE
 Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
+# Prevent applications using io_uring from hanging
+Patch1100: 1100-io_uring-always-lock-__io_cqring_overflow_flush.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION
**Issue number:**

Related to https://github.com/bottlerocket-os/bottlerocket/issues/4308

**Description of changes:**

Port back the fix from the upstream [6.1.y branch](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y).

**Testing done:**

I launched 3 aws-k8s-1.31 instances, launched Amazon Linux 2023 pods and ran the command that was previously hanging:

```bash
bash-5.2# npm-20 install -g pm2

added 138 packages in 6s

13 packages are looking for funding
  run `npm fund` for details
npm notice
npm notice New minor version of npm available! 10.8.2 -> 10.9.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v10.9.0
npm notice To update run: npm install -g npm@10.9.0
npm notice
bash-5.2#
```

The command no longer hangs

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
