### PR TITLE
schnauzer/host-ctr: add support for more aws regions

### DIFF
--- a/sources/api/schnauzer/src/helpers/mod.rs
+++ b/sources/api/schnauzer/src/helpers/mod.rs
@@ -36,6 +36,7 @@ lazy_static! {
         let mut m = HashMap::new();
         m.insert("af-south-1", "917644944286");
         m.insert("ap-east-1", "375569722642");
+        m.insert("ap-east-2", "905418444513");
         m.insert("ap-northeast-1", "328549459982");
         m.insert("ap-northeast-2", "328549459982");
         m.insert("ap-northeast-3", "328549459982");

--- a/sources/api/schnauzer/src/helpers/mod.rs
+++ b/sources/api/schnauzer/src/helpers/mod.rs
@@ -69,6 +69,11 @@ lazy_static! {
         m.insert("us-east-2", "328549459982");
         m.insert("us-gov-east-1", "388230364387");
         m.insert("us-gov-west-1", "347163068887");
+        m.insert("us-iso-east-1", "999945528765");
+        m.insert("us-iso-west-1", "928668704122");
+        m.insert("us-isob-east-1", "782457047625");
+        m.insert("us-isof-east-1", "891631471851");
+        m.insert("us-isof-south-1", "482061074055");
         m.insert("us-west-1", "328549459982");
         m.insert("us-west-2", "328549459982");
         m
@@ -104,6 +109,11 @@ lazy_static! {
         m.insert("cn-north-1", "bottlerocket-updates-cn-north-1.s3.dualstack");
         m.insert("cn-northwest-1", "bottlerocket-updates-cn-northwest-1.s3.dualstack");
         m.insert("eu-isoe-west-1", "bottlerocket-updates-eu-isoe-west-1.s3");
+        m.insert("us-iso-east-1", "bottlerocket-updates-us-iso-east-1.s3");
+        m.insert("us-iso-west-1", "bottlerocket-updates-us-iso-west-1.s3");
+        m.insert("us-isob-east-1", "bottlerocket-updates-us-isob-east-1.s3");
+        m.insert("us-isof-east-1", "bottlerocket-updates-us-isof-east-1.s3");
+        m.insert("us-isof-south-1", "bottlerocket-updates-us-isof-south-1.s3");
         m
     };
 }
@@ -119,6 +129,11 @@ lazy_static! {
         m.insert("eu-isoe-west-1", "aws-iso-e");
         m.insert("us-gov-east-1", "aws-us-gov");
         m.insert("us-gov-west-1", "aws-us-gov");
+        m.insert("us-iso-west-1", "aws-iso");
+        m.insert("us-iso-east-1", "aws-iso");
+        m.insert("us-isob-east-1", "aws-iso-b");
+        m.insert("us-isof-east-1", "aws-iso-f");
+        m.insert("us-isof-south-1", "aws-iso-f");
         m
     };
 }
