### PR TITLE
packages: several packages updated to latest

### DIFF
--- a/packages/coreutils/Cargo.toml
+++ b/packages/coreutils/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://ftp.gnu.org/gnu/coreutils"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/coreutils/coreutils-9.5.tar.xz"
-sha512 = "2ca0deac4dc10a80fd0c6fd131252e99d457fd03b7bd626a6bc74fe5a0529c0a3d48ce1f5da1d3b3a7a150a1ce44f0fbb6b68a6ac543dfd5baa3e71f5d65401c"
+url = "https://ftp.gnu.org/gnu/coreutils/coreutils-9.6.tar.xz"
+sha512 = "398391d7f9d77e6117b750abb8711eebdd9cd2549e7846cab26884fb2dd522b6bcfb8bf7fef35a12683e213ada7f89b817bf615628628d42aee3fa3102647b28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/coreutils/coreutils-9.5.tar.xz.sig"
-sha512 = "029997e0f4ee64e561853cff7c8a124f58cc891598595b44c4a46f9813b4b71c9d677464bc8a26d294e9971832f4b87c23777fea4fac6e8e30f06ad93b9957d5"
+url = "https://ftp.gnu.org/gnu/coreutils/coreutils-9.6.tar.xz.sig"
+sha512 = "a8e578b5e1d053b49e3e2c5dc94431d17c6a14662f459b2174cea23865ccca32e5ae5c13fedb0a8345d25269a9b98cb7f463a897c9663f9f9bcaf61e5c781378"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/coreutils/coreutils.spec
+++ b/packages/coreutils/coreutils.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}coreutils
-Version: 9.5
+Version: 9.6
 Release: 1%{?dist}
 Summary: A set of basic GNU tools
 License: GPL-3.0-or-later

--- a/packages/kexec-tools/Cargo.toml
+++ b/packages/kexec-tools/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/linux/utils/kernel/kexec"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.29.tar.xz"
-sha512 = "4c9e0b3df47b240f0eac2c31e8b515465f626ce043f64daa32b0b032d7132e54dada5d70875dab256345f66cf94a25dc3c160a9009ba60addd8dcb1e5205f5ca"
+url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.30.tar.xz"
+sha512 = "4550607ad7eb51d169c2565cfee9195441634624d1c8859e21bca6bd7f15031713c39ba475301c1ef5fc67c009bc6599d254da184be25e68b226155e515e3852"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.29.tar.sign"
-sha512 = "d8113d60991335f31fb21c0528ba6e619bf77c5305556c993a441af502fcc6ad8a3f3624b256847c59cbfecdc343df7dd93f7af3859b0ecf4d4f2e7f93ab2643"
+url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.30.tar.sign"
+sha512 = "6c326270b34fc805139c548a205a1283e1bf0815507313c5cd1b097ee3b386750634c51008a5c2d61cf58589a1db5976130f4bece5c787ba95b739a21fa24f04"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kexec-tools/kexec-tools.spec
+++ b/packages/kexec-tools/kexec-tools.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}kexec-tools
-Version: 2.0.29
+Version: 2.0.30
 Release: 1%{?dist}
 Epoch: 1
 Summary: Linux tool to load kernels from the running system

--- a/packages/libbpf/Cargo.toml
+++ b/packages/libbpf/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/libbpf/libbpf/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/libbpf/libbpf/archive/refs/tags/v1.4.5.tar.gz"
-sha512 = "c5ed459e89a8897ef7c892723c61efb2f2fdb0e7bea63eaff1c9936d368d2cc9e63b8c093207eef0df3109c021156c52ddb570757f69c54e713909e866dbb2f5"
+url = "https://github.com/libbpf/libbpf/archive/refs/tags/v1.5.0.tar.gz"
+sha512 = "0cc25addcf5fcee0537d598037feab4bc73a513e6025d8f559bed58fe8850a10fcfeefd1a9dafc5e0bac6202d445944b12811cb7254b9b3be4dd3d2cc1e9419b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libbpf/libbpf.spec
+++ b/packages/libbpf/libbpf.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libbpf
-Version: 1.4.5
+Version: 1.5.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for BPF

--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -13,12 +13,12 @@ releases-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libca
 # Changelog can be found here: https://sites.google.com/site/fullycapable/release-notes-for-libcap
 
 [[package.metadata.build-package.external-files]]
-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.70.tar.gz"
-sha512 = "2a4a5959958989e6a0d54ea795a706b0f12596778ac660b19b7b1479910af01b4d870111b060dac0b1cd4671b98d815ea5953cefd4edde1a0ba9efe22f897842"
+url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.75.tar.gz"
+sha512 = "152d7a135856868840da9685b0094c818312634b8bc7e9a8f5f7088fab9ff16358fc6d26886a6d93784a8d5262c787c338daad06065cd493b2686834a6e523ec"
 
 [[package.metadata.build-package.external-files]]
