### PR TITLE
Support both CDI and Legacy NVIDIA Container Runtime modes

### DIFF
--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-k8s
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-k8s
@@ -31,3 +31,9 @@ mode="legacy"
 {{else}}
 mode="legacy"
 {{/if}}
+
+[nvidia-container-runtime-hook]
+# For the legacy NVIDIA runtime, skip detecting the mode used in the
+# NVIDA Container Runtime. This prevents failures in the legacy NVIDIA runtime
+# when the selected mode is 'cdi'.
+skip-mode-detection = true

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-k8s
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-k8s
@@ -1,14 +1,33 @@
 [required-extensions]
 nvidia-container-runtime = "v1"
-std = { version = "v1", helpers = ["default"] }
+kubelet-device-plugins = "v1"
+std = { version = "v1", helpers = ["default", "is_array"] }
 
 +++
 ### generated from the template file ###
 accept-nvidia-visible-devices-as-volume-mounts = {{default true settings.nvidia-container-runtime.visible-devices-as-volume-mounts}}
 accept-nvidia-visible-devices-envvar-when-unprivileged = {{default false settings.nvidia-container-runtime.visible-devices-envvar-when-unprivileged}}
-
 [nvidia-container-cli]
 root = "/"
 path = "/usr/bin/nvidia-container-cli"
 environment = []
 ldconfig = "@/sbin/ldconfig"