@@ -1526,7 +1541,10 @@ fn ecr_registry<S: AsRef<str>>(region: S) -> String {
     };
     match partition {
         "aws-cn" => format!("{}.dkr.ecr.{}.amazonaws.com.cn", registry_id, region),
+        "aws-iso" => format!("{}.dkr.ecr.{}.c2s.ic.gov", registry_id, region),
+        "aws-iso-b" => format!("{}.dkr.ecr.{}.sc2s.sgov.gov", registry_id, region),
         "aws-iso-e" => format!("{}.dkr.ecr.{}.cloud.adc-e.uk", registry_id, region),
+        "aws-iso-f" => format!("{}.dkr.ecr.{}.csp.hci.ic.gov", registry_id, region),
         _ => {
             // Only inject the FIPS service endpoint if the variant is in FIPS mode and the
             // region supports FIPS.
@@ -1554,7 +1572,10 @@ fn tuf_repository<S: AsRef<str>>(region: S) -> String {
     };
     match partition {
         "aws-cn" => format!("https://{}.{}.amazonaws.com.cn/latest", endpoint, region),
+        "aws-iso" => format!("https://{}.{}.c2s.ic.gov/latest", endpoint, region),
+        "aws-iso-b" => format!("https://{}.{}.sc2s.sgov.gov/latest", endpoint, region),
         "aws-iso-e" => format!("https://{}.{}.cloud.adc-e.uk/latest", endpoint, region),
+        "aws-iso-f" => format!("https://{}.{}.csp.hci.ic.gov/latest", endpoint, region),
         _ => format!("https://{}.{}.amazonaws.com/latest", endpoint, region),
     }
 }
@@ -1728,6 +1749,26 @@ mod test_ecr_registry {
             "eu-isoe-west-1",
             "589460436674.dkr.ecr.eu-isoe-west-1.cloud.adc-e.uk/bottlerocket-admin:v0.5.1",
         ),
+        (
+            "us-iso-east-1",
+            "999945528765.dkr.ecr.us-iso-east-1.c2s.ic.gov/bottlerocket-admin:v0.5.1",
+        ),
+        (
+            "us-iso-west-1",
+            "928668704122.dkr.ecr.us-iso-west-1.c2s.ic.gov/bottlerocket-admin:v0.5.1",
+        ),
+        (
+            "us-isob-east-1",
+            "782457047625.dkr.ecr.us-isob-east-1.sc2s.sgov.gov/bottlerocket-admin:v0.5.1",
+        ),
+        (
+            "us-isof-south-1",
+            "482061074055.dkr.ecr.us-isof-south-1.csp.hci.ic.gov/bottlerocket-admin:v0.5.1",
+        ),
+        (
+            "us-isof-east-1",
+            "891631471851.dkr.ecr.us-isof-east-1.csp.hci.ic.gov/bottlerocket-admin:v0.5.1",
+        ),
     ];
 
     const ADMIN_CONTAINER_TEMPLATE: &str =
