### PR TITLE
fix: parse proxy URI with prepending URL scheme

### DIFF
--- a/sources/aws-smithy-experimental/src/hyper_1_0.rs
+++ b/sources/aws-smithy-experimental/src/hyper_1_0.rs
@@ -256,7 +256,8 @@ mod build_connector {
         }
         let mut proxy = Proxy::new(intercept, proxy_uri);
         // Parse https_proxy as URL to extract out auth information if any
-        let proxy_url = Url::parse(https_proxy).expect("Unable to parse HTTPS proxy as URL");
+        let proxy_url =
+            Url::parse(&proxy.uri().to_string()).expect("Unable to parse HTTPS proxy as URL");
 
         if !proxy_url.username().is_empty() || proxy_url.password().is_some() {
             proxy.set_authorization(Authorization::basic(


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #338

**Description of changes:**

parse the URI of the proxy generated from Proxy::new(intercept, proxy_uri) rather than proxy_uri directly, since proxy_uri may be missing a URL scheme and in that case can't be parsed as a URL

**Testing done:**

An aws-k8s-1.31 node with user data

```
  [settings.network]
    https-proxy = "<myproxy>:8888"
```

successfully joins the cluster. <myproxy> is the private ipV4 DNS name of an EC2 instance running [tinyproxy](https://github.com/tinyproxy/tinyproxy) in the same VPC as the node.


An aws-k8s-1.31 node with user data

```
  [settings.network]
    https-proxy = "<fake user>:<fake password>@<myproxy>:8888"
```

and `tinyproxy` configured to accept `BasicAuth <fake user> <fake password>` successfully forwards requests and joins the cluster

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
