### PR TITLE
Third party package updates

### DIFF
--- a/packages/ecr-credential-provider-1.32/Cargo.toml
+++ b/packages/ecr-credential-provider-1.32/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.32"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.32.1.tar.gz"
-path = "cloud-provider-aws-1.32.1.tar.gz"
-sha512 = "787d48f4696c358084a0a24cc8b65b1a3ee0dc6dfdd677d8e8fc599312cd44759ebed5ba684ee1f295b3084d8a67b0301e970468ffdae554a1ca6f5dd149fca5"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.32.2.tar.gz"
+path = "cloud-provider-aws-1.32.2.tar.gz"
+sha512 = "2ea6038125044850960207d509b779e439eb1325b2f4a260a8d2cfd9e9c7229a977681d4048bd06855ddaf21b985868d7da0242684a3b8706b6260430454a27b"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
+++ b/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.32.1
+%global gover 1.32.2
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.25/Cargo.toml
+++ b/packages/kubernetes-1.25/Cargo.toml
@@ -125,5 +125,9 @@ sha512 = "0e542d4c060086366b8cfeccc502e89e5cca3f8ae3c65aad443b90ab99aadd7d81cab8
 url = "https://raw.githubusercontent.com/aws/eks-distro/93c82ae30d0c044196bd0b0bcb1f1d98be9b0102/projects/kubernetes/kubernetes/1-25/patches/0028-EKS-PATCH-Lower-verbosity-for-topologycache-messages.patch"
 sha512 = "dac541c6334b699a17a2254c9a763f65e8beb472bb61db353e6f9698fd6e84714326d7db63e822959afa301438ec669a8068f1602e4b27e38baf782b2ff62058"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/f5830c618932af576c61e71a2dfa3dda26a996a6/projects/kubernetes/kubernetes/1-25/patches/0029-EKS-PATCH-Update-the-goversion-to-1.23.patch"
+sha512 = "415559ab52745c4b57c84fbc81dd6a2d58bc09cfcce48b3ac2bdc7e388cd21d6f47c2b16a6c8678b5777dbc531d768eaf3a6abdd58e6c673c3e19ef5b63cc9c4"
+
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.25/kubernetes-1.25.spec
+++ b/packages/kubernetes-1.25/kubernetes-1.25.spec
@@ -94,6 +94,7 @@ Patch0025: 0025-EKS-PATCH-Add-sourceARN-to-sts-headers.patch
 Patch0026: 0026-EKS-PATCH-skip-TestCreateBlobDisk-test.patch
 Patch0027: 0027-EKS-PATCH-Updated-added-visibility-to-apiserver-x509.patch
 Patch0028: 0028-EKS-PATCH-Lower-verbosity-for-topologycache-messages.patch
+Patch0029: 0029-EKS-PATCH-Update-the-goversion-to-1.23.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -85,5 +85,9 @@ sha512 = "0e542d4c060086366b8cfeccc502e89e5cca3f8ae3c65aad443b90ab99aadd7d81cab8
 url = "https://raw.githubusercontent.com/aws/eks-distro/93c82ae30d0c044196bd0b0bcb1f1d98be9b0102/projects/kubernetes/kubernetes/1-26/patches/0019-EKS-PATCH-Lower-verbosity-for-topologycache-messages.patch"
 sha512 = "d26e1886dc8661666fd7469b469a1cbd24d4f4d7d240c56d6d6d2148abe5e4bc278cb00f288bec9c7a0f6458a3eb857e4a1a2571c635ab4d83b347eac81d5eab"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/259009b1eefaed4a7be4df2ec1d12a280b4c28e2/projects/kubernetes/kubernetes/1-26/patches/0020-EKS-PATCH-Update-the-goversion-to-1.23.patch"
+sha512 = "22f6634afe74d3753561b1e1a3dae66ee4a532b683d38ac8d22a7bdda8f562f94ff9cc2560b12e5b5e03816b79a849d301345177a9452501b44c214e7c2264d3"
+
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.26/kubernetes-1.26.spec
+++ b/packages/kubernetes-1.26/kubernetes-1.26.spec
@@ -84,6 +84,7 @@ Patch0016: 0016-EKS-PATCH-Add-sourceARN-to-sts-headers.patch
 Patch0017: 0017-EKS-PATCH-fix-CVE-2023-47108.patch
 Patch0018: 0018-EKS-PATCH-Updated-added-visibility-to-apiserver-x509.patch
 Patch0019: 0019-EKS-PATCH-Lower-verbosity-for-topologycache-messages.patch