-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.70.tar.sign"
-sha512 = "d8a7d631d74ecdfad731e5d36087d959f9279ed837b20ed57bb518129f1ba6d144927987ca50a5459cc72d5374fe3a987583c1d5c88213e7f57f344ed698c71f"
+url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.75.tar.sign"
+sha512 = "6a6af52ef3a48356d8c205827aa039ed852ec4a1cfea44f00613457380478ebd4946caf933a8ebdf98899b14340b9a7ef9b7151c4659329e2fd80590667d59d9"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libcap
-Version: 2.70
+Version: 2.75
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for getting and setting POSIX.1e capabilities

--- a/packages/libnvme/Cargo.toml
+++ b/packages/libnvme/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-nvme/libnvme/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-nvme/libnvme/archive/v1.11/libnvme-1.11.tar.gz"
-sha512 = "5c1d00fe57ff699be01c326e24612da25e1772578928e2c70fb5f67e8a9fe0fa4c95e18f58d4abefa0e163e99c9e37b1109298e805e174b033e749d19865336b"
+url = "https://github.com/linux-nvme/libnvme/archive/v1.11.1/libnvme-1.11.1.tar.gz"
+sha512 = "8720f2907a3d13af44fb3deec883cd6eb247d5861c4459b5fe0e67ff9ecfb565462a5faf39d43e08b5284f3e8ca8e72d41b333984beaa45d3287b1a258f3e59d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnvme/libnvme.spec
+++ b/packages/libnvme/libnvme.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libnvme
-Version: 1.11
+Version: 1.11.1
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for NVM Express

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://github.com/besser82/libxcrypt/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.36/libxcrypt-4.4.36.tar.xz"
-sha512 = "468560e6f90877540d22e32c867cbcf3786983a6fdae6ef86454f4b7f2bbaae1b6589d1af75cda73078fa8f6e91b1a32f8353f26d433246eef7be3e96d4ae1c7"
+url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.38/libxcrypt-4.4.38.tar.xz"
+sha512 = "66c6f7e69d64ec6d9cca5c240bcd056c4f2802aab84325bef5c3aff189a0f81bc0944f473cbde8fdcb12cad8a9d35599afb045a5bc4be577e1c67066555bc116"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.36/libxcrypt-4.4.36.tar.xz.asc"
-sha512 = "5fdf9a48d0de4c6394122845b9e0c5eecb65b0a7fea9b48c30cb69ec6eb0d0f0e9f4711c6d9d8d8a6c86bd56e0a4e3997acabebce03c618475884bf9d6998657"
+url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.38/libxcrypt-4.4.38.tar.xz.asc"
+sha512 = "4563bddc8581b9abca4ecc02d5d0578ec141a3dedf378f64ffd5838217c48f079bf0840a0d1100a909b471490a4a2a60a2e153fed4491625079f20f754edc443"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libxcrypt
-Version: 4.4.36
+Version: 4.4.38
 Release: 1%{?dist}
 Summary: Extended crypt library for descrypt, md5crypt, bcrypt, and others
 License: LGPL-2.1-or-later

--- a/packages/makedumpfile/Cargo.toml
+++ b/packages/makedumpfile/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/makedumpfile/makedumpfile/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/makedumpfile/makedumpfile/archive/1.7.5/makedumpfile-1.7.5.tar.gz"
-sha512 = "6bb84a87959d2aa530f952acacacc669e888b6a0ae5fe3c6c627647a0e2566a73f05c70ba7b2428f9c740bfe40a773792bb302039ab62c0fa646e148c69f7c6f"
+url = "https://github.com/makedumpfile/makedumpfile/archive/1.7.6/makedumpfile-1.7.6.tar.gz"
+sha512 = "2436bbc5ced82e95e1c528cc63c6d71b5a386f34623f2f3cf6050019d21e6e81a15ddb5aa50cbec33b86228d2ba622f3ff37989b7cbeb6e66c94380380518f60"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/makedumpfile/makedumpfile.spec
+++ b/packages/makedumpfile/makedumpfile.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}makedumpfile
-Version: 1.7.5
+Version: 1.7.6
 Release: 1%{?dist}
 Epoch: 1
 Summary: Tool to create dumps from kernel memory images

--- a/packages/procps/Cargo.toml
+++ b/packages/procps/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://gitlab.com/procps-ng/procps/-/tags"
 
 [[package.metadata.build-package.external-files]]
-url = "https://gitlab.com/procps-ng/procps/-/archive/v4.0.4/procps-v4.0.4.tar.gz"
-sha512 = "b7ba28391b71ad95fda6de25c539132face53c308402d615aa6f5bdde0b5c3de3f5b1b7623e4b1fb92dc36bc2d5b73268afda21c992ef94b1059ba0cd2b6a340"
+url = "https://gitlab.com/procps-ng/procps/-/archive/v4.0.5/procps-v4.0.5.tar.gz"
+sha512 = "7c2ebb62d1babb74a7c5a69c5955ab596c491a9505b83df0cf7efa451953dc614658da490df14e2a8e813b8302b24254d2f8f6f6750c937fade7cbe2eef72b6d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/procps/procps.spec
+++ b/packages/procps/procps.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}procps
-Version: 4.0.4
+Version: 4.0.5
 Release: 1%{?dist}
 Summary: A set of process monitoring tools
 License: GPL-2.0-or-later AND LGPL-2.1-or-later

