### PR TITLE
allow lookups of .local domains using unicast DNS

### DIFF
--- a/packages/systemd/9015-allow-lookups-of-local-domains-using-unicast-DNS.patch
+++ b/packages/systemd/9015-allow-lookups-of-local-domains-using-unicast-DNS.patch
@@ -1,0 +1,34 @@
+From e72ca322112e62186ee4bc0b913ebeb81c97dd8a Mon Sep 17 00:00:00 2001
+From: Todd Neal <tnealt@amazon.com>
+Date: Thu, 10 Apr 2025 15:06:06 +0000
+Subject: [PATCH] allow lookups of .local domains using unicast DNS
+
+The .local suffix is reserved for Multicast DNS, but its sometimes used
+as a convenient suffix for internal domains. Those then fail to lookup
+correctly. Since Multicast DNS usage is tiny and not supported with
+Bottlerocket, disable this check to allow those names to resolve with
+unicast DNS.
+---
+ src/resolve/resolved-dns-scope.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/src/resolve/resolved-dns-scope.c b/src/resolve/resolved-dns-scope.c
+index 4085b01..862f5c3 100644
+--- a/src/resolve/resolved-dns-scope.c
++++ b/src/resolve/resolved-dns-scope.c
+@@ -705,11 +705,7 @@ DnsScopeMatch dns_scope_good_domain(
+                 }
+ 
+                 /* Exclude link-local IP ranges */
+-                if (match_link_local_reverse_lookups(domain) >= DNS_SCOPE_YES_BASE ||
+-                    /* If networks use .local in their private setups, they are supposed to also add .local
+-                     * to their search domains, which we already checked above. Otherwise, we consider .local
+-                     * specific to mDNS and won't send such queries ordinary DNS servers. */
+-                    dns_name_endswith(domain, "local") > 0)
++                if (match_link_local_reverse_lookups(domain) >= DNS_SCOPE_YES_BASE)
+                         return DNS_SCOPE_NO;
+ 
+                 /* If the IP address to look up matches the local subnet, then implicitly synthesizes
+-- 
+2.47.1
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -75,6 +75,9 @@ Patch9013: 9013-sd-dhcp-lease-parse-multiple-domains-in-option-15.patch
 # it since prairiedog mounts /boot depending on the partition bank in use.
 Patch9014: 9014-meson-make-gpt-auto-generator-selectable-at-build-ti.patch
 
+# Local patch to allow resolving .local domains
+Patch9015: 9015-allow-lookups-of-local-domains-using-unicast-DNS.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson


### PR DESCRIPTION
The .local suffix is reserved for Multicast DNS, but its sometimes used as a convenient suffix for internal domains. Those then fail to lookup correctly. Since Multicast DNS usage is tiny and not supported with Bottlerocket, disable this check to allow those names to resolve with unicast DNS.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Patches systemd to allow lookups of .local domains using unicast DNS


**Testing done:**

Before
```
root@my-shell:/# ping some.fake.local
ping: some.fake.local: Temporary failure in name resolution
```

After
```
root@my-shell:/# ping some.fake.local
PING some.fake.local (8.8.8.8) 56(84) bytes of data.
64 bytes from dns.google (8.8.8.8): icmp_seq=1 ttl=115 time=10.2 ms
64 bytes from dns.google (8.8.8.8): icmp_seq=2 ttl=115 time=8.63 ms
64 bytes from dns.google (8.8.8.8): icmp_seq=3 ttl=115 time=8.70 ms
64 bytes from dns.google (8.8.8.8): icmp_seq=4 ttl=115 time=8.65 ms
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
