### PR TITLE
Update nvidia package versions

### DIFF
--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "4.0.0"
+release-version = "4.0.1"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.17.1/libnvidia-container-1.17.1.tar.gz"
-sha512 = "7c643c3b119767e188752dd32314bd214ada1510f56617f9a20bc0483604d77215bcf6ce93c3b5a5111b30cf228df6d76625d1c1f2f2ce95d77e229d6c6120c4"
+url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.17.3/libnvidia-container-1.17.3.tar.gz"
+sha512 = "24293e369fea42ebe64163464f600808c0d18e8b4efeea12095de22e16d43837cb6441f46baf52e8c966810c76b0f5045737a96d173e2ecf8cd15fff37cd4c4f"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/NVIDIA/nvidia-modprobe/archive/550.54.14/nvidia-modprobe-550.54.14.tar.gz"

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -1,7 +1,7 @@
 %global nvidia_modprobe_version 550.54.14
 
 Name: %{_cross_os}libnvidia-container
-Version: 1.17.1
+Version: 1.17.3
 Release: 1%{?dist}
 Epoch: 1
 Summary: NVIDIA container runtime library

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.17.1/nvidia-container-toolkit-1.17.1.tar.gz"
-sha512 = "166c0e4644196688dbc7036020e8d2ff1b99e8c164d921fa698655033da6e1a3a76d83d8e8a27bc0bd967469c2a9fb4c2764dc0148af6c8f195c49b3c7c871d1"
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.17.3/nvidia-container-toolkit-1.17.3.tar.gz"
+sha512 = "8c7a4290a1decc448c72e9a09213e0dc4e418ec633cefb16bb6b01fef7c502d23ed72cc1f3cc6583cad07feae5ca3cf44dad73e1274e042e3b26bdc7a4152b95"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 %global gorepo nvidia-container-toolkit
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.17.1
+%global gover 1.17.3
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-container-toolkit


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
- Updates `nvidia-container-toolkit`
- Updates `libnvidia-container`
- Bump core-kit version to `4.0.1`

**Testing done:**

Built and tested Bottlerocket AMIs and ran the [`nvidia-smoke-test`](https://github.com/vigh-m/bottlerocket-test-system/tree/develop/bottlerocket/tests/workload/nvidia-smoke). No issues observed.
Variants tested:
- [x] aws-k8s-1.30-nvidia
- [x] aws-ecs-2-nvidia

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
