### PR TITLE
packages: edit versioning fields for k8s-1.32 prerelease

### DIFF
--- a/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
+++ b/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
@@ -3,13 +3,13 @@
 %global goimport %{goproject}/%{gorepo}
 
 %global gover 1.31.0
-%global rpmver %{gover}
+%global rpmver 1.32.0
 
 %global _dwz_low_mem_die_limit 0
 
 Name: %{_cross_os}ecr-credential-provider-1.32
 Version: %{rpmver}
-Release: 1%{?dist}
+Release: 0.beta1%{?dist}
 Epoch: 1
 Summary: Amazon ECR credential provider
 License: Apache-2.0

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -11,7 +11,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 %global gover 1.31.1
-%global rpmver %{gover}
+%global rpmver 1.32.0
 
 %global _dwz_low_mem_die_limit 0
 
@@ -32,7 +32,7 @@
 
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
-Release: 1%{?dist}
+Release: 0.beta1%{?dist}
 Epoch: 1
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause


### PR DESCRIPTION
**Issue number:**

Closes # N/a

**Description of changes:**

The boilerplates for `kubernetes-1.32` and `ecr-credential-provider-1.32` packages were added in #298 .

However, given these packages are still in prerelease, we are downgrading the `Release` field to < 1 in order to signal this (following [this guideline](https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_prerelease_versions)).

Also following that guideline, we are updating the `Version` field to match the new prerelease version.

**Testing done:**

`make ARCH=aarch64 && make ARCH=x86_64`

```
[downgrade-k8s-1.32]$ rpm -qpi build/rpms/kubernetes-1.32/bottlerocket-kubelet-1.32-1.32.0-0.beta1.1733797561.23b442b1.br1.x86_64.rpm 
Name        : bottlerocket-kubelet-1.32
Epoch       : 1
Version     : 1.32.0
Release     : 0.beta1.1733797561.23b442b1.br1
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 1515309
License     : Apache-2.0 AND BSD-3-Clause
Signature   : (none)
Source RPM  : bottlerocket-kubernetes-1.32.0-0.beta1.1733797561.23b442b1.br1.src.rpm
Build Date  : Tue Dec 10 22:52:15 2024
Build Host  : localhost
URL         : https://github.com/kubernetes/kubernetes
Summary     : Container cluster node agent
Description :
Container cluster node agent.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
