### PR TITLE
Allow bind mounts prefixed with /mnt/ for ephemeral storage

### DIFF
--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -703,18 +703,22 @@ async fn list_ephemeral_storage_dirs(
 ) -> Result<HttpResponse> {
     let os_info = controller::get_os_info()?;
 
-    let allowed = ephemeral_storage::allowed_bind_dirs(&os_info.variant_id);
+    let allowed_dirs = ephemeral_storage::allowed_bind_dirs(&os_info.variant_id);
     let mut text_response = String::new();
-    for dir in &allowed {
+    for dir in &allowed_dirs.allowed_exact {
         text_response.push_str(dir);
         text_response.push('\n');
     }
 
-    let allowed: Vec<String> = allowed.iter().map(|x| String::from(*x)).collect();
+    let allowed: Vec<String> = allowed_dirs
+        .allowed_exact
+        .iter()
+        .map(|x| String::from(*x))
+        .collect();
     list_ephemeral_response(req, query, allowed, text_response).await
 }
 
-// Responds to a list request with the text or JSON resposne depending on the query format.
+// Responds to a list request with the text or JSON response depending on the query format.
 async fn list_ephemeral_response(
     req: HttpRequest,
     query: web::Query<HashMap<String, String>>,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**



**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
