### PR TITLE
sources: bump tokio to latest LTS v1.43.x

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio 1.0.3",
+ "mio",
  "socket2",
  "tokio",
  "tracing",
@@ -3392,17 +3392,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
@@ -5353,28 +5342,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 0.8.11",
- "num_cpus",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -193,7 +193,7 @@ syn = { version = "2", default-features = false }
 tar = { version = "0.4", default-features = false }
 tempfile = "3"
 test-case = "3"
-tokio = { version = "~1.36", default-features = false }  # LTS
+tokio = { version = "~1.43", default-features = false }  # LTS
 tokio-retry = "0.3"
 tokio-test = "0.4"
 tokio-tungstenite = { version = "0.20", default-features = false }

--- a/sources/clarify.toml
+++ b/sources/clarify.toml
@@ -193,7 +193,7 @@ skip-files = [
 [clarify.tokio-macros]
 expression = "MIT"
 license-files = [
-    { path = "LICENSE", hash = 0x402b08de },
+    { path = "LICENSE", hash = 0x5b6af9aa },
 ]
 
 [clarify.vmw_backdoor]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to: #460 

**Description of changes:**

Upgrades `tokio` from 1.36.x to latest LTS release 1.43.x.

**Testing done:**
-  Core-kit builds for both platforms: `make ARCH="x86_64" && make ARCH="aarch64" `
- [tokio CHANGELOG](https://github.com/tokio-rs/tokio/blob/master/tokio/CHANGELOG.md) from 1.36 to 1.43 has no features Removed


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
