### PR TITLE
packages: add patches to binutils

### DIFF
--- a/packages/binutils/0001-PR32560-stack-buffer-overflow-at-objdump-disassemble.patch
+++ b/packages/binutils/0001-PR32560-stack-buffer-overflow-at-objdump-disassemble.patch
@@ -1,0 +1,54 @@
+From baac6c221e9d69335bf41366a1c7d87d8ab2f893 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Wed, 15 Jan 2025 19:13:43 +1030
+Subject: [PATCH] PR32560 stack-buffer-overflow at objdump disassemble_bytes
+
+There's always someone pushing the boundaries.
+
+	PR 32560
+	* objdump.c (MAX_INSN_WIDTH): Define.
+	(insn_width): Make it an unsigned long.
+	(disassemble_bytes): Use MAX_INSN_WIDTH to size buffer.
+	(main <OPTION_INSN_WIDTH>): Restrict size of insn_width.
+---
+ binutils/objdump.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/binutils/objdump.c b/binutils/objdump.c
+index ecbe39e942e..80044dea580 100644
+--- a/binutils/objdump.c
++++ b/binutils/objdump.c
+@@ -117,7 +117,8 @@ static bool disassemble_all;		/* -D */
+ static int disassemble_zeroes;		/* --disassemble-zeroes */
+ static bool formats_info;		/* -i */
+ int wide_output;			/* -w */
+-static int insn_width;			/* --insn-width */
++#define MAX_INSN_WIDTH 49
++static unsigned long insn_width;	/* --insn-width */
+ static bfd_vma start_address = (bfd_vma) -1; /* --start-address */
+ static bfd_vma stop_address = (bfd_vma) -1;  /* --stop-address */
+ static int dump_debugging;		/* --debugging */
+@@ -3391,7 +3392,7 @@ disassemble_bytes (struct disassemble_info *inf,
+ 	}
+       else
+ 	{
+-	  char buf[50];
++	  char buf[MAX_INSN_WIDTH + 1];
+ 	  unsigned int bpc = 0;
+ 	  unsigned int pb = 0;
+
+@@ -6070,8 +6071,9 @@ main (int argc, char **argv)
+ 	  break;
+ 	case OPTION_INSN_WIDTH:
+ 	  insn_width = strtoul (optarg, NULL, 0);
+-	  if (insn_width <= 0)
+-	    fatal (_("error: instruction width must be positive"));
++	  if (insn_width - 1 >= MAX_INSN_WIDTH)
++	    fatal (_("error: instruction width must be in the range 1 to "
++		     XSTRING (MAX_INSN_WIDTH)));
+ 	  break;
+ 	case OPTION_INLINES:
+ 	  unwind_inlines = true;
+--
+2.43.5
+

--- a/packages/binutils/binutils.spec
+++ b/packages/binutils/binutils.spec
@@ -8,6 +8,9 @@ License: GPL-2.0-or-later AND LGPL-2.0-or-later AND GPL-3.0-or-later
 Source0: https://ftp.gnu.org/gnu/binutils/binutils-%{version}.tar.xz
 Source1: https://ftp.gnu.org/gnu/binutils/binutils-%{version}.tar.xz.sig
 Source2: gpgkey-3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F.asc
+
+Patch0001: 0001-PR32560-stack-buffer-overflow-at-objdump-disassemble.patch
+
 Requires: %{_cross_os}libz
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libz-devel


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Fixes: [CVE-2025-0840](https://github.com/advisories/GHSA-c5qp-mx9f-m5c7)


**Description of changes:**
- Add the patch that fixes the CVE as mentioned in [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-0840)


**Testing done:**
- Built an [x86_64, k8s-1.32-nvidia] ami with core-kit and kernel-kit using a custom sdk that includes this patch.
- Verified that instance boots with the above ami.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
