### PR TITLE
Fix errors with apiserver and bootstrap-commands

### DIFF
--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -118,6 +118,12 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         _ => format!("{}{}", RAID_DEVICE_DIR, RAID_DEVICE_NAME),
     };
 
+    // Normalize input by trimming trailing "/"
+    let dirs: Vec<String> = dirs
+        .into_iter()
+        .map(|dir| dir.trim_end_matches("/").to_string())
+        .collect();
+
     let mount_point = format!("/mnt/{}", EPHEMERAL_MNT);
     let mount_point = Path::new(&mount_point);
     let allowed_dirs = allowed_bind_dirs(variant);


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

[Relevant Comment](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/320#issuecomment-2573821166)

**Description of changes:**
- Added a step to the `bind` command in the apicient/server to normalize the input by trimming the trailing "/"
- Explicitly check the command output in `bootstrap-commands` and throw an error on failure. Also adds a warning to the journal log on command failure

**Testing done:**
- Tested launching a container with the following userdata
  ```
  [settings.bootstrap-commands.k8s-ephemeral-storage]
  commands = [
    ["apiclient", "ephemeral-storage", "init"],
    ["apiclient", "ephemeral-storage" ,"bind", "--dirs", "/mnt/", "/mnt/testDir", "/var/lib/containerd", "/var/lib/kubelet", "/var/log/. pods"]
  ]
  essential = true
  mode = "always"
  ```
  It now fails to boot when trying to mount `/mnt/`

- Tested with `essential = false`and the boot completes but logs the error as expected

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
