### PR TITLE
package updates: aws-iam-authenticator to 0.6.29 and aws-signing-helper to 1.4.0

### DIFF
--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.28/aws-iam-authenticator-0.6.28.tar.gz"
-sha512 = "2e506dd2f0c28e74df8d7da4ceb4dd6407b5f975fb72c2b1ea34ebae6eaba4c447efdf2e37a161198befcb1a77e7bb6352becf3296a033148d5e51934c290704"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.29/aws-iam-authenticator-0.6.29.tar.gz"
+sha512 = "276efbbf44228b7ef6fe45e80c19443b134664d940706f2634e7478c4e8a3d2499bd0cbe70e1b7916af47dbc66ca1b5419f4738ad1f94ef82fe88f3a06f27d65"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.6.28
+%global gover 0.6.29
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -49,7 +49,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 
 %build
 %set_cross_go_flags
-export GO_MAJOR="1.22"
+export GO_MAJOR="1.23"
 go build -ldflags="${GOLDFLAGS}" -o aws-iam-authenticator ./cmd/aws-iam-authenticator
 gofips build -ldflags="${GOLDFLAGS}" -o fips/aws-iam-authenticator ./cmd/aws-iam-authenticator
 

--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.2.0/rolesanywhere-credential-helper-v1.2.0.tar.gz"
-sha512 = "c2c7fa2fb319aea0036bf334c59cf2a10520da56a45a3e04a99870becfee5099eeb655933b507d2627ebcfde969f1150f0025ace6e06b88bfa801ee847324d30"
+url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.4.0/rolesanywhere-credential-helper-v1.4.0.tar.gz"
+sha512 = "6da4911c89ea24a1356964f5cedc2cdb06c927a930b189efbf5ccaae60e582714b264fb787b2ed9d575ce5e588d1a057d7f311022c459aca7b7afd9f9c2bc801"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo rolesanywhere-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.2.0
+%global gover 1.4.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
**Description of changes:**
Updated aws-iam-authenticator to 0.6.29, and aws-signing helper to 1.4.0

**Testing done:**

Quick tests and smoke tests passed.

```
aarch64-aws-k8s-130-quick                    Test               passed           
 x86-64-aws-k8s-130-quick                    Test               passed    
 x86-64-aws-k8s-130-nvidia-quick             Test               passed     
 aarch64-aws-k8s-130-nvidia-quick            Test               passed    
 
NAME                STATUS     COMPLETIONS   DURATION   AGE
nvidia-smoke-test   Complete   1/1           89s        7m49s
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
