### PR TITLE
Enable CDI support for ECS

### DIFF
--- a/packages/docker-engine/daemon-nvidia-json
+++ b/packages/docker-engine/daemon-nvidia-json
@@ -25,5 +25,9 @@ std = { version = "v1", helpers = ["join_array"] }
   {{/if}}
   {{/each}}
   {{/if}}
-  "selinux-enabled": true
+  "selinux-enabled": true,
+  "features": {
+    "cdi": true
+  },
+  "cdi-spec-dirs": ["/etc/cdi/"]
 }

--- a/packages/nvidia-container-toolkit/generate-cdi-specs.service
+++ b/packages/nvidia-container-toolkit/generate-cdi-specs.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Generate CDI specifications
+# This has to be executed after the kernel modules are loaded
+# otherwise the userspace component of the driver will fail to
+# query the /dev devices
+After=load-tesla-kernel-modules.service load-open-gpu-kernel-modules.service
+# Running this unit after nvidia persistenced ensures that
+# the /dev devices are created and the hardware set to
+# persistence mode.
+Requires=nvidia-persistenced.service
+After=nvidia-persistenced.service
+# Block manual interactions with this service. It doesn't
+# make sense to regenerate CDI specifications as features
+# that might change the GPU (e.g. MIG) are not supported in
+# ECS
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+# Explanation of the options:
+# --format json: to be consistent across Bottlerocket's variants
+# --mode nvml: the default mode ("auto") resolves to this already, make it explicit
+# --device-name-strategy uuid: the ECS agent only supports device UUIDs
+# --output /etc/cdi/nvidia.json: store the CDI specifications at this location
+ExecStart=/usr/bin/nvidia-ctk cdi generate --format json \
+  --mode nvml \
+  --device-name-strategy uuid \
+  --output /etc/cdi/nvidia.json
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-ecs.toml
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-ecs.toml
@@ -3,3 +3,6 @@ root = "/"
 path = "/usr/bin/nvidia-container-cli"
 environment = []
 ldconfig = "@/sbin/ldconfig"
+
+[nvidia-container-runtime]
+mode = "cdi"

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -22,6 +22,7 @@ Source3: nvidia-gpu-devices.rules
 Source4: nvidia-container-toolkit-tmpfiles-ecs.conf
 Source5: nvidia-container-toolkit-tmpfiles-k8s.conf
 Source6: nvidia-container-toolkit-config-k8s
+Source7: generate-cdi-specs.service
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}libnvidia-container
@@ -34,6 +35,7 @@ Requires: (%{name}-k8s if %{_cross_os}variant-family(aws-k8s))
 %package ecs
 Summary: Files specific for the ECS variants
 Requires: %{name}
+Requires: %{name}-cdi-specs
 Conflicts: %{name}-k8s
 
 %description ecs
@@ -45,6 +47,13 @@ Requires: %{name}
 Conflicts: %{name}-ecs
 
 %description k8s
+%{summary}.
+
+%package cdi-specs
+Summary: Tools to generate CDI specifications
+Requires: %{name}
+
+%description cdi-specs
 %{summary}.
 
 %prep
@@ -69,6 +78,7 @@ install -d %{buildroot}%{_cross_bindir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_udevrulesdir}
+install -d %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_datadir}/nvidia-container-toolkit
 install -d %{buildroot}%{_cross_factorydir}/nvidia-container-runtime
 install -d %{buildroot}%{_cross_templatedir}/nvidia-container-runtime
@@ -82,6 +92,7 @@ install -p -m 0644 %{S:3} %{buildroot}%{_cross_udevrulesdir}/90-nvidia-gpu-devic
 install -m 0644 %{S:4} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolkit-ecs.conf
 install -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolkit-k8s.conf
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/nvidia-container-runtime/
+install -m 0644 %{S:7} %{buildroot}%{_cross_unitdir}/
 
 %files
 %license LICENSE
@@ -100,3 +111,6 @@ install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/nvidia-container-runtim
 %{_cross_factorydir}/nvidia-container-runtime/nvidia-container-toolkit-config-k8s.toml
 %{_cross_templatedir}/nvidia-container-runtime/nvidia-container-toolkit-config-k8s
 %{_cross_tmpfilesdir}/nvidia-container-toolkit-k8s.conf
+
+%files cdi-specs
+%{_cross_unitdir}/generate-cdi-specs.service

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -25,6 +25,8 @@ Source6: nvidia-container-toolkit-config-k8s
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}libnvidia-container
+Requires: (%{name}-ecs if %{_cross_os}variant-family(aws-ecs))
+Requires: (%{name}-k8s if %{_cross_os}variant-family(aws-k8s))
 
 %description
 %{summary}.


### PR DESCRIPTION
**Issue number:**

Closes #470

**Description of changes:**

The first commit in the series improves the dependency management for the configuration files provided for each orchestrator. This allows to depend only on `nvidia-container-toolkit` on the variant definition, and get the required configuration files depending on the variant built.

The remaining commits enable CDI support for ECS variants. A new package `nvidia-container-toolkit-cdi-specs` provides an additional service to generate CDI specifications. This new service can be used by downstream builders that support CDI. This new package is automatically installed for ECS variants.

The `nvidia-container-toolkit` configuration for ECS now forces the `cdi` mode. The reason for this is twofold:

- This truly enables CDI, and drops the dependency on the `prestart` hook provided by `nvidia-container-toolkit`
- This mode allows to use the `NVIDIA_VISIBLE_DEVICES` environment variable, which is what the ECS agent uses to "pass down" the devices that must be configured in the container

**Testing done:**

Ran an ECS task using `aws-ecs-2-nvidia`, and confirmed:
- Task runs successfully
- Device is accessible through the containers
- `NVIDIA_VISIBLE_DEVICES=all` doesn't have any effect in ECS as always, since the ECS agent clobbers the environment variable
- Binaries and libraries are mounted as expected

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
