### PR TITLE
advisories: add kernel-6.1 CVEs for 4.1.0 release

### DIFF
--- a/advisories/4.1.0/BRSA-cbg7nhxhibmz.toml
+++ b/advisories/4.1.0/BRSA-cbg7nhxhibmz.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-cbg7nhxhibmz"
+title = "kernel CVE-2024-49996"
+cve = "CVE-2024-49996"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: cifs: Fix buffer overflow when parsing NFS reparse points"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "6.1.119"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-12-11T18:17:05Z
+arches = ["x86_64", "aarch64"]
+version = "4.1.0"

--- a/advisories/4.1.0/BRSA-fes8wtslzjru.toml
+++ b/advisories/4.1.0/BRSA-fes8wtslzjru.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-fes8wtslzjru"
+title = "kernel CVE-2024-41080"
+cve = "CVE-2024-41080"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: io_uring: fix possible deadlock in io_register_iowq_max_workers()"
+
+[[advisory.products]]
+package-name = "kernel-6.1"
+patched-version = "6.1.119"
+patched-epoch = "0"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-12-11T18:17:05Z
+arches = ["x86_64", "aarch64"]
+version = "4.1.0"


### PR DESCRIPTION
**Description of changes:**

advisories: add kernel-6.1 CVEs for 4.1.0 release

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