@@ -1777,6 +1818,7 @@ mod test_tuf_repository {
         "https://bottlerocket-updates-cn-north-1.s3.dualstack.cn-north-1.amazonaws.com.cn/latest/metadata/2020-07-07/";
 
     const EXPECTED_URL_EU_ISOE_WEST_1: &str = "https://bottlerocket-updates-eu-isoe-west-1.s3.eu-isoe-west-1.cloud.adc-e.uk/latest/metadata/2020-07-07/";
+    const EXPECTED_URL_US_ISOF_EAST_1: &str = "https://bottlerocket-updates-us-isof-east-1.s3.us-isof-east-1.csp.hci.ic.gov/latest/metadata/2020-07-07/";
 
     #[test]
     fn url_af_south_1() {
@@ -1816,6 +1858,16 @@ mod test_tuf_repository {
         )
         .unwrap();
         assert_eq!(result, EXPECTED_URL_EU_ISOE_WEST_1);
+    }
+
+    #[test]
+    fn url_us_isof_east_1() {
+        let result = setup_and_render_template(
+            METADATA_TEMPLATE,
+            &json!({"settings": {"aws": {"region": "us-isof-east-1"}}}),
+        )
+        .unwrap();
+        assert_eq!(result, EXPECTED_URL_US_ISOF_EAST_1);
     }
 }
 

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -47,8 +47,9 @@ var ecrRegex = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(-fips)?\.([a-zA-Z0-9]
 // A set of currently supported ECR regions which are not yet present in the golang SDK
 var ecrRefPrefixMapping = map[string]string{
 	"ap-southeast-7":  "ecr.aws/arn:aws:ecr:ap-southeast-7:",
-	"eu-isoe-west-1":  "ecr.aws/arn:aws-iso-e:ecr:eu-isoe-west-1:",
 	"mx-central-1":    "ecr.aws/arn:aws:ecr:mx-central-1:",
+	"ap-east-2":       "ecr.aws/arn:aws:ecr:ap-east-2:",
+	"eu-isoe-west-1":  "ecr.aws/arn:aws-iso-e:ecr:eu-isoe-west-1:",
 	"us-iso-east-1":   "ecr.aws/arn:aws-iso:ecr:us-iso-east-1:",
 	"us-iso-west-1":   "ecr.aws/arn:aws-iso:ecr:us-iso-west-1:",
 	"us-isob-east-1":  "ecr.aws/arn:aws-iso-b:ecr:us-isob-east-1:",

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -18,13 +18,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecrpublic"
 	"github.com/awslabs/amazon-ecr-containerd-resolver/ecr"
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/api/types/runc/options"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
@@ -39,13 +39,21 @@ import (
 // Example 2: 777777777777.dkr.ecr.cn-north-1.amazonaws.com.cn/my_image:latest
 // Example 3: 777777777777.dkr.ecr.eu-isoe-west-1.cloud.adc-e.uk/my_image:latest
 // Example 4: 777777777777.dkr.ecr-fips.us-west-2.amazonaws.com/my_image:latest
-var ecrRegex = regexp.MustCompile(`(^[a-zA-Z0-9][a-zA-Z0-9-_]*)\.dkr\.ecr(-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(\.cn)?|cloud\.adc-e\.uk).*`)
+
+// ECR hostname pattern also used in the ecr-credential-provider:
+// https://github.com/kubernetes/cloud-provider-aws/blob/212135d0d7b448cd34e2e11e5e81f59e3e6c2d7a/cmd/ecr-credential-provider/main.go#L45
+var ecrRegex = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov).*$`)
 
 // A set of currently supported ECR regions which are not yet present in the golang SDK
 var ecrRefPrefixMapping = map[string]string{
-	"ap-southeast-7": "ecr.aws/arn:aws:ecr:ap-southeast-7:",
-	"eu-isoe-west-1": "ecr.aws/arn:aws-iso-e:ecr:eu-isoe-west-1:",
-	"mx-central-1":   "ecr.aws/arn:aws:ecr:mx-central-1:",
+	"ap-southeast-7":  "ecr.aws/arn:aws:ecr:ap-southeast-7:",
+	"eu-isoe-west-1":  "ecr.aws/arn:aws-iso-e:ecr:eu-isoe-west-1:",
+	"mx-central-1":    "ecr.aws/arn:aws:ecr:mx-central-1:",
+	"us-iso-east-1":   "ecr.aws/arn:aws-iso:ecr:us-iso-east-1:",
+	"us-iso-west-1":   "ecr.aws/arn:aws-iso:ecr:us-iso-west-1:",
+	"us-isob-east-1":  "ecr.aws/arn:aws-iso-b:ecr:us-isob-east-1:",
+	"us-isof-south-1": "ecr.aws/arn:aws-iso-f:ecr:us-isof-south-1:",
+	"us-isof-east-1":  "ecr.aws/arn:aws-iso-f:ecr:us-isof-east-1:",
 }
 
 // A set of the currently supported FIPS regions for ECR: https://docs.aws.amazon.com/general/latest/gr/ecr.html

--- a/sources/host-ctr/cmd/host-ctr/main_test.go
+++ b/sources/host-ctr/cmd/host-ctr/main_test.go
@@ -203,6 +203,39 @@ func TestParseImageURIAsECR(t *testing.T) {
 			},
 		},
 		{
+			"Parse special region",
+			"777777777777.dkr.ecr.us-iso-east-1.c2s.ic.gov/my_image:latest",
+			false,
+			&parsedECR{
+				Account:  "777777777777",
+				Region:   "us-iso-east-1",
+				RepoPath: "my_image:latest",
+				Fips:     false,
+			},
+		},
+		{
+			"Parse special region",
+			"777777777777.dkr.ecr.us-isob-east-1.sc2s.sgov.gov/my_image:latest",
+			false,
+			&parsedECR{
+				Account:  "777777777777",
+				Region:   "us-isob-east-1",
+				RepoPath: "my_image:latest",
+				Fips:     false,
+			},
+		},
+		{
+			"Parse special region",
+			"777777777777.dkr.ecr.us-isof-east-1.csp.hci.ic.gov/my_image:latest",
+			false,
+			&parsedECR{
+				Account:  "777777777777",
+				Region:   "us-isof-east-1",
+				RepoPath: "my_image:latest",
+				Fips:     false,
+			},
+		},
+		{
 			"Parse FIPS region for normal use-cases",
 			"777777777777.dkr.ecr-fips.us-west-2.amazonaws.com/my_image:latest",
 			false,
@@ -254,9 +287,14 @@ func TestFetchECRRef(t *testing.T) {
 			"us-gov-west-1": true,
 		},
 		EcrRefPrefixMappings: map[string]string{
-			"ap-southeast-7": "ecr.aws/arn:aws:ecr:ap-southeast-7:",
-			"eu-isoe-west-1": "ecr.aws/arn:aws-iso-e:ecr:eu-isoe-west-1:",
-			"mx-central-1":   "ecr.aws/arn:aws:ecr:mx-central-1:",
+			"ap-southeast-7":  "ecr.aws/arn:aws:ecr:ap-southeast-7:",
+			"eu-isoe-west-1":  "ecr.aws/arn:aws-iso-e:ecr:eu-isoe-west-1:",
+			"mx-central-1":    "ecr.aws/arn:aws:ecr:mx-central-1:",
+			"us-iso-east-1":   "ecr.aws/arn:aws-iso:ecr:us-iso-east-1:",
+			"us-iso-west-1":   "ecr.aws/arn:aws-iso:ecr:us-iso-west-1:",
+			"us-isob-east-1":  "ecr.aws/arn:aws-iso-b:ecr:us-isob-east-1:",
+			"us-isof-south-1": "ecr.aws/arn:aws-iso-f:ecr:us-isof-south-1:",
+			"us-isof-east-1":  "ecr.aws/arn:aws-iso-f:ecr:us-isof-east-1:",
 		},
 	}
 	tests := []struct {
@@ -279,9 +317,39 @@ func TestFetchECRRef(t *testing.T) {
 		},
 		{
 			"Parse special region",
-			"111111111111.dkr.ecr.mx-central-1.amazonaws.com/bottlerocket-control:v0.7.17",
+			"111111111111.dkr.ecr.us-iso-east-1.c2s.ic.gov/bottlerocket/container:1.2.3",
 			false,
-			"ecr.aws/arn:aws:ecr:mx-central-1:111111111111:repository/bottlerocket-control:v0.7.17",
+			"ecr.aws/arn:aws-iso:ecr:us-iso-east-1:111111111111:repository/bottlerocket/container:1.2.3",
+		},
+		{
+			"Parse special region",
+			"111111111111.dkr.ecr.us-isob-east-1.sc2s.sgov.gov/bottlerocket-control:v0.7.17",
+			false,
+			"ecr.aws/arn:aws-iso-b:ecr:us-isob-east-1:111111111111:repository/bottlerocket-control:v0.7.17",
+		},
+		{
+			"Parse special region",
+			"111111111111.dkr.ecr.us-iso-west-1.c2s.ic.gov/bottlerocket/container:1.2.3",
+			false,
+			"ecr.aws/arn:aws-iso:ecr:us-iso-west-1:111111111111:repository/bottlerocket/container:1.2.3",
+		},
+		{
+			"Parse special region",
+			"111111111111.dkr.ecr.us-isof-south-1.csp.hci.ic.gov/bottlerocket-control:v0.7.17",
+			false,
+			"ecr.aws/arn:aws-iso-f:ecr:us-isof-south-1:111111111111:repository/bottlerocket-control:v0.7.17",
+		},
+		{
+			"Parse special region",
+			"111111111111.dkr.ecr.us-isof-east-1.csp.hci.ic.gov/bottlerocket-control:v0.7.17",
+			false,
+			"ecr.aws/arn:aws-iso-f:ecr:us-isof-east-1:111111111111:repository/bottlerocket-control:v0.7.17",
+		},
+		{
+			"Parse special region",
+			"111111111111.dkr.ecr.eu-isoe-west-1.amazonaws.com/bottlerocket/container:1.2.3",
+			false,
+			"ecr.aws/arn:aws-iso-e:ecr:eu-isoe-west-1:111111111111:repository/bottlerocket/container:1.2.3",
 		},
 		{
 			"Parse China regions",


### PR DESCRIPTION
**Description of changes:**
* schnauzer: Added support for ISO, ISOB, ISOF partitions
* schnauzer: Added support for ap-east-2 in ECR map
* host-ctr: Added support for parsing ISO, ISOB, ISOF ECR URIs, as well as converting such URIs to ARNs
* host-ctr: Added support for ap-east-2

**Testing done:**
* [x] Unit tests pass
* [x] Smoke testing of host-ctr on an AMI


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
