### PR TITLE
Update Bottlerocket SDK to 0.60.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -3,7 +3,7 @@ kit = []
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.50.1"
+version = "0.60.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.50.1"
-digest = "HEh3Lx3F6P4OEPnFubF++RMpMW2vlfp/Tc/tGjnBRcM="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.60.0"
+digest = "aVbABC86XWBbfyems1C3lrEhEvL1XmNt1hcwF0oAzSs="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -6,5 +6,5 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.50.1"
+version = "0.60.0"
 vendor = "bottlerocket"

--- a/packages/binutils/Cargo.toml
+++ b/packages/binutils/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://mirrors.kernel.org/gnu/binutils/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.kernel.org/gnu/binutils/binutils-2.41.tar.xz"
-sha512 = "5df45d0bd6ddabdce4f35878c041e46a92deef01e7dea5facc97fd65cc06b59abc6fba0eb454b68e571c7e14038dc823fe7f2263843e6e627b7444eaf0fe9374"
+url = "https://mirrors.kernel.org/gnu/binutils/binutils-2.43.1.tar.xz"
+sha512 = "20977ad17729141a2c26d358628f44a0944b84dcfefdec2ba029c2d02f40dfc41cc91c0631044560d2bd6f9a51e1f15846b4b311befbe14f1239f14ff7d57824"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.kernel.org/gnu/binutils/binutils-2.41.tar.xz.sig"
-sha512 = "e86b940a1fa73775236fe8e7cf824625c6add59072fe7948a7de8f613bb1bbbbb7108e4f9651cb0f606007f4180a0fe13911d84c70149e82242169e4ce5892e2"
+url = "https://mirrors.kernel.org/gnu/binutils/binutils-2.43.1.tar.xz.sig"
+sha512 = "cf053f48a159afc7f0be10793d865a8a8c03dda283c2716b3860287c83ee2de68b04b568dff6a8d319092b89cb51cbeb16ccb6c17e630870cf440b8fb28d47f1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/binutils/binutils.spec
+++ b/packages/binutils/binutils.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}binutils
-Version: 2.41
+Version: 2.43.1
 Release: 1%{?dist}
 Epoch: 1
 Summary: Tools for working with binaries

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -13,7 +13,6 @@ use actix_web::{
 };
 use datastore::{serialize_scalar, Committed, FilesystemDataStore, Key, KeyType, Value};
 use error::Result;
-use fs2::FileExt;
 use http::StatusCode;
 use log::info;
 use model::ephemeral_storage::{Bind, Init};
@@ -598,9 +597,7 @@ async fn get_configuration_files(
 /// Get the update status from 'thar-be-updates'
 async fn get_update_status() -> Result<UpdateStatusResponse> {
     let lockfile = File::create(UPDATE_LOCKFILE).context(error::UpdateLockOpenSnafu)?;
-    lockfile
-        .try_lock_shared()
-        .context(error::UpdateShareLockSnafu)?;
+    fs2::FileExt::try_lock_shared(&lockfile).context(error::UpdateShareLockSnafu)?;
     let result = thar_be_updates::status::get_update_status(&lockfile);
     match result {
         Ok(update_status) => Ok(UpdateStatusResponse(update_status)),

--- a/sources/api/prairiedog/src/initrd.rs
+++ b/sources/api/prairiedog/src/initrd.rs
@@ -22,10 +22,8 @@ pub(crate) fn generate_initrd(bootconfig: &[u8]) -> Result<Vec<u8>> {
             .context(error::AddU32OverflowSnafu)?;
     }
     // Bottlerocket does not use an initrd, so the base initrd image size is 0
-    let total_size = BASE_INITRD_SIZE
-        + bootconfig_size
-        + size_of::<u32>() * 2
-        + BOOTCONFIG_MAGIC.as_bytes().len();
+    let total_size =
+        BASE_INITRD_SIZE + bootconfig_size + size_of::<u32>() * 2 + BOOTCONFIG_MAGIC.len();
     let mut initrd = bootconfig.to_owned();
     // initrd image file needs to be 4-byte aligned, so we add padding as necessary.
     let padding_size = (BOOTCONFIG_ALIGN - (total_size % BOOTCONFIG_ALIGN)) % BOOTCONFIG_ALIGN;

--- a/sources/netdog/src/networkd/config/network.rs
+++ b/sources/netdog/src/networkd/config/network.rs
@@ -620,7 +620,7 @@ where
             Dhcp4ConfigV1::DhcpEnabled(enabled) => *enabled,
             // If "optional" isn't set, assume DHCP is required.
             // If optional==true, DHCP is NOT required
-            Dhcp4ConfigV1::WithOptions(o) => o.optional.map_or(true, |b| !b),
+            Dhcp4ConfigV1::WithOptions(o) => o.optional.is_none_or(|b| !b),
         }
     }
 
@@ -644,7 +644,7 @@ where
             Dhcp6ConfigV1::DhcpEnabled(enabled) => *enabled,
             // If "optional" isn't set, assume DHCP is required
             // If optional==true, DHCP is NOT required
-            Dhcp6ConfigV1::WithOptions(o) => o.optional.map_or(true, |b| !b),
+            Dhcp6ConfigV1::WithOptions(o) => o.optional.is_none_or(|b| !b),
         }
     }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Bumps Bottlerocket SDK to 0.60.0 and fixes clippy warnings.

**Testing done:**
* Core-Kit Builds

**Clippy Warnings:** 

```
[cargo-make] INFO - Running Task: check-clippy
   Compiling apiserver v0.1.0 (/tmp/sources/api/apiserver)
   Compiling prairiedog v0.1.0 (/tmp/sources/api/prairiedog)
   Compiling simple-settings-plugin v0.1.0 (/tmp/sources/api/simple-settings-plugin)
   Compiling netdog v0.1.0 (/tmp/sources/netdog)
error: needless call to `as_bytes()`
  --> api/prairiedog/src/initrd.rs:28:11
   |
28 |         + BOOTCONFIG_MAGIC.as_bytes().len();
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: `len()` can be called directly on strings: `BOOTCONFIG_MAGIC.len()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_as_bytes
   = note: `-D clippy::needless-as-bytes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_as_bytes)]`

error: could not compile `prairiedog` (bin "prairiedog") due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: a method with this name may be added to the standard library in the future
   --> api/apiserver/src/server/mod.rs:602:10
    |
602 |         .try_lock_shared()
    |          ^^^^^^^^^^^^^^^
    |
    = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `fs2::FileExt::try_lock_shared(...)` to keep using the current method
    = note: `-D unstable-name-collisions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unstable_name_collisions)]`

error: this `map_or` can be simplified
   --> netdog/src/networkd/config/network.rs:623:46
    |
623 |             Dhcp4ConfigV1::WithOptions(o) => o.optional.map_or(true, |b| !b),
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use is_none_or instead: `o.optional.is_none_or(|b| !b)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
    = note: `-D clippy::unnecessary-map-or` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_map_or)]`

error: this `map_or` can be simplified
   --> netdog/src/networkd/config/network.rs:647:46
    |
647 |             Dhcp6ConfigV1::WithOptions(o) => o.optional.map_or(true, |b| !b),
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use is_none_or instead: `o.optional.is_none_or(|b| !b)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or

error: could not compile `netdog` (bin "netdog") due to 2 previous errors
error: could not compile `apiserver` (lib) due to 1 previous error
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