--- a/packages/socat/Cargo.toml
+++ b/packages/socat/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "http://www.dest-unreach.org/socat/"
 
 [[package.metadata.build-package.external-files]]
-url = "http://www.dest-unreach.org/socat/download/socat-1.8.0.1.tar.gz"
-sha512 = "2a327b4c2e00fc6afda503548d5bc285d4f120892c75ec6633201825e39e3003a8b8d827053364dc444b72ff728a82381769941c023d8b0a66d955417162b735"
+url = "http://www.dest-unreach.org/socat/download/socat-1.8.0.3.tar.gz"
+sha512 = "600a3387e9756e0937d2db49de9066df03d9818e4042da6b72109d1b5688dd72352754773a19bd2558fe93ec6a8a73e80e7cf2602fd915960f66c403fd89beef"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/socat/socat.spec
+++ b/packages/socat/socat.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}socat
-Version: 1.8.0.1
+Version: 1.8.0.3
 Release: 1%{?dist}
 Epoch: 1
 Summary: Transfer data between two channels

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://strace.io/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.12/strace-6.12.tar.xz"
-sha512 = "ae28f0b6b6fdc980898f11d1903aacb5a31760a07d63bd7cbc8f9b5f337d9db6b40464d6b61a9b03ba6442b476edb78afc91348f539f7780cdd98b174c6a9a1d"
+url = "https://strace.io/files/6.13/strace-6.13.tar.xz"
+sha512 = "e702238f32882f92a2b2834fb853b5fa3d81decb441b69f0e74ba0205f6a586bfe698e34bfbac6d4f766ebd25d0b99d4679d9eb27845e5129cfd4e34ced6a8d2"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.12/strace-6.12.tar.xz.asc"
-sha512 = "7b8d6148f3160e39033016d17a54f0b0e0a67fb20ab688486db401521d45ba5197d4a8106f6b173f08a787e59d88147a71ee88435afe0a545fc8f75f621bee79"
+url = "https://strace.io/files/6.13/strace-6.13.tar.xz.asc"
+sha512 = "a59e4aeff491ad62603b0591653e7da5e8a4ef0fedcf2faad3f485993b37b738c0809cefa5753ab7d1b85f3b6c87b423b6416dea36def65e220548ee0b4afb46"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 6.12
+Version: 6.13
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later

--- a/packages/util-linux/Cargo.toml
+++ b/packages/util-linux/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://www.kernel.org/pub/linux/utils/util-linux"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.2.tar.xz"
-sha512 = "ffe20b915a518a150401d429b0338bc7022190e4ca0ef91a6d9eea345db8c1e11ad01784163b8fcf978506f3f5cad473f29d5d4ef93a4c66a5ae0ebd9fb0c8f2"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.4.tar.xz"
+sha512 = "0024955056ba7b4c54040a917f9919f49692e57ba6d42d17a6c29c1eefe88bf48b1214a545072b71c468829a63a8f15237f49733e9127c134e11126d1e435124"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.2.tar.sign"
-sha512 = "e4ace52333df0c8dd7c8ffc3b813020615c456e06a6978e06c8183ec29896be5af7c25f59e65fc2c2849750d8d7b43043775b8504d6d01f626f1adf296493ce1"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.4.tar.sign"
+sha512 = "1ed2f8710a702e313d690c9c071c7a151df1cef7527a08ab4d1eda7a293239cf00392a78b21125df09f0af7249b473b1a51b92bb8e0494608db437c7ee4e0473"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -1,5 +1,5 @@
 %global majorminor 2.40
-%global version %{majorminor}.2
+%global version %{majorminor}.4
 
 Name: %{_cross_os}util-linux
 Version: %{version}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Updated the following packages:
- coreutils - 9.5 &rarr; 9.6
- procps - 4.0.4 &rarr; 4.0.5
- socat - 1.8.0.1 &rarr; 1.8.0.3
- util-linux - 2.40.2 &rarr; 2.40.4
- strace - 6.12 &rarr; 6.13
- libnvme - 1.11 &rarr; 1.11.1
- libcap - 2.70 &rarr; 2.75
- libxcrypt - 4.4.36 &rarr; 4.4.38
- libbpf - 1.4.5 &rarr; 1.5.0
- makedumpfile - 1.7.5 &rarr; 1.7.6
- kexec-tools - 2.0.29 &rarr; 2.0.30

**Testing done:**
coreutils - tested - Ran `sha256sum`
procps - tested - Ran `ps -ef`
socat - tested - Ran `socat`
util-linux - tested - Ran `findmnt`
strace - tested - Ran `strace` on `findmnt`
libnvme - tested - Ran `nvme list`

libcap - tested - Build ran and system boots
libxcrypt - tested - Build ran and system boots
libbpf - tested - Build ran and system boots

makedumpfile - tested - Crashed the kernel and checked `kdump`
kexec-tools - tested - Crashed the kernel and checked `kdump`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
