### PR TITLE
Third party packages update - readline

### DIFF
--- a/packages/readline/Cargo.toml
+++ b/packages/readline/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://ftp.gnu.org/gnu/readline"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz"
-sha512 = "0a451d459146bfdeecc9cdd94bda6a6416d3e93abd80885a40b334312f16eb890f8618a27ca26868cebbddf1224983e631b1cbc002c1a4d1cd0d65fba9fea49a"
+url = "https://ftp.gnu.org/gnu/readline/readline-8.2.13.tar.gz"
+sha512 = "53476c88fedcc8831bc4926c32943700dc6e99b1aa17b68fb1e59d885c609db9e335314428f98d962e4f06a1ef5433e763ec1b6fa41ee5580c05ec5380ba563a"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/readline/readline-8.2.tar.gz.sig"
-sha512 = "0effd273689e5f7fe7e049c8f2c5f3c97149f198a90d053231ee4de34901560a465ab0d4fd71fd07c7d7e233caed7f42e5b668bffaf1e23a7eb373c8f9e150fe"
+url = "https://ftp.gnu.org/gnu/readline/readline-8.2.13.tar.gz.sig"
+sha512 = "e2ee2ebc0c24620b9e69123487670a7576342442525e5c6996943e80053d51cabf9aca8583bc8bfcdd2bf81deefdea67ceae872c598e27babf50408b26451040"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/readline/readline.spec
+++ b/packages/readline/readline.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}readline
-Version: 8.2
+Version: 8.2.13
 Release: 1%{?dist}
 Summary: A library for editing typed command lines
 License: GPL-3.0-or-later


### PR DESCRIPTION
**Description of changes:**
- Updated `readline` v8.2  &rarr; v8.2.13

✅ Upload packages in look aside cache

**Testing done:**
- core-kit builds
- bash test - I am able to create an ami and login to a bottlerocket instance and run `lsblk`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
