### PR TITLE
Third party package and Rust dependency updates

### DIFF
--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ssm-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.1802.0/amazon-ssm-agent-3.3.1802.0.tar.gz"
-sha512 = "16be1f20b423b194cf8836fa27534523c988ceea6017241fbd35eb33274bcbfe05eae5ad5034ea89705cf24ad60611863d8a0e776c449c046c5835585015bc3a"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.1957.0/amazon-ssm-agent-3.3.1957.0.tar.gz"
+sha512 = "ee3ef0c05c308e81c35e1e63f33522684fe3ae4016a2769643a59e97f581383fb9abff16b12bbfdf1e097522ffb9872daf35e2b37157c278542e00f8270f0c8a"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.3.1802.0
+Version: 3.3.1957.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0

--- a/packages/aws-otel-collector/Cargo.toml
+++ b/packages/aws-otel-collector/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws-observability/aws-otel-collector/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.41.1/aws-otel-collector-v0.41.1.tar.gz"
-sha512 = "8e6436e4cec7d4f02468ad69fd6b26c97a9b592083da2725daa0b4c4777c34b2127dadc217c13be7c8de53bde021165aacbc1e5fecbd9ae0cae26d9fea8327e4"
+url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.43.1/aws-otel-collector-v0.43.1.tar.gz"
+sha512 = "8c5537c4bbdb661afebb49f0fcd926c7122dbc338394fdb0e695379f709623a7c1854f050bc02e6ab0990d12c4c6e6b0dc4268aa69b4d6e88025f6ec6df75ec7"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/aws-otel-collector/aws-otel-collector.spec
+++ b/packages/aws-otel-collector/aws-otel-collector.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}aws-otel-collector
-Version: 0.41.1
+Version: 0.43.1
 Release: 1%{?dist}
 Epoch: 1
 Summary: AWS Distro for OpenTelemetry Collector

--- a/packages/docker-cli/Cargo.toml
+++ b/packages/docker-cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/docker/cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v25.0.5/cli-25.0.5.tar.gz"
-sha512 = "39f49514605a3c78661f105094f9c28beb01927a2d7dc474048c2a27135ca8c3f075a6f05157a176c032d5e7c105f00c9100c15713298b33bd34a6f399bac84d"
+url = "https://github.com/docker/cli/archive/v25.0.7/cli-25.0.7.tar.gz"
+sha512 = "0d1a688ab402329b5f4e17c36b596c0db7af4203c376472c6e8585fb9dece33df707b080c35e2866923239f04d623642199dbf3702b02dd99756c8a71b306722"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 25.0.5
+%global gover 25.0.7
 %global rpmver %{gover}
-%global gitrev 5dc9bcc5b78ed23f12cdd68e4285ea1c216ce2a1 
+%global gitrev 5dc9bcc5b78ed23f12cdd68e4285ea1c216ce2a1
 
 %global source_date_epoch 1492525740
 

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v25.0.6/moby-25.0.6.tar.gz"
-sha512 = "dc3370927654dd2b0d201d112effc8b83416a4df4ed1c5ac6ffaec40a260b0ebdf95107e8f3dcfe91e54f885697273a2b415541f5ea87ec7c491f6325c51a4cc"
+url = "https://github.com/moby/moby/archive/v25.0.8/moby-25.0.8.tar.gz"
+sha512 = "573f738df9fa1655c56ba5836fcfd0691521b81c4807e09156dd2813b172219b283b7ff1639f19379b46a7c3e1b0da4c8ae4f11f96e50e7efb0587d6bcc682fa"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,7 +3,7 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 25.0.6
+%global gover 25.0.8
 %global rpmver %{gover}
 %global gitrev b08a51fe16eed67de3861c03b363ba403643b12e
 