+
+[nvidia-container-runtime]
+{{#if settings.kubelet-device-plugins.nvidia.device-list-strategy}}
+{{~#if (is_array settings.kubelet-device-plugins.nvidia.device-list-strategy) ~}}
+{{~#if (eq settings.kubelet-device-plugins.nvidia.device-list-strategy.[0] "cdi-cri") ~}}
+mode="cdi"
+{{~else~}}
+mode="legacy"
+{{~/if~}}
+{{~else~}}
+{{~#if (eq settings.kubelet-device-plugins.nvidia.device-list-strategy "cdi-cri") ~}}
+mode="cdi"
+{{~else~}}
+mode="legacy"
+{{~/if~}}
+{{/if}}
+{{else}}
+mode="legacy"
+{{/if}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -1,6 +1,6 @@
 [required-extensions]
 kubelet-device-plugins = "v1"
-std = { version = "v1", helpers = ["default"] }
+std = { version = "v1", helpers = ["default", "join_array", "is_array"] }
 
 +++
 version: v1
@@ -18,7 +18,15 @@ flags:
   nvidiaDriverRoot: "/"
   plugin:
     passDeviceSpecs: {{default true settings.kubelet-device-plugins.nvidia.pass-device-specs}}
-    deviceListStrategy: {{default "volume-mounts" settings.kubelet-device-plugins.nvidia.device-list-strategy}}
+    {{#if settings.kubelet-device-plugins.nvidia.device-list-strategy}}
+    {{#if (is_array settings.kubelet-device-plugins.nvidia.device-list-strategy)}}
+    deviceListStrategy: [{{join_array "," settings.kubelet-device-plugins.nvidia.device-list-strategy }}]
+    {{else}}
+    deviceListStrategy: {{settings.kubelet-device-plugins.nvidia.device-list-strategy}}
+    {{/if}}
+    {{else}}
+    deviceListStrategy: "volume-mounts"
+    {{/if}}
     deviceIDStrategy: {{default "index" settings.kubelet-device-plugins.nvidia.device-id-strategy}}
     containerDriverRoot: "/"
 {{#if settings.kubelet-device-plugins.nvidia.device-sharing-strategy}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -15,10 +15,12 @@ flags:
   migStrategy: "none"
   {{/if}}
   failOnInitError: true
+  nvidiaDriverRoot: "/"
   plugin:
     passDeviceSpecs: {{default true settings.kubelet-device-plugins.nvidia.pass-device-specs}}
     deviceListStrategy: {{default "volume-mounts" settings.kubelet-device-plugins.nvidia.device-list-strategy}}
     deviceIDStrategy: {{default "index" settings.kubelet-device-plugins.nvidia.device-id-strategy}}
+    containerDriverRoot: "/"
 {{#if settings.kubelet-device-plugins.nvidia.device-sharing-strategy}}
 {{#if (eq settings.kubelet-device-plugins.nvidia.device-sharing-strategy "time-slicing")}}
 sharing:


### PR DESCRIPTION
**Issue number:**

Closes #468


**Description of changes:**

- Set DriverRoot and DefaultContainterDriverRoot in nvidia-k8s-device-plugin
    - [k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin/blob/bafe5afdc325c9185827e50ed548415b221f5c27/api/config/v1/consts.go#L55) always mount the DefaultContainterDriverRoot at [/driver-root](https://github.com/NVIDIA/k8s-device-plugin/blob/bafe5afdc325c9185827e50ed548415b221f5c27/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml#L202), but for bottlerocket the driver is in the root filesystem.
 - Select the correct `mode` for the default NVIDIA container runtime, based off the configurations set for the `device-list-strategy` in the k8s device plugin
 - Disable mode detection in the prestart hook, as it prevents the NVIDIA legacy runtime from working when the `mode` for the default NVIDIA runtime is set to `cdi`.


**Testing done:**
In combination with: 

- [settings-sdk](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/77)
- [bottlerocket-set k8s deviceliststrategy default config](https://github.com/bottlerocket-os/bottlerocket/pull/4475)
- [bottlerocket-remove unnecessary settings for OCI Hooks API ](https://github.com/bottlerocket-os/bottlerocket/pull/4474)
- https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/511

<details>

In variants: `aws-k8s-1.29`, `aws-k8s-1.31`, `aws-k8s-1.32`, `aws-k8s-1.33` for x86_64 and aarch64:

- Verified that all the containerd runtimes are functional
- Verified that the correct mode is configured depending on the `device-list-strategy` values:

<table>
  <thead>
    <tr>
      <th colspan=3>API Value</th>
      <th>Mode</th>
      <th>Status</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>envvar</td>
      <td>-</td>
      <td>-</td>
      <td>legacy</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>envvar</td>
      <td>volume-mounts</td>
      <td>-</td>
      <td>legacy</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>envvar</td>
      <td>volume-mounts</td>
      <td>cdi-cri</td>
      <td>legacy</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>envvar</td>
      <td>cdi-cri</td>
      <td>-</td>
      <td>legacy</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>ennvar</td>
      <td>cdi-cri</td>
      <td>volume-mounts</td>
      <td>legacy</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>volume-mounts</td>
      <td>-</td>
      <td>-</td>
      <td>legacy</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>volume-mounts</td>
      <td>envvar</td>
      <td>-</td>
      <td>legacy</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>volume-mounts</td>
      <td>envvar</td>
      <td>cdi-cri</td>
      <td>legacy</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>volume-mounts</td>
      <td>cdi-cri</td>
      <td>-</td>
      <td>legacy</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>volume-mounts</td>
      <td>cdi-cri</td>
      <td>envvar</td>
      <td>legacy</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>cdi-cri</td>
      <td>-</td>
      <td>-</td>
      <td>cdi</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>cdi-cri</td>
      <td>volume-mounts</td>
      <td>-</td>
      <td>cdi</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>cdi-cri</td>
      <td>volume-mounts</td>
      <td>envvar</td>
      <td>cdi</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>cdi-cri</td>
      <td>envvar</td>
      <td>-</td>
      <td>cdi</td>
      <td>Pass</td>
    </tr>
    <tr>
      <td>cdi-cri</td>
      <td>envvar</td>
      <td>volume-mounts</td>
      <td>cdi</td>
      <td>Pass</td>
    </tr>
  </tbody>
</table>


</details>



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
