### PR TITLE
docker-cli, docker-engine: update to v25.0.7

### DIFF
--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/docker/cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v25.0.5/cli-25.0.5.tar.gz"
-sha512 = "39f49514605a3c78661f105094f9c28beb01927a2d7dc474048c2a27135ca8c3f075a6f05157a176c032d5e7c105f00c9100c15713298b33bd34a6f399bac84d"
+url = "https://github.com/docker/cli/archive/v25.0.7/cli-25.0.7.tar.gz"
+sha512 = "0d1a688ab402329b5f4e17c36b596c0db7af4203c376472c6e8585fb9dece33df707b080c35e2866923239f04d623642199dbf3702b02dd99756c8a71b306722"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 25.0.5
+%global gover 25.0.7
 %global rpmver %{gover}
-%global gitrev 5dc9bcc5b78ed23f12cdd68e4285ea1c216ce2a1 
+%global gitrev 0bab007417226f0c43a897216c4e40471b9d70d1
 
 %global source_date_epoch 1492525740
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v25.0.6/moby-25.0.6.tar.gz"
-sha512 = "dc3370927654dd2b0d201d112effc8b83416a4df4ed1c5ac6ffaec40a260b0ebdf95107e8f3dcfe91e54f885697273a2b415541f5ea87ec7c491f6325c51a4cc"
+url = "https://github.com/moby/moby/archive/v25.0.7/moby-25.0.7.tar.gz"
+sha512 = "0ff0f8304780b57893400f95be9ac669c10f1bf47fe4953f852ae06cbf4ba98d4e6350110b97cfcbf6359eece37d39f729e929d760fdef7249e0af9d4844814e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 25.0.6
+%global gover 25.0.7
 %global rpmver %{gover}
-%global gitrev b08a51fe16eed67de3861c03b363ba403643b12e
+%global gitrev 7de3a1f2ac49277cfce07b41d8568e4b49967e79
 
 %global source_date_epoch 1363394400
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #304 

**Description of changes:**
* Update docker-cli package to https://github.com/docker/cli/releases/tag/v25.0.7
  * Diff: https://github.com/docker/cli/compare/v25.0.5...v25.0.7
* Update docker-engine package to https://github.com/moby/moby/releases/tag/v25.0.7
  * Diff: https://github.com/moby/moby/compare/v25.0.6...v25.0.7

**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
