### PR TITLE
Feature: `--ebs-volumes` option for ephemeral-storage init 

### DIFF
--- a/packages/os/ephemeral-ebs-storage.rules
+++ b/packages/os/ephemeral-ebs-storage.rules
@@ -1,0 +1,12 @@
+# ephemeral storage links: /dev/disk/ephemeral-ebs
+
+ACTION=="remove", GOTO="ephemeral_ebs_storage_end"
+KERNEL!="nvme*", GOTO="ephemeral_ebs_storage_end"
+SUBSYSTEM!="block", GOTO="ephemeral_ebs_storage_end"
+ENV{DEVTYPE}!="disk", GOTO="ephemeral_ebs_storage_end"
+ATTRS{model}!="Amazon Elastic Block Store", GOTO="ephemeral_ebs_storage_end"
+
+# Create links for ephemeral EBS volumes that start with "xvdd".
+ENV{BOTTLEROCKET_DEVICE_TYPE}=="ephemeral", ENV{XVD_DEVICE_NAME}=="xvdd?", SYMLINK+="disk/ephemeral-ebs/$env{XVD_DEVICE_NAME}"
+
+LABEL="ephemeral_ebs_storage_end"

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -64,7 +64,8 @@ Source205: bootstrap-commands-tmpfiles.conf
 # 3xx sources: udev rules
 Source300: ephemeral-storage.rules
 Source301: ebs-volumes.rules
-Source302: supplemental-storage.rules
+Source302: ephemeral-ebs-storage.rules
+Source303: supplemental-storage.rules
 
 # 4xx sources: Bottlerocket licenses
 Source400: COPYRIGHT
@@ -729,7 +730,8 @@ install -p -m 0644 %{S:205} %{buildroot}%{_cross_tmpfilesdir}/bootstrap-commands
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-storage.rules
 install -p -m 0644 %{S:301} %{buildroot}%{_cross_udevrulesdir}/81-ebs-volumes.rules
-install -p -m 0644 %{S:302} %{buildroot}%{_cross_udevrulesdir}/82-supplemental-storage.rules
+install -p -m 0644 %{S:302} %{buildroot}%{_cross_udevrulesdir}/82-ephemeral-ebs-storage.rules
+install -p -m 0644 %{S:303} %{buildroot}%{_cross_udevrulesdir}/83-supplemental-storage.rules
 
 %cross_scan_attribution --clarify %{_builddir}/sources/clarify.toml \
     cargo --offline --locked %{_builddir}/sources/Cargo.toml
@@ -811,7 +813,8 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %{_cross_bindir}/ghostdog
 %{_cross_udevrulesdir}/80-ephemeral-storage.rules
 %{_cross_udevrulesdir}/81-ebs-volumes.rules
-%{_cross_udevrulesdir}/82-supplemental-storage.rules
+%{_cross_udevrulesdir}/82-ephemeral-ebs-storage.rules
+%{_cross_udevrulesdir}/83-supplemental-storage.rules
 
 %files -n %{_cross_os}signpost
 %{_cross_bindir}/signpost

--- a/sources/api/apiclient/README.md
+++ b/sources/api/apiclient/README.md
@@ -195,7 +195,7 @@ For example, if you want the name "FOO", you can `PATCH` to `/settings?tx=FOO` a
 
 ### Ephemeral storage
 
-This lets you manage ephemeral storage on instances that have local instance storage (like NVMe SSDs).
+This lets you manage ephemeral storage on instances that have local instance storage (like NVMe SSDs) or ephemeral EBS volumes with names in the xvdda-xvddx range.
 
 #### Initialize ephemeral storage
 
@@ -206,6 +206,23 @@ apiclient ephemeral-storage init
 ```
 
 This sets up the storage devices as a RAID array and formats them.
+
+The ephemeral storage array can be customized with these options:
+```
+-t, --filesystem            Filesystem to initialize the array as (ext4 or xfs). Default is
+                            xfs. If a single disk is provided, it is mounted directly without
+                            constructing an array. If no ephemeral disks are found, this
+                            operation does nothing.
+--disks DISK [DISK ...]     Local disks to configure for storage. Default is all ephemeral
+                            disks.
+--ebs-volumes VOLUME [VOLUME ..]
+                            EBS volumes in the `xvdda`-`xvddx` range to configure for storage.
+--prefer PREFERENCE [PREFERENCE ..]
+                            Ephemeral storage type preference, in descending order. Allowed
+                            values: `ephemeral-disk`, `ebs-volume` or a combination of these
+                            joined by `+`. Defaults to `ephemeral-disk` only. This option is
+                            ignored if `--disks` or `--ebs-volumes` is set.
+```
 
 #### Bind directories to ephemeral storage
 
@@ -220,15 +237,16 @@ This automatically binds the appropriate directories for your platform (Kubernet
 You can also specify custom directories:
 
 ```shell
