### PR TITLE
systemd: refactor to list packaged files

### DIFF
--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -322,6 +322,9 @@ ln -s  ../proc-sys-fs-binfmt_misc.mount \
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/issue
 
+# Remove any README files.
+find %{buildroot} -type f -name README -print -delete
+
 %files
 %license LICENSE.GPL2 LICENSE.LGPL2.1
 %{_cross_attribution_file}
@@ -329,7 +332,6 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_bindir}/journalctl
 %{_cross_bindir}/systemctl
 %{_cross_bindir}/systemd-analyze
-%{_cross_bindir}/systemd-ask-password
 %{_cross_bindir}/systemd-cat
 %{_cross_bindir}/systemd-cgls
 %{_cross_bindir}/systemd-cgtop
@@ -351,7 +353,6 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_bindir}/systemd-stdio-bridge
 %{_cross_bindir}/systemd-sysusers
 %{_cross_bindir}/systemd-tmpfiles
-%{_cross_bindir}/systemd-tty-ask-password-agent
 %{_cross_bindir}/systemd-umount
 %{_cross_bindir}/udevadm
 %{_cross_bindir}/loginctl
@@ -365,44 +366,289 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_libdir}/libsystemd.so.*
 %{_cross_libdir}/libudev.so.*
 
+%dir %{_cross_libdir}/systemd
+%{_cross_libdir}/systemd/libsystemd-core-*.so
+%{_cross_libdir}/systemd/libsystemd-shared-*.so
+%{_cross_libdir}/systemd/systemd
+%{_cross_libdir}/systemd/systemd-ac-power
+%{_cross_libdir}/systemd/systemd-boot-check-no-failures
+%{_cross_libdir}/systemd/systemd-cgroups-agent
+%{_cross_libdir}/systemd/systemd-fsck
+%{_cross_libdir}/systemd/systemd-growfs
+%{_cross_libdir}/systemd/systemd-journald
+%{_cross_libdir}/systemd/systemd-logind
+%{_cross_libdir}/systemd/systemd-makefs
+%{_cross_libdir}/systemd/systemd-modules-load
+%{_cross_libdir}/systemd/systemd-network-generator
+%{_cross_libdir}/systemd/systemd-pstore
+%{_cross_libdir}/systemd/systemd-random-seed
+%{_cross_libdir}/systemd/systemd-remount-fs
+%{_cross_libdir}/systemd/systemd-shutdown
+%{_cross_libdir}/systemd/systemd-sleep
+%{_cross_libdir}/systemd/systemd-socket-proxyd
+%{_cross_libdir}/systemd/systemd-sysctl
+%{_cross_libdir}/systemd/systemd-sysroot-fstab-check
+%{_cross_libdir}/systemd/systemd-udevd
+
+%dir %{_cross_libdir}/systemd/system-preset
+%{_cross_libdir}/systemd/system-preset/90-systemd.preset
+
+%dir %{_cross_libdir}/systemd/system-shutdown
+%dir %{_cross_libdir}/systemd/system-sleep
+
+%dir %{_cross_libdir}/systemd/journald.conf.d
+%{_cross_libdir}/systemd/journald.conf.d/journald.conf
+
 %dir %{_cross_libdir}/modprobe.d