+Patch0020: 0020-EKS-PATCH-Update-the-goversion-to-1.23.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.27/Cargo.toml
+++ b/packages/kubernetes-1.27/Cargo.toml
@@ -81,5 +81,13 @@ sha512 = "24a955f2a672338ab5d69993f6d40708617ac85ac5c9437cc03b85e0521ea5dd1c30bf
 url = "https://raw.githubusercontent.com/aws/eks-distro/7771e87603c3ae1fd29d04044689ff4cf5e349d4/projects/kubernetes/kubernetes/1-27/patches/0018-EKS-PATCH-Lower-verbosity-for-topologycache-messages.patch"
 sha512 = "d26e1886dc8661666fd7469b469a1cbd24d4f4d7d240c56d6d6d2148abe5e4bc278cb00f288bec9c7a0f6458a3eb857e4a1a2571c635ab4d83b347eac81d5eab"
 
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/259009b1eefaed4a7be4df2ec1d12a280b4c28e2/projects/kubernetes/kubernetes/1-27/patches/0019-EKS-PATCH-hack-tools-update-to-golangci-lint-v1.56.2.patch"
+sha512 = "c76f14277635fd05a6e595de6e10ed31f047c7ca6281e12acb1d024c6e32293f6c6aae18c9ec46c8e7246bb7e890c5d2fc3a78e7e1bfb6686332af7e01907f7b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://raw.githubusercontent.com/aws/eks-distro/259009b1eefaed4a7be4df2ec1d12a280b4c/projects/kubernetes/kubernetes/1-27/patches/0020-EKS-PATCH-Update-the-goversion-to-1.23.patch"
+sha512 = "59d66b1791cf7fa60158db76460f2e8da3b1d680232fa2d1e0e91419a31829b08e9c3a2b8f2fbb56b6519314769f6eaf82032bee358562ae940adacb09ab3681"
+
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -81,6 +81,8 @@ Patch0015: 0015-EKS-PATCH-Add-apf-queue-wait-audit-log-latency-annot.patch
 Patch0016: 0016-EKS-PATCH-fix-CVE-2023-47108.patch
 Patch0017: 0017-EKS-PATCH-kubelet-use-env-vars-in-node-log-query-PS-.patch
 Patch0018: 0018-EKS-PATCH-Lower-verbosity-for-topologycache-messages.patch
+Patch0019: 0019-EKS-PATCH-hack-tools-update-to-golangci-lint-v1.56.2.patch
+Patch0020: 0020-EKS-PATCH-Update-the-goversion-to-1.23.patch
 
 BuildRequires: git
 BuildRequires: rsync


### PR DESCRIPTION
**Description of changes:**
- Adds patches for kubernetes 1.25 to 1.27 from the latest upstream: https://github.com/aws/eks-distro/tree/main/projects/kubernetes/kubernetes
- ~~Update `nvidia-container-toolkit` v1.17.4  &rarr; v1.17.5~~
- ~~Update `nvidia-k8s-device-plugin` v0.17.0  &rarr; v0.17.1~~
- Update `ecr-credential-provider` v1.32.1  &rarr; v1.32.2

