### PR TITLE
Third party package updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ KIT ?= bottlerocket-core-kit
 UNAME_ARCH = $(shell uname -m)
 ARCH ?= $(UNAME_ARCH)
 VENDOR ?= bottlerocket
+UPSTREAM_SOURCE_FALLBACK = false
 
 ifeq ($(UNAME_ARCH), aarch64)
 	TWOLITER_SHA256=$(TWOLITER_SHA256_AARCH64)
@@ -40,8 +41,12 @@ update: prep
 fetch: prep
 	@$(TWOLITER) fetch --arch $(ARCH)
 
-build: fetch 
+build: fetch
+ifeq ($(UPSTREAM_SOURCE_FALLBACK), "false")
 	@$(TWOLITER) build kit $(KIT) --arch $(ARCH)
+else
+	@$(TWOLITER) build kit $(KIT) --arch $(ARCH) --upstream-source-fallback
+endif
 
 publish: prep
 	@$(TWOLITER) publish kit $(KIT) $(VENDOR)

--- a/packages/amazon-ecs-cni-plugins/Cargo.toml
+++ b/packages/amazon-ecs-cni-plugins/Cargo.toml
@@ -9,6 +9,9 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
+# This is locked against the version shipped in ecs-agent
+# Verify that the ecs-agent version shipped in bottlerocket tracks the same one here
+# https://github.com/aws/amazon-ecs-agent/releases
 url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/53a8481891251e66e35847554d52a13fc7c4fd03/amazon-ecs-cni-plugins.tar.gz"
 sha512 = "e819c1aae509d19461999bf717d126b3e918b73dc6049e415c4911be6cb11159404bb45bb6c92cdfa16b5b30bb174731e972e3f2be44fa0b51bbc7a969049ab7"
 

--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containernetworking/plugins/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/plugins/archive/v1.5.1/plugins-1.5.1.tar.gz"
-sha512 = "d2e01958dd8328407164cb6be9d962321742dae7011ce7cd7b2342f5e4b4bbcd992d8249c53d3d81250a60c27f049969bbf329a75440524f52c1f1466b6e7132"
+url = "https://github.com/containernetworking/plugins/archive/v1.6.1/plugins-1.6.1.tar.gz"
+sha512 = "62b4e2c5c4bf6a9b21880e7b145547bec153f591926419d9960345cc7fb7d499ae44b0236928bbfeb46e383f38018d7504e58da1dd8a6ad39ef4ae3122b3be56"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -2,7 +2,7 @@
 %global gorepo plugins
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.5.1
+%global gover 1.6.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -48,6 +48,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 
 %build
 %cross_go_configure %{goimport}
+export GO_MAJOR="1.23"
 for d in $(find plugins -mindepth 2 -maxdepth 2 -type d ! -name windows) ; do
   go build -ldflags="${GOLDFLAGS}" -o "bin/${d##*/}" %{goimport}/${d}
   gofips build -ldflags="${GOLDFLAGS}" -o "fips/bin/${d##*/}" %{goimport}/${d}

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.7.22/containerd-1.7.22.tar.gz"
-sha512 = "9572f2b0f49365cc3888999a0c0b7d29694922f0cbefb33e1fbbfc71781cde402537da3a23e36fd3a600a1d819bcef9acbeee423df2699fa9e3f07cfde7f9128"
+url = "https://github.com/containerd/containerd/archive/v1.7.24/containerd-1.7.24.tar.gz"
+sha512 = "eba2d562f336ffac981b67d2574c5951774f4c6a70ad1cc8aabb59204d1c8e9aa5b3be50c048bf04a018be1335b7ec8e47b73013de2e19805c978587b53bc85e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,7 +2,7 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.7.22
+%global gover 1.7.24
 %global rpmver %{gover}
 %global gitrev 7f7fdf5fed64eb6a7caf99b3e12efcf9d60e311c
 

