### PR TITLE
ecs-agent: bump version to 1.88.0

### DIFF
--- a/packages/ecs-agent/0005-bottlerocket-change-execcmd-directories-for-Bottlero.patch
+++ b/packages/ecs-agent/0005-bottlerocket-change-execcmd-directories-for-Bottlero.patch
@@ -1,4 +1,4 @@
-From cef5037351f2b214b9239d59dec7a83a0db75b0c Mon Sep 17 00:00:00 2001
+From 2beaa13c5c6089ddf69c445cd74f84bd8ed7aeec Mon Sep 17 00:00:00 2001
 From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 Date: Wed, 3 May 2023 18:23:40 +0000
 Subject: [PATCH] bottlerocket: change execcmd directories for Bottlerocket
@@ -9,6 +9,7 @@ agent runs as a service in Bottlerocket, the paths to the directories
 are different.
 
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Signed-off-by: Yutong Sun <yutongsu@amazon.com>
 ---
  agent/app/agent_capability_unix.go              | 2 +-
  agent/engine/execcmd/manager_init_task_linux.go | 4 ++--
@@ -16,20 +17,20 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  3 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/agent/app/agent_capability_unix.go b/agent/app/agent_capability_unix.go
-index 51b4393..76492c7 100644
+index aceef91c6..9feb8d9da 100644
 --- a/agent/app/agent_capability_unix.go
 +++ b/agent/app/agent_capability_unix.go
-@@ -37,7 +37,7 @@ const (
- 	SSE41                 = "sse4_1"
- 	SSE42                 = "sse4_2"
- 	CpuInfoPath           = "/proc/cpuinfo"
--	capabilityDepsRootDir = "/managed-agents"
-+	capabilityDepsRootDir = "/usr/libexec/amazon-ecs-agent/managed-agents"
- )
- 
- var (
+@@ -41,7 +41,7 @@ const (
+ 	SSE41                       = "sse4_1"
+ 	SSE42                       = "sse4_2"
+ 	CpuInfoPath                 = "/proc/cpuinfo"
+-	capabilityDepsRootDir       = "/managed-agents"
++	capabilityDepsRootDir       = "/usr/libexec/amazon-ecs-agent/managed-agents"
+ 	modInfoCmd                  = "modinfo"
+ 	faultInjectionKernelModules = "sch_netem"
+ 	ctxTimeoutDuration          = 60 * time.Second
 diff --git a/agent/engine/execcmd/manager_init_task_linux.go b/agent/engine/execcmd/manager_init_task_linux.go
-index 05af158..6117e55 100644
+index 05af1582b..6117e55ae 100644
 --- a/agent/engine/execcmd/manager_init_task_linux.go
 +++ b/agent/engine/execcmd/manager_init_task_linux.go
 @@ -24,7 +24,7 @@ import (
@@ -51,7 +52,7 @@ index 05af158..6117e55 100644
  
  	ContainerConfigFileSuffix = "configuration/" + containerConfigFileName
 diff --git a/agent/engine/execcmd/manager_linux.go b/agent/engine/execcmd/manager_linux.go
-index 706d5da..6322816 100644
+index 706d5da35..6322816f6 100644
 --- a/agent/engine/execcmd/manager_linux.go
 +++ b/agent/engine/execcmd/manager_linux.go
 @@ -16,6 +16,6 @@
@@ -63,5 +64,5 @@ index 706d5da..6322816 100644
  	HostBinDir      = hostExecDepsDir + "/bin"
  )
 -- 
-2.40.1
+2.47.0
 

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.86.3/amazon-ecs-agent-1.86.3.tar.gz"
-sha512 = "d93129c290c06cff332318644dced900618575b7e540674d58d69f8db1ef90c5a2cf8e41f5af63f97df06df1b20cf9f22bd2252d3e2317984f0ef79252ce25c5"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.88.0/amazon-ecs-agent-1.88.0.tar.gz"
+sha512 = "1d7f38cae0fb7401b48feca4d6ecb270c5c5a5efc4367c58ff8384d2175b4c0b6a76bbe350ab231108eec542a3d6f0d9b8ac60dc121d5fee9a86ef812fdf9785"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,7 +2,7 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.86.3
+%global agent_gover 1.88.0
 
 # git rev-parse --short=8
 %global agent_gitrev b7e96508


### PR DESCRIPTION
- The original patch was incompatible with this version (1.88.0). This commit updated the patch to address the incompatibility.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Update ECS agent to upstream [v1.88.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.88.0). 

I had to update the patch `0005-bottlerocket-change-execcmd-directories-for-Bottlero.patch` because it is not compatible with the version 1.88.0.

**Testing done:**

- [x] Built `aws-ecs-1` AMI and ran conformance testing


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
