### PR TITLE
Update EKS 1.28-1.31 versions to latest

### DIFF
--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/35/artifacts/kubernetes/v1.28.14/kubernetes-src.tar.gz"
-sha512 = "171a3d8875706d43a753cb03039fa6cffc6e9f7422bad3dbc558e41bf997b6cbdb85859eadad13e31dbabac6e032024d6b697c96f8671bc7b8875b76cf193b81"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/38/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
+sha512 = "5eee692289fc554b0001c588a5d4a4c5eeaf6a5919d815a1575d3ffa5758b743f1de6850779f45cfe3ed002a58cc6a74660e0332662bba88d8b9ebf5668896c7"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.28.14
+%global gover 1.28.15
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/35/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/38/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/24/artifacts/kubernetes/v1.29.9/kubernetes-src.tar.gz"
-sha512 = "5b0d50c6779feb5f2b06a15cc5962e69d97d1554bcc456171ef3780699529c1a28357e82d22614fb48941dc450e6150d1a3c41dfe1be27d4c38894c99cc5e656"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/27/artifacts/kubernetes/v1.29.11/kubernetes-src.tar.gz"
+sha512 = "c06e7b45164363ed18667222d8cabbfc07c346cfd7243b3ff49ac7b3b47ca9ce5630d33eb6d1823dc70579a5cff0378dcd9a1c7078b66217f6e2a4d4c4d909f6"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.29.9
+%global gover 1.29.11
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/24/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/27/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/17/artifacts/kubernetes/v1.30.5/kubernetes-src.tar.gz"
-sha512 = "6d574561603f72c1743333d87b560cd375d3f022206f8751dbd5370ab08096ec414a3c9be5f1e026b420974c786b2ced568e4c8508634c01f326615f7e4d40b2"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/20/artifacts/kubernetes/v1.30.7/kubernetes-src.tar.gz"
+sha512 = "590651f6bee133079e2d0907d1242b9b57b7254436f7206118f24239d57ee232d9755b94e85cf153471ccf63345896ae1de5c7df0d1543fe3ff478b871aed5b1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.30.5
+%global gover 1.30.7
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/17/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/20/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/6/artifacts/kubernetes/v1.31.1/kubernetes-src.tar.gz"
-sha512 = "d776cf029babde78af7f88aad7b337f2b73a18617a098d61666f462f6af7f9628e1d99a2abb6d840a8fead38ef2561ec5a41f8087d7c6c4d714f23b78e8b8ca7"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/9/artifacts/kubernetes/v1.31.3/kubernetes-src.tar.gz"
+sha512 = "c383516d9661ef5545dbd88194b805e913571bd78b709373b4601dd15d95020812d14eea33836a692fdb14a4c1d7be0b328723e4f8adcfc4685649c4ccecfa14"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.31.1
+%global gover 1.31.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-31/releases/6/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-31/releases/9/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

    * Updates kubernetes-1.28 through 1.31 to the latest upstream versions.



**Testing done:**

