### PR TITLE
nvidia-container-toolkit: add a comment in spec file to clarify why do we need non-template config files

### DIFF
--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -14,6 +14,8 @@ License: Apache-2.0
 URL: https://%{goimport}
 
 Source0: https://%{goimport}/archive/v%{gover}/nvidia-container-toolkit-%{gover}.tar.gz
+# non-templated version of the config files for k8s are provided for downstream
+# builders that don't use the NVIDIA Container Runtime settings
 Source1: nvidia-container-toolkit-config-k8s.toml
 Source2: nvidia-container-toolkit-config-ecs.toml
 Source3: nvidia-oci-hooks-json


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
**Issue number:**
Closes [#450](https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/450)


**Description of changes:**
- add a comment in nvidia-container-runtim.spce for mom-template config files

```
bash-5.1# cat /etc/nvidia-container-runtime/config.toml
### generated from the template file ###
accept-nvidia-visible-devices-as-volume-mounts = true
accept-nvidia-visible-devices-envvar-when-unprivileged = false

[nvidia-container-cli]
root = "/"
path = "/usr/bin/nvidia-container-cli"
environment = []
ldconfig = "@/sbin/ldconfig"
```


**Testing done:**
build a AMI and testing if the nvidia gpu is still working
- checking the nvidia and OS version
```
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "833cf9ad-dirty",
    "pretty_name": "Bottlerocket OS 1.35.0 (aws-k8s-1.27-nvidia)",
    "variant_id": "aws-k8s-1.27-nvidia",
    "version_id": "1.35.0"
  }
}
```
- running a pod and running a nvidia workload test
```
╰$ kubectl get pod
NAME        READY   STATUS    RESTARTS   AGE
move-test   1/1     Running   0          2m23s
╭─ in ~/k8s
╰$ kubectl logs move-test
╭─ in ~/k8s
╰$ cat pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: move-test
spec:
  restartPolicy: OnFailure
  containers:
    - name: test
      image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2
      command: ["sleep", "infinity"]
      resources:
        limits:
          nvidia.com/gpu: 1

╭─ in ~/k8s
╰$ kubectl exec -it move-test -- /bin/bash
root@move-test:/# find / -name vectorAdd
/tmp/vectorAdd
root@move-test:/# /tmp/vectorAdd
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done
root@move-test:/#
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
