### PR TITLE
optimize gzip decompression for containerd 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "libgcc",
  "libglib",
  "libinih",
+ "libisal",
  "libiw",
  "libjson-c",
  "libmnl",
@@ -574,6 +575,13 @@ dependencies = [
 
 [[package]]
 name = "libinih"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "libisal"
 version = "0.1.0"
 dependencies = [
  "glibc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
   "packages/libgcc",
   "packages/libglib",
   "packages/libinih",
+  "packages/libisal",
   "packages/libiw",
   "packages/libmnl",
   "packages/libncurses",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -73,6 +73,7 @@ libjson-c = { path = "../../packages/libjson-c" }
 libgcc = { path = "../../packages/libgcc" }
 libglib = { path = "../../packages/libglib" }
 libinih = { path = "../../packages/libinih" }
+libisal = { path = "../../packages/libisal" }
 libiw = { path = "../../packages/libiw" }
 libmnl = { path = "../../packages/libmnl" }
 libncurses = { path = "../../packages/libncurses" }

--- a/packages/containerd/1001-Use-Intel-ISA-L-s-igzip-if-available.patch
+++ b/packages/containerd/1001-Use-Intel-ISA-L-s-igzip-if-available.patch
@@ -1,0 +1,183 @@
+From 796ca04aa424a7770f79079917b7fcd18c993a57 Mon Sep 17 00:00:00 2001
+From: Kazuyoshi Kato <kaz@fly.io>
+Date: Thu, 5 Oct 2023 22:11:14 -0700
+Subject: [PATCH 1/2] Use Intel ISA-L's igzip if available
+
+Intel ISA-L is Intel's open source (BSD) library that outperforms both
+gzip and pigz. This commit checks and uses igzip if available.
+
+Signed-off-by: Kazuyoshi Kato <kaz@fly.io>
+(cherry picked from commit 34378ec9b4579c9f647dd6724fcb04b3390bc3dd)
+---
+ archive/compression/benchmark_test.go   | 28 +++++++++++++------
+ archive/compression/compression.go      | 36 ++++++++++++++-----------
+ archive/compression/compression_test.go | 10 +++----
+ 3 files changed, 46 insertions(+), 28 deletions(-)
+
+diff --git a/archive/compression/benchmark_test.go b/archive/compression/benchmark_test.go
+index f8340802a..845f5f9e8 100644
+--- a/archive/compression/benchmark_test.go
++++ b/archive/compression/benchmark_test.go
+@@ -20,6 +20,7 @@ import (
+ 	"fmt"
+ 	"io"
+ 	"net/http"
++	"os/exec"
+ 	"testing"
+ 
+ 	"github.com/stretchr/testify/require"
+@@ -49,19 +50,30 @@ func BenchmarkDecompression(b *testing.B) {
+ 		zstd := testCompress(b, data, Zstd)
+ 
+ 		b.Run(fmt.Sprintf("size=%dMiB", sizeInMiB), func(b *testing.B) {
+-			b.Run("gzip", func(b *testing.B) {
+-				testDecompress(b, gz)
+-			})
++			original := gzipPath
++			defer func() {
++				gzipPath = original
++			}()
++
+ 			b.Run("zstd", func(b *testing.B) {
+ 				testDecompress(b, zstd)
+ 			})
+-			if unpigzPath != "" {
+-				original := unpigzPath
+-				unpigzPath = ""
+-				b.Run("gzipPureGo", func(b *testing.B) {
++
++			gzipPath = ""
++			b.Run("gzipPureGo", func(b *testing.B) {
++				testDecompress(b, gz)
++			})
++			gzipPath, err = exec.LookPath("igzip")
++			if err == nil {
++				b.Run("igzip", func(b *testing.B) {
++					testDecompress(b, gz)
++				})
++			}
++			gzipPath, err = exec.LookPath("unpigz")
++			if err == nil {
++				b.Run("unpigz", func(b *testing.B) {
+ 					testDecompress(b, gz)
+ 				})
+-				unpigzPath = original
+ 			}
+ 		})
+ 	}
+diff --git a/archive/compression/compression.go b/archive/compression/compression.go
+index 23ddfab1a..5ad13eccf 100644
+--- a/archive/compression/compression.go
++++ b/archive/compression/compression.go
+@@ -47,11 +47,14 @@ const (
+ 	Zstd
+ )
+ 
+-const disablePigzEnv = "CONTAINERD_DISABLE_PIGZ"
++const (
++	disablePigzEnv  = "CONTAINERD_DISABLE_PIGZ"
++	disableIgzipEnv = "CONTAINERD_DISABLE_IGZIP"
++)
+ 
+ var (
+-	initPigz   sync.Once
+-	unpigzPath string
++	initGzip sync.Once
++	gzipPath string
+ )
+ 
+ var (
+@@ -259,17 +262,20 @@ func (compression *Compression) Extension() string {
+ }
+ 
+ func gzipDecompress(ctx context.Context, buf io.Reader) (io.ReadCloser, error) {
+-	initPigz.Do(func() {
+-		if unpigzPath = detectPigz(); unpigzPath != "" {
+-			log.L.Debug("using pigz for decompression")
++	initGzip.Do(func() {
++		if gzipPath = detectCommand("igzip", disableIgzipEnv); gzipPath != "" {
++			log.L.Debug("using igzip for decompression")
++			return
++		}
++		if gzipPath = detectCommand("unpigz", disablePigzEnv); gzipPath != "" {
++			log.L.Debug("using unpigz for decompression")
+ 		}
+ 	})
+ 
+-	if unpigzPath == "" {
++	if gzipPath == "" {
+ 		return gzip.NewReader(buf)
+ 	}
+-
+-	return cmdStream(exec.CommandContext(ctx, unpigzPath, "-d", "-c"), buf)
++	return cmdStream(exec.CommandContext(ctx, gzipPath, "-d", "-c"), buf)
+ }
+ 
+ func cmdStream(cmd *exec.Cmd, in io.Reader) (io.ReadCloser, error) {
+@@ -296,22 +302,22 @@ func cmdStream(cmd *exec.Cmd, in io.Reader) (io.ReadCloser, error) {
+ 	return reader, nil
+ }
+ 
+-func detectPigz() string {
+-	path, err := exec.LookPath("unpigz")
++func detectCommand(path, disableEnvName string) string {
++	path, err := exec.LookPath(path)
+ 	if err != nil {
+-		log.L.WithError(err).Debug("unpigz not found, falling back to go gzip")
++		log.L.WithError(err).Debugf("%s not found", path)
+ 		return ""
+ 	}
+ 
+-	// Check if pigz disabled via CONTAINERD_DISABLE_PIGZ env variable
+-	value := os.Getenv(disablePigzEnv)
++	// Check if this command is disabled via the env variable
++	value := os.Getenv(disableEnvName)
+ 	if value == "" {
+ 		return path
+ 	}
+ 
+ 	disable, err := strconv.ParseBool(value)
+ 	if err != nil {
+-		log.L.WithError(err).Warnf("could not parse %s: %s", disablePigzEnv, value)
++		log.L.WithError(err).Warnf("could not parse %s: %s", disableEnvName, value)
+ 		return path
+ 	}
+ 
+diff --git a/archive/compression/compression_test.go b/archive/compression/compression_test.go
+index f9a535dde..64f61b4a5 100644
+--- a/archive/compression/compression_test.go
++++ b/archive/compression/compression_test.go
+@@ -101,9 +101,9 @@ func testCompressDecompress(t testing.TB, size int, compression Compression) Dec
+ }
+ 
+ func TestCompressDecompressGzip(t *testing.T) {
+-	oldUnpigzPath := unpigzPath
+-	unpigzPath = ""
+-	defer func() { unpigzPath = oldUnpigzPath }()
++	oldUnpigzPath := gzipPath
++	gzipPath = ""
++	defer func() { gzipPath = oldUnpigzPath }()
+ 
+ 	decompressor := testCompressDecompress(t, 1024*1024, Gzip)
+ 	wrapper := decompressor.(*readCloserWrapper)
+@@ -147,7 +147,7 @@ func TestDetectPigz(t *testing.T) {
+ 
+ 	t.Setenv("PATH", tempPath)
+ 
+-	if pigzPath := detectPigz(); pigzPath == "" {
++	if pigzPath := detectCommand("unpigz", disablePigzEnv); pigzPath == "" {
+ 		t.Fatal("failed to detect pigz path")
+ 	} else if pigzPath != fullPath {
+ 		t.Fatalf("wrong pigz found: %s != %s", pigzPath, fullPath)
+@@ -155,7 +155,7 @@ func TestDetectPigz(t *testing.T) {
+ 
+ 	t.Setenv(disablePigzEnv, "1")
+ 
+-	if pigzPath := detectPigz(); pigzPath != "" {
++	if pigzPath := detectCommand("unpigz", disablePigzEnv); pigzPath != "" {
+ 		t.Fatalf("disable via %s doesn't work", disablePigzEnv)
+ 	}
+ }
+-- 
+2.47.0
+

--- a/packages/containerd/1002-Skip-exec.LookPath-if-a-specific-gzip-implementation.patch
+++ b/packages/containerd/1002-Skip-exec.LookPath-if-a-specific-gzip-implementation.patch
@@ -1,0 +1,60 @@
+From 8a769caffd5dcae9b59f7ddc8a9e54331e3ae870 Mon Sep 17 00:00:00 2001
+From: kaz <kato.kazuyoshi@gmail.com>
+Date: Fri, 6 Oct 2023 09:20:08 -0700
+Subject: [PATCH 2/2] Skip exec.LookPath if a specific gzip implementation is
+ disabled
+
+Both pigz and igzip can be disabled via the environment variables.
+If disabled, calling exec.LookPath and logging "not found" message is,
+even in the debug level, doesn't make much sense.
+
+Signed-off-by: Kazuyoshi Kato <kaz@fly.io>
+(cherry picked from commit 535916d1d0a586acad617ceb37f07be487a09847)
+---
+ archive/compression/compression.go | 25 +++++++++++--------------
+ 1 file changed, 11 insertions(+), 14 deletions(-)
+
+diff --git a/archive/compression/compression.go b/archive/compression/compression.go
+index 5ad13eccf..91cb2305d 100644
+--- a/archive/compression/compression.go
++++ b/archive/compression/compression.go
+@@ -303,25 +303,22 @@ func cmdStream(cmd *exec.Cmd, in io.Reader) (io.ReadCloser, error) {
+ }
+ 
+ func detectCommand(path, disableEnvName string) string {
+-	path, err := exec.LookPath(path)
+-	if err != nil {
+-		log.L.WithError(err).Debugf("%s not found", path)
+-		return ""
+-	}
+-
+ 	// Check if this command is disabled via the env variable
+ 	value := os.Getenv(disableEnvName)
+-	if value == "" {
+-		return path
+-	}
++	if value != "" {
++		disable, err := strconv.ParseBool(value)
++		if err != nil {
++			log.L.WithError(err).Warnf("could not parse %s: %s", disableEnvName, value)
++		}
+ 
+-	disable, err := strconv.ParseBool(value)
+-	if err != nil {
+-		log.L.WithError(err).Warnf("could not parse %s: %s", disableEnvName, value)
+-		return path
++		if disable {
++			return ""
++		}
+ 	}
+ 
+-	if disable {
++	path, err := exec.LookPath(path)
++	if err != nil {
++		log.L.WithError(err).Debugf("%s not found", path)
+ 		return ""
+ 	}
+ 
+-- 
+2.47.0
+

--- a/packages/containerd/containerd-disable-igzip.conf
+++ b/packages/containerd/containerd-disable-igzip.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=CONTAINERD_DISABLE_IGZIP=1

--- a/packages/containerd/containerd-disable-pigz.conf
+++ b/packages/containerd/containerd-disable-pigz.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=CONTAINERD_DISABLE_PIGZ=1

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -31,6 +31,10 @@ Source110: prepare-var-lib-containerd.service
 
 Source1000: clarify.toml
 
+# Backport of upstream patches for igzip support.
+Patch1001: 1001-Use-Intel-ISA-L-s-igzip-if-available.patch
+Patch1002: 1002-Skip-exec.LookPath-if-a-specific-gzip-implementation.patch
+
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}runc

--- a/packages/containerd/containerd.spec
+++ b/packages/containerd/containerd.spec
@@ -29,6 +29,10 @@ Source100: etc-containerd.mount
 # Create container storage mount point.
 Source110: prepare-var-lib-containerd.service
 
+# Drop-ins to disable igzip or pigz if the other implementation is preferred.
+Source200: containerd-disable-igzip.conf
+Source201: containerd-disable-pigz.conf
+
 Source1000: clarify.toml
 
 # Backport of upstream patches for igzip support.
@@ -38,7 +42,7 @@ Patch1002: 1002-Skip-exec.LookPath-if-a-specific-gzip-implementation.patch
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}runc
-Requires: %{_cross_os}pigz
+Requires: %{_cross_os}containerd(optimized-gunzip)
 Requires: %{name}(binaries)
 
 %description
@@ -60,6 +64,30 @@ Requires: (%{_cross_os}image-feature(fips) and %{name})
 Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 
 %description fips-bin
+%{summary}.
+
+%package pigz
+Summary: Prefer pigz for gzip decompression
+Requires: %{_cross_os}pigz
+Requires: %{name}
+Conflicts: %{name}-igzip
+Provides: %{_cross_os}containerd(optimized-gunzip) = 1:
+
+%description pigz
+%{summary}.
+
+%package igzip
+Summary: Prefer igzip for gzip decompression
+Requires: %{_cross_os}igzip
+Requires: %{name}
+Conflicts: %{name}-pigz
+%if "%{_cross_arch}" == "x86_64"
+Provides: %{_cross_os}containerd(optimized-gunzip) = 2:
+%else
+Provides: %{_cross_os}containerd(optimized-gunzip) = 0:
+%endif
+
+%description igzip
 %{summary}.
 
 %prep
@@ -112,6 +140,10 @@ install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
 
+install -d %{buildroot}%{_cross_unitdir}/containerd.service.d
+install -p -m 0644 %{S:200} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
+install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-pigz.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files
@@ -139,5 +171,11 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
 %{_cross_fips_bindir}/containerd-shim-runc-v1
 %{_cross_fips_bindir}/containerd-shim-runc-v2
 %{_cross_fips_bindir}/ctr
+
+%files pigz
+%{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
+
+%files igzip
+%{_cross_unitdir}/containerd.service.d/005-disable-pigz.conf
 
 %changelog

--- a/packages/libisal/0001-igzip-increase-stdin-and-stdout-pipe-sizes.patch
+++ b/packages/libisal/0001-igzip-increase-stdin-and-stdout-pipe-sizes.patch
@@ -1,0 +1,49 @@
+From 27c24697b497495d5af5a8d8040ebbe6a2fdc23c Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Wed, 19 Mar 2025 18:13:17 +0000
+Subject: [PATCH] igzip: increase stdin and stdout pipe sizes
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ programs/igzip_cli.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/programs/igzip_cli.c b/programs/igzip_cli.c
+index f85ef96..d80df8b 100644
+--- a/programs/igzip_cli.c
++++ b/programs/igzip_cli.c
+@@ -39,6 +39,7 @@
+ #include <stdbool.h>
+ #include <stdarg.h>
+ #include <errno.h>
++#include <fcntl.h>
+ #include "igzip_lib.h" /* Normally you use isa-l.h instead for external programs */
+ 
+ #if defined(HAVE_THREADS)
+@@ -392,8 +393,10 @@ void
+ open_in_file(FILE **in, char *infile_name)
+ {
+         *in = NULL;
+-        if (infile_name == NULL)
++        if (infile_name == NULL) {
+                 *in = stdin;
++                fcntl(STDIN_FILENO, F_SETPIPE_SZ, BLOCK_SIZE);
++        }
+         else
+                 *in = fopen_safe(infile_name, "rb");
+ }
+@@ -402,8 +405,10 @@ void
+ open_out_file(FILE **out, char *outfile_name)
+ {
+         *out = NULL;
+-        if (global_options.use_stdout)
++        if (global_options.use_stdout) {
+                 *out = stdout;
++                fcntl(STDOUT_FILENO, F_SETPIPE_SZ, BLOCK_SIZE);
++        }
+         else if (outfile_name != NULL)
+                 *out = fopen_safe(outfile_name, "wb");
+         else if (!isatty(fileno(stdout)) || global_options.force)
+-- 
+2.48.1
+

--- a/packages/libisal/Cargo.toml
+++ b/packages/libisal/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "libisal"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/intel/isa-l/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/intel/isa-l/archive/v2.31.1/isa-l-2.31.1.tar.gz"
+sha512 = "65199d054af1edc26d477883f7878f25fd4db65622aa98247069f1296c5f07b75da24f0361a6c3889ddb3168d940b508cd2f6340548a62ff3157977179fd002d"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/libisal/libisal.spec
+++ b/packages/libisal/libisal.spec
@@ -1,0 +1,60 @@
+Name: %{_cross_os}libisal
+Version: 2.31.1
+Release: 1%{?dist}
+Summary: Library for Intel ISA
+License: BSD-3-Clause
+URL: https://github.com/intel/isa-l
+Source0: https://github.com/intel/isa-l/archive/v%{version}/isa-l-%{version}.tar.gz
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the library for Intel ISA
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%package -n %{_cross_os}igzip
+Summary: Compress or decompress files using the library for Intel ISA
+Requires: %{name}
+
+%description -n %{_cross_os}igzip
+%{summary}.
+
+%prep
+%autosetup -n isa-l-%{version} -p1
+
+%build
+autoreconf -fi
+%cross_configure \
+  --enable-static \
+  %{nil}
+
+%force_disable_rpath
+
+%make_build
+
+%install
+%make_install
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_libdir}/*.so.*
+%exclude %{_cross_mandir}
+
+%files devel
+%{_cross_libdir}/*.a
+%{_cross_libdir}/*.so
+%{_cross_includedir}/isa-l.h
+%dir %{_cross_includedir}/isa-l
+%{_cross_includedir}/isa-l/*.h
+%{_cross_pkgconfigdir}/*.pc
+
+%files -n %{_cross_os}igzip
+%{_cross_bindir}/igzip
+
+%changelog

--- a/packages/libisal/libisal.spec
+++ b/packages/libisal/libisal.spec
@@ -5,6 +5,10 @@ Summary: Library for Intel ISA
 License: BSD-3-Clause
 URL: https://github.com/intel/isa-l
 Source0: https://github.com/intel/isa-l/archive/v%{version}/isa-l-%{version}.tar.gz
+
+# Patch to optimize stdin / stdout pipe usage for containerd.
+Patch0001: 0001-igzip-increase-stdin-and-stdout-pipe-sizes.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 
 %description

--- a/packages/libz/Cargo.toml
+++ b/packages/libz/Cargo.toml
@@ -9,15 +9,11 @@ build = "../build.rs"
 path = "../packages.rs"
 
 [package.metadata.build-package]
-releases-url = "https://www.zlib.net"
+releases-url = "https://github.com/zlib-ng/zlib-ng/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.zlib.net/zlib-1.3.1.tar.xz"
-sha512 = "1e8e70b362d64a233591906a1f50b59001db04ca14aaffad522198b04680be501736e7d536b4191e2f99767e7001ca486cd802362cca2be05d5d409b83ea732d"
-
-[[package.metadata.build-package.external-files]]
-url = "https://www.zlib.net/zlib-1.3.1.tar.xz.asc"
-sha512 = "d181e9772a8139b3b2f3f42b994a65a966101db35eb46b5c84021c5eb0cc3b4511eb5e9172c509483bd9f7015794b15cfca78ed0959bd91e8216dc12c1c6e668"
+url = "https://github.com/zlib-ng/zlib-ng/archive/2.2.4/zlib-ng-2.2.4.tar.gz"
+sha512 = "f49a89497988db55a2f2375f79443e7e2c57470dbd94b35ae38a39d988eb42f8ecc295a1bd68845fc273b59ea508d0e74b142585d85b7e869dd3c01cc6923d8d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libz/libz.spec
+++ b/packages/libz/libz.spec
@@ -1,13 +1,11 @@
 Name: %{_cross_os}libz
-Version: 1.3.1
+Version: 2.2.4
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for zlib compression
-URL: https://www.zlib.net/
+URL: https://github.com/zlib-ng/zlib-ng
 License: Zlib
-Source0: https://www.zlib.net/zlib-%{version}.tar.xz
-Source1: https://www.zlib.net/zlib-%{version}.tar.xz.asc
-Source2: gpgkey-5ED46A6721D365587791E2AA783FCD8E58BCAFBA.asc
+Source0: https://github.com/zlib-ng/zlib-ng/archive/%{version}/zlib-ng-%{version}.tar.gz
 BuildRequires: %{_cross_os}glibc-devel
 
 %description
@@ -21,8 +19,7 @@ Requires: %{name}
 %{summary}.
 
 %prep
-%{gpgverify} --data=%{S:0} --signature=%{S:1} --keyring=%{S:2}
-%autosetup -n zlib-%{version} -p1
+%autosetup -n zlib-ng-%{version} -p1
 
 # Sets cross build flags, target cross compiler, and env variables
 # required to `make install` libz
@@ -33,8 +30,10 @@ export CROSS_PREFIX="%{_cross_target}-" \\\
 
 %build
 %set_env
-# zlib only reads prefix from this argument, not the environment
-./configure --prefix='%{_cross_prefix}'
+./configure \
+  --prefix='%{_cross_prefix}' \
+  --without-new-strategies \
+  --zlib-compat
 %make_build
 
 %install
@@ -42,7 +41,7 @@ export CROSS_PREFIX="%{_cross_target}-" \\\
 %make_install
 
 %files
-%license README
+%license LICENSE.md
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_mandir}


### PR DESCRIPTION
**Issue number:**
Fixes #392

**Description of changes:**
Switch to zlib-ng as the upstream for zlib, which improves the performance of `pigz`, and add `igzip` as an optimized decompressor for x86_64.

Backport support for `igzip` to containerd 1.7, and adjust the dependencies so that `pigz` is preferred for aarch64 and `igzip` is preferred for x86_64.

Add a patch to `igzip` to adjust the pipe size for stdin and stdout to 1 MiB, which greatly improves performance if either one is a pipe.

**Testing done:**
Pulled a 23 GiB image via `ctr`. 
```
ctr image pull nvcr.io/nvidia/pytorch:25.02-py3
```

For x86_64, I used an `m6id.16xlarge` instance type. For aarch64, I used an `m7gd.16xlarge` instance type. Both had the instance store disks configured as the backing store for container images:
```
[settings.bootstrap-commands.ephemeral-storage]
commands = [
  ["apiclient", "ephemeral-storage", "init"],
  ["apiclient", "ephemeral-storage" ,"bind", "--dirs", "/var/lib/containerd", "/var/lib/kubelet", "/var/log/pods"]]
essential = true
mode = "always"
```

Before, using the official `aws-k8s-1.32` v1.34.0 AMIs:
```
# x86_64 with pigz+zlib
unpacking linux/amd64 sha256:50e2ea138815ed088a60e6d642c9d0298b98a42b90666f7f19924640ccc519eb...
done: 2m20.592503638s

# aarch64 with pigz+zlib
unpacking linux/arm64/v8 sha256:50e2ea138815ed088a60e6d642c9d0298b98a42b90666f7f19924640ccc519eb...
done: 1m40.090797734s
```

After, using `aws-k8s-1.32` AMIs built with these changes:
```
# x86_64 with igzip
unpacking linux/amd64 sha256:50e2ea138815ed088a60e6d642c9d0298b98a42b90666f7f19924640ccc519eb...
done: 1m5.287939797s

# aarch64 with pigz+zlib-ng
unpacking linux/arm64/v8 sha256:50e2ea138815ed088a60e6d642c9d0298b98a42b90666f7f19924640ccc519eb...
done: 1m22.394084064s
```

For x86_64, image unpack time decreased by 53%. For aarch64, image unpack time decreased by 18%.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
