### PR TITLE
advisories: backfill binutils BRSAs for 5.0.0

### DIFF
--- a/advisories/5.0.0/BRSA-0khj8kjohnfy.toml
+++ b/advisories/5.0.0/BRSA-0khj8kjohnfy.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-0khj8kjohnfy"
+title = "binutils CVE-2022-47010"
+cve = "CVE-2022-47010"
+severity = "moderate"
+description = "A flaw was found in binutils where an issue in the pr_function_type function in prdbg.c could cause memory leaks and lead to a denial of service."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-1q7yahvpheci.toml
+++ b/advisories/5.0.0/BRSA-1q7yahvpheci.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-1q7yahvpheci"
+title = "binutils CVE-2023-1579"
+cve = "CVE-2023-1579"
+severity = "high"
+description = "A flaw was found in binutils where bfd_getl64 in binutils-gdb/bfd/libbfd.c could cause a heap-based buffer overflow."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-2cp5qbcspr8r.toml
+++ b/advisories/5.0.0/BRSA-2cp5qbcspr8r.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-2cp5qbcspr8r"
+title = "binutils CVE-2023-1972"
+cve = "CVE-2023-1972"
+severity = "moderate"
+description = "A flaw was found in binutils in _bfd_elf_slurp_version_tables() in bfd/elf.c where a potential heap based buffer overflow could lead to loss of availability."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-2vcgxe5a1gi8.toml
+++ b/advisories/5.0.0/BRSA-2vcgxe5a1gi8.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-2vcgxe5a1gi8"
+title = "binutils CVE-2022-48065"
+cve = "CVE-2022-48065"
+severity = "moderate"
+description = "A flaw was found in binutils in the find_abstract_instance function in dwarf2.c which could cause a memory leak vulnerability."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-abcrltx3gdzh.toml
+++ b/advisories/5.0.0/BRSA-abcrltx3gdzh.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-abcrltx3gdzh"
+title = "binutils CVE-2022-35205"
+cve = "CVE-2022-35205"
+severity = "moderate"
+description = "A flaw was found in binutils readelf where a reachable assertion failure in the display_debug_names function could cause a denial of service."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-bvc4l89azoro.toml
+++ b/advisories/5.0.0/BRSA-bvc4l89azoro.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-bvc4l89azoro"
+title = "binutils CVE-2022-47673"
+cve = "CVE-2022-47673"
+severity = "high"
+description = "A flaw was found in binutils addr2line where the parse_module function contains multiple out-of-bounds reads which could cause a denial of service."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-cuqjzwtm0l8o.toml
+++ b/advisories/5.0.0/BRSA-cuqjzwtm0l8o.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-cuqjzwtm0l8o"
+title = "binutils CVE-2023-25585"
+cve = "CVE-2023-25585"
+severity = "moderate"
+description = "A flaw was found in binutils where the use of an uninitialized field in the struct module *module could lead to application crash and local denial of service."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-cz6dip9kzbvg.toml
+++ b/advisories/5.0.0/BRSA-cz6dip9kzbvg.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-cz6dip9kzbvg"
+title = "binutils CVE-2023-25586"
+cve = "CVE-2023-25586"
+severity = "moderate"
+description = "A flaw was found in binutils where a logic fail in the bfd_init_section_decompress_status function could lead to the use of an uninitialized variable that can cause a crash and local denial of service."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-dmyrtubzntzz.toml
+++ b/advisories/5.0.0/BRSA-dmyrtubzntzz.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-dmyrtubzntzz"
+title = "binutils CVE-2022-47011"
+cve = "CVE-2022-47011"
+severity = "moderate"
+description = "A flaw was found in binutils in the parse_stab_struct_fields function in stabs.c which could cause memory leaks and a denial of service."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-dvso9pxc9axy.toml
+++ b/advisories/5.0.0/BRSA-dvso9pxc9axy.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-dvso9pxc9axy"
+title = "binutils CVE-2022-48063"
+cve = "CVE-2022-48063"
+severity = "moderate"
+description = "A flaw was found in binutils where an excessive memory consumption vulnerability via the function load_separate_debug_files at dwarf2.c. could be triggered by a specially crafted ELF file and cause a DNS attack."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-eqm9d3oif9ab.toml
+++ b/advisories/5.0.0/BRSA-eqm9d3oif9ab.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-eqm9d3oif9ab"
+title = "binutils CVE-2023-25588"
+cve = "CVE-2023-25588"
+severity = "moderate"
+description = "A flaw was found in binutils where the uninitialized field of struct in the bfd_mach_o_get_synthetic_symtab function could lead to an application crash and local denial of service."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-kvhzdpsmxquk.toml
+++ b/advisories/5.0.0/BRSA-kvhzdpsmxquk.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-kvhzdpsmxquk"
+title = "binutils CVE-2022-38533"
+cve = "CVE-2022-38533"
+severity = "moderate"
+description = "A flaw was found in binutils in the bfd_getl32 function when called from the strip_main function in strip-new via a crafted file, which could cause a heap-buffer-overflow."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-n8dchsayuh98.toml
+++ b/advisories/5.0.0/BRSA-n8dchsayuh98.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-n8dchsayuh98"
+title = "binutils CVE-2022-4285"
+cve = "CVE-2022-4285"
+severity = "moderate"
+description = "A flaw was found in binutils where parsing an ELF file containing corrupt symbol version information could result in an illegal memory access and cause a denial of service."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-naplkd21isa9.toml
+++ b/advisories/5.0.0/BRSA-naplkd21isa9.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-naplkd21isa9"
+title = "binutils CVE-2023-25584"
+cve = "CVE-2023-25584"
+severity = "high"
+description = "A flaw was found in binutils in the parse_module function in bfd/vms-alpha.c which could lead to an out-of-bounds read issue."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-nbgwqejadxsx.toml
+++ b/advisories/5.0.0/BRSA-nbgwqejadxsx.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-nbgwqejadxsx"
+title = "binutils CVE-2022-35206"
+cve = "CVE-2022-35206"
+severity = "moderate"
+description = "A flaw was found in binutils readelf in the read_and_display_attr_value function in dwarf.c which could lead to a null pointer dereference vulnerability."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-rpx4fhcip2vr.toml
+++ b/advisories/5.0.0/BRSA-rpx4fhcip2vr.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-rpx4fhcip2vr"
+title = "binutils CVE-2022-48064"
+cve = "CVE-2022-48064"
+severity = "moderate"
+description = "A flaw was found in binutils where an excessive memory consumption vulnerability via the bfd_dwarf2_find_nearest_line_with_alt function in dwarf2.c could be triggered by a specially crafted ELF file and cause a DNS attack."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-si0ai9i3ewve.toml
+++ b/advisories/5.0.0/BRSA-si0ai9i3ewve.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-si0ai9i3ewve"
+title = "binutils CVE-2022-45703"
+cve = "CVE-2022-45703"
+severity = "high"
+description = "A flaw was found in binutils readelf in the display_debug_section function in readelf.c which could lead to a heap buffer overflow vulnerability."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-vfybarzdd1zk.toml
+++ b/advisories/5.0.0/BRSA-vfybarzdd1zk.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-vfybarzdd1zk"
+title = "binutils CVE-2022-44840"
+cve = "CVE-2022-44840"
+severity = "high"
+description = "A flaw was found in binutils readelf in the find_section_in_set function in readelf.c which could lead to a heap buffer overflow vulnerability."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-xxkjnkht27yf.toml
+++ b/advisories/5.0.0/BRSA-xxkjnkht27yf.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-xxkjnkht27yf"
+title = "binutils CVE-2022-47008"
+cve = "CVE-2022-47008"
+severity = "moderate"
+description = "A flaw was found in binutils in the make_tempdir and make_tempname functions in bucomm.c which could cause memory leaks and a denial of service."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-z1ziwuqpyacc.toml
+++ b/advisories/5.0.0/BRSA-z1ziwuqpyacc.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-z1ziwuqpyacc"
+title = "binutils CVE-2022-47007"
+cve = "CVE-2022-47007"
+severity = "moderate"
+description = "A flaw was found in binutils in the stab_demangle_v3_arg function in stabs.c which could cause memory leaks and lead to a denial of service."
+
+[[advisory.products]]
+package-name = "binutils"
+patched-version = "2.41"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2024-12-12T20:18:48Z
+arches = ["aarch64", "x86_64"]
+version = "5.0.0"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Backfilling BRSAs for the `binutils` update included in Core-kit v5.0.0: https://github.com/bottlerocket-os/bottlerocket-core-kit/releases/tag/v5.0.0


**Testing done:**

N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
