### PR TITLE
migrator: clear configuration-files and services

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3350,6 +3350,7 @@ dependencies = [
  "generate-readme",
  "log",
  "lz4",
+ "maplit",
  "models",
  "nix",
  "pentacle",

--- a/sources/api/migration/migrator/Cargo.toml
+++ b/sources/api/migration/migrator/Cargo.toml
@@ -42,6 +42,7 @@ generate-readme.workspace = true
 
 [dev-dependencies]
 chrono = { workspace = true, features = ["clock", "std"] }
+maplit.workspace = true
 storewolf.workspace = true
 tempfile.workspace = true
 

--- a/sources/api/migration/migrator/src/main.rs
+++ b/sources/api/migration/migrator/src/main.rs
@@ -75,11 +75,16 @@ async fn main() {
     }
 }
 
-async fn get_current_version<P>(datastore_dir: P) -> Result<Version>
+async fn get_current_version<P>(datastore_path: P) -> Result<Version>
 where
     P: AsRef<Path>,
 {
-    let datastore_dir = datastore_dir.as_ref();
+    let datastore_path = datastore_path.as_ref();
+    let datastore_dir = datastore_path
+        .parent()
+        .context(error::DataStoreLinkToRootSnafu {
+            path: datastore_path,
+        })?;
 
     // Find the current patch version link, which contains our full version number
     let current = datastore_dir.join("current");
@@ -116,27 +121,9 @@ where
 }
 
 pub(crate) async fn run(args: &Args) -> Result<()> {
-    let migrated_datastore = perform_migrations(args).await?;
+    let current_version = get_current_version(&args.datastore_path).await?;
 
-    // Remove all the weak setting and all metadata
-    let datastore =
-        remove_weak_settings_and_metadata(migrated_datastore, &args.migrate_to_version).await?;
-    flip_to_new_version(&args.migrate_to_version, datastore).await?;
-
-    Ok(())
-}
-
-pub(crate) async fn perform_migrations(args: &Args) -> Result<PathBuf> {
-    // Get the directory we're working in.
-    let datastore_dir = args
-        .datastore_path
-        .parent()
-        .context(error::DataStoreLinkToRootSnafu {
-            path: &args.datastore_path,
-        })?;
-
-    let current_version = get_current_version(datastore_dir).await?;
-    let direction = Direction::from_versions(&current_version, &args.migrate_to_version)
+    let migration_version_meta = MigrationVersionMeta::new(current_version, args.migrate_to_version.clone())
         .unwrap_or_else(|| {
             info!(
                 "Requested version {} matches version of given datastore at '{}'; nothing to do. Exiting from migrator.",
@@ -146,6 +133,40 @@ pub(crate) async fn perform_migrations(args: &Args) -> Result<PathBuf> {
             process::exit(0);
         });
 
+    let migrated_datastore = perform_migrations(&migration_version_meta, args).await?;
+
+    let datastore =
+        remove_transient_datastore_entries(migrated_datastore, &args.migrate_to_version).await?;
+
+    flip_to_new_version(&args.migrate_to_version, datastore).await?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct MigrationVersionMeta {
+    pub(crate) current_version: Version,
+    pub(crate) target_version: Version,
+    pub(crate) direction: Direction,
+}
+
+impl MigrationVersionMeta {
+    /// Creates a new `MigrationVersionMeta`
+    ///
+    /// Returns `None` if `current_version` == `target_version`.
+    pub(crate) fn new(current_version: Version, target_version: Version) -> Option<Self> {
+        Direction::from_versions(&current_version, &target_version).map(|direction| Self {
+            current_version,
+            target_version,
+            direction,
+        })
+    }
+}
+
+pub(crate) async fn perform_migrations(
+    version_meta: &MigrationVersionMeta,
+    args: &Args,
+) -> Result<PathBuf> {
     // create URLs from the metadata and targets directory paths
     let metadata_base_url = Url::from_directory_path(&args.metadata_directory).map_err(|_| {
         error::Error::DirectoryUrl {
@@ -192,9 +213,12 @@ pub(crate) async fn perform_migrations(args: &Args) -> Result<PathBuf> {
         .await
         .context(error::RepoLoadSnafu)?;
     let manifest = load_manifest(repo.clone()).await?;
-    let migrations =
-        update_metadata::find_migrations(&current_version, &args.migrate_to_version, &manifest)
-            .context(error::FindMigrationsSnafu)?;
+    let migrations = update_metadata::find_migrations(
+        &version_meta.current_version,
+        &version_meta.target_version,
+        &manifest,
+    )
+    .context(error::FindMigrationsSnafu)?;
 
     if migrations.is_empty() {
         // Not all new OS versions need to change the data store format.  If there's been no
@@ -203,14 +227,8 @@ pub(crate) async fn perform_migrations(args: &Args) -> Result<PathBuf> {
         // have a chain of symlinks that could go past the maximum depth.)
         Ok(args.datastore_path.clone())
     } else {
-        let copy_path = run_migrations(
-            &repo,
-            direction,
-            &migrations,
-            &args.datastore_path,
-            &args.migrate_to_version,
-        )
-        .await?;
+        let copy_path =
+            run_migrations(&repo, version_meta, &migrations, &args.datastore_path).await?;
         Ok(copy_path)
     }
 }
@@ -251,8 +269,16 @@ where
     Ok(to)
 }
 
-/// Removes weak settings and delete all metadata.
-async fn remove_weak_settings_and_metadata<P>(
+/// Removes transient data from the datastore.
+///
+/// This data is typically repopulated to new defaults later in the boot process by storewolf
+/// (for static defaults) and sundog (for dynamic ones.)
+///
+/// Transient data includes:
+/// * Settings where the `strength` metadata is set to `weak`
+/// * All settings metadata
+/// * Bottlerocket services and configuration files
+async fn remove_transient_datastore_entries<P>(
     datastore_path: P,
     new_version: &Version,
 ) -> Result<PathBuf>
@@ -270,11 +296,11 @@ where
     let source = DataStoreImplementation::new(source_datastore);
     let mut target = DataStoreImplementation::new(&target_datastore);
 
-    copy_without_weak_settings_and_metadata(source, &mut target)?;
+    copy_without_transient_entries(source, &mut target)?;
     Ok(target_datastore)
 }
 
-fn copy_without_weak_settings_and_metadata(
+fn copy_without_transient_entries(
     source: impl DataStore,
     target: &mut impl DataStore,
 ) -> Result<()> {
@@ -290,6 +316,8 @@ fn copy_without_weak_settings_and_metadata(
 
         remove_weak_setting_from_datastore(&mut input)?;
         remove_metadata_from_datastore(&mut input)?;
+        remove_keys_with_prefix(&mut input, "configuration-files.")?;
+        remove_keys_with_prefix(&mut input, "services.")?;
 
         set_output_data(target, &input, &committed)?;
     }
@@ -323,6 +351,12 @@ fn remove_metadata_from_datastore(datastore: &mut DataStoreData) -> Result<()> {
     Ok(())
 }
 
+// Removes all data from the datastore where the key begins with the given prefix
+fn remove_keys_with_prefix(datastore: &mut DataStoreData, prefix: &str) -> Result<()> {
+    datastore.data.retain(|key, _| !key.starts_with(prefix));
+    Ok(())
+}
+
 /// Runs the given migrations in their given order.  The given direction is passed to each
 /// migration so it knows which direction we're migrating.
 ///
@@ -330,10 +364,9 @@ fn remove_metadata_from_datastore(datastore: &mut DataStoreData) -> Result<()> {
 /// previous migration, and the final output becomes the new data store.
 async fn run_migrations<P, S>(
     repository: &tough::Repository,
-    direction: Direction,
+    version_meta: &MigrationVersionMeta,
     migrations: &[S],
     source_datastore: P,
-    new_version: &Version,
 ) -> Result<PathBuf>
 where
     P: AsRef<Path>,
@@ -381,13 +414,13 @@ where
         })?;
 
         let mut command_args = vec![
-            direction.to_string(),
+            version_meta.direction.to_string(),
             "--source-datastore".to_string(),
             source_datastore.display().to_string(),
         ];
 
         // Create a new output location for this migration.
-        target_datastore = new_datastore_location(source_datastore, new_version)?;
+        target_datastore = new_datastore_location(source_datastore, &version_meta.target_version)?;
 
         command_args.push("--target-datastore".to_string());
         command_args.push(target_datastore.display().to_string());

--- a/sources/api/migration/migrator/src/test.rs
+++ b/sources/api/migration/migrator/src/test.rs
@@ -1,7 +1,9 @@
 //! Provides an end-to-end test of `migrator` via the `run` function. This module is conditionally
 //! compiled for cfg(test) only.
 use crate::args::Args;
-use crate::{copy_without_weak_settings_and_metadata, flip_to_new_version, perform_migrations};
+use crate::{
+    copy_without_transient_entries, flip_to_new_version, perform_migrations, MigrationVersionMeta,
+};
 use chrono::{DateTime, Utc};
 use datastore::memory::MemoryDataStore;
 use datastore::{serialize_scalar, Committed, DataStore, Key};
@@ -341,7 +343,8 @@ async fn list_dir_files(dir: impl AsRef<Path>) -> Vec<PathBuf> {
 async fn migrate_forward() {
     let from_version = Version::parse("0.99.0").unwrap();
     let to_version = Version::parse("0.99.1").unwrap();
-    let test_datastore = TestDatastore::new(from_version);
+    let version_meta = MigrationVersionMeta::new(from_version.clone(), to_version.clone()).unwrap();
+    let test_datastore = TestDatastore::new(from_version.clone());
     let test_repo = create_test_repo(TestType::Success).await;
     let args = Args {
         datastore_path: test_datastore.datastore.clone(),
@@ -351,7 +354,7 @@ async fn migrate_forward() {
         root_path: root(),
         metadata_directory: test_repo.metadata_path.clone(),
     };
-    let datastore = perform_migrations(&args).await.unwrap();
+    let datastore = perform_migrations(&version_meta, &args).await.unwrap();
     // the migrations should write to a file named result.txt.
     let output_file = test_datastore.tmp.path().join("result.txt");
     let contents = std::fs::read_to_string(&output_file).unwrap();
@@ -393,7 +396,8 @@ async fn migrate_forward() {
 async fn migrate_backward() {
     let from_version = Version::parse("0.99.1").unwrap();
     let to_version = Version::parse("0.99.0").unwrap();
-    let test_datastore = TestDatastore::new(from_version);
+    let version_meta = MigrationVersionMeta::new(from_version.clone(), to_version.clone()).unwrap();
+    let test_datastore = TestDatastore::new(from_version.clone());
     let test_repo = create_test_repo(TestType::Success).await;
     let args = Args {
         datastore_path: test_datastore.datastore.clone(),
@@ -403,7 +407,7 @@ async fn migrate_backward() {
         root_path: root(),
         metadata_directory: test_repo.metadata_path.clone(),
     };
-    let datastore = perform_migrations(&args).await.unwrap();
+    let datastore = perform_migrations(&version_meta, &args).await.unwrap();
     let output_file = test_datastore.tmp.path().join("result.txt");
     let contents = std::fs::read_to_string(&output_file).unwrap();
     let lines: Vec<&str> = contents.split('\n').collect();
@@ -442,6 +446,7 @@ async fn migrate_backward() {
 async fn migrate_forward_with_failed_migration() {
     let from_version = Version::parse("0.99.0").unwrap();
     let to_version = Version::parse("0.99.1").unwrap();
+    let version_meta = MigrationVersionMeta::new(from_version.clone(), to_version.clone()).unwrap();
     let test_datastore = TestDatastore::new(from_version.clone());
     let test_repo = create_test_repo(TestType::ForwardFailure).await;
     let args = Args {
@@ -452,7 +457,7 @@ async fn migrate_forward_with_failed_migration() {
         root_path: root(),
         metadata_directory: test_repo.metadata_path.clone(),
     };
-    let result = perform_migrations(&args).await;
+    let result = perform_migrations(&version_meta, &args).await;
     assert!(result.is_err());
 
     // the migrations should write to a file named result.txt.
@@ -495,6 +500,7 @@ async fn migrate_forward_with_failed_migration() {
 async fn migrate_backward_with_failed_migration() {
     let from_version = Version::parse("0.99.1").unwrap();
     let to_version = Version::parse("0.99.0").unwrap();
+    let version_meta = MigrationVersionMeta::new(from_version.clone(), to_version.clone()).unwrap();
     let test_datastore = TestDatastore::new(from_version.clone());
     let test_repo = create_test_repo(TestType::BackwardFailure).await;
     let args = Args {
@@ -505,7 +511,7 @@ async fn migrate_backward_with_failed_migration() {
         root_path: root(),
         metadata_directory: test_repo.metadata_path.clone(),
     };
-    let result = perform_migrations(&args).await;
+    let result = perform_migrations(&version_meta, &args).await;
     assert!(result.is_err());
 
     let output_file = test_datastore.tmp.path().join("result.txt");
@@ -566,7 +572,7 @@ async fn test_remove_all_metadata() {
 
     let mut target = MemoryDataStore::new();
 
-    let result = copy_without_weak_settings_and_metadata(source, &mut target);
+    let result = copy_without_transient_entries(source, &mut target);
     assert!(result.is_ok());
 
     // Ensure that metadata does not exists in the target datastore
@@ -627,7 +633,7 @@ async fn test_only_weak_settings_are_removed() {
 
     let mut target = MemoryDataStore::new();
 
-    let result = copy_without_weak_settings_and_metadata(source, &mut target);
+    let result = copy_without_transient_entries(source, &mut target);
     assert!(result.is_ok());
 
     // Ensure that metadata does not exists in the target datastore
@@ -638,4 +644,56 @@ async fn test_only_weak_settings_are_removed() {
     let strong_data = target.get_key(&strong_data_key, &Committed::Live).unwrap();
     assert!(strong_data.is_some());
     assert_eq!(strong_data.unwrap(), strong_data_value);
+}
+
+#[tokio::test]
+async fn test_configuration_files_data_removed() {
+    let mut source = MemoryDataStore::new();
+    source.set_keys(&maplit::hashmap! {
+        Key::new(datastore::KeyType::Data, "settings.a.b").unwrap() => "\"hello\"",
+        Key::new(datastore::KeyType::Data, "settings.a.c").unwrap() => "\"world\"",
+        Key::new(datastore::KeyType::Data, "something-else.d.e").unwrap() => "\"bottlerocket\"",
+        Key::new(datastore::KeyType::Data, "yet-another-thing.f.g").unwrap() => "\"rules\"",
+        Key::new(datastore::KeyType::Data, "configuration-files.aws-config.path").unwrap() => "\"/root/.aws/config\"",
+        Key::new(datastore::KeyType::Data, "configuration-files.aws-config.template-path").unwrap() => "\"/usr/share/templates/aws-config\"",
+    }, &Committed::Live).unwrap();
+
+    let mut target = MemoryDataStore::new();
+    copy_without_transient_entries(source, &mut target).unwrap();
+
+    assert_eq!(
+        target.get_prefix("", &Committed::Live).unwrap(),
+        maplit::hashmap! {
+            Key::new(datastore::KeyType::Data, "settings.a.b").unwrap() => "\"hello\"".to_string(),
+            Key::new(datastore::KeyType::Data, "settings.a.c").unwrap() => "\"world\"".to_string(),
+            Key::new(datastore::KeyType::Data, "something-else.d.e").unwrap() => "\"bottlerocket\"".to_string(),
+            Key::new(datastore::KeyType::Data, "yet-another-thing.f.g").unwrap() => "\"rules\"".to_string(),
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_services_removed() {
+    let mut source = MemoryDataStore::new();
+    source.set_keys(&maplit::hashmap! {
+        Key::new(datastore::KeyType::Data, "settings.a.b").unwrap() => "\"hello\"",
+        Key::new(datastore::KeyType::Data, "settings.a.c").unwrap() => "\"world\"",
+        Key::new(datastore::KeyType::Data, "something-else.d.e").unwrap() => "\"bottlerocket\"",
+        Key::new(datastore::KeyType::Data, "yet-another-thing.f.g").unwrap() => "\"rules\"",
+        Key::new(datastore::KeyType::Data, "services.dns.configuration-files").unwrap() => "[\"netdog-toml\"]",
+        Key::new(datastore::KeyType::Data, "services.aws.restart-commands").unwrap() => "[]",
+    }, &Committed::Live).unwrap();
+
+    let mut target = MemoryDataStore::new();
+    copy_without_transient_entries(source, &mut target).unwrap();
+
+    assert_eq!(
+        target.get_prefix("", &Committed::Live).unwrap(),
+        maplit::hashmap! {
+            Key::new(datastore::KeyType::Data, "settings.a.b").unwrap() => "\"hello\"".to_string(),
+            Key::new(datastore::KeyType::Data, "settings.a.c").unwrap() => "\"world\"".to_string(),
+            Key::new(datastore::KeyType::Data, "something-else.d.e").unwrap() => "\"bottlerocket\"".to_string(),
+            Key::new(datastore::KeyType::Data, "yet-another-thing.f.g").unwrap() => "\"rules\"".to_string(),
+        }
+    );
 }


### PR DESCRIPTION
**Description of changes:**
In `bottlerocket-core-kit` [v6.0.0](https://github.com/bottlerocket-os/bottlerocket-core-kit/releases/tag/v6.0.0) we began to clear weak settings and all metadata from Bottlerocket's datastore whenever the migrator performed an upgrade or downgrade.

This change expands this behavior to "transient data" which also now includes:
* `services` -- configurations for processes to restart when certain Bottlerocket settings change
* `configuration-files` -- Configuration files to re-render from templates when certain Bottlerocket settings change.

The change also includes a slight refactor of migrator to make it more clear that the process will exit when no version change has occurred.

**Testing done:**
* [x] Unit testing
* [x] Ensure configuration-files and services are cleared & restored on upgrade
* [x] Ensure configuration-files and services are cleared & restored on downgrade


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
