### PR TITLE
packages: bump runc version from 1.1.15 to 1.2.6

### DIFF
--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -12,14 +12,14 @@ path = "../packages.rs"
 releases-url = "https://github.com/opencontainers/runc/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.1.15/runc.tar.xz"
-path = "runc-v1.1.15.tar.xz"
-sha512 = "55282eb699565ba77e7db883a89c005d4663cfa1270534a0bd383db9935f0477e9406fe0c689bad4f93b39b7f1c9915559a1bf9bf52b38eea51028d1d3eb0887"
+url = "https://github.com/opencontainers/runc/releases/download/v1.2.6/runc.tar.xz"
+path = "runc-v1.2.6.tar.xz"
+sha512 = "772265769316e62d9f3d3e09eb48c6f7a1299bedede0a9472add430474b33758b5e723a33b5121411c20e15cd171e3133e80ab88b7a8c082327181be5507f65b"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.1.15/runc.tar.xz.asc"
-path = "runc-v1.1.15.tar.xz.asc"
-sha512 = "01c259efa90d1ba73dee09251d942bd8936a470b24151eb56149a0aa864cc7e7ff53a7e085e1e617423040354d8c60729147231efe1e9e8ac77da605c465f783"
+url = "https://github.com/opencontainers/runc/releases/download/v1.2.6/runc.tar.xz.asc"
+path = "runc-v1.2.6.tar.xz.asc"
+sha512 = "f6892bf5aa171cbbf6ef12f1453ac6a31e931a3d3a7a69c6a7c632250ab5136698b919a6a600c1faeb16d8945b3c42d1d203bafd566098b4c282dceebd08fdaf"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -2,7 +2,7 @@
 %global gorepo runc
 %global goimport %{goproject}/%{gorepo}
 %global commit 2c9f5602f0ba3d9da1c2596322dfc4e156844890
-%global gover 1.1.15
+%global gover 1.2.6
 
 %global _dwz_low_mem_die_limit 0
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
- Bump `runc` version from `1.1.15` to `1.2.6`.


**Testing done:**

#### 1. Conformance test results
| Variant Name | Test Status | Passed | Failed | Skipped |
|-------------|------------|--------|--------|---------|
| aarch64-aws-k8s-125 | passed | 363 | 0 | 6706 |
| aarch64-aws-k8s-125-nvidia | passed | 363 | 0 | 6706 |
| aarch64-aws-k8s-132 | passed | 415 | 0 | 6213 |
| aarch64-aws-k8s-132-nvidia | passed | 415 | 0 | 6213 |
| x86-64-aws-k8s-125 | passed | 363 | 0 | 6706 |
| x86-64-aws-k8s-125-nvidia | passed | 363 | 0 | 6706 |
| x86-64-aws-k8s-132 | passed | 415 | 0 | 6213 |
| x86-64-aws-k8s-132-nvidia | passed | 415 | 0 | 6213 |

#### 2. ECS conformance test

| Variant Name                       | Status    |
|-----------------------------------|-----------|
| bottlerocket-aws-ecs-1-aarch64    | ✅ PASSED |
| bottlerocket-aws-ecs-1-nvidia-aarch64 | ✅ PASSED |
| bottlerocket-aws-ecs-1-nvidia-x86_64 | ✅ PASSED |
| bottlerocket-aws-ecs-1-x86_64     | ✅ PASSED |
| bottlerocket-aws-ecs-2-aarch64    | ✅ PASSED |
| bottlerocket-aws-ecs-2-nvidia-aarch64 | ✅ PASSED |
| bottlerocket-aws-ecs-2-nvidia-x86_64 | ✅ PASSED |
| bottlerocket-aws-ecs-2-x86_64     | ✅ PASSED |

#### 3. Load test

Ran internal load test on 1.32 k8s AMI for 48hr. Did not see any issue.
All metrics were stable during the testing:
- No node failure.
- No pod failure.
- Network throughput is within the normal band.

#### 4. GuardDuty Compatibility

Installed GuardDuty agents on the node.

```
k get pods -n amazon-guardduty                      
NAMESPACE          NAME                             READY   STATUS    RESTARTS      AGE
amazon-guardduty   aws-guardduty-agent-vhqlg        1/1     Running   4 (12m ago)   13m
amazon-guardduty   aws-guardduty-agent-zc2sd        1/1     Running   4 (12m ago)   13m
```

No finding were reported for the node/EKS cluster in GuardDuty console.

#### 5. Falco Compatibility

Installed Falco

```
k get pods -n falco
NAME          READY   STATUS    RESTARTS   AGE
falco-mgjqk   2/2     Running   0          4m30s
falco-xw8pp   2/2     Running   0          4m30s
```

Launched nginx-pod

```
apiVersion: v1
kind: Pod
metadata:
  name: nginx-ecr-2
  labels:
    app: nginx
spec:
  containers:
  - name: public-ecr
    image: public.ecr.aws/nginx/nginx:mainline
    imagePullPolicy: Always
    ports:
    - containerPort: 80
```

No findings reported from Falco pod as well.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
