### PR TITLE
apiserver: improve error message for invalid metadata

### DIFF
--- a/sources/api/apiserver/src/server/controller.rs
+++ b/sources/api/apiserver/src/server/controller.rs
@@ -408,8 +408,12 @@ pub(crate) fn get_metadata_for_data_keys<D: DataStore, S: AsRef<str>>(
             Err(_) => continue,
         };
         trace!("Deserializing scalar from metadata");
-        let value: Value = deserialize_scalar::<_, ScalarError>(&value_str)
-            .context(error::InvalidMetadataSnafu { key: md_key.name() })?;
+        let value: Value = deserialize_scalar::<_, ScalarError>(&value_str).context(
+            error::InvalidMetadataSnafu {
+                key: md_key.name(),
+                data_key: data_key.name(),
+            },
+        )?;
         result.insert(data_key.to_string(), value);
     }
 
@@ -436,6 +440,7 @@ pub(crate) fn get_metadata_for_all_data_keys<D: DataStore, S: AsRef<str>>(
             let value: Value = deserialize_scalar::<_, ScalarError>(&value_str).context(
                 error::InvalidMetadataSnafu {
                     key: meta_key.name(),
+                    data_key: data_key.name(),
                 },
             )?;
             result.insert(data_key.to_string(), value);

--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -136,9 +136,15 @@ pub enum Error {
         source: Box<datastore::Error>,
     },
 
-    #[snafu(display("Metadata '{}' is not valid JSON: {}", key, source))]
+    #[snafu(display(
+        "Metadata '{}' for key '{}' is not valid JSON: {}",
+        key,
+        data_key,
+        source
+    ))]
     InvalidMetadata {
         key: String,
+        data_key: String,
         source: serde_json::Error,
     },
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

The error message for an invalid metadata value doesn't include which data key the invalid metadata is on, making it difficult to determine exactly what the issue is. This adds the missing data key to the error message.

**Testing done:**

```
cargo build
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