--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/opencontainers/runc/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.1.14/runc.tar.xz"
-path = "runc-v1.1.14.tar.xz"
-sha512 = "71c21c2cff82402d937163e73805dc4f73eca948d5a05c2fe2aa0b1161438adf538caad2e3b98d9e0b786d7f04c01971a494a1fc3e24fe94fb76e64bf9453ad9"
+url = "https://github.com/opencontainers/runc/releases/download/v1.1.15/runc.tar.xz"
+path = "runc-v1.1.15.tar.xz"
+sha512 = "55282eb699565ba77e7db883a89c005d4663cfa1270534a0bd383db9935f0477e9406fe0c689bad4f93b39b7f1c9915559a1bf9bf52b38eea51028d1d3eb0887"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -2,7 +2,7 @@
 %global gorepo runc
 %global goimport %{goproject}/%{gorepo}
 %global commit 2c9f5602f0ba3d9da1c2596322dfc4e156844890
-%global gover 1.1.14
+%global gover 1.1.15
 
 %global _dwz_low_mem_die_limit 0
 

--- a/packages/soci-snapshotter/Cargo.toml
+++ b/packages/soci-snapshotter/Cargo.toml
@@ -12,15 +12,15 @@ path = "../packages.rs"
 releases-url = "https://github.com/awslabs/soci-snapshotter/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.7.0.tar.gz"
-sha512 = "91c07db47a971b0e32554457036ae4eb90850c076e6e7c3c99d590332dd24a805ca977a8092bf60cf72fb82b42e2fb22c29fdf96de801625e1d44a4c9431b9b9"
-bundle-root-path = "soci-snapshotter-0.7.0/cmd"
+url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.8.0.tar.gz"
+sha512 = "aeec6a71a6df0325cac05bc7f87a0ca1ba3145b4ad4cad7647c5159b36fd2f600577487584218a75e8aee820c9c826976c752e718295c94fca9272b6a2dff10a"
+bundle-root-path = "soci-snapshotter-0.8.0/cmd"
 bundle-output-path = "bundled-cmd.tar.gz"
 bundle-modules = [ "go" ]
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.7.0.tar.gz"
-sha512 = "91c07db47a971b0e32554457036ae4eb90850c076e6e7c3c99d590332dd24a805ca977a8092bf60cf72fb82b42e2fb22c29fdf96de801625e1d44a4c9431b9b9"
+url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.8.0.tar.gz"
+sha512 = "aeec6a71a6df0325cac05bc7f87a0ca1ba3145b4ad4cad7647c5159b36fd2f600577487584218a75e8aee820c9c826976c752e718295c94fca9272b6a2dff10a"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -1,5 +1,5 @@
 %global gorepo soci-snapshotter
-%global gover 0.7.0
+%global gover 0.8.0
 %global rpmver %{gover}
 
 Name: %{_cross_os}soci-snapshotter


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
* Update the following packages
  * containerd to v1.7.24
  * soci-snapshotter to v0.8.0
  * runc to v1.1.15
  * cni-plugins to v1.6.1
* Add support for a `UPSTREAM_SOURCE_FALLBACK` env variable when building new packages in the core-kit

  Command:
  ```
  make ARCH=aarch64 UPSTREAM_SOURCE_FALLBACK=true && make ARCH=x86_64 UPSTREAM_SOURCE_FALLBACK=true
  ```

**Testing done:**
* Testsys tests for `aws-k8s-1.30` AMI:
  ```
  NAME                                         TYPE                         STATE                                           PASSED                     FAILED                    SKIPPED   BUILD ID                          LAST UPDATE
   x86-64-aws-k8s-130-quick                     Test                         passed                                               5                          0                       7198   a8df6eb2-dirty                    2024-12-17T19:36:18Z
   x86-64-aws-k8s-130                           Resource                     completed                                                                                                      a8df6eb2-dirty                    2024-12-17T19:34:29Z
  ```
* Also manually launched a java workload via `kubectl`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
