### PR TITLE
Update nvidia-container-toolkit and libnvidia-container to v1.17.4

### DIFF
--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.17.3/libnvidia-container-1.17.3.tar.gz"
-sha512 = "24293e369fea42ebe64163464f600808c0d18e8b4efeea12095de22e16d43837cb6441f46baf52e8c966810c76b0f5045737a96d173e2ecf8cd15fff37cd4c4f"
+url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.17.4/libnvidia-container-1.17.4.tar.gz"
+sha512 = "a5edb4eec8cc4a9bd221c3cbb14515656854700b1a6aef7b47147d96b67511d5cfcae38c740fd946452768da0f993edf6c656697cd01189de88b67a4ae00aae5"
 
 [[package.metadata.build-package.external-files]]
 url = "https://github.com/NVIDIA/nvidia-modprobe/archive/550.54.14/nvidia-modprobe-550.54.14.tar.gz"

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -1,7 +1,7 @@
 %global nvidia_modprobe_version 550.54.14
 
 Name: %{_cross_os}libnvidia-container
-Version: 1.17.3
+Version: 1.17.4
 Release: 1%{?dist}
 Epoch: 1
 Summary: NVIDIA container runtime library

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.17.3/nvidia-container-toolkit-1.17.3.tar.gz"
-sha512 = "8c7a4290a1decc448c72e9a09213e0dc4e418ec633cefb16bb6b01fef7c502d23ed72cc1f3cc6583cad07feae5ca3cf44dad73e1274e042e3b26bdc7a4152b95"
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.17.4/nvidia-container-toolkit-1.17.4.tar.gz"
+sha512 = "ba79670cfc5e0abec388af858f2f7f1a153c5bc90f0b9540ffc6a095b8724f08c329742bc22cdc700299e063668bf574a7ac0bfa4c964763370c9b0500d5057c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 %global gorepo nvidia-container-toolkit
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.17.3
+%global gover 1.17.4
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-container-toolkit


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
- Updates `nvidia-container-toolkit`
- Updates `libnvidia-container`

**Testing done:**

Built and tested Bottlerocket AMIs and ran the [`nvidia-smoke-test`](https://github.com/bottlerocket-os/bottlerocket-test-system/tree/develop/bottlerocket/tests/workload/nvidia-smoke).
Variants tested, both `x86_64` and `aarch64`:
- [x] aws-k8s-1.31-nvidia
- [x] aws-ecs-2-nvidia

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
