### PR TITLE
nvidia-container-toolkit, nvidia-k8s-device-plugin: change template to support CDI and legacy stack

### DIFF
--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-k8s
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-k8s
@@ -12,3 +12,12 @@ root = "/"
 path = "/usr/bin/nvidia-container-cli"
 environment = []
 ldconfig = "@/sbin/ldconfig"
+
+[nvidia-contaienr-runtime]
+{{#if settings.kubelet-device-plugins.nvidia.device-list-strategy}}
+{{#if (eq settings.kubelet-device-plugins.nvidia.device-list-strategy "cdi-cri")}}
+mode="cdi"
+{{else}}
+mode="legacy"
+{{/if}}
+{{/if}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -1,10 +1,12 @@
 [required-extensions]
 kubelet-device-plugins = "v1"
+container-runtime = "v1"
 std = { version = "v1", helpers = ["default"] }
 
 +++
 version: v1
 flags:
+  
   {{#if settings.kubelet-device-plugins.nvidia.device-partitioning-strategy}}
   {{#if (eq settings.kubelet-device-plugins.nvidia.device-partitioning-strategy "mig")}}
   migStrategy: "single"
@@ -17,7 +19,15 @@ flags:
   failOnInitError: true
   plugin:
     passDeviceSpecs: {{default true settings.kubelet-device-plugins.nvidia.pass-device-specs}}
-    deviceListStrategy: {{default "volume-mounts" settings.kubelet-device-plugins.nvidia.device-list-strategy}}
+    {{#if settings.kubelet-device-plugins.nvidia.device-list-strategy}}
+    {{#if (eq settings.kubelet-device-plugins.nvidia.device-list-strategy "cdi-cri")}}
+    deviceListStrategy: "cdi-cri"
+    {{else}}
+    deviceListStrategy: {{settings.kubelet-device-plugins.nvidia.device-list-strategy}}
+    {{/if}}
+    {{else}}
+    deviceListStrategy: "volume-mounts"
+    {{/if}}
     deviceIDStrategy: {{default "index" settings.kubelet-device-plugins.nvidia.device-id-strategy}}
 {{#if settings.kubelet-device-plugins.nvidia.device-sharing-strategy}}
 {{#if (eq settings.kubelet-device-plugins.nvidia.device-sharing-strategy "time-slicing")}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
- Update nvidia-container-toolkit to support both CDI and legacy mode
- Update nvidia-device-plugin to support the DeviceListStrategy="cdi-cri"


**Testing done:**
All the template current render and also able to change the DeviceListStrategy to "cdi-cri"
```
[root@admin]# apiclient set settings.kubelet-device-plugins.nvidia.device-list-strategy="volume-mount"
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-ftkRMWBGBNks2ZSk': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-ftkRMWBGBNks2ZSk: Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error during deserialization: unknown variant `volume-mount`, expected one of `envvar`, `volume-mounts`, `cdi-cri` at line 1 column 74
[root@admin]# apiclient set settings.kubelet-device-plugins.nvidia.device-list-strategy="volume-mounts"
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia.device-list-strategy
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-list-strategy": "volume-mounts"
      }
    }
  }
}
[root@admin]# sheltie /etc/nvidia-k8s-device-plugin/settings.yaml
nsenter: failed to execute /etc/nvidia-k8s-device-plugin/settings.yaml: Permission denied
[root@admin]# sheltie cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:

  migStrategy: "none"
  failOnInitError: true
  nvidiaDriverRoot: "/"
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: volume-mounts
    deviceIDStrategy: index
    containerDriverRoot: "/"

[root@admin]# apiclient set settings.kubelet-device-plugins.nvidia.device-list-strategy="envvar"
[root@admin]# sheltie cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:

  migStrategy: "none"
  failOnInitError: true
  nvidiaDriverRoot: "/"
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: envvar
    deviceIDStrategy: index
    containerDriverRoot: "/"
[root@admin]# apiclient set settings.kubelet-device-plugins.nvidia.device-list-strategy="cdi-cri"
[root@admin]# sheltie cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:

  migStrategy: "none"
  failOnInitError: true
  nvidiaDriverRoot: "/"
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: "cdi-cri"
    deviceIDStrategy: index
    containerDriverRoot: "/"
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
