### PR TITLE
packages: update containerd from 1.7.24 to 1.7.25

### DIFF
--- a/packages/containerd/0001-fix-master-tty-leak-due-to-leaking-init-container-ob.patch
+++ b/packages/containerd/0001-fix-master-tty-leak-due-to-leaking-init-container-ob.patch
@@ -1,0 +1,28 @@
+From 78cf83a583a097e43cf45c5341dfd8e635133fdd Mon Sep 17 00:00:00 2001
+From: Henry Wang <henwang@amazon.com>
+Date: Sat, 14 Dec 2024 03:57:38 +0000
+Subject: [PATCH] fix master tty leak due to leaking init container object
+
+Signed-off-by: Henry Wang <henwang@amazon.com>
+(cherry picked from commit aedb079bf18f1f913b705d9b791beebcf1962cdd)
+---
+ runtime/v2/runc/task/service.go | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/runtime/v2/runc/task/service.go b/runtime/v2/runc/task/service.go
+index 5d9f3df59..e270168c5 100644
+--- a/runtime/v2/runc/task/service.go
++++ b/runtime/v2/runc/task/service.go
+@@ -366,6 +366,9 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (*taskAP
+ 			ExitStatus:  uint32(p.ExitStatus()),
+ 			ExitedAt:    protobuf.ToTimestamp(p.ExitedAt()),
+ 		})
++		s.lifecycleMu.Lock()
++		delete(s.containerInitExit, container)
++		s.lifecycleMu.Unlock()
+ 	}
+ 	return &taskAPI.DeleteResponse{
+ 		ExitStatus: uint32(p.ExitStatus()),
+-- 
+2.47.1
+

--- a/packages/containerd/0002-fix-fatal-error-concurrent-map-iteration-and-map-wri.patch
+++ b/packages/containerd/0002-fix-fatal-error-concurrent-map-iteration-and-map-wri.patch
@@ -1,0 +1,27 @@
+From 04fe3749073edbc29afdf8e278dd27da40e03079 Mon Sep 17 00:00:00 2001
+From: ningmingxiao <ning.mingxiao@zte.com.cn>
+Date: Thu, 23 Jan 2025 17:31:57 +0800
+Subject: [PATCH] fix fatal error: concurrent map iteration and map write
+
+Signed-off-by: ningmingxiao <ning.mingxiao@zte.com.cn>
+(cherry picked from commit 0fe9f0b52f7b700689df46d13de36e67b62486e1)
+---
+ pkg/cri/streaming/portforward/httpstream.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pkg/cri/streaming/portforward/httpstream.go b/pkg/cri/streaming/portforward/httpstream.go
+index e1570380b..140a2f5ef 100644
+--- a/pkg/cri/streaming/portforward/httpstream.go
++++ b/pkg/cri/streaming/portforward/httpstream.go
+@@ -279,7 +279,7 @@ func (h *httpStreamHandler) portForward(p *httpStreamPair) {
+ 		// see: https://github.com/kubernetes/kubernetes/issues/74551 for detail
+ 		//
+ 		// In both cases, we should RESET the httpStream.
+-		klog.ErrorS(err, "forwarding port", "conn", h.conn, "request", p.requestID, "port", portString)
++		klog.Errorf("(conn=%p, request=%s) forwarding port %s failed: %v", h.conn, p.requestID, portString, err)
+ 		resetStreams = true
+ 		return
+ 	}
+-- 
+2.47.1
+

--- a/packages/containerd/Cargo.toml
+++ b/packages/containerd/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.7.24/containerd-1.7.24.tar.gz"
-sha512 = "eba2d562f336ffac981b67d2574c5951774f4c6a70ad1cc8aabb59204d1c8e9aa5b3be50c048bf04a018be1335b7ec8e47b73013de2e19805c978587b53bc85e"
+url = "https://github.com/containerd/containerd/archive/v1.7.25/containerd-1.7.25.tar.gz"
+sha512 = "83477f9ed1d5d0653f5a4829d1ac6299cdd8958ca5534de1b22d7b5858d0118e97c9d3ce4c5d58e5b06393be007007f7bf4ac511e1903d1fe407579fa96ab36d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -2,7 +2,7 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.7.24
+%global gover 1.7.25
 %global rpmver %{gover}
 %global gitrev 7f7fdf5fed64eb6a7caf99b3e12efcf9d60e311c
 
@@ -30,6 +30,13 @@ Source100: etc-containerd.mount
 Source110: prepare-var-lib-containerd.service
 
 Source1000: clarify.toml
+
+# Backport of upstream patch for issue: https://github.com/containerd/containerd/issues/11160
+# Bottlerocket must maintain this patch until containerd v1.7.26 update
+Patch0001: 0001-fix-master-tty-leak-due-to-leaking-init-container-ob.patch
+# Backport of upstream patch for issue: https://github.com/containerd/containerd/issues/11302
+# Bottlerocket must maintain this patch until containerd v1.7.26 update
+Patch0002: 0002-fix-fatal-error-concurrent-map-iteration-and-map-wri.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #346 

**Description of changes:**

Updates `containerd` pkg from 1.7.24 to 1.7.25.

Backports patches for known issues with 1.7.25 which must be kept until 1.7.26:
- https://github.com/containerd/containerd/issues/11302
- https://github.com/containerd/containerd/issues/11160

**Testing done:**

Core-kit builds with package and patches on both platforms, but more testing is necessary:

- [x] Boot AMI and check containerd service on both platforms

x86_64 host
```
bash-5.1# systemctl status containerd
● containerd.service - containerd container runtime
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/containerd.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Thu 2025-02-13 19:54:26 UTC; 2min 50s ago
```

aarch64 host
```
bash-5.1# systemctl status containerd
● containerd.service - containerd container runtime
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/containerd.service; enabled; preset: enabled)
    Drop-In: /aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Thu 2025-02-13 19:59:21 UTC; 2min 19s ago
```

- [x] testsys tests for k8s and ecs variant AMIs

```
 NAME                                  TYPE        STATE        PASSED   FAILED   SKIPPED   BUILD ID         LAST UPDATE
 aarch64-aws-ecs-2-quick               Test        passed            1        0         0   f818b28c-dirty   2025-02-13T19:25:26Z
 x86-64-aws-ecs-2-quick                Test        passed            1        0         0   f818b28c-dirty   2025-02-13T19:24:25Z

 aarch64-aws-k8s-131-quick             Test        passed            5        0      6604   f818b28c-dirty   2025-02-13T20:15:59Z
 x86-64-aws-k8s-131-quick              Test        passed            5        0      6604   f818b28c-dirty   2025-02-13T19:38:23Z

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