```
aarch64-aws-k8s-128-nvidia-conformance                   Test                    passed                                   384                     0                   7012   a8df6eb2-dirty               2024-12-18T10:30:25Z
 aarch64-aws-k8s-128-nvidia-quick                         Test                    passed                                     5                     0                   7391   a8df6eb2-dirty               2024-12-18T08:39:20Z
 aarch64-aws-k8s-128-quick                                Test                    passed                                     5                     0                   7391   a8df6eb2-dirty               2024-12-18T08:24:39Z
 aarch64-aws-k8s-129-conformance                          Test                    passed                                   392                     0                   7022   a8df6eb2-dirty               2024-12-18T10:18:25Z
 aarch64-aws-k8s-129-nvidia-quick                         Test                    passed                                     5                     0                   7409   a8df6eb2-dirty               2024-12-18T08:43:13Z
 aarch64-aws-k8s-129-quick                                Test                    passed                                     5                     0                   7409   a8df6eb2-dirty               2024-12-18T08:29:10Z
 aarch64-aws-k8s-130-conformance                          Test                    passed                                   406                     0                   6797   a8df6eb2-dirty               2024-12-18T10:15:21Z
 aarch64-aws-k8s-130-quick                                Test                    passed                                     5                     0                   7198   a8df6eb2-dirty               2024-12-18T08:32:42Z
 aarch64-aws-k8s-131-conformance                          Test                    passed                                   408                     0                   6201   a8df6eb2-dirty               2024-12-18T10:09:14Z
 aarch64-aws-k8s-131-nvidia-conformance                   Test                    passed                                   408                     0                   6201   a8df6eb2-dirty               2024-12-18T10:30:56Z
 aarch64-aws-k8s-131-nvidia-quick                         Test                    passed                                     5                     0                   6604   a8df6eb2-dirty               2024-12-18T08:37:32Z
 aarch64-aws-k8s-131-quick                                Test                    passed                                     5                     0                   6604   a8df6eb2-dirty               2024-12-18T08:20:24Z
 x86-64-aws-k8s-128-conformance                           Test                    passed                                   384                     0                   7012   a8df6eb2-dirty               2024-12-18T10:07:11Z
 x86-64-aws-k8s-128-nvidia-conformance                    Test                    passed                                   384                     0                   7012   a8df6eb2-dirty               2024-12-18T10:32:07Z
 x86-64-aws-k8s-128-nvidia-quick                          Test                    passed                                     5                     0                   7391   a8df6eb2-dirty               2024-12-18T08:38:35Z
 x86-64-aws-k8s-128-quick                                 Test                    passed                                     5                     0                   7391   a8df6eb2-dirty               2024-12-18T08:25:18Z
 x86-64-aws-k8s-129-conformance                           Test                    passed                                   392                     0                   7022   a8df6eb2-dirty               2024-12-18T10:19:46Z
 x86-64-aws-k8s-129-quick                                 Test                    passed                                     5                     0                   7409   a8df6eb2-dirty               2024-12-18T08:27:36Z
 x86-64-aws-k8s-130-conformance                           Test                    passed                                   406                     0                   6797   a8df6eb2-dirty               2024-12-18T10:14:04Z
 x86-64-aws-k8s-130-quick                                 Test                    passed                                     5                     0                   7198   a8df6eb2-dirty               2024-12-18T08:30:07Z
 x86-64-aws-k8s-131-conformance                           Test                    passed                                   408                     0                   6201   a8df6eb2-dirty               2024-12-18T10:06:03Z
 x86-64-aws-k8s-131-nvidia-conformance                    Test                    passed                                   408                     0                   6201   a8df6eb2-dirty               2024-12-18T10:29:33Z
 x86-64-aws-k8s-131-nvidia-quick                          Test                    passed                                     5                     0                   6604   a8df6eb2-dirty               2024-12-18T08:35:29Z
 x86-64-aws-k8s-131-quick                                 Test                    passed                                     5                     0                   6604   a8df6eb2-dirty               2024-12-18T08:18:42Z
 aarch64-aws-k8s-129-nvidia-conformance                   Test                    passed                                   392                     0                   7022   a8df6eb2-dirty               2024-12-18T19:12:23Z
 aarch64-aws-k8s-129-nvidia-quick                         Test                    passed                                     5                     0                   7409   a8df6eb2-dirty               2024-12-18T17:11:50Z
 aarch64-aws-k8s-130-nvidia-quick                         Test                    passed                                     5                     0                   7198   a8df6eb2-dirty               2024-12-18T17:11:55Z
 x86-64-aws-k8s-129-nvidia-conformance                    Test                    passed                                   392                     0                   7022   a8df6eb2-dirty               2024-12-18T19:09:16Z
 x86-64-aws-k8s-129-nvidia-quick                          Test                    passed                                     5                     0                   7409   a8df6eb2-dirty               2024-12-18T17:11:55Z
 x86-64-aws-k8s-130-nvidia-conformance                    Test                    passed                                   406                     0                   6797   a8df6eb2-dirty               2024-12-18T19:05:30Z
 x86-64-aws-k8s-130-nvidia-quick                          Test                    passed                                     5                     0                   7198   a8df6eb2-dirty
 ```

* Manually launched aarch64 nvidia 1.30 and deployed NVIDIA Pod.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
