### PR TITLE
feat: tag sd* drives as ephemeral also

### DIFF
--- a/packages/os/ephemeral-storage.rules
+++ b/packages/os/ephemeral-storage.rules
@@ -7,7 +7,7 @@ ENV{DEVTYPE}!="disk", GOTO="ephemeral_storage_end"
 # Known sources of ephemeral disks:
 # - EC2 instance types with instance storage volumes
 # - KVM VMs with additional virtio disks
-KERNEL!="nvme*|vd*", GOTO="ephemeral_storage_end"
+KERNEL!="nvme*|vd*|sd*", GOTO="ephemeral_storage_end"
 
 # We can't be sure that devices with similar kernel names are all ephemeral.
 # Our udev helper checks for known system partitions to classify the device.

--- a/packages/os/supplemental-storage.rules
+++ b/packages/os/supplemental-storage.rules
@@ -9,7 +9,7 @@ SUBSYSTEM!="block", GOTO="supplemental_storage_end"
 ENV{DEVTYPE}!="partition", GOTO="supplemental_storage_end"
 
 # Only these drivers have "interesting" volume types.
-KERNEL!="nvme*|xvd*|vd*", GOTO="supplemental_storage_end"
+KERNEL!="nvme*|xvd*|vd*|sd*", GOTO="supplemental_storage_end"
 
 # Set the volume type for each supported driver, annotating it with the volume
 # sub-type, if any.
@@ -18,6 +18,7 @@ ENV{BOTTLEROCKET_VOLUME_TYPE}!="?*", KERNEL=="nvme*", ATTRS{model}=="Amazon Elas
 ENV{BOTTLEROCKET_VOLUME_TYPE}!="?*", KERNEL=="nvme*", ENV{BOTTLEROCKET_VOLUME_TYPE}="nvme"
 ENV{BOTTLEROCKET_VOLUME_TYPE}!="?*", KERNEL=="xvd*", ENV{BOTTLEROCKET_VOLUME_TYPE}="xen"
 ENV{BOTTLEROCKET_VOLUME_TYPE}!="?*", KERNEL=="vd*", ENV{BOTTLEROCKET_VOLUME_TYPE}="virtio"
+ENV{BOTTLEROCKET_VOLUME_TYPE}!="?*", KERNEL=="sd*", ENV{BOTTLEROCKET_VOLUME_TYPE}="scsi"
 
 ENV{ID_PART_ENTRY_UUID}=="?*" SYMLINK+="disk/by-volume-type-partuuid/$env{BOTTLEROCKET_VOLUME_TYPE}-$env{ID_PART_ENTRY_UUID}"
 


### PR DESCRIPTION
**Issue number:**

Closes [#4370](https://github.com/bottlerocket-os/bottlerocket/issues/4370)

**Description of changes:**
Minor change, adding the `sd*` pattern to the allowlist of disks to be tagged by the `ghostdog` utility. 


**Testing done:**
Mirrored these two rules in one custom rule, packaged it in our custom image, installed it on a system with `sd*` disks and saw them tagged.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