-%{_cross_libdir}/modprobe.d/*
+%{_cross_libdir}/modprobe.d/systemd.conf
 
 %dir %{_cross_libdir}/modules-load.d
 %{_cross_libdir}/modules-load.d/nf_conntrack.conf
 
 %dir %{_cross_sysctldir}
-%{_cross_sysctldir}/*
+%{_cross_sysctldir}/50-default.conf
+%{_cross_sysctldir}/50-pid-max.conf
 
-%dir %{_cross_libdir}/systemd
-%{_cross_libdir}/systemd/*
-%exclude %{_cross_libdir}/systemd/systemd-binfmt
-%exclude %{_cross_libdir}/systemd/systemd-user-runtime-dir
-%exclude %{_cross_unitdir}/dbus-org.freedesktop.login1.service
-%exclude %{_cross_unitdir}/proc-sys-fs-binfmt_misc.automount
-%exclude %{_cross_unitdir}/systemd-binfmt.service
-%exclude %{_cross_unitdir}/systemd-repart.service
+%dir %{_cross_unitdir}
+%{_cross_unitdir}/basic.target
+%{_cross_unitdir}/blockdev@.target
+%{_cross_unitdir}/boot-complete.target
+%{_cross_unitdir}/ctrl-alt-del.target
+%{_cross_unitdir}/dev-hugepages.mount
+%{_cross_unitdir}/dev-mqueue.mount
+%{_cross_unitdir}/exit.target
+%{_cross_unitdir}/factory-reset.target
+%{_cross_unitdir}/final.target
+%{_cross_unitdir}/first-boot-complete.target
+%{_cross_unitdir}/getty-pre.target
+%{_cross_unitdir}/getty.target
+%{_cross_unitdir}/halt.target
+%{_cross_unitdir}/kexec.target
+%{_cross_unitdir}/kmod-static-nodes.service
+%{_cross_unitdir}/ldconfig.service
+%{_cross_unitdir}/local-fs-pre.target
+%{_cross_unitdir}/local-fs.target
+%dir %{_cross_unitdir}/local-fs.target.wants
+%{_cross_unitdir}/local-fs.target.wants/tmp.mount
+%{_cross_unitdir}/modprobe@.service
+%dir %{_cross_unitdir}/multi-user.target.wants
+%{_cross_unitdir}/multi-user.target.wants/getty.target
+%{_cross_unitdir}/multi-user.target.wants/systemd-logind.service
+%{_cross_unitdir}/network-online.target
+%{_cross_unitdir}/network-pre.target
+%{_cross_unitdir}/network.target
+%{_cross_unitdir}/nss-lookup.target
+%{_cross_unitdir}/nss-user-lookup.target
+%{_cross_unitdir}/paths.target
+%{_cross_unitdir}/poweroff.target
+%{_cross_unitdir}/proc-sys-fs-binfmt_misc.mount
+%{_cross_unitdir}/reboot.target
+%{_cross_unitdir}/rpcbind.target
+%{_cross_unitdir}/shutdown.target
+%{_cross_unitdir}/sigpwr.target
+%{_cross_unitdir}/sleep.target
+%{_cross_unitdir}/slices.target
+%{_cross_unitdir}/sockets.target
+%dir %{_cross_unitdir}/sockets.target.wants
+%{_cross_unitdir}/sockets.target.wants/systemd-journald-audit.socket
+%{_cross_unitdir}/sockets.target.wants/systemd-journald-dev-log.socket
+%{_cross_unitdir}/sockets.target.wants/systemd-journald.socket
+%{_cross_unitdir}/sockets.target.wants/systemd-udevd-control.socket
+%{_cross_unitdir}/sockets.target.wants/systemd-udevd-kernel.socket
+%{_cross_unitdir}/suspend.target
+%{_cross_unitdir}/swap.target
+%{_cross_unitdir}/sys-fs-fuse-connections.mount
+%{_cross_unitdir}/sys-kernel-config.mount
+%{_cross_unitdir}/sys-kernel-debug.mount
+%{_cross_unitdir}/sys-kernel-tracing.mount
+%{_cross_unitdir}/sysinit.target
+%dir %{_cross_unitdir}/sysinit.target.wants
+%{_cross_unitdir}/sysinit.target.wants/dev-hugepages.mount
+%{_cross_unitdir}/sysinit.target.wants/dev-mqueue.mount
+%{_cross_unitdir}/sysinit.target.wants/kmod-static-nodes.service
+%{_cross_unitdir}/sysinit.target.wants/ldconfig.service
+%{_cross_unitdir}/sysinit.target.wants/proc-sys-fs-binfmt_misc.mount
+%{_cross_unitdir}/sysinit.target.wants/sys-fs-fuse-connections.mount
+%{_cross_unitdir}/sysinit.target.wants/sys-kernel-config.mount
+%{_cross_unitdir}/sysinit.target.wants/sys-kernel-debug.mount
+%{_cross_unitdir}/sysinit.target.wants/sys-kernel-tracing.mount
+%{_cross_unitdir}/sysinit.target.wants/systemd-journal-catalog-update.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-journal-flush.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-journald.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-machine-id-commit.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-modules-load.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-random-seed.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-repart.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-sysctl.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-sysusers.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-tmpfiles-setup-dev.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-tmpfiles-setup.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-udev-trigger.service
+%{_cross_unitdir}/sysinit.target.wants/systemd-udevd.service
+%{_cross_unitdir}/syslog.socket
+%{_cross_unitdir}/systemd-boot-check-no-failures.service
+%{_cross_unitdir}/systemd-exit.service
+%{_cross_unitdir}/systemd-fsck-root.service
+%{_cross_unitdir}/systemd-fsck@.service
+%{_cross_unitdir}/systemd-halt.service
+%{_cross_unitdir}/systemd-journal-catalog-update.service
+%{_cross_unitdir}/systemd-journal-flush.service
+%{_cross_unitdir}/systemd-journald-audit.socket
+%{_cross_unitdir}/systemd-journald-dev-log.socket
+%{_cross_unitdir}/systemd-journald-varlink@.socket
+%{_cross_unitdir}/systemd-journald.service
+%dir %{_cross_unitdir}/systemd-journald.service.d
+%{_cross_unitdir}/systemd-journald.service.d/systemd-journald.conf
+%{_cross_unitdir}/systemd-journald.socket
+%{_cross_unitdir}/systemd-journald@.service
+%{_cross_unitdir}/systemd-journald@.socket
+%{_cross_unitdir}/systemd-kexec.service
+%{_cross_unitdir}/systemd-logind.service
+%{_cross_unitdir}/systemd-machine-id-commit.service
+%{_cross_unitdir}/systemd-modules-load.service
+%{_cross_unitdir}/systemd-network-generator.service
+%{_cross_unitdir}/systemd-nspawn@.service
+%{_cross_unitdir}/systemd-poweroff.service
+%{_cross_unitdir}/systemd-pstore.service
+%{_cross_unitdir}/systemd-random-seed.service
+%{_cross_unitdir}/systemd-reboot.service
+%{_cross_unitdir}/systemd-remount-fs.service
+%{_cross_unitdir}/systemd-suspend.service
+%{_cross_unitdir}/systemd-sysctl.service
+%{_cross_unitdir}/systemd-sysusers.service
+%dir %{_cross_unitdir}/systemd-sysusers.service.d
+%{_cross_unitdir}/systemd-sysusers.service.d/systemd-sysusers.conf
+%{_cross_unitdir}/systemd-tmpfiles-clean.service
+%{_cross_unitdir}/systemd-tmpfiles-clean.timer
+%{_cross_unitdir}/systemd-tmpfiles-setup-dev.service
+%{_cross_unitdir}/systemd-tmpfiles-setup.service
+%{_cross_unitdir}/systemd-udev-settle.service
+%{_cross_unitdir}/systemd-udev-trigger.service
+%{_cross_unitdir}/systemd-udevd-control.socket
+%{_cross_unitdir}/systemd-udevd-kernel.socket
+%{_cross_unitdir}/systemd-udevd.service
+%{_cross_unitdir}/time-set.target
+%{_cross_unitdir}/time-sync.target
+%{_cross_unitdir}/timers.target
+%dir %{_cross_unitdir}/timers.target.wants
+%{_cross_unitdir}/timers.target.wants/systemd-tmpfiles-clean.timer
+%{_cross_unitdir}/tmp.mount
+%{_cross_unitdir}/umount.target
+%{_cross_unitdir}/dbus-org.freedesktop.login1.service
+
+# Exclude desktop related targets.
+%exclude %{_cross_unitdir}/bluetooth.target
+%exclude %{_cross_unitdir}/printer.target
+%exclude %{_cross_unitdir}/smartcard.target
+%exclude %{_cross_unitdir}/sound.target
+%exclude %{_cross_unitdir}/usb-gadget.target
+
+# Exclude remote filesystem targets.
+%exclude %{_cross_unitdir}/remote-fs-pre.target
+%exclude %{_cross_unitdir}/remote-fs.target
+
+# Exclude user-related functionality.
 %exclude %{_cross_unitdir}/user-runtime-dir@.service
 %exclude %{_cross_unitdir}/user@.service
 %exclude %{_cross_unitdir}/user@.service.d
 %exclude %{_cross_unitdir}/user@0.service.d
+%exclude %{_cross_unitdir}/user-.slice.d/10-defaults.conf
+%exclude %{_cross_unitdir}/user.slice
+%exclude %{_cross_userunitdir}
+%exclude %{_cross_libdir}/systemd/systemd-user-runtime-dir
+%exclude %{_cross_libdir}/systemd/user-preset/90-systemd.preset
+
+# Exclude units related to the initrd.
+%exclude %{_cross_unitdir}/initrd-root-device.target.wants
+%exclude %{_cross_unitdir}/initrd-root-fs.target.wants
+
+# Exclude repart service since we have custom repart logic.
+%exclude %{_cross_unitdir}/systemd-repart.service
+
+# Exclude upstream binfmt functionality.
+%exclude %{_cross_libdir}/systemd/systemd-binfmt
+%exclude %{_cross_unitdir}/systemd-binfmt.service
+%exclude %{_cross_unitdir}/proc-sys-fs-binfmt_misc.automount
 %exclude %{_cross_unitdir}/sysinit.target.wants/proc-sys-fs-binfmt_misc.automount
 %exclude %{_cross_unitdir}/sysinit.target.wants/systemd-binfmt.service
 
+# Exclude functionality related to offline updates.
+%exclude %{_cross_libdir}/systemd/systemd-update-done
+%exclude %{_cross_libdir}/systemd/systemd-update-helper
+%exclude %{_cross_systemdgeneratordir}/systemd-system-update-generator
+%exclude %{_cross_unitdir}/sysinit.target.wants/systemd-update-done.service
+%exclude %{_cross_unitdir}/system-update-cleanup.service
+%exclude %{_cross_unitdir}/system-update-pre.target
+%exclude %{_cross_unitdir}/system-update.target
+%exclude %{_cross_unitdir}/systemd-update-done.service
+
 %dir %{_cross_libdir}/udev
-%{_cross_libdir}/udev/*
-%exclude %{_cross_libdir}/udev/rules.d/70-uaccess.rules
-%exclude %{_cross_libdir}/udev/rules.d/71-seat.rules
-%exclude %{_cross_libdir}/udev/rules.d/73-seat-late.rules
+%{_cross_libdir}/udev/ata_id
+%{_cross_libdir}/udev/cdrom_id
+%{_cross_libdir}/udev/dmi_memory_id
+%{_cross_libdir}/udev/fido_id
+%{_cross_libdir}/udev/mtd_probe
+%{_cross_libdir}/udev/scsi_id
+%exclude %{_cross_libdir}/udev/v4l_id
+
+%dir %{_cross_udevrulesdir}
+%{_cross_udevrulesdir}/50-udev-default.rules
+%{_cross_udevrulesdir}/60-autosuspend.rules
+%{_cross_udevrulesdir}/60-block.rules
+%{_cross_udevrulesdir}/60-cdrom_id.rules
+%{_cross_udevrulesdir}/60-drm.rules
+%{_cross_udevrulesdir}/60-evdev.rules
+%{_cross_udevrulesdir}/60-fido-id.rules
+%{_cross_udevrulesdir}/60-infiniband.rules
+%{_cross_udevrulesdir}/60-input-id.rules
+%{_cross_udevrulesdir}/60-persistent-input.rules
+%{_cross_udevrulesdir}/60-persistent-storage-tape.rules
+%{_cross_udevrulesdir}/60-persistent-storage.rules
+%{_cross_udevrulesdir}/60-sensor.rules
+%{_cross_udevrulesdir}/60-serial.rules
+%{_cross_udevrulesdir}/64-btrfs.rules
+%{_cross_udevrulesdir}/70-memory.rules
+%{_cross_udevrulesdir}/70-power-switch.rules
+%{_cross_udevrulesdir}/75-net-description.rules
+%{_cross_udevrulesdir}/75-probe_mtd.rules
+%{_cross_udevrulesdir}/80-drivers.rules
+%{_cross_udevrulesdir}/80-net-setup-link.rules
+%{_cross_udevrulesdir}/81-net-dhcp.rules
+%{_cross_udevrulesdir}/99-systemd.rules
+
+# Exclude desktop-related device rules.
+%exclude %{_cross_udevrulesdir}/60-persistent-alsa.rules
+%exclude %{_cross_udevrulesdir}/60-persistent-v4l.rules
+%exclude %{_cross_udevrulesdir}/70-camera.rules
+%exclude %{_cross_udevrulesdir}/70-joystick.rules
+%exclude %{_cross_udevrulesdir}/70-mouse.rules
+%exclude %{_cross_udevrulesdir}/70-touchpad.rules
+%exclude %{_cross_udevrulesdir}/70-uaccess.rules
+%exclude %{_cross_udevrulesdir}/71-seat.rules
+%exclude %{_cross_udevrulesdir}/73-seat-late.rules
+%exclude %{_cross_udevrulesdir}/78-sound-card.rules
 
 %dir %{_cross_sysusersdir}
-%{_cross_sysusersdir}/*
+%{_cross_sysusersdir}/basic.conf
+%{_cross_sysusersdir}/systemd-journal.conf
 
 %dir %{_cross_tmpfilesdir}
-%{_cross_tmpfilesdir}/*
+%{_cross_tmpfilesdir}/etc.conf
+%{_cross_tmpfilesdir}/home.conf
+%{_cross_tmpfilesdir}/journal-nocow.conf
+%{_cross_tmpfilesdir}/provision.conf
+%{_cross_tmpfilesdir}/static-nodes-permissions.conf
+%{_cross_tmpfilesdir}/systemd-pstore.conf
+%{_cross_tmpfilesdir}/systemd-tmp.conf
+%{_cross_tmpfilesdir}/systemd-tmpfiles.conf
+%{_cross_tmpfilesdir}/systemd.conf
+%{_cross_tmpfilesdir}/tmp.conf
+%{_cross_tmpfilesdir}/var.conf
 %exclude %{_cross_tmpfilesdir}/x11.conf
 
-%{_cross_datadir}/dbus-1/*
+%{_cross_datadir}/dbus-1/services/org.freedesktop.systemd1.service
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.login1.conf
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.systemd1.conf
 %exclude %{_cross_datadir}/dbus-1/system-services
 
 %dir %{_cross_factorydir}
@@ -413,6 +659,29 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/pam.d/other
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/pam.d/system-auth
 
+%dir %{_cross_journalcatalogdir}
+%{_cross_journalcatalogdir}/systemd.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.be.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.be@latin.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.bg.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.da.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.de.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.fr.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.hr.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.hu.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.it.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.ko.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.pl.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.pt_BR.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.ru.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.sr.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.zh_CN.catalog
+%exclude %{_cross_journalcatalogdir}/systemd.zh_TW.catalog
+
+%dir %{_cross_systemdgeneratordir}
+%{_cross_systemdgeneratordir}/systemd-fstab-generator
+%{_cross_systemdgeneratordir}/systemd-run-generator
+
 %exclude %{_cross_datadir}/polkit-1
 %exclude %{_cross_docdir}
 %exclude %{_cross_libdir}/pam.d/systemd-user
@@ -420,44 +689,6 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %exclude %{_cross_sysconfdir}/udev/
 %exclude %{_cross_sysconfdir}/X11
 %exclude %{_cross_sysconfdir}/xdg
-
-# exclude files for subpackages
-%exclude %{_cross_bindir}/systemd-ask-password
-%exclude %{_cross_bindir}/systemd-tty-ask-password-agent
-%exclude %{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
-%exclude %{_cross_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
-%exclude %{_cross_libdir}/systemd/resolv.conf
-%exclude %{_cross_libdir}/systemd/systemd-networkd
-%exclude %{_cross_libdir}/systemd/systemd-networkd-wait-online
-%exclude %{_cross_libdir}/systemd/systemd-reply-password
-%exclude %{_cross_libdir}/systemd/systemd-resolved
-%exclude %{_cross_libdir}/systemd/systemd-sulogin-shell
-%exclude %{_cross_systemdgeneratordir}/systemd-debug-generator
-%exclude %{_cross_systemdgeneratordir}/systemd-getty-generator
-%exclude %{_cross_sysusersdir}/systemd-network.conf
-%exclude %{_cross_sysusersdir}/systemd-resolve.conf
-%exclude %{_cross_tmpfilesdir}/systemd-network.conf
-%exclude %{_cross_tmpfilesdir}/systemd-resolve.conf
-%exclude %{_cross_unitdir}/autovt@.service
-%exclude %{_cross_unitdir}/console-getty.service
-%exclude %{_cross_unitdir}/container-getty@.service
-%exclude %{_cross_unitdir}/debug-shell.service
-%exclude %{_cross_unitdir}/emergency.service
-%exclude %{_cross_unitdir}/emergency.target
-%exclude %{_cross_unitdir}/getty@.service
-%exclude %{_cross_unitdir}/rescue.service
-%exclude %{_cross_unitdir}/rescue.target
-%exclude %{_cross_unitdir}/serial-getty@.service
-%exclude %{_cross_unitdir}/systemd-ask-password-console.service
-%exclude %{_cross_unitdir}/systemd-ask-password-console.path
-%exclude %{_cross_unitdir}/systemd-ask-password-wall.path
-%exclude %{_cross_unitdir}/systemd-networkd.service
-%exclude %{_cross_unitdir}/systemd-networkd-wait-online.service
-%exclude %{_cross_unitdir}/systemd-networkd-wait-online@.service
-%exclude %{_cross_unitdir}/systemd-networkd.socket
-%exclude %{_cross_unitdir}/systemd-resolved.service
-%exclude %{_cross_unitdir}/sysinit.target.wants/systemd-ask-password-console.path
-%exclude %{_cross_unitdir}/multi-user.target.wants/systemd-ask-password-wall.path
 
 %files devel
 %{_cross_libdir}/libsystemd.so
@@ -488,11 +719,13 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %{_cross_unitdir}/systemd-ask-password-console.service
 %{_cross_unitdir}/systemd-ask-password-console.path
 %{_cross_unitdir}/systemd-ask-password-wall.path
+%{_cross_unitdir}/systemd-ask-password-wall.service
 %{_cross_unitdir}/sysinit.target.wants/systemd-ask-password-console.path
 %{_cross_unitdir}/multi-user.target.wants/systemd-ask-password-wall.path
 
 %files networkd
 %{_cross_bindir}/networkctl
+%dir %{_cross_libdir}/systemd/network
 %{_cross_libdir}/systemd/systemd-networkd
 %{_cross_libdir}/systemd/systemd-networkd-wait-online
 %{_cross_sysusersdir}/systemd-network.conf
@@ -515,4 +748,3 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 %exclude %{_cross_bindir}/systemd-resolve
 %exclude %{_cross_sbindir}/resolvconf
 
-%changelog


### PR DESCRIPTION
**Issue number:**
Related: #327

**Description of changes:**
The current wildcard-based file includes make it harder to review the impact of changing the build time configuration to enable features.

For optional functionality, it also makes it more tedious to place files into the correct subpackage, since each file has to be excluded from the main package and then also listed in the subpackage. It's easy to miss a related file and then it ends up packaged twice or not moved to the subpackage.

Remove all wildcard includes and replace with lists of files. While we're at it, remove a handful of units that are unlikely to ever be useful for Bottlerocket.


**Testing done:**
Here's a cleaned-up diff of the RPM contents before and after.

```
diff --git a/before/bottlerocket-systemd.aarch64.txt b/after/bottlerocket-systemd.aarch64.txt
index 7455299..fa7f9b9 100644
--- a/before/bottlerocket-systemd.aarch64.txt
+++ b/after/bottlerocket-systemd.aarch64.txt
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/modprobe.d/README
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/sysctl.d/README
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.be.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.be@latin.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.bg.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.da.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.de.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.fr.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.hr.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.hu.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.it.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.ko.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.pl.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.pt_BR.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.ru.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.sr.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.zh_CN.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.zh_TW.catalog
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/network
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system-generators/systemd-system-update-generator
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/bluetooth.target
+/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/dbus-org.freedesktop.login1.service
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/initrd-root-fs.target.wants
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/initrd-root-fs.target.wants/systemd-repart.service
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/printer.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/remote-fs-pre.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/remote-fs.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/smartcard.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/sound.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/sysinit.target.wants/systemd-update-done.service
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/system-update-cleanup.service
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/system-update-pre.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/system-update.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/systemd-ask-password-wall.service
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/systemd-update-done.service
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/usb-gadget.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/user-.slice.d
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/user-.slice.d/10-defaults.conf
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/user.slice
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/systemd-update-done
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/systemd-update-helper
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user-generators
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user-preset
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user-preset/90-systemd.preset
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/app.slice
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/background.slice
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/basic.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/bluetooth.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/exit.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/graphical-session-pre.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/graphical-session.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/paths.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/printer.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/session.slice
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/shutdown.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/smartcard.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/sockets.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/sound.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/systemd-exit.service
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/systemd-tmpfiles-clean.service
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/systemd-tmpfiles-clean.timer
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/systemd-tmpfiles-setup.service
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/timers.target
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/sysusers.d/README
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/tmpfiles.d/README
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/60-persistent-alsa.rules
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/60-persistent-v4l.rules
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/70-camera.rules
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/70-joystick.rules
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/70-mouse.rules
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/70-touchpad.rules
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/78-sound-card.rules
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/README
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/v4l_id
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/dbus-1/services
-/aarch64-bottlerocket-linux-gnu/sys-root/usr/share/dbus-1/system.d

diff --git a/before/bottlerocket-systemd-console.aarch64.txt b/after/bottlerocket-systemd-console.aarch64.txt
index 86899aa..dc99eab 100644
--- a/before/bottlerocket-systemd-console.aarch64.txt
+++ b/after/bottlerocket-systemd-console.aarch64.txt
+/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/systemd-ask-password-wall.service

diff --git a/before/bottlerocket-systemd-console.x86_64.txt b/after/bottlerocket-systemd-console.x86_64.txt
index 4d4a38c..e0a76ff 100644
--- a/before/bottlerocket-systemd-console.x86_64.txt
+++ b/after/bottlerocket-systemd-console.x86_64.txt
+/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/systemd-ask-password-wall.service

diff --git a/before/bottlerocket-systemd-networkd.aarch64.txt b/after/bottlerocket-systemd-networkd.aarch64.txt
index 1662c8a..648f1ae 100644
--- a/before/bottlerocket-systemd-networkd.aarch64.txt
+++ b/after/bottlerocket-systemd-networkd.aarch64.txt
+/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/network

diff --git a/before/bottlerocket-systemd-networkd.x86_64.txt b/after/bottlerocket-systemd-networkd.x86_64.txt
index f5d3836..7dcd2e8 100644
--- a/before/bottlerocket-systemd-networkd.x86_64.txt
+++ b/after/bottlerocket-systemd-networkd.x86_64.txt
+/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/network

diff --git a/before/bottlerocket-systemd.x86_64.txt b/after/bottlerocket-systemd.x86_64.txt
index e3de8b0..af3f706 100644
--- a/before/bottlerocket-systemd.x86_64.txt
+++ b/after/bottlerocket-systemd.x86_64.txt
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/modprobe.d/README
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/sysctl.d/README
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.be.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.be@latin.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.bg.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.da.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.de.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.fr.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.hr.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.hu.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.it.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.ko.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.pl.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.pt_BR.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.ru.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.sr.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.zh_CN.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/catalog/systemd.zh_TW.catalog
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/network
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system-generators/systemd-system-update-generator
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/bluetooth.target
+/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/dbus-org.freedesktop.login1.service
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/initrd-root-fs.target.wants
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/initrd-root-fs.target.wants/systemd-repart.service
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/printer.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/remote-fs-pre.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/remote-fs.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/smartcard.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/sound.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/sysinit.target.wants/systemd-update-done.service
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/system-update-cleanup.service
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/system-update-pre.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/system-update.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/systemd-ask-password-wall.service
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/systemd-update-done.service
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/usb-gadget.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/user-.slice.d
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/user-.slice.d/10-defaults.conf
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/user.slice
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/systemd-update-done
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/systemd-update-helper
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user-generators
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user-preset
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user-preset/90-systemd.preset
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/app.slice
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/background.slice
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/basic.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/bluetooth.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/exit.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/graphical-session-pre.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/graphical-session.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/paths.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/printer.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/session.slice
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/shutdown.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/smartcard.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/sockets.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/sound.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/systemd-exit.service
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/systemd-tmpfiles-clean.service
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/systemd-tmpfiles-clean.timer
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/systemd-tmpfiles-setup.service
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/user/timers.target
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/sysusers.d/README
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/tmpfiles.d/README
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/60-persistent-alsa.rules
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/60-persistent-v4l.rules
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/70-camera.rules
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/70-joystick.rules
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/70-mouse.rules
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/70-touchpad.rules
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/78-sound-card.rules
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/rules.d/README
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/udev/v4l_id
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/dbus-1/services
-/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/dbus-1/system.d
``` 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
