### PR TITLE
containerd: add support for device-ownership to nvidia

### DIFF
--- a/packages/containerd/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -2,7 +2,7 @@
 container-registry = "v1"
 container-runtime = "v1"
 kubernetes = "v1"
-std = { version = "v1", helpers = ["join_array"]}
+std = { version = "v1", helpers = ["join_array", "default"]}
 +++
 version = 2
 root = "/var/lib/containerd"
@@ -19,6 +19,7 @@ disabled_plugins = [
 address = "/run/containerd/containerd.sock"
 
 [plugins."io.containerd.grpc.v1.cri"]
+device_ownership_from_security_context = {{default false settings.kubernetes.device-ownership-from-security-context}}
 enable_selinux = true
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
 sandbox_image = "localhost/kubernetes/pause:0.1.0"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Following up from PR #329. Use of the new `device-ownership-from-security-context` setting was missed in the nvidia settings for containerd. This PR fixes that.

**Testing done:**

- Launched nvidia variants and validated CUDA workloads with the setting set to `true` and `false`
- Oversubscribed instances with resource requests with the setting set to `true` and `false`
- Bypassed the plugin with the `envvar` settings to allocate all GPUs to a container

In all these cases, the workloads did no throw any errors and behaved as expected.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
