### PR TITLE
package: bump rdma-core version to 56.0

### DIFF
--- a/packages/rdma-core/Cargo.toml
+++ b/packages/rdma-core/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-rdma/rdma-core/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-rdma/rdma-core/releases/download/v54.0/rdma-core-54.0.tar.gz"
-sha512 = "efb98dec017e1eb71ed6f2b652d557d0444c672ff388927bdd724c81bb4baeb5617c81fff609f794c1ff128ab93ae26ed4502bd0ebf14e157737b1b08d0fb4b9"
+url = "https://github.com/linux-rdma/rdma-core/releases/download/v56.0/rdma-core-56.0.tar.gz"
+sha512 = "2f59f70e80d3a93d0159aecf8b1b3c5cfc489661121be06bd1cefe3cda510e63b106b6d19730534150d403c552926c760520b9a848d7ba82f94501ef14d92a63"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/rdma-core/rdma-core.spec
+++ b/packages/rdma-core/rdma-core.spec
@@ -1,7 +1,7 @@
 %global abiver rdmav34
 
 Name: %{_cross_os}rdma-core
-Version: 54.0
+Version: 56.0
 Release: 1%{?dist}
 Summary: RDMA core userspace infrastructure, including core libraries and util programs.
 License: Linux-OpenIB AND MIT


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Bump `rdma-core` version to 56.0.


**Testing done:**
- Built a test AMI and verify that it boots.
- Performed internal confirmation tests to ensure EKS Auto Mode compatibility.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
