### PR TITLE
mdadm: fix usage of /var/run in tmpfiles snippet

### DIFF
--- a/packages/mdadm/mdadm-tmpfiles.conf
+++ b/packages/mdadm/mdadm-tmpfiles.conf
@@ -1,2 +1,2 @@
-d /var/run/mdadm 0700 root root -
-Z /var/run/mdadm 0700 root root -
+d /run/mdadm 0700 root root -
+Z /run/mdadm 0700 root root -


### PR DESCRIPTION
**Issue number:**
Fixes #441

**Description of changes:**
Use `/run` instead of `/var/run` in `mdadm.conf`.


**Testing done:**
Before, `systemd-tmpfiles` logs warnings in the journal and fixes the path.

After, no warnings are printed, and `/run/mdadm` is still created.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
