### PR TITLE
xfsprogs: add patch to load default config file

### DIFF
--- a/packages/xfsprogs/0001-mkfs-source-defaults-from-config-file.patch
+++ b/packages/xfsprogs/0001-mkfs-source-defaults-from-config-file.patch
@@ -1,0 +1,42 @@
+From eea379598278cc62a74c9932f624c89407a966f8 Mon Sep 17 00:00:00 2001
+From: Sparks Song <shijiao@amazon.com>
+Date: Mon, 3 Feb 2025 22:44:31 +0000
+Subject: [PATCH] mkfs: source defaults from config file to make nrext64
+ default off on multiple kernel versions
+
+---
+ mkfs/xfs_mkfs.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/mkfs/xfs_mkfs.c b/mkfs/xfs_mkfs.c
+index 6d2469c..87e7457 100644
+--- a/mkfs/xfs_mkfs.c
++++ b/mkfs/xfs_mkfs.c
+@@ -39,6 +39,9 @@
+  */
+ #define WHACK_SIZE (128 * 1024)
+
++/* Default path for the mkfs.xfs configuration file */
++#define DEFAULT_CONFIG_PATH "/usr/share/xfsprogs/mkfs/default.conf"
++
+ /*
+  * XXX: The configured block and sector sizes are defined as global variables so
+  * that they don't need to be passed to getnum/cvtnum().
+@@ -4428,6 +4431,14 @@ main(
+ 	 * the options from this file parsed, we can then proceed with parameter
+ 	 * and bounds checking and making the filesystem.
+ 	 */
++
++	if (cli.cfgfile == NULL) {
++		struct stat defcfg_statbuf;
++		if (stat(DEFAULT_CONFIG_PATH, &defcfg_statbuf) == 0) {
++			cli.cfgfile = DEFAULT_CONFIG_PATH;
++		}
++	}
++
+ 	cfgfile_parse(&cli);
+
+ 	protostring = setup_proto(cli.protofile);
+--
+2.47.0
+

--- a/packages/xfsprogs/xfsprogs.spec
+++ b/packages/xfsprogs/xfsprogs.spec
@@ -8,6 +8,8 @@ Source0: http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-%{version}.t
 Source1: http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-%{version}.tar.sign
 Source2: gpgkey-0C1D891C50A732E0680F7B644675A111E50B5FA6.asc
 
+Patch1000: 0001-mkfs-source-defaults-from-config-file.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libuuid-devel
 BuildRequires: %{_cross_os}libinih-devel
@@ -29,7 +31,7 @@ Requires: %{name}
 
 %prep
 %{gpgverify} --data=<(xzcat %{S:0}) --signature=%{S:1} --keyring=%{S:2}
-%autosetup -n xfsprogs-%{version}
+%autosetup -n xfsprogs-%{version} -p1
 
 %build
 %cross_configure \


### PR DESCRIPTION
Issue number:

Closes https://github.com/bottlerocket-os/bottlerocket/issues/4281

Description of changes:
A new PR for https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/251, see discussion there.

Testing done:

Manual testing done using the exact setup as original issue mentioned , see the nrext64 value changed to 0 as expected.
Also, tested config files consuming behavior and made sure the program would not crash when receive a bad default config file. It would just continue with the default value given in the `xfs_mkfs.c` file.

With correct config files:
```
bash-5.1# xfs_info /dev/nvme2n1
meta-data=/dev/nvme2n1           isize=512    agcount=4, agsize=7629394 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=1
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=0
data     =                       bsize=4096   blocks=30517576, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=16384, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
bash-5.1#
bash-5.1#
bash-5.1# umount /dev/nvme2n1
bash-5.1# mkfs.xfs /dev/nvme2n1
Parameters parsed from default config file /usr/share/xfs/mkfs.xfs.conf successfully
mkfs.xfs: /dev/nvme2n1 contains a mounted filesystem
```

Without correct config files:
```
bash-5.1# mount | grep ephemeral
/dev/nvme2n1 on /mnt/.ephemeral type xfs (rw,relatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota)
bash-5.1# xfs_info /dev/nvme2n1
meta-data=/dev/nvme2n1           isize=512    agcount=4, agsize=7629394 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=1
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=1
data     =                       bsize=4096   blocks=30517576, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=16384, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
bash-5.1#
bash-5.1# umount /dev/nvme2n1
bash-5.1# mkfs.xfs /dev/nvme2n1
/usr/share/xfs/mkfs.xfs.conf: Unrecognised input on line 6. Aborting.
mkfs.xfs: /dev/nvme2n1 contains a mounted filesystem
```
The program would abort the `parse default config` function and keep other functions work well.
We can always track if default config file works by using
```
bash-5.1# umount /dev/nvme2n1
bash-5.1# mkfs.xfs /dev/nvme2n1
```
And see if there's a log message showing
```
Parameters parsed from default config file /usr/share/xfs/mkfs.xfs.conf successfully
```
This log message is expected every time we call mkfs.xfs, with or without manual CLI config file provided.
Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.