### PR TITLE
libcap: avoid %optflags macro

### DIFF
--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -37,7 +37,7 @@ make\\\
   CFLAGS="%{_cross_cflags} -fPIC"\\\
   LDFLAGS="%{_cross_ldflags}"\\\
   BUILD_CC="gcc"\\\
-  BUILD_CFLAGS="%{optflags}"\\\
+  BUILD_CFLAGS="%{__global_compiler_flags}"\\\
   BUILD_LDFLAGS="%{build_ldflags}"\\\
   prefix=%{_cross_prefix}\\\
   lib=%{_cross_lib}\\\


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/244

**Description of changes:**
`%optflags` is the result of augmenting `%__global_compiler_flags` with arch-specific flags. These may not work when cross-compiling as the target arch may not match the host arch.

Switch to the baseline `%__global_compiler_flags` instead. These flags are only relevant when compiling software for the host, which should not be included in the final set of packaged artifacts, so any missed optimizations are not a concern.


**Testing done:**
Before this change, cross-compiling for x86_64 on an aarch64 build host fails with this error:
```
  0.306 gcc -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Dlinux -Wall -Wwrite-strings -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wshadow -Wunreachable-code  -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -I/home/builder/rpmbuild/BUILD/bottlerocket-libcap-2.70-build/libcap-2.70/libcap/../libcap/include/uapi -I/home/builder/rpmbuild/BUILD/bottlerocket-libcap-2.70-build/libcap-2.70/libcap/../libcap/include _makenames.c -o _makenames
  0.308 gcc: error: unrecognized argument in option ‘-mtls-dialect=gnu2’
  0.308 gcc: note: valid arguments to ‘-mtls-dialect=’ are: desc trad
  0.309 make[1]: *** [Makefile:79: _makenames] Error 1
```

After, the build succeeds.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