--- a/packages/ecs-agent/0003-bottlerocket-bind-introspection-to-localhost.patch
+++ b/packages/ecs-agent/0003-bottlerocket-bind-introspection-to-localhost.patch
@@ -1,25 +1,26 @@
-From 4341f9ecc3e527ffd2329359e86c5f74e64c5b74 Mon Sep 17 00:00:00 2001
-From: Samuel Karp <skarp@amazon.com>
-Date: Fri, 21 Aug 2020 11:07:32 -0700
+From f7c3bf0c6520c0a7c18173d28feb5c127c6f0417 Mon Sep 17 00:00:00 2001
+From: Piyush Jena <piyushjena1996@gmail.com>
+Date: Tue, 8 Apr 2025 08:45:59 +0000
 Subject: [PATCH] bottlerocket: bind introspection to localhost
 
+Signed-off-by: Piyush Jena <piyushjena1996@gmail.com>
 ---
- agent/handlers/introspection_server_setup.go | 2 +-
+ .../aws/amazon-ecs-agent/ecs-agent/introspection/server.go      | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/agent/handlers/introspection_server_setup.go b/agent/handlers/introspection_server_setup.go
-index 3ca0ecc..b7f70e9 100644
---- a/agent/handlers/introspection_server_setup.go
-+++ b/agent/handlers/introspection_server_setup.go
-@@ -88,7 +88,7 @@ func introspectionServerSetup(containerInstanceArn *string, taskEngine handlersu
- 		wTimeout = writeTimeoutForPprof
- 	}
- 	server := &http.Server{
--		Addr:         ":" + strconv.Itoa(config.AgentIntrospectionPort),
-+		Addr:         "127.0.0.1:" + strconv.Itoa(config.AgentIntrospectionPort),
- 		Handler:      loggingServeMux,
- 		ReadTimeout:  readTimeout,
+diff --git a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/server.go b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/server.go
+index 156f496f6..3740f241b 100644
+--- a/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/server.go
++++ b/agent/vendor/github.com/aws/amazon-ecs-agent/ecs-agent/introspection/server.go
+@@ -163,7 +163,7 @@ func setup(
+ 	loggingServeMux.Handle("/", logging.NewLoggingHandler(serveMux))
+
+ 	return &http.Server{
+-		Addr:         ":" + strconv.Itoa(Port),
++		Addr:         "127.0.0.1:" + strconv.Itoa(Port),
+ 		Handler:      panicHandler(loggingServeMux, metricsFactory),
+ 		ReadTimeout:  config.readTimeout,
  		WriteTimeout: wTimeout,
--- 
-2.40.1
+--
+2.47.1
 

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.89.2/amazon-ecs-agent-1.89.2.tar.gz"
-sha512 = "024f30daa6192f6e03771e507d776d01ec2c86b6cd7682e3b62d5f0e3e1b017b56360ca8e088ea183a4d04e104dc6e2e572ad9658d4bfcdab166d579a3ee1bc8"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.91.2/amazon-ecs-agent-1.91.2.tar.gz"
+sha512 = "c079dc22ee60ff0701d9a66f59add26fcab02baae36c72f98e8397ea6747a1858c4df2cada9ed3e2af3657d65920d2495b0b94c88dfbd573a6485ce2a4d6a816"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,7 +2,7 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.89.2
+%global agent_gover 1.91.2
 
 # git rev-parse --short=8
 %global agent_gitrev b7e96508

--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/44/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/46/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
 sha512 = "17b51900b88e1b7cbcb0e9097c2fd84ab09b7a1c667616d22a5936b5fcf865de461c3e56cf3230badd6ebd01554d58f3da0eb44cae0e97ce2e10ab72a15333b2"
 
 [build-dependencies]

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 44
+%global releasever 46
 %global gover 1.28.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/33/artifacts/kubernetes/v1.29.14/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/35/artifacts/kubernetes/v1.29.14/kubernetes-src.tar.gz"
 sha512 = "bc7851aca6cc064c07a7982dc42161e67fc3255be98d92c824c15a111dd52d8e14da7ea685219bb9fc139071ad92eb70ef87cc44e87717663299122cf64f680e"
 
 [build-dependencies]

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 33
+%global releasever 35
 %global gover 1.29.14
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/26/artifacts/kubernetes/v1.30.10/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/28/artifacts/kubernetes/v1.30.10/kubernetes-src.tar.gz"
 sha512 = "97f6fa90f7f9c2298761cfb69e2454bac73e9534ba17056cf3f49e2dd128835ac9a23c59b7aea019df8742b42e5b4ef8dd22ba60df8982bb6ef764cdc0938afb"
 
 [build-dependencies]

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 26
+%global releasever 28
 %global gover 1.30.10
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/15/artifacts/kubernetes/v1.31.6/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/17/artifacts/kubernetes/v1.31.6/kubernetes-src.tar.gz"
 sha512 = "bc42e7af387b5fd49da3248ec3d9680315457ff6d4f8cc82dfa68a62750ff3e0e2980def4a3164d4638f730be314baf23c7a5a0116e864bd210a931d522db7e6"
 
 [build-dependencies]

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 15
+%global releasever 17
 %global gover 1.31.6
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.32/Cargo.toml
+++ b/packages/kubernetes-1.32/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.32"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/7/artifacts/kubernetes/v1.32.2/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/10/artifacts/kubernetes/v1.32.2/kubernetes-src.tar.gz"
 sha512 = "8dae5d4e9bd017b627eb08e6f62c81de04e3374a90f1eeacef1b0113834ade77c264061cfd5b764eb6df0748b01402f79098ae5d7c065feadefbdef1d4bfdc89"
 
 [build-dependencies]

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 7
+%global releasever 10
 %global gover 1.32.2
 %global rpmver %{gover}
 

--- a/packages/libzstd/Cargo.toml
+++ b/packages/libzstd/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://github.com/facebook/zstd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz"
-sha512 = "54a578f2484da0520a6e9a24f501b9540a3fe3806785d6bc9db79fc095b7c142a7c121387c7eecd460ca71446603584ef1ba4d29a33ca90873338c9ffbd04f14"
+url = "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz"
+sha512 = "b4de208f179b68d4c6454139ca60d66ed3ef3893a560d6159a056640f83d3ee67cdf6ffb88971cdba35449dba4b597eaa8b4ae908127ef7fd58c89f40bf9a705"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz.sig"
-sha512 = "aea8d07589a7bf26d0dd1047ca1c3448f41203d2da21fcb730d169529f87bcab1a3651775a1d39e8de17f5a0863fbd598c8becb0fed5d3c8c3154916ee7d51d1"
+url = "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz.sig"
+sha512 = "9d88171296cffd9b02700999c86d3509dc0349a857fc8961bb1fe34b7dfec19bd0c8622c79e02a0165f067ba28a8430c48804a937e548aa7f52d8ff482ba586c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libzstd/libzstd.spec
+++ b/packages/libzstd/libzstd.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libzstd
-Version: 1.5.6
+Version: 1.5.7
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for Zstandard compression

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3163,7 +3163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5499,9 +5499,9 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f60327896014cd6f78d6a15ef07de21d21b1046efc86e8046ecd48e688fc12"
+checksum = "6fe73519c5c485dc0b585088523ad861cda19836b2eb94896fac278db68bd5ab"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6035,7 +6035,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -199,7 +199,7 @@ tokio-test = "0.4"
 tokio-tungstenite = { version = "0.20", default-features = false }
 tokio-util = "0.7"
 toml = "0.8"
-tough = "0.19"
+tough = "0.20"
 tower = "0.4"
 tracing = "0.1"
 unindent = "0.2"


### PR DESCRIPTION
**Description of changes:**
- Updated `amazon-ssm-agent` v3.3.1802.0  &rarr; v3.3.1957.0
- Updated `aws-otel-collector` v0.41.1  &rarr; v0.43.1
- Updated `docker-cli` v25.0.5  &rarr; v25.0.7
- Updated `docker-engine` v25.0.6 &rarr; v25.0.8
- Updated `ecs-agent` v1.89.2  &rarr; v1.91.2
- Updated `libzstd` v1.5.6  &rarr; v1.5.7
- Updates kubernetes 1.28 through 1.32 to the latest upstream versions: https://github.com/aws/eks-distro?tab=readme-ov-file#releases
- Updated `tough` v0.19 &rarr; v0.20

✅ Upload packages in look aside cache

**Testing done:**
1. **tough**
Migration test

In current Bottlerocket version
```
[root@admin]# sheltie
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "af533f46-dirty",
    "pretty_name": "Bottlerocket OS 1.35.0 (aws-k8s-1.29-nvidia)",
    "variant_id": "aws-k8s-1.29-nvidia",
    "version_id": "1.35.0"
  }
}
bash-5.1# updog check-update -a --json
[
  {
    "variant": "aws-k8s-1.29-nvidia",
    "arch": "x86_64",
    "version": "1.36.0",
    "max_version": "1.36.0",
    "waves": {
      "0": "2025-04-04T00:08:37.864228309Z",
      "20": "2025-04-04T03:08:37.864228309Z",
      "102": "2025-04-04T23:08:37.864228309Z",
      "307": "2025-04-05T23:08:37.864228309Z",
      "819": "2025-04-07T23:08:37.864228309Z",
      "1228": "2025-04-08T23:08:37.864228309Z",
      "1843": "2025-04-09T23:08:37.864228309Z"
    },
    "images": {
      "boot": "bottlerocket-aws-k8s-1.29-nvidia-x86_64-1.36.0-af533f46-dirty-boot.ext4.lz4",
      "root": "bottlerocket-aws-k8s-1.29-nvidia-x86_64-1.36.0-af533f46-dirty-root.ext4.lz4",
      "hash": "bottlerocket-aws-k8s-1.29-nvidia-x86_64-1.36.0-af533f46-dirty-root.verity.lz4"
    }
  }
]
bash-5.1# updog update -i 1.36.0 -r -n
Starting update to 1.36.0
Reboot scheduled for Thu 2025-04-03 23:19:28 UTC, use 'shutdown -c' to cancel.
Update applied: aws-k8s-1.29-nvidia 1.36.0
```

In Bottlerocket 1.36
```
[root@admin]# sheltie
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "af533f46-dirty",
    "pretty_name": "Bottlerocket OS 1.36.0 (aws-k8s-1.29-nvidia)",
    "variant_id": "aws-k8s-1.29-nvidia",
    "version_id": "1.36.0"
  }
}
bash-5.1# signpost rollback-to-inactive
bash-5.1# apiclient reboot
23:21:20 [INFO] Rebooting, goodbye...
```

Back in Bottlerocket 1.35
```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "af533f46-dirty",
    "pretty_name": "Bottlerocket OS 1.35.0 (aws-k8s-1.29-nvidia)",
    "variant_id": "aws-k8s-1.29-nvidia",
    "version_id": "1.35.0"
  }
}
```

2. **libzstd**
✅ core-kit builds
✅ ami with the above core-kit boots

**aws-otel-collector**
Added the package in `aws-dev` and made sure the service is running
```
bash-5.1# systemctl status aws-otel-collector
● aws-otel-collector.service - AWS OTEL collector
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/aws-otel-collector.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Thu 2025-04-03 22:21:03 UTC; 55s ago
   Main PID: 1402 (aws-otel-collec)
      Tasks: 6 (limit: 1108)
     Memory: 45.0M
        CPU: 163ms
     CGroup: /system.slice/aws-otel-collector.service
             └─1402 /usr/bin/aws-otel-collector --config /etc/aws-otel-collector.yaml

Apr 03 22:21:11 ip-xxxxxxxxxxxxx.us-west-2.compute.internal aws-otel-collector[1402]: 2025-04-03T22:21:11.248Z        warn        grpc/clientconn.go:1381        [core] [Channel #3 SubChannel #4]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:4318", ServerNa…
Apr 03 22:21:11 ip-xxxxxxxxxxxxx.us-west-2.compute.internal aws-otel-collector[1402]: 2025-04-03T22:21:11.782Z        warn        grpc/clientconn.go:1381        [core] [Channel #1 SubChannel #2]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:4318", ServerNa…
Apr 03 22:21:15 ip-xxxxxxxxxxxxx.us-west-2.compute.internal aws-otel-collector[1402]: 2025-04-03T22:21:15.103Z        warn        grpc/clientconn.go:1381        [core] [Channel #3 SubChannel #4]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:4318", ServerNa…
Apr 03 22:21:16 ip-xxxxxxxxxxxxx.us-west-2.compute.internal aws-otel-collector[1402]: 2025-04-03T22:21:16.368Z        warn        grpc/clientconn.go:1381        [core] [Channel #1 SubChannel #2]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:4318", ServerNa…
Apr 03 22:21:22 ip-xxxxxxxxxxxxx.us-west-2.compute.internal aws-otel-collector[1402]: 2025-04-03T22:21:22.938Z        warn        grpc/clientconn.go:1381        [core] [Channel #3 SubChannel #4]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:4318", ServerNa…
Apr 03 22:21:23 ip-xxxxxxxxxxxxx.us-west-2.compute.internal aws-otel-collector[1402]: 2025-04-03T22:21:23.762Z        warn        grpc/clientconn.go:1381        [core] [Channel #1 SubChannel #2]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:4318", ServerNa…
Apr 03 22:21:33 ip-xxxxxxxxxxxxx.us-west-2.compute.internal aws-otel-collector[1402]: 2025-04-03T22:21:33.605Z        warn        grpc/clientconn.go:1381        [core] [Channel #1 SubChannel #2]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:4318", ServerNa…
Apr 03 22:21:34 ip-xxxxxxxxxxxxx.us-west-2.compute.internal aws-otel-collector[1402]: 2025-04-03T22:21:34.721Z        warn        grpc/clientconn.go:1381        [core] [Channel #3 SubChannel #4]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:4318", ServerNa…
Apr 03 22:21:50 ip-xxxxxxxxxxxxx.us-west-2.compute.internal aws-otel-collector[1402]: 2025-04-03T22:21:50.346Z        warn        grpc/clientconn.go:1381        [core] [Channel #1 SubChannel #2]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:4318", ServerNa…
Apr 03 22:21:53 ip-xxxxxxxxxxxxx.us-west-2.compute.internal aws-otel-collector[1402]: 2025-04-03T22:21:53.710Z        warn        grpc/clientconn.go:1381        [core] [Channel #3 SubChannel #4]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:4318", ServerNa…
Hint: Some lines were ellipsized, use -l to show in full.
```

3. **ecs**  - tests amazon-ssm-agent, docker-engine, docker-cli, ecs-agent
- **x86_64**
✅ NVIDIA Smoke test
✅ Internal Integration tests for ECS

- **aarch64**
✅ NVIDIA Smoke test
✅ Internal Integration tests for ECS

4. **k8s** - tests k8s 1.28-1.32
- **x86_64**
```
NAME                                            TYPE           STATE             PASSED       FAILED       SKIPPED   BUILD ID             LAST UPDATE
 x86-64-aws-k8s-128-conformance                  Test           passed               384            0          7012   d949ac20-dirty       2025-04-03T08:17:27Z
 x86-64-aws-k8s-128-ipv6-conformance             Test           passed               384            0          7012   d949ac20-dirty       2025-04-03T08:33:14Z
 x86-64-aws-k8s-128-ipv6-quick                   Test           passed                 5            0          7391   d949ac20-dirty       2025-04-03T06:37:12Z
 x86-64-aws-k8s-128-nvidia-conformance           Test           passed               384            0          7012   d949ac20-dirty       2025-04-03T08:24:35Z
 x86-64-aws-k8s-128-nvidia-quick                 Test           passed                 5            0          7391   d949ac20-dirty       2025-04-03T06:36:25Z
 x86-64-aws-k8s-128-quick                        Test           passed                 5            0          7391   d949ac20-dirty       2025-04-03T06:36:05Z
 x86-64-aws-k8s-129-conformance                  Test           passed               392            0          7023   d949ac20-dirty       2025-04-03T08:26:58Z
 x86-64-aws-k8s-129-ipv6-conformance             Test           passed               392            0          7023   d949ac20-dirty       2025-04-03T08:35:43Z
 x86-64-aws-k8s-129-ipv6-quick                   Test           passed                 5            0          7410   d949ac20-dirty       2025-04-03T06:37:01Z
 x86-64-aws-k8s-129-nvidia-conformance           Test           passed               392            0          7023   d949ac20-dirty       2025-04-03T08:36:24Z
 x86-64-aws-k8s-129-nvidia-quick                 Test           passed                 5            0          7410   d949ac20-dirty       2025-04-03T06:37:06Z
 x86-64-aws-k8s-129-quick                        Test           passed                 5            0          7410   d949ac20-dirty       2025-04-03T06:36:22Z
 x86-64-aws-k8s-130-conformance                  Test           passed               406            0          6800   d949ac20-dirty       2025-04-03T08:24:34Z
 x86-64-aws-k8s-130-ipv6-conformance             Test           passed               406            0          6800   d949ac20-dirty       2025-04-03T08:38:15Z
 x86-64-aws-k8s-130-ipv6-quick                   Test           passed                 5            0          7201   d949ac20-dirty       2025-04-03T06:37:21Z
 x86-64-aws-k8s-130-nvidia-conformance           Test           passed               406            0          6800   d949ac20-dirty       2025-04-03T08:24:44Z
 x86-64-aws-k8s-130-nvidia-quick                 Test           passed                 5            0          7201   d949ac20-dirty       2025-04-03T06:37:26Z
 x86-64-aws-k8s-130-quick                        Test           passed                 5            0          7201   d949ac20-dirty       2025-04-03T06:35:25Z
 x86-64-aws-k8s-131-conformance                  Test           passed               408            0          6203   d949ac20-dirty       2025-04-03T08:23:22Z
 x86-64-aws-k8s-131-ipv6-conformance             Test           passed               408            0          6203   d949ac20-dirty       2025-04-03T20:51:48Z
 x86-64-aws-k8s-131-ipv6-quick                   Test           passed                 5            0          6606   d949ac20-dirty       2025-04-03T18:55:23Z
 x86-64-aws-k8s-131-nvidia-conformance           Test           passed               408            0          6203   d949ac20-dirty       2025-04-03T22:16:20Z
 x86-64-aws-k8s-131-nvidia-quick                 Test           passed                 5            0          6606   d949ac20-dirty       2025-04-03T09:31:52Z
 x86-64-aws-k8s-131-quick                        Test           passed                 5            0          6606   d949ac20-dirty       2025-04-03T06:35:15Z
 x86-64-aws-k8s-132-conformance                  Test           passed               415            0          6213   d949ac20-dirty       2025-04-03T08:19:45Z
 x86-64-aws-k8s-132-ipv6-conformance             Test           passed               415            0          6213   d949ac20-dirty       2025-04-03T22:42:20Z
 x86-64-aws-k8s-132-ipv6-quick                   Test           passed                 5            0          6623   d949ac20-dirty       2025-04-03T20:35:10Z
 x86-64-aws-k8s-132-nvidia-conformance           Test           passed               415            0          6213   d949ac20-dirty       2025-04-03T08:36:13Z
 x86-64-aws-k8s-132-nvidia-quick                 Test           passed                 5            0          6623   d949ac20-dirty       2025-04-03T06:37:45Z
 x86-64-aws-k8s-132-quick                        Test           passed                 5            0          6623   d949ac20-dirty       2025-04-03T06:36:46Z
```

- **aarch64**
```
 aarch64-aws-k8s-128-conformance              Test        passed         384        0      7012   d949ac20-dirty   2025-04-02T23:35:56Z
 aarch64-aws-k8s-128-ipv6-conformance         Test        passed         384        0      7012   d949ac20-dirty   2025-04-02T23:50:33Z
 aarch64-aws-k8s-128-ipv6-quick               Test        passed           5        0      7391   d949ac20-dirty   2025-04-02T21:55:33Z
 aarch64-aws-k8s-128-nvidia-conformance       Test        passed         384        0      7012   d949ac20-dirty   2025-04-02T23:52:55Z
 aarch64-aws-k8s-128-nvidia-quick             Test        passed           5        0      7391   d949ac20-dirty   2025-04-02T22:03:16Z
 aarch64-aws-k8s-128-quick                    Test        passed           5        0      7391   d949ac20-dirty   2025-04-02T21:54:02Z
 aarch64-aws-k8s-129-conformance              Test        passed         392        0      7023   d949ac20-dirty   2025-04-02T23:43:27Z
 aarch64-aws-k8s-129-ipv6-conformance         Test        passed         392        0      7023   d949ac20-dirty   2025-04-02T23:55:58Z
 aarch64-aws-k8s-129-ipv6-quick               Test        passed           5        0      7410   d949ac20-dirty   2025-04-02T21:56:25Z
 aarch64-aws-k8s-129-nvidia-conformance       Test        passed         392        0      7023   d949ac20-dirty   2025-04-03T04:13:26Z
 aarch64-aws-k8s-129-nvidia-quick             Test        passed           5        0      7410   d949ac20-dirty   2025-04-02T22:05:08Z
 aarch64-aws-k8s-129-quick                    Test        passed           5        0      7410   d949ac20-dirty   2025-04-02T21:55:40Z
 aarch64-aws-k8s-130-conformance              Test        passed         406        0      6800   d949ac20-dirty   2025-04-02T23:41:00Z
 aarch64-aws-k8s-130-ipv6-conformance         Test        passed         406        0      6800   d949ac20-dirty   2025-04-03T01:47:15Z
 aarch64-aws-k8s-130-ipv6-quick               Test        passed           5        0      7201   d949ac20-dirty   2025-04-02T21:58:01Z
 aarch64-aws-k8s-130-nvidia-conformance       Test        passed         406        0      6800   d949ac20-dirty   2025-04-03T04:11:22Z
 aarch64-aws-k8s-130-nvidia-quick             Test        passed           5        0      7201   d949ac20-dirty   2025-04-02T22:07:05Z
 aarch64-aws-k8s-130-quick                    Test        passed           5        0      7201   d949ac20-dirty   2025-04-02T21:57:24Z
 aarch64-aws-k8s-131-conformance              Test        passed         408        0      6203   d949ac20-dirty   2025-04-03T01:47:16Z
 aarch64-aws-k8s-131-ipv6-conformance         Test        passed         408        0      6203   d949ac20-dirty   2025-04-02T23:57:33Z
 aarch64-aws-k8s-131-ipv6-quick               Test        passed           5        0      6606   d949ac20-dirty   2025-04-02T21:59:55Z
 aarch64-aws-k8s-131-nvidia-conformance       Test        passed         408        0      6203   d949ac20-dirty   2025-04-03T04:10:57Z
 aarch64-aws-k8s-131-nvidia-quick             Test        passed           5        0      6606   d949ac20-dirty   2025-04-02T22:10:12Z
 aarch64-aws-k8s-131-quick                    Test        passed           5        0      6606   d949ac20-dirty   2025-04-02T22:01:01Z
 aarch64-aws-k8s-132-conformance              Test        passed         415        0      6213   d949ac20-dirty   2025-04-02T23:46:25Z
 aarch64-aws-k8s-132-ipv6-conformance         Test        passed         415        0      6213   d949ac20-dirty   2025-04-02T23:58:37Z
 aarch64-aws-k8s-132-ipv6-quick               Test        passed           5        0      6623   d949ac20-dirty   2025-04-02T22:03:13Z
 aarch64-aws-k8s-132-nvidia-conformance       Test        passed         415        0      6213   d949ac20-dirty   2025-04-03T04:07:23Z
 aarch64-aws-k8s-132-nvidia-quick             Test        passed           5        0      6623   d949ac20-dirty   2025-04-02T22:11:11Z
 aarch64-aws-k8s-132-quick                    Test        passed           5        0      6623   d949ac20-dirty   2025-04-02T22:00:14Z
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.