### PR TITLE
advisories: add BRSAs for NVIDIA Container Toolkit 1.17.1

### DIFF
--- a/advisories/3.3.0/BRSA-udcwjbo4nlwj.toml
+++ b/advisories/3.3.0/BRSA-udcwjbo4nlwj.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "BRSA-udcwjbo4nlwj"
+title = "nvidia-container-toolkit CVE-2024-0135"
+cve = "CVE-2024-0135"
+severity = "high"
+description = "A flaw was found in the NVIDIA Container Toolkit where a specially crafted container image could lead to modification of a host binary."
+
+[[advisory.products]]
+package-name = "nvidia-container-toolkit"
+patched-version = "1.17.1"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "libnvidia-container"
+patched-version = "1.17.1"
+patched-epoch = "1"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2024-11-12T21:04:22Z
+arches = ["aarch64", "x86_64"]
+version = "3.3.0"


### PR DESCRIPTION

**Description of changes:**

Add advisories for the recently public NVIDIA security bulletin for fixes in NVIDIA Container Toolkit 1.17.1 https://nvidia.custhelp.com/app/answers/detail/a_id/5599

These updates were included in the 3.3.0 core kit released in November.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