-apiclient ephemeral-storage bind --dirs /var/lib/containerd /custom/path
+apiclient ephemeral-storage bind --dirs /var/lib/containerd /mnt/custom/path
 ```
 
 #### List ephemeral storage information
 
-You can list available disks and currently bound directories:
+You can list available disks, ebs volumes, and directories that can be bound to ephemeral storage:
 
 ```shell
 apiclient ephemeral-storage list-disks
+apiclient ephemeral-storage list-ebs-volumes
 apiclient ephemeral-storage list-dirs
 ```
 

--- a/sources/api/apiclient/README.tpl
+++ b/sources/api/apiclient/README.tpl
@@ -195,7 +195,7 @@ For example, if you want the name "FOO", you can `PATCH` to `/settings?tx=FOO` a
 
 ### Ephemeral storage
 
-This lets you manage ephemeral storage on instances that have local instance storage (like NVMe SSDs).
+This lets you manage ephemeral storage on instances that have local instance storage (like NVMe SSDs) or ephemeral EBS volumes with names in the xvdda-xvddx range.
 
 #### Initialize ephemeral storage
 
@@ -206,6 +206,23 @@ apiclient ephemeral-storage init
 ```
 
 This sets up the storage devices as a RAID array and formats them.
+
+The ephemeral storage array can be customized with these options:
+```
+-t, --filesystem            Filesystem to initialize the array as (ext4 or xfs). Default is
+                            xfs. If a single disk is provided, it is mounted directly without
+                            constructing an array. If no ephemeral disks are found, this
+                            operation does nothing.
+--disks DISK [DISK ...]     Local disks to configure for storage. Default is all ephemeral
+                            disks.
+--ebs-volumes VOLUME [VOLUME ..]
+                            EBS volumes in the `xvdda`-`xvddx` range to configure for storage.
+--prefer PREFERENCE [PREFERENCE ..]
+                            Ephemeral storage type preference, in descending order. Allowed
+                            values: `ephemeral-disk`, `ebs-volume` or a combination of these
+                            joined by `+`. Defaults to `ephemeral-disk` only. This option is
+                            ignored if `--disks` or `--ebs-volumes` is set.
+```
 
 #### Bind directories to ephemeral storage
 
@@ -220,15 +237,16 @@ This automatically binds the appropriate directories for your platform (Kubernet
 You can also specify custom directories:
 
 ```shell
-apiclient ephemeral-storage bind --dirs /var/lib/containerd /custom/path
+apiclient ephemeral-storage bind --dirs /var/lib/containerd /mnt/custom/path
 ```
 
 #### List ephemeral storage information
 
-You can list available disks and currently bound directories:
+You can list available disks, ebs volumes, and directories that can be bound to ephemeral storage:
 
 ```shell
 apiclient ephemeral-storage list-disks
+apiclient ephemeral-storage list-ebs-volumes
 apiclient ephemeral-storage list-dirs
 ```
 

--- a/sources/api/apiclient/src/ephemeral_storage.rs
+++ b/sources/api/apiclient/src/ephemeral_storage.rs
@@ -50,7 +50,15 @@ where
     list(socket_path, "list-disks", format).await
 }
 
-/// Lists the ephemeral disks available for configuration
+/// Lists the ephemeral ebs volumes available for configuration
+pub async fn list_ebs_volumes<P>(socket_path: P, format: Option<String>) -> Result<String>
+where
+    P: AsRef<Path>,
+{
+    list(socket_path, "list-ebs-volumes", format).await
+}
+
+/// Lists a variant-specific set of directories that can be bound to ephemeral storage.
 pub async fn list_dirs<P>(socket_path: P, format: Option<String>) -> Result<String>
 where
     P: AsRef<Path>,

--- a/sources/api/apiclient/src/ephemeral_storage.rs
+++ b/sources/api/apiclient/src/ephemeral_storage.rs
@@ -1,4 +1,4 @@
-use model::ephemeral_storage::{Bind, Filesystem, Init};
+use model::ephemeral_storage::{Bind, Filesystem, Init, Preference};
 use snafu::ResultExt;
 use std::path::Path;
 
