### PR TITLE
fix incorrect hyphens used in BRSA for nvidia-container-toolkit CVE-2025-23359

### DIFF
--- a/advisories/5.4.2/BRSA-i3wlupztu5jm.toml
+++ b/advisories/5.4.2/BRSA-i3wlupztu5jm.toml
@@ -1,7 +1,7 @@
 [advisory]
 id = "BRSA-i3wlupztu5jm"
-title = "nvidia-container-toolkit CVE‑2025‑23359"
-cve = "CVE‑2025-23359"
+title = "nvidia-container-toolkit CVE-2025-23359"
+cve = "CVE-2025-23359"
 severity = "high"
 description = "A flaw was found in the NVIDIA Container Toolkit with its default configuration where a specially crafted container could gain access to the host filesystem"
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Text copied directly from https://nvidia.custhelp.com/app/answers/detail/a_id/5616 for `CVE-2025-23359` uses a special "non-breaking hyphen" character for hyphens, resulted in encodings `CVE&#x2011;2025&#x2011;23359` instead of using a normal "-"

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
