### PR TITLE
build: fix upstream-source-fallback variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ KIT ?= bottlerocket-core-kit
 UNAME_ARCH = $(shell uname -m)
 ARCH ?= $(UNAME_ARCH)
 VENDOR ?= bottlerocket
-UPSTREAM_SOURCE_FALLBACK = false
+UPSTREAM_SOURCE_FALLBACK ?= false
 
 ifeq ($(UNAME_ARCH), aarch64)
 	TWOLITER_SHA256=$(TWOLITER_SHA256_AARCH64)
@@ -42,7 +42,7 @@ fetch: prep
 	@$(TWOLITER) fetch --arch $(ARCH)
 
 build: fetch
-ifeq ($(UPSTREAM_SOURCE_FALLBACK), "false")
+ifeq ($(UPSTREAM_SOURCE_FALLBACK), false)
 	@$(TWOLITER) build kit $(KIT) --arch $(ARCH)
 else
 	@$(TWOLITER) build kit $(KIT) --arch $(ARCH) --upstream-source-fallback


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Fix the `UPSTREAM_SOURCE_FALLBACK` variable. It now throws the right error when building a package that is not available in the the cache.

**Testing done:**

- `make build` resulted in build failures
- `UPSTREAM_SOURCE_FALLBACK=true make build` resulted in successful builds


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
