### PR TITLE
updata: fix fetching max version in remove-update

### DIFF
--- a/sources/updater/updog/src/bin/updata.rs
+++ b/sources/updater/updog/src/bin/updata.rs
@@ -121,7 +121,7 @@ impl RemoveUpdateArgs {
         if let Some(current) = manifest.updates.first() {
             info!(
                 "Update {}-{}-{} removed. Current maximum version: {}",
-                self.arch, self.variant, self.image_version, current.version
+                self.arch, self.variant, self.image_version, current.max_version
             );
         } else {
             info!(


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #366

**Description of changes:**
- When running the remove-update command it would report the max version available in the manifest. But it is checking the wrong order so that the latest version is not correctly reported. This is a simple fix for that.


**Testing done:**
Before the fix:
```
cargo run --bin updata -- remove-update "${MANIFEST_PATH}/aws-k8s-1.29/x86_64/tuf_in/manifest.json" \
    --arch x86_64\
    --version 1.30.0 \
    --variant aws-k8s-1.29

22:56:06 [INFO] Update x86_64-aws-k8s-1.29-1.30.0 removed. Current maximum version: 1.18.0
```

After:
```
cargo run --bin updata -- remove-update "${MANIFEST_PATH}/aws-k8s-1.29/x86_64/tuf_in/manifest.json" \
    --arch x86_64\
    --version 1.30.0 \
    --variant aws-k8s-1.29

22:56:06 [INFO] Update x86_64-aws-k8s-1.29-1.30.0 removed. Current maximum version: 1.31.0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
