### PR TITLE
nvidia-k8s-device-plugin: fix template for migStrategy

### DIFF
--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -5,8 +5,12 @@ std = { version = "v1", helpers = ["default"] }
 +++
 version: v1
 flags:
+  {{#if settings.kubelet-device-plugins.nvidia.device-partitioning-strategy}}
   {{#if (eq settings.kubelet-device-plugins.nvidia.device-partitioning-strategy "mig")}}
   migStrategy: "single"
+  {{else}}
+  migStrategy: "none"
+  {{/if}}
   {{else}}
   migStrategy: "none"
   {{/if}}


### PR DESCRIPTION
**Description of changes:**
The additional condition to the template makes sure that `kubelet-device-plugins` doesn't break if a default value is not set for `settings.kubelet-device-plugins.nvidia.device-partitioning-strategy`.

**Testing done:**
- built bottlerocket nvidia variant by manually removing the default settings and verified if kubelet functions. 
```
[root@admin]# apiclient get settings.kubelet-device-plugins
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "volume-mounts",
        "device-sharing-strategy": "none",
        "pass-device-specs": true
      }
    }
  }
}
[root@admin]# sheltie
bash-5.1# systemctl status nvidia-k8s-device-plugin
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
             /etc/systemd/system/nvidia-k8s-device-plugin.service.d
             └─exec-start.conf
     Active: active (running) since Wed 2025-03-12 21:41:04 UTC; 9min ago
```
- Rendered template with `device-partitioning-strategy` unset.
```
bash-5.1# cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: volume-mounts
    deviceIDStrategy: index
```
- Rendered template with `device-partitioning-strategy` set to `none`.
```
bash-5.1# apiclient set settings.kubelet-device-plugins.nvidia.device-partitioning-strategy="none"
bash-5.1# cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: volume-mounts
    deviceIDStrategy: index
```
- Rendered template with `device-partitioning-strategy` set to `mig`.
```
bash-5.1# apiclient set settings.kubelet-device-plugins.nvidia.device-partitioning-strategy="mig"
bash-5.1# cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "single"
  failOnInitError: true
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: volume-mounts
    deviceIDStrategy: index
```
- `kubectl describe node` also advertises the correct number of GPUs. 

`g4dn.xlarge`
```
Capacity:
*****
  nvidia.com/gpu:     1
*****
Allocatable:
*****
  nvidia.com/gpu:     1
*****
```
`p4d.24xlarge` with MIG **disabled**
```
Capacity:
*****
  nvidia.com/gpu:     8
*****
Allocatable:
*****
  nvidia.com/gpu:     8
*****
```
`p4d.24xlarge` with MIG **enabled**
```
Capacity:
*****
  nvidia.com/gpu:     56
*****
Allocatable:
*****
  nvidia.com/gpu:     56
*****
```

- For `p4d.24xlarge` ran an additional CUDA workload test to make sure MIG is functioning as expected.
```
[fedora@ip-172-31-48-208 kubernetes]$ kubectl get pods -A
NAMESPACE     NAME                              READY   STATUS      RESTARTS       AGE
default       nvidia-cuda-workload-5tqlh        0/1     Completed   0              72s
default       nvidia-cuda-workload-6hsgs        0/1     Completed   0              72s
default       nvidia-cuda-workload-7cr4n        0/1     Completed   0              72s
*****
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
