### PR TITLE
release: restrict load-crash-kernel to x86_64

### DIFF
--- a/packages/release/load-crash-kernel.service
+++ b/packages/release/load-crash-kernel.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=Load crash kernel
+# No kexec support yet for arm64's zstd-compressed zboot image on 6.12+
+ConditionKernelVersion=|<6.12
+ConditionArchitecture=|!arm64
 ConditionKernelCommandLine=crashkernel
 ConditionPathExists=!/proc/vmcore
 RefuseManualStart=true


### PR DESCRIPTION
The kexec-tools package is unable to parse ARM EFI_ZBOOT images, so only enable the crash kernel on x86_64.

**Description of changes:**

Add a ConditionArchitecture=x86-64 to the load-crash-kernel unit file. The `kexec-tools` package is not able to decompress and parse a compressed kernel image on aarch64, so restrict crash kernel loading to x86_64 hosts which meet the other conditions specified in the unit file. At present, we do not release aarch64 AMIs with a crash kernel, so nothing changes in our AMI behavior.

**Testing done:**

Booted a sufficiently large aws-dev AMI (which does enable the crash kernel by default) on both x86_64 and aarch64. Verified that the crash kernel loads on x86_64, and the load-crash-kernel service is skipped on aarch64. Verified that the follow-on disable-kexec-load service runs on both architectures (and disables kexec loading as it should).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
