### PR TITLE
3rd Party packages update: ECS-agent and amazon-ecs-cni-plugins

### DIFF
--- a/packages/amazon-ecs-cni-plugins/Cargo.toml
+++ b/packages/amazon-ecs-cni-plugins/Cargo.toml
@@ -16,8 +16,8 @@ releases-url = "https://github.com/aws/amazon-ecs-agent/commits/master/amazon-ec
 # This is locked against the version shipped in ecs-agent
 # Verify that the ecs-agent version shipped in bottlerocket tracks the same one here
 # https://github.com/aws/amazon-ecs-agent/releases
-url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/53a8481891251e66e35847554d52a13fc7c4fd03/amazon-ecs-cni-plugins.tar.gz"
-sha512 = "e819c1aae509d19461999bf717d126b3e918b73dc6049e415c4911be6cb11159404bb45bb6c92cdfa16b5b30bb174731e972e3f2be44fa0b51bbc7a969049ab7"
+url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/7b4ec6016ab221469fa3abfc00ea7c05f236c26c/amazon-ecs-cni-plugins.tar.gz"
+sha512 = "234021e1132a8c7101603f26c2b4d18e2a54dd8d6e879ae5138fcafac012f792dc25ab1bad37bde5d4e299b996340de557dbe9ba928eae2a8565adff5bd481a8"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
+++ b/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
@@ -1,11 +1,11 @@
 %global ecscni_goproject github.com/aws
 %global ecscni_gorepo amazon-ecs-cni-plugins
 %global ecscni_goimport %{ecscni_goproject}/%{ecscni_gorepo}
-%global ecscni_gitrev 53a8481891251e66e35847554d52a13fc7c4fd03
+%global ecscni_gitrev 7b4ec6016ab221469fa3abfc00ea7c05f236c26c
 
 Name: %{_cross_os}amazon-ecs-cni-plugins
-# https://github.com/aws/amazon-ecs-cni-plugins/blob/53a8481891251e66e35847554d52a13fc7c4fd03/VERSION#L1
-Version: 2020.09.0
+# https://github.com/aws/amazon-ecs-cni-plugins/blob/7b4ec6016ab221469fa3abfc00ea7c05f236c26c/VERSION#L1
+Version: 2024.09.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: Networking plugins for ECS task networking

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.88.0/amazon-ecs-agent-1.88.0.tar.gz"
-sha512 = "1d7f38cae0fb7401b48feca4d6ecb270c5c5a5efc4367c58ff8384d2175b4c0b6a76bbe350ab231108eec542a3d6f0d9b8ac60dc121d5fee9a86ef812fdf9785"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.89.2/amazon-ecs-agent-1.89.2.tar.gz"
+sha512 = "024f30daa6192f6e03771e507d776d01ec2c86b6cd7682e3b62d5f0e3e1b017b56360ca8e088ea183a4d04e104dc6e2e572ad9658d4bfcdab166d579a3ee1bc8"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,7 +2,7 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.88.0
+%global agent_gover 1.89.2
 
 # git rev-parse --short=8
 %global agent_gitrev b7e96508


### PR DESCRIPTION
**Description of changes:**
Update ECS agent to upstream [v1.89.2](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.89.2).
Update amazon-ecs-cni-plugins to upstream (https://github.com/aws/amazon-ecs-cni-plugins/commit/7b4ec6016ab221469fa3abfc00ea7c05f236c26c)

**Testing done:**

Built AMI and connected, worked well.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
