### PR TITLE
packages: remove GO_MAJOR="1.22" export

### DIFF
--- a/packages/aws-otel-collector/aws-otel-collector.spec
+++ b/packages/aws-otel-collector/aws-otel-collector.spec
@@ -45,7 +45,6 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %autosetup -n %{gorepo}-%{version} -p1
 
 %build
-export GO_MAJOR="1.22"
 
 %set_cross_go_flags
 

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -171,7 +171,6 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
-export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make generated_files
 

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -161,7 +161,6 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
-export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -158,7 +158,6 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
-export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -144,7 +144,6 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
-export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -144,7 +144,6 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 
 %build
 export FORCE_HOST_GO=1
-export GO_MAJOR="1.22"
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -145,8 +145,6 @@ cp third_party/forked/golang/PATENTS PATENTS.golang
 %build
 export FORCE_HOST_GO=1
 
-export GO_MAJOR="1.22"
-
 # Build codegen programs with the host toolchain.
 make hack/update-codegen.sh
 

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -48,7 +48,6 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %cross_go_setup %{gorepo}-%{gover} %{goproject} %{goimport}
 
 %build
-export GO_MAJOR="1.22"
 %cross_go_configure %{goimport}
 # We don't set `-Wl,-z,now`, because the binary uses lazy loading
 # to load the NVIDIA libraries in the host


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket-sdk/issues/262

**Description of changes:**

Remove the `export GO_MAJOR="1.22"` line from pkg specs since we are working on dropping Go 1.22 from the SDK.

This won't break the current core-kit pkgs since the Go major default is still 1.22 in SDK: https://github.com/bottlerocket-os/bottlerocket-sdk/blob/develop/Dockerfile#L1275

**Testing done:**

- `make ARCH=x86_64 && make ARCH=aarch64`

- Test suite run with Go major default set to 1.23 here: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/263

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
