### PR TITLE
sources: update bloodhound bottlerocket-cis-checks

### DIFF
--- a/sources/bloodhound/src/bin/bottlerocket-cis-checks/checks.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-cis-checks/checks.rs
@@ -701,7 +701,7 @@ impl Checker for BR03040102Checker {
         if let Some(found) = look_for_string_in_output(
             IPTABLES_CMD,
             ["-L", "OUTPUT", "-v", "-n"],
-            "ACCEPT     0    --  *      lo      0.0.0.0/0            0.0.0.0/0",
+            "ACCEPT     all  --  *      lo      0.0.0.0/0            0.0.0.0/0",
         ) {
             if !found {
                 result.error = "iptables OUTPUT rule not found".to_string();
@@ -808,7 +808,7 @@ impl Checker for BR03040202Checker {
         if let Some(found) = look_for_string_in_output(
             IP6TABLES_CMD,
             ["-L", "OUTPUT", "-v", "-n"],
-            "ACCEPT     0    --  *      lo      ::/0                 ::/0",
+            "ACCEPT     all  --  *      lo      ::/0                 ::/0",
         ) {
             if !found {
                 result.error = "iptables OUTPUT rule not found".to_string();


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Fixes #349 

**Description of changes:**

Updated bottlerocket-cis-checks to account for output formatting change for network protocol in iptables via this [commit](https://git.netfilter.org/iptables/commit/?id=34f085b1607364f4eaded1140060dcaf965a2649)

iptables v1.8.10
```
$ iptables -V
iptables v1.8.10 (legacy)
$ iptables -L OUTPUT -v -n
Chain OUTPUT (policy ACCEPT 2209K packets, 21G bytes)
 pkts bytes target     prot opt in     out     source               destination         
 134K   30M ACCEPT     0    --  *      lo      0.0.0.0/0            0.0.0.0/0 
$ ip6tables -L OUTPUT -v -n
Chain OUTPUT (policy ACCEPT 58 packets, 2931 bytes)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 ACCEPT     0    --  *      lo      ::/0                 ::/0   
```
iptables v1.8.11
```
bash-5.1# /sbin/iptables -V
iptables v1.8.11 (legacy)
bash-5.1# /sbin/iptables -L OUTPUT -v -n
Chain OUTPUT (policy ACCEPT 47266 packets, 14M bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 ACCEPT     all  --  *      lo      0.0.0.0/0            0.0.0.0/0

bash-5.1# /sbin/ip6tables -L OUTPUT -v -n
Chain OUTPUT (policy ACCEPT 621 packets, 76776 bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 ACCEPT     all  --  *      lo      ::/0                 ::/0
```

**Testing done:**

Tested variant `aws-k8s-1.32-nvidia` with the following:
For bottlerocket-cis-checks 3.4.1.2
```
bash-5.1# /sbin/iptables -A INPUT -i lo -j ACCEPT
bash-5.1# /sbin/iptables -A OUTPUT -o lo -j ACCEPT
bash-5.1# /sbin/iptables -A INPUT -s 127.0.0.0/8 -j DROP
bash-5.1# /usr/libexec/cis-checks/bottlerocket/br03040102
{"status":"PASS","error":""}
```
For bottlerocket-cis-checks 3.4.2.2
```
bash-5.1# /sbin/ip6tables -A INPUT -i lo -j ACCEPT
bash-5.1# /sbin/ip6tables -A OUTPUT -o lo -j ACCEPT
bash-5.1# /sbin/ip6tables -A INPUT -s ::1 -j DROP
bash-5.1# /usr/libexec/cis-checks/bottlerocket/br03040202
{"status":"PASS","error":""}
```
`apiclient report cis -l 2 -f json` report PASS on 3.4.1.2 and 3.4.2.2
```
  "br03040102":{
    "name":"br03040102",
    "id":"3.4.1.2",
    "level":2,
    "title":"Ensure IPv4 loopback traffic is configured",
    "mode":"Automatic",
    "status":"PASS",
    "error":""
  },

  "br03040202":{
    "name":"br03040202",
    "id":"3.4.2.2",
    "level":2,
    "title":"Ensure IPv6 loopback traffic is configured",
    "mode":"Automatic",
    "status":"PASS",
    "error":""
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