@@ -7,13 +7,20 @@ pub async fn initialize<P>(
     socket_path: P,
     filesystem: Option<Filesystem>,
     disks: Option<Vec<String>>,
+    ebs_volumes: Option<Vec<String>>,
+    prefer: Option<Vec<Preference>>,
 ) -> Result<()>
 where
     P: AsRef<Path>,
 {
     let uri = "/actions/ephemeral-storage/init";
-    let opts =
-        serde_json::to_string(&Init { filesystem, disks }).context(error::JsonSerializeSnafu {})?;
+    let opts = serde_json::to_string(&Init {
+        filesystem,
+        disks,
+        ebs_volumes,
+        prefer,
+    })
+    .context(error::JsonSerializeSnafu {})?;
     let method = "POST";
     let (_status, _body) = crate::raw_request(&socket_path, &uri, method, Some(opts))
         .await

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -150,6 +150,7 @@ enum EphemeralStorageSubcommand {
     Init(EphemeralStorageInitArgs),
     Bind(EphemeralStorageBindArgs),
     ListDisks(EphemeralStorageFormatArgs),
+    ListEbsVolumes(EphemeralStorageFormatArgs),
     ListDirs(EphemeralStorageFormatArgs),
 }
 
@@ -167,7 +168,7 @@ struct EphemeralStorageInitArgs {
 struct EphemeralStorageBindArgs {
     targets: Vec<String>,
 }
-/// Stores user-supplied arguments for the 'ephemeral-storage list-disks/list-dirs' subcommand.
+/// Stores user-supplied arguments for the 'ephemeral-storage list-disks/list-ebs-volumes/list-dirs' subcommand.
 #[derive(Debug)]
 struct EphemeralStorageFormatArgs {
     format: Option<String>,
@@ -203,6 +204,8 @@ fn usage() -> ! {
             ephemeral-storage bind     Bind directories to previously initialized ephemeral storage.
             ephemeral-storage list-disks
                                        List the discovered ephemeral disks that can be initialized.
+            ephemeral-storage list-ebs-volumes
+                                       List the discovered ephemeral ebs volumes that can be initialized.
             ephemeral-storage list-dirs
                                        List the directories that can be bound to ephemeral storage.
 
@@ -274,7 +277,7 @@ fn usage() -> ! {
             --ebs-volumes VOLUME [VOLUME ..]
                                        EBS volumes in the `xvdda`-`xvddx` range to configure for storage.
             --prefer PREFERENCE [PREFERENCE ..]
-                                       Epheremeral storage type preference, in descending order. Allowed
+                                       Ephemeral storage type preference, in descending order. Allowed
                                        values: `ephemeral-disk`, `ebs-volume` or a combination of these
                                        joined by `+`. Defaults to `ephemeral-disk` only. This option is
                                        ignored if `--disks` or `--ebs-volumes` is set.
@@ -286,6 +289,9 @@ fn usage() -> ! {
 
         ephemeral-storage list-disks options:
             -f, --format               Format of the disk listing (text or json). Default format is text.
+
+        ephemeral-storage list-ebs-volumes options:
+            -f, --format               Format of the volume listing (text or json). Default format is text.   
 
         ephemeral-storage list-dirs options:
             -f, --format               Format of the directory listing (text or json). Default format is text.
@@ -757,7 +763,7 @@ fn parse_ephemeral_storage_args(args: Vec<String>) -> Subcommand {
     for arg in args.into_iter() {
         match arg.as_ref() {
             // Subcommands
-            "init" | "bind" | "list-disks" | "list-dirs"
+            "init" | "bind" | "list-disks" | "list-ebs-volumes" | "list-dirs"
                 if subcommand.is_none() && !arg.starts_with('-') =>
             {
                 subcommand = Some(arg)
@@ -772,6 +778,9 @@ fn parse_ephemeral_storage_args(args: Vec<String>) -> Subcommand {
         Some("init") => parse_ephemeral_storage_init_args(subcommand_args),
         Some("bind") => parse_ephemeral_storage_bind_args(subcommand_args),
         Some("list-disks") => EphemeralStorageSubcommand::ListDisks(
+            parse_ephemeral_storage_list_format_args(subcommand_args),
+        ),
+        Some("list-ebs-volumes") => EphemeralStorageSubcommand::ListEbsVolumes(
             parse_ephemeral_storage_list_format_args(subcommand_args),
         ),
         Some("list-dirs") => EphemeralStorageSubcommand::ListDirs(
@@ -880,7 +889,7 @@ fn parse_ephemeral_storage_bind_args(args: Vec<String>) -> EphemeralStorageSubco
     EphemeralStorageSubcommand::Bind(EphemeralStorageBindArgs { targets })
 }
 
-/// Parses arguments for the 'list-disks' and 'list-dirs' ephemeral-storage subcommand.
+/// Parses arguments for the 'list-disks', 'list-ebs-volumes', and 'list-dirs' ephemeral-storage subcommands.
 fn parse_ephemeral_storage_list_format_args(args: Vec<String>) -> EphemeralStorageFormatArgs {
     let mut format = None;
 
@@ -1139,6 +1148,14 @@ async fn run() -> Result<()> {
             }
             EphemeralStorageSubcommand::ListDisks(bind_args) => {
                 let body = ephemeral_storage::list_disks(&args.socket_path, bind_args.format)
+                    .await
+                    .context(error::EphemeralStorageSnafu)?;
+                if !body.is_empty() {
+                    print!("{body}");
+                }
+            }
+            EphemeralStorageSubcommand::ListEbsVolumes(bind_args) => {
+                let body = ephemeral_storage::list_ebs_volumes(&args.socket_path, bind_args.format)
                     .await
                     .context(error::EphemeralStorageSnafu)?;
                 if !body.is_empty() {

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -8,7 +8,7 @@
 
 use apiclient::{apply, ephemeral_storage, exec, get, reboot, report, set, update, SettingsInput};
 use log::{info, log_enabled, trace, warn};
-use model::ephemeral_storage::Filesystem;
+use model::ephemeral_storage::{Filesystem, Preference};
 use serde::{Deserialize, Serialize};
 use simplelog::{
     ColorChoice, ConfigBuilder as LogConfigBuilder, LevelFilter, TermLogger, TerminalMode,
@@ -157,6 +157,8 @@ enum EphemeralStorageSubcommand {
 #[derive(Debug)]
 struct EphemeralStorageInitArgs {
     disks: Option<Vec<String>>,
+    ebs_volumes: Option<Vec<String>>,
+    prefer: Option<Vec<Preference>>,
     filesystem: Option<Filesystem>,
 }
 
@@ -269,7 +271,13 @@ fn usage() -> ! {
                                        operation does nothing.
             --disks DISK [DISK ...]    Local disks to configure for storage. Default is all ephemeral
                                        disks.
-
+            --ebs-volumes VOLUME [VOLUME ..]
+                                       EBS volumes in the `xvdda`-`xvddx` range to configure for storage.
+            --prefer PREFERENCE [PREFERENCE ..]
+                                       Epheremeral storage type preference, in descending order. Allowed
+                                       values: `ephemeral-disk`, `ebs-volume` or a combination of these
+                                       joined by `+`. Defaults to `ephemeral-disk` only. This option is
+                                       ignored if `--disks` or `--ebs-volumes` is set.
         ephemeral-storage bind options:
             --dirs DIR [DIR ...]       Directories to bind to configured ephemeral storage
                                        (e.g. /var/lib/containerd). If not specified, uses platform (k8s vs. ECS)
@@ -777,6 +785,8 @@ fn parse_ephemeral_storage_args(args: Vec<String>) -> Subcommand {
 /// Parses arguments for the 'init' ephemeral-storage subcommand.
 fn parse_ephemeral_storage_init_args(args: Vec<String>) -> EphemeralStorageSubcommand {
     let mut disks: Option<Vec<String>> = None;
+    let mut ebs_volumes: Option<Vec<String>> = None;
+    let mut prefer: Option<Vec<Preference>> = None;
     let mut filesystem = None;
     let mut iter = args.into_iter().peekable();
     while let Some(arg) = iter.next() {
@@ -803,10 +813,45 @@ fn parse_ephemeral_storage_init_args(args: Vec<String>) -> EphemeralStorageSubco
                     disks = Some(names);
                 }
             }
+            "--ebs-volumes" => {
+                let mut names = collect_non_args(&mut iter);
+                if names.is_empty() {
+                    usage_msg("Did not give argument to --ebs-volumes")
+                }
+                if let Some(existing) = &mut ebs_volumes {
+                    existing.append(&mut names);
+                } else {
+                    ebs_volumes = Some(names);
+                }
+            }
+            "--prefer" => {
+                let prefs = collect_non_args(&mut iter);
+                if prefs.is_empty() {
+                    usage_msg("Did not give argument to --prefer")
+                }
+                if let Some(existing) = &mut prefer {
+                    for p in &prefs {
+                        if let Ok(p) = p.as_str().try_into() {
+                            existing.push(p);
+                        } else {
+                            usage_msg("Invalid ephemeral storage type preference");
+                        }
+                    }
+                } else if let Ok(p) = prefs.iter().map(|x| x.as_str().try_into()).collect() {
+                    prefer = Some(p);
+                } else {
+                    usage_msg("Invalid ephemeral storage type preference");
+                }
+            }
             x => usage_msg(format!("Unknown argument '{x}'")),
         }
     }
-    EphemeralStorageSubcommand::Init(EphemeralStorageInitArgs { disks, filesystem })
+    EphemeralStorageSubcommand::Init(EphemeralStorageInitArgs {
+        disks,
+        ebs_volumes,
+        filesystem,
+        prefer,
+    })
 }
 
 /// Parses arguments for the 'bind' ephemeral-storage subcommand.
@@ -1081,6 +1126,8 @@ async fn run() -> Result<()> {
                     &args.socket_path,
                     cfg_args.filesystem,
                     cfg_args.disks,
+                    cfg_args.ebs_volumes,
+                    cfg_args.prefer,
                 )
                 .await
                 .context(error::EphemeralStorageSnafu)?;

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -1,6 +1,6 @@
 //! The 'ephemeral_storage' module supports configuring and using local instance storage.
 
-use model::ephemeral_storage::Filesystem;
+use model::ephemeral_storage::{Filesystem, Preference};
 
 use snafu::{ensure, ResultExt};
 use std::collections::HashSet;
@@ -22,6 +22,8 @@ static EPHEMERAL_MNT: &str = ".ephemeral";
 /// Name of the device and its path from the MD driver
 static RAID_DEVICE_DIR: &str = "/dev/md/";
 static RAID_DEVICE_NAME: &str = "ephemeral";
+/// Symlink to ephemeral storage array or disk
+static EPHEMERAL_STORAGE_LINK: &str = "/dev/disk/ephemeral-storage";
 
 pub struct BindDirs {
     pub allowed_exact: HashSet<&'static str>,
@@ -32,14 +34,25 @@ pub struct BindDirs {
 /// initialize prepares the ephemeral storage for formatting and formats it.  For multiple disks
 /// preparation is the creation of a RAID0 array, for a single disk this is a no-op. The array or disk
 /// is then formatted with the specified filesystem (default=xfs) if not formatted already.
-pub fn initialize(fs: Option<Filesystem>, disks: Option<Vec<String>>) -> Result<()> {
+pub fn initialize(
+    fs: Option<Filesystem>,
+    disks: Option<Vec<String>>,
+    ebs_volumes: Option<Vec<String>>,
+    prefer: Option<Vec<Preference>>,
+) -> Result<()> {
     let known_disks = ephemeral_devices()?;
     let known_disks_hash = HashSet::<_>::from_iter(known_disks.iter());
+    let known_ebs_volumes = ephemeral_ebs_volumes()?;
+    let known_ebs_volumes_hash = HashSet::<_>::from_iter(known_ebs_volumes.iter());
 
-    let disks = match disks {
-        Some(disks) => {
-            // we have disks provided, so match them against the list of valid disks
-            for disk in &disks {
+    let any_specified = disks.as_ref().is_some_and(|x| !x.is_empty())
+        || ebs_volumes.as_ref().is_some_and(|x| !x.is_empty());
+
+    let disks = if any_specified {
+        // use all specified ephemeral disks and ebs volumes, if they're all valid
+        let mut selected_disks = vec![];
+        if let Some(d) = disks {
+            for disk in &d {
                 ensure!(
                     known_disks_hash.contains(disk),
                     error::InvalidParameterSnafu {
@@ -48,26 +61,57 @@ pub fn initialize(fs: Option<Filesystem>, disks: Option<Vec<String>>) -> Result<
                     }
                 )
             }
-            disks
+            selected_disks.extend(d);
         }
-        None => {
-            // if there are no disks specified, and none are available we treat the init as a
-            // no-op to allow "ephemeral-storage init"/"ephemeral-storage bind" to work on instances
-            // with and without ephemeral storage
-            if known_disks.is_empty() {
-                info!("no ephemeral disks found, skipping ephemeral storage initialization");
-                return Ok(());
+
+        if let Some(e) = ebs_volumes {
+            for ebs_volume in &e {
+                ensure!(
+                    known_ebs_volumes_hash.contains(ebs_volume),
+                    error::InvalidParameterSnafu {
+                        parameter: "ebs_volumes",
+                        reason: format!("unknown ebs volume {ebs_volume:?}"),
+                    }
+                )
             }
-            // no disks specified, so use the default
-            known_disks
+            selected_disks.extend(e);
         }
+        selected_disks
+    } else {
+        // if there are no specified disks, use preference list to find a non-empty set of disks
+        let preferences = prefer.unwrap_or_else(|| {
+            vec![Preference {
+                ephemeral_disk: true,
+                ebs_volume: false,
+            }]
+        });
+
+        let mut disks = vec![];
+        for preference in preferences {
+            if preference.ephemeral_disk {
+                disks.extend(&known_disks);
+            }
+            if preference.ebs_volume {
+                disks.extend(&known_ebs_volumes);
+            }
+            if !disks.is_empty() {
+                break;
+            }
+        }
+        if disks.is_empty() {
+            // no disks were specified and none of the preferences produced any disks
+            // this is special-cased as a no-op
+            info!("no ephemeral disks found, skipping ephemeral storage initialization");
+            return Ok(());
+        }
+        disks.into_iter().cloned().collect()
     };
 
     ensure!(
         !disks.is_empty(),
         error::InvalidParameterSnafu {
             parameter: "disks",
-            reason: "no local ephemeral disks specified",
+            reason: "no valid local ephemeral disks or ebs volumes specified",
         }
     );
 
@@ -95,22 +139,21 @@ pub fn initialize(fs: Option<Filesystem>, disks: Option<Vec<String>>) -> Result<
         info!("{device_name:?} is already formatted as {fs}, skipping format");
     }
 
+    // Create link to formatted device for use in `bind`
+    std::os::unix::fs::symlink(&device_name, EPHEMERAL_STORAGE_LINK)
+        .context(error::DiskSymlinkFailureSnafu {})?;
+
     Ok(())
 }
 
 /// binds the specified directories to the pre-configured array, creating those directories if
 /// they do not exist.
 pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
-    let device_name = match ephemeral_devices()?.len() {
-        // handle the no local instance storage case
-        0 => {
-            info!("no ephemeral disks found, skipping ephemeral storage binding");
-            return Ok(());
-        }
-        // If there is only one device, use that
-        1 => ephemeral_devices()?.first().expect("non-empty").clone(),
-        _ => format!("{RAID_DEVICE_DIR}{RAID_DEVICE_NAME}"),
-    };
+    let device_name = EPHEMERAL_STORAGE_LINK;
+    if !std::fs::exists(device_name).is_ok_and(|x| x) {
+        info!("ephemeral storage not initialized, skipping binding");
+        return Ok(());
+    }
 
     let dirs = if dirs.is_empty() {
         let allowed_dirs = allowed_bind_dirs(variant);
@@ -154,10 +197,7 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         std::fs::create_dir_all(&mount_point).context(error::MkdirSnafu {})?;
         info!("mounting {device_name} as {mount_point}");
         let output = Command::new(MOUNT)
-            .args([
-                OsString::from(device_name.clone()),
-                OsString::from(&mount_point),
-            ])
+            .args([OsString::from(device_name), OsString::from(&mount_point)])
             .output()
             .context(error::ExecutionFailureSnafu { command: MOUNT })?;
 
@@ -298,6 +338,29 @@ pub fn ephemeral_devices() -> Result<Vec<String>> {
     Ok(filenames)
 }
 
+/// ephemeral_ebs_volumes returns the full path name to the ebs volumes in /dev/disk/ephemeral-ebs
+pub fn ephemeral_ebs_volumes() -> Result<Vec<String>> {
+    const EPHEMERAL_EBS_PATH: &str = "/dev/disk/ephemeral-ebs";
+    let mut filenames = Vec::new();
+    // for instances without ebs volumes attached, we don't error and just return an empty vector so
+    // it can be handled gracefully
+    if fs::metadata(EPHEMERAL_EBS_PATH).is_err() {
+        return Ok(filenames);
+    }
+
+    let entries =
+        std::fs::read_dir(EPHEMERAL_EBS_PATH).context(error::DiscoverEbsVolumesSnafu {
+            path: String::from(EPHEMERAL_EBS_PATH),
+        })?;
+    for entry in entries {
+        let entry = entry.context(error::DiscoverEbsVolumesSnafu {
+            path: String::from(EPHEMERAL_EBS_PATH),
+        })?;
+        filenames.push(entry.path().into_os_string().to_string_lossy().to_string());
+    }
+    Ok(filenames)
+}
+
 /// allowed_bind_dirs returns a set of the directories that can be bound to ephemeral storage, which
 /// varies based on the variant, a set of the prefixes of directories that are allowed to be bound.
 /// and a set of substrings that are disallowed in the directory name.
@@ -390,6 +453,12 @@ pub mod error {
 
         #[snafu(display("Failed to discover ephemeral disks from {}: {}", path, source))]
         DiscoverEphemeral {
+            source: std::io::Error,
+            path: String,
+        },
+
+        #[snafu(display("Failed to discover ebs volumes from {}: {}", path, source))]
+        DiscoverEbsVolumes {
             source: std::io::Error,
             path: String,
         },

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -24,6 +24,10 @@ static RAID_DEVICE_DIR: &str = "/dev/md/";
 static RAID_DEVICE_NAME: &str = "ephemeral";
 /// Symlink to ephemeral storage array or disk
 static EPHEMERAL_STORAGE_LINK: &str = "/dev/disk/ephemeral-storage";
+/// Path to ephemeral devices (instance storage disks)
+static EPHEMERAL_PATH: &str = "/dev/disk/ephemeral";
+/// Path to ebs volumes marked for ephemeral storage use
+static EPHEMERAL_EBS_PATH: &str = "/dev/disk/ephemeral-ebs";
 
 pub struct BindDirs {
     pub allowed_exact: HashSet<&'static str>,
@@ -316,45 +320,29 @@ fn mdadm_create<T: AsRef<str>>(name: T, disks: Vec<T>) -> Result<()> {
     Ok(())
 }
 
-/// ephemeral_devices returns the full path name to the block devices in /dev/disk/ephemeral
+/// ephemeral_devices returns the full path name to the block devices in EPHEMERAL_PATH
 pub fn ephemeral_devices() -> Result<Vec<String>> {
-    const EPHEMERAL_PATH: &str = "/dev/disk/ephemeral";
+    discover_disks(EPHEMERAL_PATH)
+}
+
+/// ephemeral_ebs_volumes returns the full path name to the ebs volumes in EPHEMERAL_EBS_PATH
+pub fn ephemeral_ebs_volumes() -> Result<Vec<String>> {
+    discover_disks(EPHEMERAL_EBS_PATH)
+}
+
+/// discover_disks returns the full path name to the entries in the specified path,
+/// or an empty vector if the specified path does not exist
+fn discover_disks(path: &str) -> Result<Vec<String>> {
     let mut filenames = Vec::new();
-    // for instances without ephemeral storage, we don't error and just return an empty vector so
-    // it can be handled gracefully
-    if fs::metadata(EPHEMERAL_PATH).is_err() {
+    if fs::metadata(path).is_err() {
         return Ok(filenames);
     }
-
-    let entries = std::fs::read_dir(EPHEMERAL_PATH).context(error::DiscoverEphemeralSnafu {
-        path: String::from(EPHEMERAL_PATH),
+    let entries = std::fs::read_dir(path).context(error::DiscoverEphemeralSnafu {
+        path: String::from(path),
     })?;
     for entry in entries {
         let entry = entry.context(error::DiscoverEphemeralSnafu {
-            path: String::from(EPHEMERAL_PATH),
-        })?;
-        filenames.push(entry.path().into_os_string().to_string_lossy().to_string());
-    }
-    Ok(filenames)
-}
-
-/// ephemeral_ebs_volumes returns the full path name to the ebs volumes in /dev/disk/ephemeral-ebs
-pub fn ephemeral_ebs_volumes() -> Result<Vec<String>> {
-    const EPHEMERAL_EBS_PATH: &str = "/dev/disk/ephemeral-ebs";
-    let mut filenames = Vec::new();
-    // for instances without ebs volumes attached, we don't error and just return an empty vector so
-    // it can be handled gracefully
-    if fs::metadata(EPHEMERAL_EBS_PATH).is_err() {
-        return Ok(filenames);
-    }
-
-    let entries =
-        std::fs::read_dir(EPHEMERAL_EBS_PATH).context(error::DiscoverEbsVolumesSnafu {
-            path: String::from(EPHEMERAL_EBS_PATH),
-        })?;
-    for entry in entries {
-        let entry = entry.context(error::DiscoverEbsVolumesSnafu {
-            path: String::from(EPHEMERAL_EBS_PATH),
+            path: String::from(path),
         })?;
         filenames.push(entry.path().into_os_string().to_string_lossy().to_string());
     }
@@ -453,12 +441,6 @@ pub mod error {
 
         #[snafu(display("Failed to discover ephemeral disks from {}: {}", path, source))]
         DiscoverEphemeral {
-            source: std::io::Error,
-            path: String,
-        },
-
-        #[snafu(display("Failed to discover ebs volumes from {}: {}", path, source))]
-        DiscoverEbsVolumes {
             source: std::io::Error,
             path: String,
         },

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -143,6 +143,11 @@ pub fn initialize(
         info!("{device_name:?} is already formatted as {fs}, skipping format");
     }
 
+    // Clear previous link if it exists
+    if std::fs::exists(EPHEMERAL_STORAGE_LINK).is_ok_and(|x| x) {
+        std::fs::remove_file(EPHEMERAL_STORAGE_LINK).context(error::DiskUnlinkFailureSnafu {})?;
+    }
+
     // Create link to formatted device for use in `bind`
     std::os::unix::fs::symlink(&device_name, EPHEMERAL_STORAGE_LINK)
         .context(error::DiskSymlinkFailureSnafu {})?;
@@ -451,6 +456,9 @@ pub mod error {
             dest: String,
             output: std::process::Output,
         },
+
+        #[snafu(display("Failed to remove disk symlink {}", source))]
+        DiskUnlinkFailure { source: std::io::Error },
 
         #[snafu(display("Failed to create disk symlink {}", source))]
         DiskSymlinkFailure { source: std::io::Error },

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -149,6 +149,10 @@ where
                         web::get().to(list_ephemeral_storage_disks),
                     )
                     .route(
+                        "/ephemeral-storage/list-ebs-volumes",
+                        web::get().to(list_ephemeral_ebs_volumes),
+                    )
+                    .route(
                         "/ephemeral-storage/list-dirs",
                         web::get().to(list_ephemeral_storage_dirs),
                     ),
@@ -759,7 +763,23 @@ async fn list_ephemeral_storage_disks(
     list_ephemeral_response(req, query, disks, text_response).await
 }
 
-/// Lists the known ephemeral disks that can be configured.
+/// Lists the known ephemeral ebs volumes that can be configured.
+async fn list_ephemeral_ebs_volumes(
+    req: HttpRequest,
+    query: web::Query<HashMap<String, String>>,
+) -> Result<HttpResponse> {
+    let disks =
+        ephemeral_storage::ephemeral_ebs_volumes().context(error::EphemeralListDisksSnafu {})?;
+
+    let mut text_response = String::new();
+    for disk in &disks {
+        text_response.push_str(disk);
+        text_response.push('\n');
+    }
+    list_ephemeral_response(req, query, disks, text_response).await
+}
+
+/// Lists a variant-specific set of directories that can be bound to ephemeral storage.
 async fn list_ephemeral_storage_dirs(
     req: HttpRequest,
     query: web::Query<HashMap<String, String>>,

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -726,8 +726,13 @@ async fn get_fips_report(query: web::Query<HashMap<String, String>>) -> Result<H
 
 /// Configure ephemeral storage (raid & format, or just format for single disk)
 async fn initialize_ephemeral_storage(cfg: web::Json<Init>) -> Result<HttpResponse> {
-    ephemeral_storage::initialize(cfg.0.filesystem, cfg.0.disks)
-        .context(error::EphemeralInitializeSnafu {})?;
+    ephemeral_storage::initialize(
+        cfg.0.filesystem,
+        cfg.0.disks,
+        cfg.0.ebs_volumes,
+        cfg.0.prefer,
+    )
+    .context(error::EphemeralInitializeSnafu {})?;
     Ok(HttpResponse::NoContent().finish()) // 204
 }
 /// Bind directories to ephemeral storage (mount array, bind, and unmount)

--- a/sources/models/src/ephemeral_storage.rs
+++ b/sources/models/src/ephemeral_storage.rs
@@ -18,11 +18,59 @@ impl Display for Filesystem {
     }
 }
 
+/// Storage type preferences for ephemeral storage
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Preference {
+    pub ephemeral_disk: bool,
+    pub ebs_volume: bool,
+}
+impl Display for Preference {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut first = false;
+        let mut write = |s| {
+            if first {
+                first = false;
+            } else {
+                f.write_str("+")?;
+            }
+            f.write_str(s)
+        };
+        if self.ephemeral_disk {
+            write("ephemeral-disk")?;
+        }
+        if self.ebs_volume {
+            write("ebs-volume")?;
+        }
+        Ok(())
+    }
+}
+impl<'a> TryFrom<&'a str> for Preference {
+    type Error = &'a str;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        let mut preference = Self {
+            ephemeral_disk: false,
+            ebs_volume: false,
+        };
+        for i in value.split("+") {
+            match i {
+                "ephemeral-disk" => preference.ephemeral_disk = true,
+                "ebs-volume" => preference.ebs_volume = true,
+                "" => {}
+                x => return Err(x),
+            }
+        }
+        Ok(preference)
+    }
+}
+
 /// Initialize ephemeral storage
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Init {
     pub filesystem: Option<Filesystem>,
     pub disks: Option<Vec<String>>,
+    pub ebs_volumes: Option<Vec<String>>,
+    pub prefer: Option<Vec<Preference>>,
 }
 
 /// Bind directories to configured ephemeral storage


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #389

**Description of changes:**

Adds two new options to `ephemeral-storage init`:

* `--ebs-volumes` specifies EBS volumes to be included in the ephemeral storage array (e.g. `--ebs-volumes /dev/disk/ephemeral-ebs/xvdda /dev/disk/ephemeral-ebs/xvddb`

* `--prefer` specifies combinations of storage types to be included in the ephemeral storage array in order of preference. Currently supported storage types are `ephemeral-disk` and `ebs-volume`. Storage types can be combined with the `+` operator.  For example, `--prefer ephemeral-disk ebs-volume` uses ephemeral disks if available and ebs volumes otherwise. To use a mix of both types, specify `--prefer ephemeral-disk+ebs-volume`.


**Testing done:**

Manual testing of a few different configurations on EKS (see [this comment](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/395#issuecomment-3224069765))

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