**Testing done:**
```
 NAME                                         TYPE        STATE       PASSED   FAILED   SKIPPED   BUILD ID         LAST UPDATE
 aarch64-aws-k8s-125-conformance              Test        passed         363        0      6706   d2a85f05-dirty   2025-04-16T02:47:16Z
 aarch64-aws-k8s-125-ipv6-conformance         Test        passed         363        0      6706   d2a85f05-dirty   2025-04-16T03:00:05Z
 aarch64-aws-k8s-125-ipv6-quick               Test        passed           4        0      7065   d2a85f05-dirty   2025-04-16T01:14:50Z
 aarch64-aws-k8s-125-nvidia-conformance       Test        passed         363        0      6706   d2a85f05-dirty   2025-04-16T02:37:12Z
 aarch64-aws-k8s-125-nvidia-quick             Test        passed           4        0      7065   d2a85f05-dirty   2025-04-16T00:56:57Z
 aarch64-aws-k8s-125-quick                    Test        passed           4        0      7065   d2a85f05-dirty   2025-04-16T01:14:19Z
 aarch64-aws-k8s-126-conformance              Test        passed         371        0      6701   d2a85f05-dirty    2025-04-16T05:15:32Z
 aarch64-aws-k8s-126-ipv6-conformance         Test        passed         371        0      6701   d2a85f05-dirty   2025-04-16T03:07:52Z
 aarch64-aws-k8s-126-ipv6-quick               Test        passed           4        0      7068   d2a85f05-dirty   2025-04-16T01:18:05Z
 aarch64-aws-k8s-126-nvidia-conformance       Test        passed         371        0      6701   d2a85f05-dirty    2025-04-16T05:12:01Z
 aarch64-aws-k8s-126-nvidia-quick             Test        passed           4        0      7068   d2a85f05-dirty   2025-04-16T01:15:10Z
 aarch64-aws-k8s-126-quick                    Test        passed           4        0      7068   d2a85f05-dirty   2025-04-16T01:15:40Z
 aarch64-aws-k8s-127-conformance              Test        passed         382        0      6832   d2a85f05-dirty   2025-04-16T03:02:53Z
 aarch64-aws-k8s-127-ipv6-conformance         Test        passed         382        0      6832   d2a85f05-dirty   2025-04-16T03:11:01Z
 aarch64-aws-k8s-127-ipv6-quick               Test        passed           5        0      7209   d2a85f05-dirty   2025-04-16T01:17:20Z
 aarch64-aws-k8s-127-nvidia-conformance       Test        passed         382        0      6832   d2a85f05-dirty    2025-04-16T05:21:09Z
 aarch64-aws-k8s-127-nvidia-quick             Test        passed           5        0      7209   d2a85f05-dirty   2025-04-16T01:14:39Z
 aarch64-aws-k8s-127-quick                    Test        passed           5        0      7209   d2a85f05-dirty   2025-04-16T01:14:29Z
 x86-64-aws-k8s-125-conformance               Test        passed         363        0      6706   d2a85f05-dirty   2025-04-16T00:05:29Z
 x86-64-aws-k8s-125-ipv6-conformance          Test        passed         363        0      6706   d2a85f05-dirty   2025-04-16T00:15:52Z
 x86-64-aws-k8s-125-ipv6-quick                Test        passed           4        0      7065   d2a85f05-dirty   2025-04-15T22:31:50Z
 x86-64-aws-k8s-125-nvidia-conformance        Test        passed         363        0      6706   d2a85f05-dirty   2025-04-16T00:08:52Z
 x86-64-aws-k8s-125-nvidia-quick              Test        passed           4        0      7065   d2a85f05-dirty   2025-04-15T22:30:50Z
 x86-64-aws-k8s-125-quick                     Test        passed           4        0      7065   d2a85f05-dirty   2025-04-15T22:31:21Z
 x86-64-aws-k8s-126-conformance               Test        passed         371        0      6701   d2a85f05-dirty   2025-04-16T00:08:13Z
 x86-64-aws-k8s-126-ipv6-conformance          Test        passed         371        0      6701   d2a85f05-dirty   2025-04-16T00:16:59Z
 x86-64-aws-k8s-126-ipv6-quick                Test        passed           4        0      7068   d2a85f05-dirty   2025-04-15T22:32:20Z
 x86-64-aws-k8s-126-nvidia-conformance        Test        passed         371        0      6701   d2a85f05-dirty   2025-04-16T02:36:01Z
 x86-64-aws-k8s-126-nvidia-quick              Test        passed           4        0      7068   d2a85f05-dirty   2025-04-15T22:32:31Z
 x86-64-aws-k8s-126-quick                     Test        passed           4        0      7068   d2a85f05-dirty   2025-04-15T22:30:39Z
 x86-64-aws-k8s-127-conformance               Test        passed         382        0      6832   d2a85f05-dirty   2025-04-16T00:14:24Z
 x86-64-aws-k8s-127-ipv6-conformance          Test        passed         382        0      6832   d2a85f05-dirty   2025-04-16T00:26:57Z
 x86-64-aws-k8s-127-ipv6-quick                Test        passed           5        0      7209   d2a85f05-dirty   2025-04-15T22:32:59Z
 x86-64-aws-k8s-127-nvidia-conformance        Test        passed         382        0      6832   d2a85f05-dirty   2025-04-16T00:13:24Z
 x86-64-aws-k8s-127-nvidia-quick              Test        passed           5        0      7209   d2a85f05-dirty   2025-04-15T22:31:27Z
 x86-64-aws-k8s-127-quick                     Test        passed           5        0      7209   d2a85f05-dirty   2025-04-15T22:31:03Z
```

