### PR TITLE
advisories: move staging BRSA to 4.0.0 release

### DIFF
--- a/advisories/4.0.0/BRSA-u9kwccsbt96l.toml
+++ b/advisories/4.0.0/BRSA-u9kwccsbt96l.toml
@@ -13,6 +13,6 @@ patched-epoch = "1"
 
 [updateinfo]
 author = "kushupad"
-issue-date = 2024-11-20T02:26:33Z
+issue-date = 2024-11-21T00:52:00Z
 arches = ["aarch64", "x86_64"]
-version = "staging"
+version = "4.0.0"


### PR DESCRIPTION
**Issue number:**

N/a 

**Description of changes:**

Moving libexpat BRSA from `staging` to `4.0.0`, [the version its fix was released.](https://github.com/bottlerocket-os/bottlerocket-core-kit/releases/tag/v4.0.0)

**Testing done:**

N/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
