### PR TITLE
Third party package updates

### DIFF
--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.26/aws-iam-authenticator-0.6.26.tar.gz"
-sha512 = "eae6f2cf8e7735b0cebe0758e1a34eaf3347d43c224edf250f618272b3af3577c58205d1fa46b43bc056ad00f71fd4bcd0c398f7a78ec919fce7f34109bf3786"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.28/aws-iam-authenticator-0.6.28.tar.gz"
+sha512 = "2e506dd2f0c28e74df8d7da4ceb4dd6407b5f975fb72c2b1ea34ebae6eaba4c447efdf2e37a161198befcb1a77e7bb6352becf3296a033148d5e51934c290704"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.6.26
+%global gover 0.6.28
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.27/Cargo.toml
+++ b/packages/ecr-credential-provider-1.27/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.27"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.27.9"
-path = "cloud-provider-aws-1.27.9.tar.gz"
-sha512 = "f9d078144cb1f8f04c9ea613ef0a348c0b5ac864307d4d35b82df4f0480d8b4d010dfff0b85ebaf7b981bfa9e913d48c7055ac396bb9c15aa4e00be52b5994cb"
+url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.27.10"
+path = "cloud-provider-aws-1.27.10.tar.gz"
+sha512 = "e173d4504dd0912530cf5db6d16319df62e06a7f982f835f8a69bd86501179cba78926f3fa6406da926424eab02cb4610f63c9d22ce6ed83fb43203c3ae0cb6b"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.27/ecr-credential-provider-1.27.spec
+++ b/packages/ecr-credential-provider-1.27/ecr-credential-provider-1.27.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.27.9
+%global gover 1.27.10
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.29/Cargo.toml
+++ b/packages/ecr-credential-provider-1.29/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.29"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.29.6"
-path = "cloud-provider-aws-1.29.6.tar.gz"
-sha512 = "de484b7cc87f3cef5bcc1d9d03ea2f81b25f83f52427a4006ebb07768495cb42281063c3ddd43ab1f92c1e4f82659823012dcd58db1226e15cdf61c3a9d0af01"
+url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.29.7"
+path = "cloud-provider-aws-1.29.7.tar.gz"
+sha512 = "e4cedb1adfaac2ab3c82817ce2ec3b1c4a6c50a456ba01b032baac4cebad94d804adafbf09d7bea5550c3dadf6576313d81bae6b522f42d71e37c1f4ce7a2c08"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.29/ecr-credential-provider-1.29.spec
+++ b/packages/ecr-credential-provider-1.29/ecr-credential-provider-1.29.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.29.6
+%global gover 1.29.7
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.30/Cargo.toml
+++ b/packages/ecr-credential-provider-1.30/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.30"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.30.3"
-path = "cloud-provider-aws-1.30.3.tar.gz"
-sha512 = "aa351cd531e452dd4ccead4a591a9161a25737ada93a7317c5c181c3d4fe55b279e94b686d8c03665ebee01191129a52b01c9dabfba7075c5e9bde52e6a341c8"
+url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.30.6"
+path = "cloud-provider-aws-1.30.6.tar.gz"
+sha512 = "834ff1abf041a29d3f655e4299ab2534a4e371c130165ee37a44d899740712e097836b96e14a3406678092190e33d8ea7fb066652869505f867f3a8a2d7c73c1"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
+++ b/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.30.3
+%global gover 1.30.6
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.31/Cargo.toml
+++ b/packages/ecr-credential-provider-1.31/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.31"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.31.0"
-path = "cloud-provider-aws-1.31.0.tar.gz"
-sha512 = "962973013984a802853311182e1cfd1eabb1bcdf164000f607aeb2631ac98a0b4fd5ba1f7aff08491040979bd2321bcd5debd567c9aa74889b09d7599bc4dcfd"
+url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.31.4"
+path = "cloud-provider-aws-1.31.4.tar.gz"
+sha512 = "d66898e34f2a0d4504ace6bb685897a360a315fd81371fbb2db727e65b4207cd728d07a3313f34985a0a1af26865fbbdde310aa88ee4af77d6ab02c354a6f223"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
+++ b/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.31.0
+%global gover 1.31.4
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/nvidia-k8s-device-plugin/Cargo.toml
+++ b/packages/nvidia-k8s-device-plugin/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/k8s-device-plugin/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.16.2/v0.16.2.tar.gz"
-path = "k8s-device-plugin-0.16.2.tar.gz"
-sha512 = "0be166ba3f2ae51882e62e71dc625f6e83c4c18321e9e6beb05b7f2f6b3628e5ca7f480576f422faba0e6ad232085dff200b474f2453aeef307f9a6a5d13e1b6"
+url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.17.0/v0.17.0.tar.gz"
+path = "k8s-device-plugin-0.17.0.tar.gz"
+sha512 = "912d324d22bc18994319d4188a3d859e5af58ec6bd7da01f632a210dbb313b6ac8d5105e4558f03b49ed56005383eca6c25f215c24ca7b981b60cd0c510516ed"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -2,7 +2,7 @@
 %global gorepo k8s-device-plugin
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.16.2
+%global gover 0.17.0
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-k8s-device-plugin


### PR DESCRIPTION
**Issue number: N/A**

Closes #

**Description of changes:**
    aws-iam-authenticator: update to 0.6.28
    ecr-credential-provider-1.27: update to 1.27.10
    ecr-credential-provider-1.29: update to 1.29.7
    ecr-credential-provider-1.30: update to 1.30.6
    ecr-credential-provider-1.31: update to 1.31.4
    nvidia-k8s-device-plugin: update to 0.17.0

**Testing done:**
For non-nvidia variants, run quick tests
```
 x86-64-aws-ecs-1-quick                           Test           passed  
 x86-64-aws-k8s-124-ipv6-quick                    Test           passed  
 x86-64-aws-k8s-124-quick                         Test           passed 
 aarch64-aws-ecs-1-quick                          Test           passed   
 aarch64-aws-k8s-124-ipv6-quick                   Test           passed     
 aarch64-aws-k8s-124-quick                        Test           passed       
 aarch64-aws-k8s-129-ipv6-quick                   Test           passed   
 aarch64-aws-k8s-129-quick                        Test           passed      
 x86-64-aws-k8s-129-ipv6-quick                    Test           passed    
 x86-64-aws-k8s-129-quick                         Test           passed       
```

For nvidia variants, run smoke tests

```
x86_64 (NVIDIA L4):

Device 0: "NVIDIA L4"
CUDA Driver Version / Runtime Version          12.2 / 11.4
CUDA Capability Major/Minor version number:    8.9

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.2, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS

[Vector addition of 50000 elements]
Test PASSED

Warp Aggregated Atomics PASSED
ARM64 (NVIDIA T4G):

Device 0: "NVIDIA T4G"
CUDA Driver Version / Runtime Version          12.2 / 11.4
CUDA Capability Major/Minor version number:    7.5

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.2, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS

[Vector addition of 50000 elements]
Test PASSED

Warp Aggregated Atomics PASSED
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
