### PR TITLE
packages: add official source for kubernetes-1.32

### DIFF
--- a/packages/kubernetes-1.32/Cargo.toml
+++ b/packages/kubernetes-1.32/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.32"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/1/artifacts/kubernetes/v1.32.0-beta.0/kubernetes-src.tar.gz"
-sha512 = "b63b89d191593890e0c246a88bde3191b10ba47db47f5c522707c1eca44b74fb295ee1b6fe31410621bb2e46fe30898883e83d42c652d676f75f09183f081ecb"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/3/artifacts/kubernetes/v1.32.0/kubernetes-src.tar.gz"
+sha512 = "dd3907b28a10686b63b8aeba88b2ee9d79a1f42546a2f57b3e5a8c837ea186e807d70822fa65c3fc4f36d57209365a204c4d4a7e3eddf4191c45abfde592bc44"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -32,12 +32,12 @@
 
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
-Release: 0.beta0%{?dist}
+Release: 1%{?dist}
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-32/releases/1/artifacts/kubernetes/v1.32.0-beta.0/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-32/releases/3/artifacts/kubernetes/v1.32.0/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:N/A**

https://github.com/bottlerocket-os/bottlerocket/issues/4318

**Description of changes:**
Add official source of kubenetes-1.32


**Testing done:**
- [x] aarch64 IPv4 conformance tests
- [x] aarch64 IPv6 conformance tests
- [x] aarch64 NVIDIA conformance tests
- [x] aarch64 NVIDIA smoke tests
- [x] x86_64 IPv4 conformance tests
- [x] x86_64 IPv6 conformance tests
- [x] x86_64 NVIDIA conformance tests
- [x] x86_64 NVIDIA smoke tests
- [x] aarch64 FIPS IPv4 conformance tests
- [x] aarch64 FIPS IPv6 conformance tests
- [x] x86_64 FIPS IPv4 conformance tests
- [x] x86_64 FIPS IPv6 conformance tests
- [x] x86_64 Karpenter tests
- [x] x86_64 nvidia Karpenter tests
- [x] aarch64 Karpenter tests
- [x] aarch64 nvidia Karpenter tests

```
kubectl get jobs --kubeconfig x86-64-aws-k8s-132-nvidia.kubeconfig
 
NAME STATUS COMPLETIONS DURATION AGE
nvidia-smoke-test Complete 1/1 73s 11m
 
kubectl get jobs --kubeconfig aarch64-aws-k8s-132-nvidia.kubeconfig
 
NAME STATUS COMPLETIONS DURATION AGE
nvidia-smoke-test Complete 1/1 20s 11m
 
 
sonobuoy status --kubeconfig x86-64-aws-k8s-132.kubeconfig 
 PLUGIN STATUS RESULT COUNT PROGRESS
 e2e complete passed 1 Passed: 0, Failed: 0, Remaining:411

 
sonobuoy status --kubeconfig x86-64-aws-k8s-132-nvidia.kubeconfig 
 PLUGIN STATUS RESULT COUNT PROGRESS
 e2e complete passed 1 Passed: 0, Failed: 0, Remaining:411

 
sonobuoy status --kubeconfig x86-64-aws-k8s-132-ipv6.kubeconfig 
 PLUGIN STATUS RESULT COUNT PROGRESS
 e2e complete passed 1 Passed: 0, Failed: 0, Remaining:411

 
 sonobuoy status --kubeconfig aarch64-aws-k8s-132.kubeconfig 
 PLUGIN STATUS RESULT COUNT PROGRESS
 e2e complete passed 1 Passed: 0, Failed: 0, Remaining:411

 
sonobuoy status --kubeconfig aarch64-aws-k8s-132-nvidia.kubeconfig 
 PLUGIN STATUS RESULT COUNT PROGRESS
 e2e complete passed 1 Passed: 0, Failed: 0, Remaining:411
 
sonobuoy status --kubeconfig aarch64-aws-k8s-132-ipv6.kubeconfig 
 PLUGIN STATUS RESULT COUNT PROGRESS
 e2e complete passed 1 Passed: 0, Failed: 0, Remaining:411



```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
