### PR TITLE
Host container migrations

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3425,6 +3425,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "serde_plain",
  "toml",
 ]
 

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "serde_plain",
  "simple-settings-plugin",
  "simplelog",
  "snafu",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1958,6 +1958,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
+ "serde_plain",
  "snafu",
  "toml",
  "walkdir",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -5099,6 +5099,7 @@ dependencies = [
  "http 0.2.12",
  "log",
  "models",
+ "serde",
  "serde_json",
  "shlex",
  "simplelog",

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3350,15 +3350,19 @@ dependencies = [
  "bottlerocket-release",
  "bytes",
  "chrono",
+ "datastore",
  "futures",
  "futures-core",
  "generate-readme",
  "log",
  "lz4",
+ "models",
  "nix",
  "pentacle",
+ "percent-encoding",
  "rand",
  "semver",
+ "serde_json",
  "simplelog",
  "snafu",
  "storewolf",
@@ -3368,6 +3372,7 @@ dependencies = [
  "tough",
  "update_metadata",
  "url",
+ "walkdir",
 ]
 
 [[package]]

--- a/sources/api/apiclient/README.md
+++ b/sources/api/apiclient/README.md
@@ -174,6 +174,10 @@ You can see all your pending settings like this:
 ```shell
 apiclient raw -u /tx
 ```
+You can also see pending metadata along with pending setting using version 2 of `/tx` like this:
+```shell
+apiclient raw -u /v2/tx
+```
 
 To *commit* the settings, and let the system apply them to any relevant configuration files or services, do this:
 ```shell

--- a/sources/api/apiclient/README.tpl
+++ b/sources/api/apiclient/README.tpl
@@ -174,6 +174,10 @@ You can see all your pending settings like this:
 ```shell
 apiclient raw -u /tx
 ```
+You can also see pending metadata along with pending setting using version 2 of `/tx` like this:
+```shell
+apiclient raw -u /v2/tx
+```
 
 To *commit* the settings, and let the system apply them to any relevant configuration files or services, do this:
 ```shell

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -27,6 +27,7 @@ num.workspace = true
 rand = { workspace = true, features = ["default"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+serde_plain.workspace = true
 simplelog.workspace = true
 snafu.workspace = true
 thar-be-updates.workspace = true

--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -92,6 +92,9 @@ pub enum Error {
         source: datastore::deserialization::Error,
     },
 
+    #[snafu(display("Unable to deserialize data: {}", source))]
+    DeserializeStrength { source: serde_json::Error },
+
     #[snafu(display("Unable to serialize data: {}", source))]
     Serialize { source: serde_json::Error },
 
@@ -240,9 +243,31 @@ pub enum Error {
         stdout: Vec<u8>,
         source: serde_json::Error,
     },
+
+    #[snafu(display("Error deserializing response value to SettingsGenerator: {}", source))]
+    DeserializeSettingsGenerator { source: serde_json::Error },
+
+    #[snafu(display(
+        "Provided strength is not one of weak or strong. The given strength is: {}. {}",
+        strength,
+        source
+    ))]
+    InvalidStrength {
+        strength: String,
+        source: serde_plain::Error,
+    },
+
+    #[snafu(display(
+        "Trying to change the strength from strong to weak for key: {}, Operation restricted",
+        key
+    ))]
+    DisallowStrongToWeakStrength { key: String },
+
+    #[snafu(display("Unable to parse the given strength. Error: "))]
+    ParseStrength { source: serde_plain::Error },
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 impl From<Error> for actix_web::HttpResponse {
     fn from(e: Error) -> Self {

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -17,6 +17,7 @@ use fs2::FileExt;
 use http::StatusCode;
 use log::info;
 use model::ephemeral_storage::{Bind, Init};
+use model::generator::{RawSettingsGenerator, Strength};
 use model::{ConfigurationFiles, Model, Report, Services, Settings};
 use nix::unistd::{chown, Gid};
 use serde::{Deserialize, Serialize};
@@ -28,6 +29,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::str::FromStr;
 use std::sync;
 use thar_be_updates::status::{UpdateStatus, UPDATE_LOCKFILE};
 use tokio::process::Command as AsyncCommand;
@@ -106,6 +108,14 @@ where
                     .route(
                         "/commit_and_apply",
                         web::post().to(commit_transaction_and_apply),
+                    ),
+            )
+            .service(
+                web::scope("/v2")
+                    .route("/tx", web::get().to(get_transaction_v2))
+                    .route(
+                        "/metadata/setting-generators",
+                        web::get().to(get_setting_generators_v2),
                     ),
             )
             .service(web::scope("/os").route("", web::get().to(get_os_info)))
@@ -304,8 +314,9 @@ async fn patch_settings(
     data: web::Data<SharedData>,
 ) -> Result<HttpResponse> {
     let transaction = transaction_name(&query);
+    let strength = query_strength(&query)?;
     let mut datastore = data.ds.write().ok().context(error::DataStoreLockSnafu)?;
-    controller::set_settings(&mut *datastore, &settings, transaction)?;
+    controller::set_settings(&mut *datastore, &settings, transaction, strength)?;
     Ok(HttpResponse::NoContent().finish()) // 204
 }
 
@@ -318,13 +329,14 @@ async fn patch_settings_key_pair(
     // Convert to a Map of Key Value pairs.
     let settings_key_pair_map = construct_key_pair_map(&settings.request_payload)?;
     let transaction = transaction_name(&query);
+    let strength = query_strength(&query)?;
     let mut datastore = data.ds.write().ok().context(error::DataStoreLockSnafu)?;
     // We massage the values in the input key pair map.
     // The data store deserialization code understands how to turn the key names
     // (a.b.c) and serialized values into the nested Settings structure.
     let settings_model = datastore::deserialization::from_map(&settings_key_pair_map)
         .context(error::DeserializeMapSnafu)?;
-    controller::set_settings(&mut *datastore, &settings_model, transaction)?;
+    controller::set_settings(&mut *datastore, &settings_model, transaction, strength)?;
     Ok(HttpResponse::NoContent().finish()) // 204
 }
 
@@ -342,7 +354,27 @@ async fn get_transaction(
     let transaction = transaction_name(&query);
     let datastore = data.ds.read().ok().context(error::DataStoreLockSnafu)?;
     let data = controller::get_transaction(&*datastore, transaction)?;
+
     Ok(SettingsResponse(data))
+}
+
+/// Get any pending settings in the given transaction, or the "default" transaction if unspecified.
+async fn get_transaction_v2(
+    query: web::Query<HashMap<String, String>>,
+    data: web::Data<SharedData>,
+) -> Result<SettingsResponseWithMetadata> {
+    let transaction = transaction_name(&query);
+    let datastore = data.ds.read().ok().context(error::DataStoreLockSnafu)?;
+    let settings = controller::get_transaction(&*datastore, transaction)?;
+    let transaction_metadata =
+        controller::get_transaction_metadata(&*datastore, transaction, None)?;
+
+    let data = SettingsWithMetadata {
+        settings,
+        metadata: transaction_metadata.inner,
+    };
+
+    Ok(SettingsResponseWithMetadata(data))
 }
 
 /// Delete the given transaction, or the "default" transaction if unspecified.
@@ -365,7 +397,10 @@ async fn commit_transaction(
     let transaction = transaction_name(&query);
     let mut datastore = data.ds.write().ok().context(error::DataStoreLockSnafu)?;
 
-    let changes = controller::commit_transaction(&mut *datastore, transaction)?;
+    let changes = controller::commit_transaction::<datastore::filesystem::FilesystemDataStore>(
+        &mut *datastore,
+        transaction,
+    )?;
 
     if changes.is_empty() {
         return error::CommitWithNoPendingSnafu.fail();
@@ -397,7 +432,10 @@ async fn commit_transaction_and_apply(
     let transaction = transaction_name(&query);
     let mut datastore = data.ds.write().ok().context(error::DataStoreLockSnafu)?;
 
-    let changes = controller::commit_transaction(&mut *datastore, transaction)?;
+    let changes = controller::commit_transaction::<datastore::filesystem::FilesystemDataStore>(
+        &mut *datastore,
+        transaction,
+    )?;
 
     if changes.is_empty() {
         return error::CommitWithNoPendingSnafu.fail();
@@ -454,7 +492,30 @@ async fn get_affected_services(
 /// Get all settings that have setting-generator metadata
 async fn get_setting_generators(data: web::Data<SharedData>) -> Result<MetadataResponse> {
     let datastore = data.ds.read().ok().context(error::DataStoreLockSnafu)?;
-    let resp = controller::get_metadata_for_all_data_keys(&*datastore, "setting-generator")?;
+    let metadata_for_keys =
+        controller::get_settings_generator_metadata(&*datastore, "setting-generator")?;
+    let mut resp: HashMap<String, Value> = HashMap::new();
+
+    for (key, value) in metadata_for_keys.iter() {
+        let setting_generator: RawSettingsGenerator = serde_json::from_value(value.clone())
+            .context(error::DeserializeSettingsGeneratorSnafu)?;
+
+        // Not return weak setting generators because the callers using
+        // v1 of this api are not aware of the strength.
+        if setting_generator.strength == Strength::Strong {
+            resp.insert(
+                key.to_string(),
+                serde_json::Value::String(setting_generator.command),
+            );
+        }
+    }
+
+    Ok(MetadataResponse(resp))
+}
+
+async fn get_setting_generators_v2(data: web::Data<SharedData>) -> Result<MetadataResponse> {
+    let datastore = data.ds.read().ok().context(error::DataStoreLockSnafu)?;
+    let resp = controller::get_settings_generator_metadata(&*datastore, "setting-generator")?;
     Ok(MetadataResponse(resp))
 }
 
@@ -753,8 +814,19 @@ fn transaction_name(query: &web::Query<HashMap<String, String>>) -> &str {
     query.get("tx").map(String::as_str).unwrap_or("default")
 }
 
-// Helpers methods for the 'set' API
+fn query_strength(query: &web::Query<HashMap<String, String>>) -> Result<Strength> {
+    if let Some(strength) = query.get("strength") {
+        Ok(
+            Strength::from_str(strength).context(error::InvalidStrengthSnafu {
+                strength: strength.to_string(),
+            })?,
+        )
+    } else {
+        Ok(Strength::default())
+    }
+}
 
+// Helpers methods for the 'set' API
 fn construct_key_pair_map(settings_key_pair_vec: &Vec<String>) -> Result<HashMap<Key, String>> {
     let mut settings_key_pair_map = HashMap::new();
     for settings_key_pair in settings_key_pair_vec {
@@ -892,6 +964,11 @@ impl ResponseError for error::Error {
             UpdateLockOpen { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ReportExec { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ReportResult { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            DeserializeSettingsGenerator { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            DeserializeStrength { .. } => StatusCode::BAD_REQUEST,
+            InvalidStrength { .. } => StatusCode::BAD_REQUEST,
+            DisallowStrongToWeakStrength { .. } => StatusCode::BAD_REQUEST,
+            ParseStrength { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         };
 
         HttpResponse::build(status_code).body(self.to_string())
@@ -943,6 +1020,16 @@ macro_rules! impl_responder_for {
 /// those results into a Model/BottlerocketRelease would fail, so it's just intended for viewing.)
 struct ModelResponse(serde_json::Value);
 impl_responder_for!(ModelResponse, self, self.0);
+
+/// This lets us respond from our handler methods with the Settings and Metadata
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+struct SettingsWithMetadata {
+    settings: Settings,
+    metadata: HashMap<String, HashMap<String, String>>,
+}
+
+struct SettingsResponseWithMetadata(SettingsWithMetadata);
+impl_responder_for!(SettingsResponseWithMetadata, self, self.0);
 
 /// This lets us respond from our handler methods with a Settings (or Result<Settings>)
 struct SettingsResponse(Settings);

--- a/sources/api/datastore/Cargo.toml
+++ b/sources/api/datastore/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 snafu.workspace = true
 walkdir.workspace = true
+serde_plain.workspace =  true
 
 [build-dependencies]
 generate-readme.workspace = true

--- a/sources/api/datastore/src/constraints_check.rs
+++ b/sources/api/datastore/src/constraints_check.rs
@@ -1,0 +1,52 @@
+//! The outcome of the constraint check determines whether the transaction can proceed to commit.
+//! A ‘rejected’ result means that one or more constraints have not been satisfied,
+//! preventing the transaction from being committed. On the other hand, an ‘approved’
+//! result confirms that all constraints are satisfied and provides the required
+//! settings and metadata for the commit.
+//! Constraint checks can alter the write.
+
+use std::collections::HashMap;
+
+use crate::{error, Key};
+
+type RejectReason = String;
+
+/// Represents a successful write operation after constraints have been approved.
+/// Contains the following fields:
+/// - `settings`: A collection of key-value pairs representing the settings to be committed.
+/// - `metadata`: A collection of metadata entries.
+#[derive(PartialEq)]
+pub struct ApprovedWrite {
+    pub settings: HashMap<Key, String>,
+    pub metadata: Vec<(Key, Key, String)>,
+}
+
+/// Represents the result of a constraint check.
+/// The result can either reject the operation or approve it with the required data.
+#[derive(PartialEq)]
+pub enum ConstraintCheckResult {
+    Reject(RejectReason),
+    Approve(ApprovedWrite),
+}
+
+impl TryFrom<ConstraintCheckResult> for ApprovedWrite {
+    type Error = error::Error;
+
+    fn try_from(constraint_check_result: ConstraintCheckResult) -> Result<Self, Self::Error> {
+        match constraint_check_result {
+            ConstraintCheckResult::Reject(err) => error::ConstraintCheckRejectSnafu { err }.fail(),
+            ConstraintCheckResult::Approve(approved_write) => Ok(approved_write),
+        }
+    }
+}
+
+impl From<Option<ApprovedWrite>> for ConstraintCheckResult {
+    fn from(approved_write: Option<ApprovedWrite>) -> Self {
+        match approved_write {
+            None => ConstraintCheckResult::Reject(
+                "The write for the given transaction is rejected".to_string(),
+            ),
+            Some(approved_write) => ConstraintCheckResult::Approve(approved_write),
+        }
+    }
+}

--- a/sources/api/datastore/src/error.rs
+++ b/sources/api/datastore/src/error.rs
@@ -59,6 +59,20 @@ pub enum Error {
 
     #[snafu(display("Key name beyond maximum length {}: {}", name, max))]
     KeyTooLong { name: String, max: usize },
+
+    #[snafu(display("Unable to serialize data: {}", source))]
+    Serialize { source: serde_json::Error },
+
+    #[snafu(display("Unable to run the check constraint function: {}", source))]
+    CheckConstraintExecution {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display(
+        "Check constraint function rejected the transaction. Aborting commit : {}",
+        err
+    ))]
+    ConstraintCheckReject { err: String },
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/sources/api/datastore/src/lib.rs
+++ b/sources/api/datastore/src/lib.rs
@@ -27,6 +27,7 @@ The `deserialization` module provides code to deserialize datastore-acceptable k
 * The `serialization` module can't handle complex types under lists; it assumes lists can be serialized as scalars.
 */
 
+pub mod constraints_check;
 pub mod deserialization;
 pub mod error;
 pub mod filesystem;
@@ -34,11 +35,12 @@ pub mod key;
 pub mod memory;
 pub mod serialization;
 
+use constraints_check::ConstraintCheckResult;
 pub use error::{Error, Result};
 pub use filesystem::FilesystemDataStore;
 pub use key::{Key, KeyType, KEY_SEPARATOR, KEY_SEPARATOR_STR};
 
-use log::{info, trace};
+use log::trace;
 use serde::{Deserialize, Serialize};
 use snafu::OptionExt;
 use std::collections::{HashMap, HashSet};
@@ -72,6 +74,7 @@ pub trait DataStore {
     fn list_populated_metadata<S1, S2>(
         &self,
         prefix: S1,
+        committed: &Committed,
         metadata_key_name: &Option<S2>,
     ) -> Result<HashMap<Key, HashSet<Key>>>
     where
@@ -89,7 +92,12 @@ pub trait DataStore {
 
     /// Retrieve the value for a single metadata key from the datastore.  Values will inherit from
     /// earlier in the tree, if more specific values are not found later.
-    fn get_metadata(&self, metadata_key: &Key, data_key: &Key) -> Result<Option<String>> {
+    fn get_metadata(
+        &self,
+        metadata_key: &Key,
+        data_key: &Key,
+        committed: &Committed,
+    ) -> Result<Option<String>> {
         let mut result = Ok(None);
         let mut current_path = Vec::new();
 
@@ -101,7 +109,7 @@ pub trait DataStore {
                 unreachable!("Prefix of Key failed to make Key: {:?}", current_path)
             });
 
-            if let Some(md) = self.get_metadata_raw(metadata_key, &data_key)? {
+            if let Some(md) = self.get_metadata_raw(metadata_key, &data_key, committed)? {
                 result = Ok(Some(md));
             }
         }
@@ -110,13 +118,19 @@ pub trait DataStore {
 
     /// Retrieve the value for a single metadata key from the datastore, without taking into
     /// account inheritance of metadata from earlier in the tree.
-    fn get_metadata_raw(&self, metadata_key: &Key, data_key: &Key) -> Result<Option<String>>;
+    fn get_metadata_raw(
+        &self,
+        metadata_key: &Key,
+        data_key: &Key,
+        committed: &Committed,
+    ) -> Result<Option<String>>;
     /// Set the value of a single metadata key in the datastore.
     fn set_metadata<S: AsRef<str>>(
         &mut self,
         metadata_key: &Key,
         data_key: &Key,
         value: S,
+        committed: &Committed,
     ) -> Result<()>;
     /// Removes the given metadata key from the given data key in the datastore.  If we
     /// succeeded, we return Ok(()); if the data or metadata key didn't exist, we also return
@@ -125,9 +139,20 @@ pub trait DataStore {
 
     /// Applies pending changes from the given transaction to the live datastore.  Returns the
     /// list of changed keys.
-    fn commit_transaction<S>(&mut self, transaction: S) -> Result<HashSet<Key>>
+    fn commit_transaction<S, C>(
+        &mut self,
+        transaction: S,
+        constraint_check: &C,
+    ) -> Result<HashSet<Key>>
     where
-        S: Into<String> + AsRef<str>;
+        S: Into<String> + AsRef<str>,
+        C: Fn(
+            &mut Self,
+            &Committed,
+        ) -> std::result::Result<
+            ConstraintCheckResult,
+            Box<dyn std::error::Error + Send + Sync + 'static>,
+        >;
 
     /// Remove the given pending transaction from the datastore.  Returns the list of removed
     /// keys.  If the transaction doesn't exist, will return Ok with an empty list.
@@ -149,7 +174,7 @@ pub trait DataStore {
         for (key, value) in pairs {
             match committed {
                 Committed::Live => {
-                    info!("Committed data key {}", key.name());
+                    trace!("Committed data key {}", key.name());
                 }
                 state => {
                     trace!("Data key {} state changed to {:?}", key.name(), state);
@@ -205,13 +230,14 @@ pub trait DataStore {
     fn get_metadata_prefix<S1, S2>(
         &self,
         find_prefix: S1,
+        committed: &Committed,
         metadata_key_name: &Option<S2>,
     ) -> Result<HashMap<Key, HashMap<Key, String>>>
     where
         S1: AsRef<str>,
         S2: AsRef<str>,
     {
-        let meta_map = self.list_populated_metadata(&find_prefix, metadata_key_name)?;
+        let meta_map = self.list_populated_metadata(&find_prefix, committed, metadata_key_name)?;
         trace!("Found populated metadata: {:?}", meta_map);
         if meta_map.is_empty() {
             return Ok(HashMap::new());
@@ -234,12 +260,12 @@ pub trait DataStore {
                     meta_key,
                     &data_key
                 );
-                let value = self.get_metadata(&meta_key, &data_key)?.context(
-                    error::ListedMetaNotPresentSnafu {
+                let value = self
+                    .get_metadata(&meta_key, &data_key, committed)?
+                    .context(error::ListedMetaNotPresentSnafu {
                         meta_key: meta_key.name(),
                         data_key: data_key.name(),
-                    },
-                )?;
+                    })?;
 
                 // Insert a top-level map entry for the data key if we've found metadata.
                 let data_entry = result.entry(data_key.clone()).or_insert_with(HashMap::new);
@@ -336,14 +362,20 @@ mod test {
         let grandchild = Key::new(KeyType::Data, "a.b.c").unwrap();
 
         // Set metadata on parent
-        m.set_metadata(&meta, &parent, "value").unwrap();
+        m.set_metadata(&meta, &parent, "value", &Committed::Live)
+            .unwrap();
         // Metadata shows up on grandchild...
         assert_eq!(
-            m.get_metadata(&meta, &grandchild).unwrap(),
+            m.get_metadata(&meta, &grandchild, &Committed::Live)
+                .unwrap(),
             Some("value".to_string())
         );
         // ...but only through inheritance, not directly.
-        assert_eq!(m.get_metadata_raw(&meta, &grandchild).unwrap(), None);
+        assert_eq!(
+            m.get_metadata_raw(&meta, &grandchild, &Committed::Live)
+                .unwrap(),
+            None
+        );
     }
 
     #[test]
@@ -379,20 +411,92 @@ mod test {
         let mk1 = Key::new(KeyType::Meta, "metatest1").unwrap();
         let mk2 = Key::new(KeyType::Meta, "metatest2").unwrap();
         let mk3 = Key::new(KeyType::Meta, "metatest3").unwrap();
-        m.set_metadata(&mk1, &k1, "41").unwrap();
-        m.set_metadata(&mk2, &k2, "42").unwrap();
-        m.set_metadata(&mk3, &k3, "43").unwrap();
+        m.set_metadata(&mk1, &k1, "41", &Committed::Live).unwrap();
+        m.set_metadata(&mk2, &k2, "42", &Committed::Live).unwrap();
+        m.set_metadata(&mk3, &k3, "43", &Committed::Live).unwrap();
 
         // Check all metadata
         assert_eq!(
-            m.get_metadata_prefix("x.", &None as &Option<&str>).unwrap(),
+            m.get_metadata_prefix("x.", &Committed::Live, &None as &Option<&str>)
+                .unwrap(),
             hashmap!(k1 => hashmap!(mk1 => "41".to_string()),
                      k2.clone() => hashmap!(mk2.clone() => "42".to_string()))
         );
 
         // Check metadata matching a given name
         assert_eq!(
-            m.get_metadata_prefix("x.", &Some("metatest2")).unwrap(),
+            m.get_metadata_prefix("x.", &Committed::Live, &Some("metatest2"))
+                .unwrap(),
+            hashmap!(k2 => hashmap!(mk2 => "42".to_string()))
+        );
+    }
+
+    #[test]
+    fn get_metadata_prefix_from_pending() {
+        let mut m = MemoryDataStore::new();
+
+        // Build some data keys to which we can attach metadata; they don't actually have to be
+        // set in the data store.
+        let k1 = Key::new(KeyType::Data, "x.1").unwrap();
+        let k2 = Key::new(KeyType::Data, "x.2").unwrap();
+        let k3 = Key::new(KeyType::Data, "y.3").unwrap();
+
+        // Set some metadata to check
+        let mk1 = Key::new(KeyType::Meta, "metatest1").unwrap();
+        let mk2 = Key::new(KeyType::Meta, "metatest2").unwrap();
+        let mk3 = Key::new(KeyType::Meta, "metatest3").unwrap();
+        m.set_metadata(
+            &mk1,
+            &k1,
+            "41",
+            &Committed::Pending {
+                tx: "test".to_owned(),
+            },
+        )
+        .unwrap();
+        m.set_metadata(
+            &mk2,
+            &k2,
+            "42",
+            &Committed::Pending {
+                tx: "test".to_owned(),
+            },
+        )
+        .unwrap();
+        m.set_metadata(
+            &mk3,
+            &k3,
+            "43",
+            &Committed::Pending {
+                tx: "test".to_owned(),
+            },
+        )
+        .unwrap();
+
+        // Check all metadata
+        assert_eq!(
+            m.get_metadata_prefix(
+                "x.",
+                &Committed::Pending {
+                    tx: "test".to_owned()
+                },
+                &None as &Option<&str>
+            )
+            .unwrap(),
+            hashmap!(k1 => hashmap!(mk1 => "41".to_string()),
+                     k2.clone() => hashmap!(mk2.clone() => "42".to_string()))
+        );
+
+        // Check metadata matching a given name
+        assert_eq!(
+            m.get_metadata_prefix(
+                "x.",
+                &Committed::Pending {
+                    tx: "test".to_owned()
+                },
+                &Some("metatest2")
+            )
+            .unwrap(),
             hashmap!(k2 => hashmap!(mk2 => "42".to_string()))
         );
     }

--- a/sources/api/datastore/src/memory.rs
+++ b/sources/api/datastore/src/memory.rs
@@ -5,6 +5,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::constraints_check::{ApprovedWrite, ConstraintCheckResult};
+
 use super::{Committed, DataStore, Key, Result};
 
 #[derive(Debug, Default)]
@@ -16,6 +18,9 @@ pub struct MemoryDataStore {
     // Map of data keys to their metadata, which in turn is a mapping of metadata keys to
     // arbitrary (string/serialized) values.
     metadata: HashMap<Key, HashMap<Key, String>>,
+    // Map of data keys to their metadata, which in turn is a mapping of metadata keys to
+    // arbitrary (string/serialized) values in pending transaction
+    pending_metadata: HashMap<Key, HashMap<Key, String>>,
 }
 
 impl MemoryDataStore {
@@ -57,14 +62,21 @@ impl DataStore for MemoryDataStore {
     fn list_populated_metadata<S1, S2>(
         &self,
         prefix: S1,
+        committed: &Committed,
         metadata_key_name: &Option<S2>,
     ) -> Result<HashMap<Key, HashSet<Key>>>
     where
         S1: AsRef<str>,
         S2: AsRef<str>,
     {
+        let metadata_to_use = match committed {
+            Committed::Live => &self.metadata,
+            Committed::Pending { .. } => &self.pending_metadata,
+        };
+
         let mut result = HashMap::new();
-        for (data_key, meta_map) in self.metadata.iter() {
+
+        for (data_key, meta_map) in metadata_to_use.iter() {
             // Confirm data key matches requested prefix.
             if !data_key.name().starts_with(prefix.as_ref()) {
                 continue;
@@ -112,8 +124,19 @@ impl DataStore for MemoryDataStore {
         Ok(dataset.contains_key(key))
     }
 
-    fn get_metadata_raw(&self, metadata_key: &Key, data_key: &Key) -> Result<Option<String>> {
-        let metadata_for_data = self.metadata.get(data_key);
+    fn get_metadata_raw(
+        &self,
+        metadata_key: &Key,
+        data_key: &Key,
+        committed: &Committed,
+    ) -> Result<Option<String>> {
+        let metadata_to_use = match committed {
+            Committed::Live => &self.metadata,
+            Committed::Pending { .. } => &self.pending_metadata,
+        };
+
+        let metadata_for_data = metadata_to_use.get(data_key);
+
         // If we have a metadata entry for this data key, then we can try fetching the requested
         // metadata key, otherwise we'll return early with Ok(None).
         let result = metadata_for_data.and_then(|m| m.get(metadata_key));
@@ -125,17 +148,14 @@ impl DataStore for MemoryDataStore {
         metadata_key: &Key,
         data_key: &Key,
         value: S,
+        committed: &Committed,
     ) -> Result<()> {
-        // If we don't already have a metadata entry for this data key, insert one.
-        let metadata_for_data = self
-            .metadata
-            // Clone data key because we want the HashMap key type to be Key, not &Key, and we
-            // can't pass ownership because we only have a reference from our parameters.
-            .entry(data_key.clone())
-            .or_default();
-
-        metadata_for_data.insert(metadata_key.clone(), value.as_ref().to_owned());
-        Ok(())
+        match committed {
+            Committed::Live => set_metadata_raw(&mut self.metadata, metadata_key, data_key, value),
+            Committed::Pending { .. } => {
+                set_metadata_raw(&mut self.pending_metadata, metadata_key, data_key, value)
+            }
+        }
     }
 
     fn unset_metadata(&mut self, metadata_key: &Key, data_key: &Key) -> Result<()> {
@@ -146,19 +166,45 @@ impl DataStore for MemoryDataStore {
         Ok(())
     }
 
-    fn commit_transaction<S>(&mut self, transaction: S) -> Result<HashSet<Key>>
+    fn commit_transaction<S, C>(
+        &mut self,
+        transaction: S,
+        constraint_check: &C,
+    ) -> Result<HashSet<Key>>
     where
         S: Into<String> + AsRef<str>,
+        C: Fn(
+            &mut Self,
+            &Committed,
+        ) -> std::result::Result<
+            ConstraintCheckResult,
+            Box<dyn std::error::Error + Send + Sync + 'static>,
+        >,
     {
+        let tx = transaction.as_ref();
+        let pending = Committed::Pending { tx: tx.into() };
+
+        let constraint_check_result =
+            constraint_check(self, &pending).unwrap_or(ConstraintCheckResult::Reject(
+                "Check constraint function rejected the transaction. Aborting commit".to_string(),
+            ));
+        let approved_write = ApprovedWrite::try_from(constraint_check_result)?;
+
+        let mut pending_keys: HashSet<Key> = Default::default();
         // Remove anything pending for this transaction
-        if let Some(pending) = self.pending.remove(transaction.as_ref()) {
+
+        if !approved_write.settings.is_empty() {
+            // Save Keys for return value
+            pending_keys = approved_write.settings.keys().cloned().collect();
+
             // Apply pending changes to live
-            self.set_keys(&pending, &Committed::Live)?;
-            // Return keys that were committed
-            Ok(pending.keys().cloned().collect())
-        } else {
-            Ok(HashSet::new())
+            self.set_keys(&approved_write.settings, &Committed::Live)?;
         }
+
+        self.pending.remove(tx);
+
+        // Return keys that were committed
+        Ok(pending_keys)
     }
 
     fn delete_transaction<S>(&mut self, transaction: S) -> Result<HashSet<Key>>
@@ -179,11 +225,73 @@ impl DataStore for MemoryDataStore {
     }
 }
 
+fn set_metadata_raw<S: AsRef<str>>(
+    metadata_to_use: &mut HashMap<Key, HashMap<Key, String>>,
+    metadata_key: &Key,
+    data_key: &Key,
+    value: S,
+) -> Result<()> {
+    // If we don't already have a metadata entry for this data key, insert one.
+    let metadata_for_data = metadata_to_use
+        // Clone data key because we want the HashMap key type to be Key, not &Key, and we
+        // can't pass ownership because we only have a reference from our parameters.
+        .entry(data_key.clone())
+        .or_default();
+
+    metadata_for_data.insert(metadata_key.clone(), value.as_ref().to_owned());
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use super::super::{Committed, DataStore, Key, KeyType};
     use super::MemoryDataStore;
+    use crate::constraints_check::{ApprovedWrite, ConstraintCheckResult};
+    use crate::{deserialize_scalar, serialize_scalar, ScalarError};
     use maplit::hashset;
+
+    fn constraint_check(
+        datastore: &mut MemoryDataStore,
+        committed: &Committed,
+    ) -> super::Result<ConstraintCheckResult, Box<dyn std::error::Error + Send + Sync + 'static>>
+    {
+        let mut transaction_metadata = datastore
+            .get_metadata_prefix("settings.", committed, &None as &Option<&str>)
+            .unwrap();
+
+        let settings_to_commit: HashMap<Key, String> = match committed {
+            Committed::Pending { tx: transaction } => datastore
+                .pending
+                .get(transaction)
+                .unwrap_or(&HashMap::new())
+                .clone(),
+            Committed::Live => HashMap::new(),
+        };
+
+        let mut metadata_to_commit: Vec<(Key, Key, String)> = Vec::new();
+
+        for (key, value) in transaction_metadata.iter_mut() {
+            for (metadata_key, metadata_value) in value {
+                if metadata_key.name() != "strength" {
+                    continue;
+                }
+
+                // strength in pending transaction
+                let pending_strength: String =
+                    deserialize_scalar::<_, ScalarError>(&metadata_value.clone()).unwrap();
+                let met_value = serialize_scalar::<_, ScalarError>(&pending_strength).unwrap();
+                metadata_to_commit.push((metadata_key.clone(), key.clone(), met_value));
+            }
+        }
+        let approved_write = ApprovedWrite {
+            settings: settings_to_commit,
+            metadata: metadata_to_commit,
+        };
+
+        Ok(ConstraintCheckResult::from(Some(approved_write)))
+    }
 
     #[test]
     fn get_set_unset() {
@@ -198,14 +306,38 @@ mod test {
 
         let mdkey = Key::new(KeyType::Meta, "testmd").unwrap();
         let md = "mdval";
-        m.set_metadata(&mdkey, &k, md).unwrap();
+        m.set_metadata(&mdkey, &k, md, &Committed::Live).unwrap();
         assert_eq!(
-            m.get_metadata_raw(&mdkey, &k).unwrap(),
+            m.get_metadata_raw(&mdkey, &k, &Committed::Live).unwrap(),
+            Some(md.to_string())
+        );
+
+        m.set_metadata(
+            &mdkey,
+            &k,
+            md,
+            &Committed::Pending {
+                tx: "test".to_owned(),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            m.get_metadata_raw(
+                &mdkey,
+                &k,
+                &Committed::Pending {
+                    tx: "test".to_owned()
+                }
+            )
+            .unwrap(),
             Some(md.to_string())
         );
 
         m.unset_metadata(&mdkey, &k).unwrap();
-        assert_eq!(m.get_metadata_raw(&mdkey, &k).unwrap(), None);
+        assert_eq!(
+            m.get_metadata_raw(&mdkey, &k, &Committed::Live).unwrap(),
+            None
+        );
 
         m.unset_key(&k, &Committed::Live).unwrap();
         assert_eq!(m.get_key(&k, &Committed::Live).unwrap(), None);
@@ -242,7 +374,7 @@ mod test {
 
         assert!(m.key_populated(&k, &pending).unwrap());
         assert!(!m.key_populated(&k, &Committed::Live).unwrap());
-        m.commit_transaction(tx).unwrap();
+        m.commit_transaction(tx, &constraint_check).unwrap();
         assert!(!m.key_populated(&k, &pending).unwrap());
         assert!(m.key_populated(&k, &Committed::Live).unwrap());
     }

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -20,10 +20,12 @@ futures = { workspace = true, features = ["default"] }
 futures-core.workspace = true
 log.workspace = true
 lz4.workspace = true
+models.workspace = true
 nix.workspace = true
 pentacle.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
 semver.workspace = true
+serde_json.workspace = true
 simplelog.workspace = true
 snafu.workspace = true
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
@@ -31,6 +33,9 @@ tokio-util = { workspace = true, features = ["compat", "io-util"] }
 tough = { workspace = true }
 update_metadata.workspace = true
 url.workspace = true
+walkdir.workspace = true
+datastore.workspace = true
+percent-encoding.workspace = true
 
 [build-dependencies]
 generate-readme.workspace = true

--- a/sources/api/migration/migrator/src/datastore_helper.rs
+++ b/sources/api/migration/migrator/src/datastore_helper.rs
@@ -1,0 +1,119 @@
+//! This module contains the functions that interact with the data store, retrieving data to
+//! update and writing back updated data.
+
+use snafu::ResultExt;
+use std::collections::HashMap;
+
+use crate::{error, Result};
+use datastore::{deserialize_scalar, serialize_scalar, Committed, DataStore, Key, KeyType, Value};
+
+/// Mapping of metadata key name to arbitrary value.  Each data key can have a Metadata describing
+/// its metadata keys.
+/// example: Key: settings.host-containers.admin.source, Metadata: strength and Value: "weak"
+pub type Metadata = HashMap<String, Value>;
+
+/// DataStoreData holds all data that exists in datastore.
+// We will take this as an input and use it to delete weak settings and settings generator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataStoreData {
+    /// Mapping of data key names to their arbitrary values.
+    pub data: HashMap<String, Value>,
+    /// Mapping of data key names to their metadata.
+    pub metadata: HashMap<String, Metadata>,
+}
+
+// To get input data from the existing data store, we use datastore methods.
+// This method is private to the crate, so we can
+// reconsider as needed.
+/// Retrieves data from the specified data store in a consistent format for easy modification.
+pub(crate) fn get_input_data<D: DataStore>(
+    datastore: &D,
+    committed: &Committed,
+) -> Result<DataStoreData> {
+    let raw_data = datastore
+        .get_prefix("", committed)
+        .with_context(|_| error::GetDataSnafu {
+            committed: committed.clone(),
+        })?;
+
+    let mut data = HashMap::new();
+    for (data_key, value_str) in raw_data.into_iter() {
+        // Store keys with just their name, rather than the full Key.
+        let key_name = data_key.name();
+        // Deserialize values to Value so there's a consistent input type.  (We can't specify item
+        // types because we'd have to know the model structure.)
+        let value =
+            deserialize_scalar(&value_str).context(error::DeserializeSnafu { input: value_str })?;
+        data.insert(key_name.clone(), value);
+    }
+
+    let mut metadata = HashMap::new();
+
+    let raw_metadata = datastore
+        .get_metadata_prefix("", committed, &None as &Option<&str>)
+        .context(error::GetMetadataSnafu)?;
+
+    for (data_key, meta_map) in raw_metadata.into_iter() {
+        let data_key_name = data_key.name();
+
+        let data_entry = metadata
+            .entry(data_key_name.clone())
+            .or_insert_with(HashMap::new);
+
+        for (metadata_key, value_str) in meta_map.into_iter() {
+            let metadata_key_name = metadata_key.name();
+            let value = deserialize_scalar(&value_str)
+                .context(error::DeserializeSnafu { input: value_str })?;
+            data_entry.insert(metadata_key_name.clone(), value);
+        }
+    }
+    Ok(DataStoreData { data, metadata })
+}
+
+// Similar to get_input_data, we use datastore methods here;
+// This method is also private to the crate, so we can reconsider as needed.
+/// Updates the given data store with the given (updated) data.
+pub(crate) fn set_output_data<D: DataStore>(
+    datastore: &mut D,
+    input: &DataStoreData,
+    committed: &Committed,
+) -> Result<()> {
+    // Prepare serialized data
+    let mut data = HashMap::new();
+    for (data_key_name, raw_value) in &input.data {
+        let data_key = Key::new(KeyType::Data, data_key_name).context(error::InvalidKeySnafu {
+            key_type: KeyType::Data,
+            key: data_key_name,
+        })?;
+        let value = serialize_scalar(raw_value).context(error::SerializeSnafu)?;
+        data.insert(data_key, value);
+    }
+
+    // This is one of the rare cases where we want to set keys directly in the datastore:
+    // * We're operating on a temporary copy of the datastore, so no concurrency issues
+    // * We're either about to reboot or just have, and the settings applier will run afterward
+    datastore
+        .set_keys(&data, committed)
+        .context(error::DataStoreWriteSnafu)?;
+
+    // Set metadata in a loop (currently no batch API)
+    for (data_key_name, meta_map) in &input.metadata {
+        let data_key = Key::new(KeyType::Data, data_key_name).context(error::InvalidKeySnafu {
+            key_type: KeyType::Data,
+            key: data_key_name,
+        })?;
+        for (metadata_key_name, raw_value) in meta_map.iter() {
+            let metadata_key =
+                Key::new(KeyType::Meta, metadata_key_name).context(error::InvalidKeySnafu {
+                    key_type: KeyType::Meta,
+                    key: metadata_key_name,
+                })?;
+            let value = serialize_scalar(&raw_value).context(error::SerializeSnafu)?;
+            datastore
+                .set_metadata(&metadata_key, &data_key, value, committed)
+                .context(error::DataStoreWriteSnafu)?;
+        }
+    }
+
+    Ok(())
+}

--- a/sources/api/migration/migrator/src/error.rs
+++ b/sources/api/migration/migrator/src/error.rs
@@ -106,6 +106,48 @@ pub(crate) enum Error {
         #[snafu(source(from(tough::error::Error, Box::new)))]
         source: Box<tough::error::Error>,
     },
+
+    #[snafu(display("Unable to get {:?} data from datastore: {}", committed, source))]
+    GetData {
+        committed: datastore::Committed,
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
+    },
+
+    #[snafu(display("Unable to deserialize to Value from '{}': {}", input, source))]
+    Deserialize {
+        input: String,
+        source: datastore::ScalarError,
+    },
+
+    #[snafu(display("Unable to get metadata from datastore: {}", source))]
+    GetMetadata {
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
+    },
+
+    #[snafu(display("Update used invalid {:?} key '{}': {}", key_type, key, source))]
+    InvalidKey {
+        key_type: datastore::KeyType,
+        key: String,
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
+    },
+
+    #[snafu(display("Unable to write to data store: {}", source))]
+    DataStoreWrite {
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
+    },
+
+    #[snafu(display("Unable to serialize Value: {}", source))]
+    Serialize { source: datastore::ScalarError },
+
+    #[snafu(display("Unable to list transactions in data store: {}", source))]
+    ListTransactions {
+        #[snafu(source(from(datastore::Error, Box::new)))]
+        source: Box<datastore::Error>,
+    },
 }
 
 /// Result alias containing our Error type.

--- a/sources/api/migration/migrator/src/test.rs
+++ b/sources/api/migration/migrator/src/test.rs
@@ -1,8 +1,10 @@
 //! Provides an end-to-end test of `migrator` via the `run` function. This module is conditionally
 //! compiled for cfg(test) only.
 use crate::args::Args;
-use crate::run;
+use crate::{copy_without_weak_settings_and_metadata, flip_to_new_version, perform_migrations};
 use chrono::{DateTime, Utc};
+use datastore::memory::MemoryDataStore;
+use datastore::{serialize_scalar, Committed, DataStore, Key};
 use semver::Version;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -349,7 +351,7 @@ async fn migrate_forward() {
         root_path: root(),
         metadata_directory: test_repo.metadata_path.clone(),
     };
-    run(&args).await.unwrap();
+    let datastore = perform_migrations(&args).await.unwrap();
     // the migrations should write to a file named result.txt.
     let output_file = test_datastore.tmp.path().join("result.txt");
     let contents = std::fs::read_to_string(&output_file).unwrap();
@@ -367,6 +369,10 @@ async fn migrate_forward() {
     let want = format!("{}: --forward", THIRD_MIGRATION);
     let got: String = third_line.chars().take(want.len()).collect();
     assert_eq!(got, want);
+
+    flip_to_new_version(&args.migrate_to_version, datastore)
+        .await
+        .unwrap();
 
     // Check the directory.
     let current = assert_directory_structure(test_datastore.tmp.path()).await;
@@ -397,7 +403,7 @@ async fn migrate_backward() {
         root_path: root(),
         metadata_directory: test_repo.metadata_path.clone(),
     };
-    run(&args).await.unwrap();
+    let datastore = perform_migrations(&args).await.unwrap();
     let output_file = test_datastore.tmp.path().join("result.txt");
     let contents = std::fs::read_to_string(&output_file).unwrap();
     let lines: Vec<&str> = contents.split('\n').collect();
@@ -414,6 +420,10 @@ async fn migrate_backward() {
     let want = format!("{}: --backward", FIRST_MIGRATION);
     let got: String = second_line.chars().take(want.len()).collect();
     assert_eq!(got, want);
+
+    flip_to_new_version(&args.migrate_to_version, datastore)
+        .await
+        .unwrap();
 
     // Check the directory.
     let current = assert_directory_structure(test_datastore.tmp.path()).await;
@@ -442,7 +452,7 @@ async fn migrate_forward_with_failed_migration() {
         root_path: root(),
         metadata_directory: test_repo.metadata_path.clone(),
     };
-    let result = run(&args).await;
+    let result = perform_migrations(&args).await;
     assert!(result.is_err());
 
     // the migrations should write to a file named result.txt.
@@ -495,7 +505,7 @@ async fn migrate_backward_with_failed_migration() {
         root_path: root(),
         metadata_directory: test_repo.metadata_path.clone(),
     };
-    let result = run(&args).await;
+    let result = perform_migrations(&args).await;
     assert!(result.is_err());
 
     let output_file = test_datastore.tmp.path().join("result.txt");
@@ -531,4 +541,101 @@ async fn migrate_backward_with_failed_migration() {
         .to_str()
         .unwrap()
         .starts_with("v0.99.1"));
+}
+
+#[tokio::test]
+async fn test_remove_all_metadata() {
+    let mut source = MemoryDataStore::new();
+    let data_key = Key::new(datastore::KeyType::Data, "a.b.c").unwrap();
+    let metadata_key = Key::new(datastore::KeyType::Meta, "c").unwrap();
+    let value = serialize_scalar::<std::string::String, serde_json::Error>(
+        &"Test metadata value".to_string(),
+    )
+    .unwrap();
+
+    source
+        .set_metadata(&metadata_key, &data_key, value, &Committed::Live)
+        .unwrap();
+
+    // Ensure that metadata exists in the source datastore
+    let metadata = source
+        .get_metadata(&metadata_key, &data_key, &Committed::Live)
+        .unwrap();
+    assert!(metadata.is_some());
+    assert_eq!(metadata.unwrap(), "\"Test metadata value\"");
+
+    let mut target = MemoryDataStore::new();
+
+    let result = copy_without_weak_settings_and_metadata(source, &mut target);
+    assert!(result.is_ok());
+
+    // Ensure that metadata does not exists in the target datastore
+    let metadata = target
+        .get_metadata(&metadata_key, &data_key, &Committed::Live)
+        .unwrap();
+    assert!(metadata.is_none());
+}
+
+#[tokio::test]
+async fn test_only_weak_settings_are_removed() {
+    let mut source = MemoryDataStore::new();
+    let weak_data_key = Key::new(datastore::KeyType::Data, "a.b.c").unwrap();
+    let weak_metadata_key = Key::new(datastore::KeyType::Meta, "strength").unwrap();
+    let weak_metadata_value =
+        serialize_scalar::<std::string::String, serde_json::Error>(&"weak".to_string()).unwrap();
+    let weak_data_value = serialize_scalar::<std::string::String, serde_json::Error>(
+        &"strong data value".to_string(),
+    )
+    .unwrap();
+
+    source
+        .set_key(&weak_data_key, weak_data_value, &Committed::Live)
+        .unwrap();
+    source
+        .set_metadata(
+            &weak_metadata_key,
+            &weak_data_key,
+            weak_metadata_value,
+            &Committed::Live,
+        )
+        .unwrap();
+
+    let strong_data_key = Key::new(datastore::KeyType::Data, "e.f").unwrap();
+    let strong_metadata_key = Key::new(datastore::KeyType::Meta, "strength").unwrap();
+    let strong_metadata_value =
+        serialize_scalar::<std::string::String, serde_json::Error>(&"strong".to_string()).unwrap();
+    let strong_data_value = serialize_scalar::<std::string::String, serde_json::Error>(
+        &"strong data value".to_string(),
+    )
+    .unwrap();
+
+    source
+        .set_key(
+            &strong_data_key,
+            strong_data_value.clone(),
+            &Committed::Live,
+        )
+        .unwrap();
+    source
+        .set_metadata(
+            &strong_metadata_key,
+            &strong_data_key,
+            strong_metadata_value,
+            &Committed::Live,
+        )
+        .unwrap();
+
+    let mut target = MemoryDataStore::new();
+
+    let result = copy_without_weak_settings_and_metadata(source, &mut target);
+    assert!(result.is_ok());
+
+    // Ensure that metadata does not exists in the target datastore
+    let weak_data = target.get_key(&weak_data_key, &Committed::Live).unwrap();
+    assert!(weak_data.is_none());
+
+    // Ensure that metadata does not exists in the target datastore
+    let strong_data = target.get_key(&strong_data_key, &Committed::Live).unwrap();
+    assert!(strong_data.is_some());
+    assert_eq!(strong_data.unwrap(), strong_data_value);
 }

--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -129,6 +129,13 @@ components:
               type: array
               items:
                 type: string
+        SettingsResponseWithMetadata:
+          type: object
+          properties:
+            settings:
+              $ref: '#/components/schemas/Settings'
+            metadata:
+              $ref: '#/components/schemas/HashMap'
         network:
           type: object
           properties:
@@ -210,6 +217,23 @@ components:
       properties:
         targets:
           type: array
+    SettingGenerators:
+      type: object
+      additionalProperties:
+        oneOf:
+        - type: string
+        - type: object
+          additionalProperties: false
+          properties:
+            command:
+              type: string
+            strength:
+              enum:
+              - weak
+              - strong
+              type: string
+          required:
+          - command
 paths:
   /:
     get:
@@ -343,6 +367,27 @@ paths:
       responses:
         200:
           description: "Successful deleted pending settings - deleted keys are returned"
+        500:
+          description: "Server error"
+  
+  /v2/tx:
+    get:
+      summary: "Get pending settings and metadata in a transaction"
+      operationId: "get_tx_v2"
+      parameters:
+        - in: query
+          name: tx
+          description: "Transaction to retrieve pending settings and metadata; defaults to user 'default' transaction"
+          schema:
+            type: string
+          required: false
+      responses:
+        200:
+          description: "Successful request"
+          content:
+            application/json:
+              schema:
+                $ref: #/components/schemas/SettingsResponseWithMetadata"
         500:
           description: "Server error"
 
@@ -492,6 +537,26 @@ paths:
                 type: object
                 additionalProperties:
                   type: string
+        500:
+          description: "Server error"
+  /v2/metadata/setting-generators:
+    get:
+      summary: "Get programs to generate settings, and the strength of the generated settings"
+      operationId: "get_setting_generators_v2"
+      responses:
+        200:
+          description: "Successful request"
+          content:
+            application/json:
+              # The response is a hashmap of string to Object. Example:
+              # { "settings.foobar": "/usr/bin/foobar" } or 
+              # { "settings.foobar": {
+              #     "command": "/usr/bin/foobar",
+              #     "strength": "weak"
+              #    } 
+              # }
+              schema:
+                $ref: "#/components/schemas/SettingGenerators"
         500:
           description: "Server error"
 

--- a/sources/api/settings-committer/src/main.rs
+++ b/sources/api/settings-committer/src/main.rs
@@ -16,7 +16,7 @@ use snafu::ResultExt;
 use std::str::FromStr;
 use std::{collections::HashMap, env, process};
 
-const API_PENDING_URI_BASE: &str = "/tx";
+const API_PENDING_URI_BASE: &str = "/v2/tx";
 const API_COMMIT_URI_BASE: &str = "/tx/commit";
 
 type Result<T> = std::result::Result<T, error::SettingsCommitterError>;

--- a/sources/api/storewolf/tests/data/metadata.toml
+++ b/sources/api/storewolf/tests/data/metadata.toml
@@ -1,0 +1,10 @@
+[metadata.a.setting-generator]
+command = "my test command"
+strength = "weak"
+depth = 0
+
+[metadata.c.d]
+setting-generator = "shibaken generate-admin-userdata"
+
+[metadata.e.f]
+affected-services = ["cfsignal"]

--- a/sources/api/sundog/Cargo.toml
+++ b/sources/api/sundog/Cargo.toml
@@ -16,6 +16,7 @@ datastore.workspace = true
 http.workspace = true
 log.workspace = true
 models.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 simplelog.workspace = true
 shlex.workspace = true

--- a/sources/api/sundog/src/main.rs
+++ b/sources/api/sundog/src/main.rs
@@ -23,6 +23,7 @@ use tokio::process::Command as AsyncCommand;
 
 use datastore::serialization::to_pairs_with_prefix;
 use datastore::{self, deserialization, Key, KeyType};
+use model::generator::{SettingsGenerator, Strength};
 
 // Limit settings generator execution to at most 6 minutes to prevent boot from hanging for too long.
 const SETTINGS_GENERATOR_TIMEOUT: Duration = Duration::from_secs(360);
@@ -169,7 +170,7 @@ use error::SundogError;
 type Result<T> = std::result::Result<T, SundogError>;
 
 /// Request the setting generators from the API.
-async fn get_setting_generators<S>(socket_path: S) -> Result<HashMap<String, String>>
+async fn get_setting_generators<S>(socket_path: S) -> Result<HashMap<String, SettingsGenerator>>
 where
     S: AsRef<str>,
 {
@@ -189,8 +190,9 @@ where
         }
     );
 
-    let generators: HashMap<String, String> = serde_json::from_str(&response_body)
+    let generators: HashMap<String, SettingsGenerator> = serde_json::from_str(&response_body)
         .context(error::ResponseJsonSnafu { method: "GET", uri })?;
+
     trace!("Generators: {:?}", &generators);
 
     Ok(generators)
@@ -301,14 +303,16 @@ where
 }
 
 /// Run the setting generators and collect the output
+/// separately for weak and strong settings
 async fn get_dynamic_settings<P>(
     socket_path: P,
-    generators: HashMap<String, String>,
-) -> Result<model::Settings>
+    generators: HashMap<String, SettingsGenerator>,
+) -> Result<(Option<model::Settings>, Option<model::Settings>)>
 where
     P: AsRef<Path>,
 {
-    let mut settings = HashMap::new();
+    let mut strong_settings = HashMap::new();
+    let mut weak_settings = HashMap::new();
 
     // Build the list of settings to query from the datastore to see if they
     // are currently populated.
@@ -321,7 +325,9 @@ where
     let proxy_envs = build_proxy_env(socket_path).await?;
 
     // For each generator, run it and capture the output
-    for (setting_str, generator) in generators {
+    for (setting_str, generator_object) in generators {
+        let generator = generator_object.command;
+
         let setting = Key::new(KeyType::Data, &setting_str).context(error::InvalidKeySnafu {
             key_type: KeyType::Data,
             key: &setting_str,
@@ -334,6 +340,7 @@ where
         // TODO: We can optimize by using a prefix trie here. But there are no satisfactory trie
         //  implementations I can find on crates.io. We can roll our own at some point if this
         //  becomes a bottleneck
+
         if populated_settings
             .iter()
             .any(|k| k.starts_with_segments(setting.segments()))
@@ -445,19 +452,31 @@ where
             })?;
         trace!("Serialized output: {}", &serialized_output);
 
-        settings.insert(setting, serialized_output);
+        // Add the setting to the appropriate map
+        if generator_object.strength == Strength::Strong {
+            strong_settings.insert(setting, serialized_output);
+        } else {
+            weak_settings.insert(setting, serialized_output);
+        }
     }
 
     // The API takes a properly nested Settings struct, so deserialize our map to a Settings
     // and ensure it is correct
-    let settings_struct: model::Settings =
-        deserialization::from_map(&settings).context(error::DeserializeSnafu)?;
+    let weak_settings_struct: Option<model::Settings> = (!weak_settings.is_empty())
+        .then_some(deserialization::from_map(&weak_settings).context(error::DeserializeSnafu)?);
 
-    Ok(settings_struct)
+    let strong_settings_struct: Option<model::Settings> = (!strong_settings.is_empty())
+        .then_some(deserialization::from_map(&strong_settings).context(error::DeserializeSnafu)?);
+
+    Ok((weak_settings_struct, strong_settings_struct))
 }
 
 /// Send the settings to the datastore through the API
-async fn set_settings<S>(socket_path: S, settings: model::Settings) -> Result<()>
+async fn set_settings<S>(
+    socket_path: S,
+    settings: model::Settings,
+    strength: Strength,
+) -> Result<()>
 where
     S: AsRef<str>,
 {
@@ -465,9 +484,10 @@ where
     let request_body = serde_json::to_string(&settings).context(error::SerializeRequestSnafu)?;
 
     let uri = &format!(
-        "{}?tx={}",
+        "{}?tx={}&strength={}",
         constants::API_SETTINGS_URI,
-        constants::LAUNCH_TRANSACTION
+        constants::LAUNCH_TRANSACTION,
+        strength
     );
     let method = "PATCH";
     trace!("Settings to {} to {}: {}", method, uri, &request_body);
@@ -566,10 +586,28 @@ async fn run() -> Result<()> {
     }
 
     info!("Retrieving settings values");
-    let settings = get_dynamic_settings(&args.socket_path, generators).await?;
+
+    let (weak_settings, strong_settings) =
+        get_dynamic_settings(&args.socket_path, generators).await?;
+
+    trace!(
+        "Weak settings from dynamic settings function: {:#?}",
+        weak_settings
+    );
+    trace!(
+        "Strong settings from dynamic settings function: {:#?}",
+        strong_settings
+    );
 
     info!("Sending settings values to the API");
-    set_settings(&args.socket_path, settings).await?;
+
+    if let Some(weak_set) = weak_settings {
+        set_settings(&args.socket_path, weak_set, Strength::Weak).await?;
+    };
+
+    if let Some(strong_set) = strong_settings {
+        set_settings(&args.socket_path, strong_set, Strength::Strong).await?;
+    }
 
     Ok(())
 }

--- a/sources/constants/src/lib.rs
+++ b/sources/constants/src/lib.rs
@@ -5,7 +5,7 @@
 // Shared API settings
 pub const API_SOCKET: &str = "/run/api.sock";
 pub const API_SETTINGS_URI: &str = "/settings";
-pub const API_SETTINGS_GENERATORS_URI: &str = "/metadata/setting-generators";
+pub const API_SETTINGS_GENERATORS_URI: &str = "/v2/metadata/setting-generators";
 
 // Shared transaction used by boot time services
 pub const LAUNCH_TRANSACTION: &str = "bottlerocket-launch";

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -17,6 +17,7 @@ serde_json.workspace = true
 toml.workspace = true
 bottlerocket-settings-plugin.workspace = true
 bottlerocket-settings-models.workspace = true
+serde_plain.workspace = true
 
 [build-dependencies]
 generate-readme.workspace = true

--- a/sources/models/src/generator.rs
+++ b/sources/models/src/generator.rs
@@ -1,0 +1,258 @@
+//! The 'generator' module holds types that handles the settings generator metadata
+//! definition (containing command, strength and depth) among various systems
+//! like apiserver, sundog, datastore.
+//!
+//! The command field defines the command that needs to be executed to populate the
+//! setting.
+//! The strength field defines whether a setting needs to be deleted on reboot.
+//! The depth field defines how metadata is inherited across hierarchical levels,
+//! allowing a parent to provide metadata that can be applied at children at a given depth.
+//!
+//! SettingsGenerator type is used to hold generator that is applied strictly
+//! to the given setting and have depth 0.
+//! The RawSettingsGenerator holds the generators that can be dynamically applied
+//! to the successors at the given depth where a depth '0' means the generator
+//! should be applied on the given key.
+//!
+//! We use a custom deserializer because the metadata may not always be
+//! structured as an object; it can also appear as a string. This deserializer
+//! handles both formats, keeping the deserialization logic close to the struct
+//! for maintainability and clarity.
+
+use serde::{
+    de::{self, MapAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+use serde_plain::derive_fromstr_from_deserialize;
+use std::fmt::{self, Display};
+
+/// Weak settings are ephemeral and deleted on reboot, regardless of whether or not it
+/// is written by a setting generator.
+#[derive(Default, Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum Strength {
+    #[default]
+    Strong,
+    Weak,
+}
+
+impl Display for Strength {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Strength::Strong => write!(f, "strong"),
+            Strength::Weak => write!(f, "weak"),
+        }
+    }
+}
+
+derive_fromstr_from_deserialize!(Strength);
+
+/// Struct to hold the setting generator definition containing
+/// command, strength, depth
+#[derive(Clone, Default, Serialize, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct RawSettingsGenerator {
+    pub command: String,
+    pub strength: Strength,
+    pub depth: u32,
+}
+
+impl RawSettingsGenerator {
+    pub fn is_weak(&self) -> bool {
+        self.strength == Strength::Weak
+    }
+}
+
+impl<'de> Deserialize<'de> for RawSettingsGenerator {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SettingsGeneratorVisitor;
+        impl<'de> Visitor<'de> for SettingsGeneratorVisitor {
+            type Value = RawSettingsGenerator;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string or a map")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                // If the value is a string, use it as the `command` with defaults for other fields.
+                Ok(RawSettingsGenerator {
+                    command: value.to_string(),
+                    ..RawSettingsGenerator::default()
+                })
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                // Extract values from the map
+                let mut command = None;
+                let mut strength = None;
+                let mut depth = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "command" => command = Some(map.next_value()?),
+                        "strength" => strength = Some(map.next_value()?),
+                        "depth" => depth = Some(map.next_value()?),
+                        _ => {
+                            return Err(de::Error::unknown_field(
+                                &key,
+                                &["command", "strength", "depth"],
+                            ))
+                        }
+                    }
+                }
+                Ok(RawSettingsGenerator {
+                    command: command.ok_or_else(|| de::Error::missing_field("command"))?,
+                    strength: strength.unwrap_or_default(),
+                    depth: depth.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_any(SettingsGeneratorVisitor)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn test_setting_generator_deserialization() {
+        let api_response = r#"
+            {
+                "host-containers.admin.source": "generator1",
+                "host-containers.control.source": {
+                    "command": "generator2",
+                    "strength": "weak",
+                    "depth": 0
+                },
+                "host-containers.no_depth.source": {
+                    "command": "generator3",
+                    "strength": "weak"
+                },
+                "host-containers.depth_given.source": {
+                    "command": "generator4",
+                    "strength": "weak",
+                    "depth": 1
+                }
+            }"#;
+
+        let expected_admin = RawSettingsGenerator {
+            command: "generator1".to_string(),
+            strength: Strength::Strong,
+            depth: 0,
+        };
+
+        let expected_control = RawSettingsGenerator {
+            command: "generator2".to_string(),
+            strength: Strength::Weak,
+            depth: 0,
+        };
+
+        let expected_no_depth = RawSettingsGenerator {
+            command: "generator3".to_string(),
+            strength: Strength::Weak,
+            depth: 0,
+        };
+
+        let expected_depth_given = RawSettingsGenerator {
+            command: "generator4".to_string(),
+            strength: Strength::Weak,
+            depth: 1,
+        };
+
+        let result: HashMap<String, RawSettingsGenerator> =
+            serde_json::from_str(api_response).unwrap();
+
+        assert_eq!(
+            result.get("host-containers.admin.source").unwrap(),
+            &expected_admin
+        );
+        assert_eq!(
+            result.get("host-containers.control.source").unwrap(),
+            &expected_control
+        );
+        assert_eq!(
+            result.get("host-containers.no_depth.source").unwrap(),
+            &expected_no_depth
+        );
+        assert_eq!(
+            result.get("host-containers.depth_given.source").unwrap(),
+            &expected_depth_given
+        );
+    }
+}
+
+/// Struct to hold the setting generator definition containing
+/// command, strength
+#[derive(Default, Serialize, std::fmt::Debug, PartialEq)]
+pub struct SettingsGenerator {
+    pub command: String,
+    pub strength: Strength,
+}
+
+impl From<RawSettingsGenerator> for SettingsGenerator {
+    fn from(value: RawSettingsGenerator) -> Self {
+        SettingsGenerator {
+            command: value.command,
+            strength: value.strength,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SettingsGenerator {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SettingsGeneratorVisitor;
+        impl<'de> Visitor<'de> for SettingsGeneratorVisitor {
+            type Value = SettingsGenerator;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string or a map")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                // If the value is a string, use it as the `command` with defaults for other fields.
+                Ok(SettingsGenerator {
+                    command: value.to_string(),
+                    ..SettingsGenerator::default()
+                })
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                // Extract values from the map
+                let mut command = None;
+                let mut strength = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "command" => command = Some(map.next_value()?),
+                        "strength" => strength = Some(map.next_value()?),
+                        _ => return Err(de::Error::unknown_field(&key, &["command", "strength"])),
+                    }
+                }
+                Ok(SettingsGenerator {
+                    command: command.ok_or_else(|| de::Error::missing_field("command"))?,
+                    strength: strength.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_any(SettingsGeneratorVisitor)
+    }
+}

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -24,6 +24,9 @@ pub mod exec;
 // Types used to communicate between client and server for 'apiclient ephemeral-storage'.
 pub mod ephemeral_storage;
 
+// Types used to handle the settings generator metadata among various systems
+pub mod generator;
+
 use bottlerocket_release::BottlerocketRelease;
 use bottlerocket_settings_models::model_derive::model;
 use bottlerocket_settings_plugin::BottlerocketSettings;


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
In case of host container upgrade in BoB repo, we need to write migrations. By this PR we are incorperating the concept of weak and strong setting, where a weak setting will be deleted on upgrade and downgrade and default setting will be populated from the settings-defaults. 

```
migrator: remove all the weak setting and settings-generator
apiserver: add version 2 for /tx and /metadata/settings-generator 
apiclient: update README to document version 2 of /tx API 
datastore: support committing metadata from transactions 
models: add strength enum and Settings generator struct 
constants: Use version 2 API to get setting-generators 
openapi: Add version 2 for /tx and /metadata/settings-generator 
settings-committer: change transaction API endpoint to /v2/tx 
sundog: Parse settings generators as a table 
storewolf: enable parsing setting-generator metadata as table
```

**Testing done:**
Refer https://gist.github.com/vyaghras/cc7391ade3b276b223d1814a8770eea7

**Terms of contribution:**
By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
