### PR TITLE
prariedog: accept comment lines in boot config

### DIFF
--- a/sources/api/prairiedog/src/bootconfig.rs
+++ b/sources/api/prairiedog/src/bootconfig.rs
@@ -231,6 +231,10 @@ fn parse_boot_config_to_boot_settings(bootconfig: &str) -> Result<BootSettings> 
     let mut kernel_params: HashMap<BootConfigKey, Vec<BootConfigValue>> = HashMap::new();
     let mut init_params: HashMap<BootConfigKey, Vec<BootConfigValue>> = HashMap::new();
     for line in bootconfig.trim().lines() {
+        // ignore comment lines
+        if line.trim_start().starts_with("#") {
+            continue;
+        }
         let mut kv = line.trim().splitn(2, '=').map(|kv| kv.trim());
         // Ensure the key is a valid boot config key
         let key: BootConfigKey = kv


### PR DESCRIPTION

**Description of changes:**

`prariedog` may receive comment lines, and it should accept and ignore them.

**Testing done:**

Tested that a kernel that presents comments to `prariedog` will boot with the change.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
