### PR TITLE
Update EKS 1.28-1.31 versions to latest 

### DIFF
--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/38/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
-sha512 = "5eee692289fc554b0001c588a5d4a4c5eeaf6a5919d815a1575d3ffa5758b743f1de6850779f45cfe3ed002a58cc6a74660e0332662bba88d8b9ebf5668896c7"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/41/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
+sha512 = "0aef3a3b300d8e3d1b22357ee118077b45dd235a06ae318bcca440964b116267f71c523e49021457f1ff7cdd1f3c558be0b1c477a0ce6efd288f471d23152515"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/38/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-28/releases/41/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/27/artifacts/kubernetes/v1.29.11/kubernetes-src.tar.gz"
-sha512 = "c06e7b45164363ed18667222d8cabbfc07c346cfd7243b3ff49ac7b3b47ca9ce5630d33eb6d1823dc70579a5cff0378dcd9a1c7078b66217f6e2a4d4c4d909f6"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/30/artifacts/kubernetes/v1.29.12/kubernetes-src.tar.gz"
+sha512 = "8dce868ee0e168f4f5779541c5b0b3dbe13c88311e511db87faff9f8ff1326806d0ddab19ad897e6a1041d08ab8b78149f9ad7b07706b27b5697fbf9d2d6c91b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.29.11
+%global gover 1.29.12
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/27/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-29/releases/30/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/20/artifacts/kubernetes/v1.30.7/kubernetes-src.tar.gz"
-sha512 = "590651f6bee133079e2d0907d1242b9b57b7254436f7206118f24239d57ee232d9755b94e85cf153471ccf63345896ae1de5c7df0d1543fe3ff478b871aed5b1"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/23/artifacts/kubernetes/v1.30.8/kubernetes-src.tar.gz"
+sha512 = "06d308d962354ab763871a613fcbc83992b1e84482a90a7a0a7c218cd19c80471095c204dd416c8947547a0faf4ec3f0490bfef12ec663abc6db5af0727d9a9b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.30.7
+%global gover 1.30.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/20/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-30/releases/23/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/9/artifacts/kubernetes/v1.31.3/kubernetes-src.tar.gz"
-sha512 = "c383516d9661ef5545dbd88194b805e913571bd78b709373b4601dd15d95020812d14eea33836a692fdb14a4c1d7be0b328723e4f8adcfc4685649c4ccecfa14"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/12/artifacts/kubernetes/v1.31.4/kubernetes-src.tar.gz"
+sha512 = "822cb865536757b1e62e3799a36dc2e2bde914aedef7a4e8179946a363a5bfd415d0c5a0f4c1ad031266b429cea2faff5fa75f12f63ac13cb25525b40ecd1dd4"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.31.3
+%global gover 1.31.4
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -38,7 +38,7 @@ Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-31/releases/9/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-31/releases/12/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

    * Updates kubernetes-1.28 through 1.31 to the latest upstream versions.



**Testing done:**

| Test Name | Status | Result |
|-----------|--------|--------|
| aarch64-aws-k8s-128-conformance | Test | passed |
| aarch64-aws-k8s-128-nvidia-conformance | Test | passed |
| aarch64-aws-k8s-129-conformance | Test | passed |
| aarch64-aws-k8s-129-nvidia-conformance | Test | passed |
| aarch64-aws-k8s-130-conformance | Test | passed |
| aarch64-aws-k8s-130-nvidia-conformance | Test | passed |
| aarch64-aws-k8s-131-conformance | Test | passed |
| aarch64-aws-k8s-131-nvidia-conformance | Test | passed |
| x86-64-aws-k8s-128-conformance | Test | passed |
| x86-64-aws-k8s-128-nvidia-conformance | Test | passed |
| x86-64-aws-k8s-129-conformance | Test | passed |
| x86-64-aws-k8s-129-nvidia-conformance | Test | passed |
| x86-64-aws-k8s-130-conformance | Test | passed |
| x86-64-aws-k8s-130-nvidia-conformance | Test | passed |
| x86-64-aws-k8s-131-conformance | Test | passed |
| x86-64-aws-k8s-131-nvidia-conformance | Test | passed |

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