nvidia-smoke-test for `k8s-1.25` - All tests passed
nvidia-smoke-test for `k8s-1.26` - All tests passed
nvidia-smoke-test for `k8s-1.27` - All tests passed
```
[fedora@xxxxxxxxxxxxxxxx kubernetes]$ kubectl logs nvidia-pod

=========================================
  Running sample UnifiedMemoryPerf
=========================================

GPU Device 0: "Turing" with compute capability 7.5

Running ........................................................

Overall Time For matrixMultiplyPerf 

Printing Average of 20 measurements in (ms)
Size_KB  UMhint UMhntAs  UMeasy   0Copy MemCopy CpAsync CpHpglk CpPglAs
4         0.210   0.218   0.322   0.018   0.035   0.029   0.038   0.029
16        0.237   0.245   0.477   0.043   0.066   0.057   0.068   0.065
64        0.326   0.369   0.751   0.136   0.174   0.162   0.139   0.132
256       0.872   0.908   1.326   0.759   0.631   0.582   0.492   0.482
1024      3.116   3.394   3.574   5.075   2.531   2.340   1.994   1.974
4096     12.097  11.311  14.541  34.921   9.661   9.567   9.033   8.845
16384    57.290  54.821  67.666 298.469  49.458  49.102  46.070  46.066

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample deviceQuery
=========================================

./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "Tesla T4"
  CUDA Driver Version / Runtime Version          12.2 / 11.4
  CUDA Capability Major/Minor version number:    7.5
  Total amount of global memory:                 14931 MBytes (15655829504 bytes)
  (040) Multiprocessors, (064) CUDA Cores/MP:    2560 CUDA Cores
  GPU Max Clock rate:                            1590 MHz (1.59 GHz)
  Memory Clock rate:                             5001 Mhz
  Memory Bus Width:                              256-bit
  L2 Cache Size:                                 4194304 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        65536 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1024
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 3 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 30
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.2, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS

=========================================
  Running sample globalToShmemAsyncCopy
=========================================

[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Turing" with compute capability 7.5

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 336.58 GFlop/s, Time= 12.461 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample immaTensorCoreGemm
=========================================

Initializing...
GPU Device 0: "Turing" with compute capability 7.5

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma 
Time: 4.263872 ms
TOPS: 32.23

=========================================
  Running sample reductionMultiBlockCG
=========================================

reductionMultiBlockCG Starting...

GPU Device 0: "Turing" with compute capability 7.5

33554432 elements
numThreads: 1024
numBlocks: 40

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 1.158770 ms
Bandwidth:    115.827795 GB/s

GPU result = 1.992401361465
CPU result = 1.992401361465

=========================================
  Running sample shfl_scan
=========================================

Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.028704
65536 elements scanned in 0.028704 ms -> 2283.166260 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.030500 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.050784 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.128256 ms 
CheckSum: 2073600, (expect 1920x1080=2073600)

=========================================
  Running sample simpleAWBarrier
=========================================

./simpleAWBarrier starting...
GPU Device 0: "Turing" with compute capability 7.5

Launching normVecByDotProductAWBarrier kernel with numBlocks = 40 blockSize = 1024
Result = PASSED
./simpleAWBarrier completed, returned OK

=========================================
  Running sample simpleAtomicIntrinsics
=========================================

simpleAtomicIntrinsics starting...
GPU Device 0: "Turing" with compute capability 7.5

Processing time: 124.762001 (ms)
simpleAtomicIntrinsics completed, returned OK

=========================================
  Running sample simpleVoteIntrinsics
=========================================

[simpleVoteIntrinsics]
GPU Device 0: "Turing" with compute capability 7.5

> GPU device has 40 Multi-Processors, SM 7.5 compute capabilities

[VOTE Kernel Test 1/3]
        Running <<Vote.Any>> kernel1 ...
        OK

[VOTE Kernel Test 2/3]
        Running <<Vote.All>> kernel2 ...
        OK

[VOTE Kernel Test 3/3]
        Running <<Vote.Any>> kernel3 ...
        OK
        Shutting down...

=========================================
  Running sample vectorAdd
=========================================

[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

=========================================
  Running sample warpAggregatedAtomicsCG
=========================================

GPU Device 0: "Turing" with compute capability 7.5

CPU max matches GPU max

Warp Aggregated Atomics PASSED 
```
```
default       nvidia-pod-x86-64                 0/1     Completed   0          60s
default       nvidia-pod-aarch64                0/1     Completed   0          54s
```
```
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  63s   default-scheduler  Successfully assigned default/nvidia-pod to xxxxxxxxxxxxxxxx.us-west-2.compute.internal
  Normal  Pulling    63s   kubelet            Pulling image "public.ecr.aws/xxxxxxx/nvidia-smoke-test:latest"
  Normal  Pulled     56s   kubelet            Successfully pulled image "public.ecr.aws/xxxxxxx/nvidia-smoke-test:latest" in 6.825257197s (6.825268734s including waiting)
  Normal  Created    56s   kubelet            Created container nvidia-smoke-test
  Normal  Started    56s   kubelet            Started container nvidia-smoke-test
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
