### PR TITLE
kubernetes: let kubelet start when swap is on

### DIFF
--- a/packages/kubernetes-1.25/kubelet-config
+++ b/packages/kubernetes-1.25/kubelet-config
@@ -194,3 +194,4 @@ reservedMemory:
 {{#if settings.kubernetes.reserved-cpus}}
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
+failSwapOn: false

--- a/packages/kubernetes-1.26/kubelet-config
+++ b/packages/kubernetes-1.26/kubelet-config
@@ -194,3 +194,4 @@ reservedMemory:
 {{#if settings.kubernetes.reserved-cpus}}
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
+failSwapOn: false

--- a/packages/kubernetes-1.27/kubelet-config
+++ b/packages/kubernetes-1.27/kubelet-config
@@ -195,3 +195,4 @@ reservedMemory:
 {{#if settings.kubernetes.reserved-cpus}}
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
+failSwapOn: false

--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -193,3 +193,4 @@ reservedMemory:
 {{#if settings.kubernetes.reserved-cpus}}
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
+failSwapOn: false

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -193,3 +193,4 @@ reservedMemory:
 {{#if settings.kubernetes.reserved-cpus}}
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
+failSwapOn: false

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -193,3 +193,4 @@ reservedMemory:
 {{#if settings.kubernetes.reserved-cpus}}
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
+failSwapOn: false

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -193,3 +193,4 @@ reservedMemory:
 {{#if settings.kubernetes.reserved-cpus}}
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
+failSwapOn: false

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -193,3 +193,4 @@ reservedMemory:
 {{#if settings.kubernetes.reserved-cpus}}
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
+failSwapOn: false


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/4075

**Description of changes:**
Set `failSwapOn: false` for all kubelet configs.

The goal of this change is to simplify experiments with swap enabled on the host as a possible remedy for the unreachable nodes discussed in the related issue. This requires letting `kubelet` actually start if swap is enabled. Allowing pods to use swap is a larger change that's out of scope here.


**Testing done:**
For each Kubernetes variant from 1.25 to 1.32, I confirmed that `kubelet` started when swap was enabled on the node, in both cgroups v1 and cgroups v2 configurations.

With cgroups v1, I confirmed that `memory.memsw.limit_in_bytes` was set to the same value as `memory.limit_in_bytes`, which prevents the use of swap:
```
$ find /sys/fs/cgroup -mindepth 6 -name memory.memsw.limit_in_bytes -exec head -v {} \;
==> /sys/fs/cgroup/memory/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod958dcfcf_dfbf_4f6d_91a2_df92b5e0bf9a.slice/cri-containerd-986e63e82f67895ee8300badee54629b6b445d77a75b5d4bc2d2c221b2cf99d1.scope/memory.memsw.limit_in_bytes <==
268435456

$ head -v /sys/fs/cgroup/memory/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod958dcfcf_dfbf_4f6d_91a2_df92b5e0bf9a.slice/cri-containerd-986e63e82f67895ee8300badee54629b6b445d77a75b5d4bc2d2c221b2cf99d1.scope/memory.limit_in_bytes
==> /sys/fs/cgroup/memory/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod958dcfcf_dfbf_4f6d_91a2_df92b5e0bf9a.slice/cri-containerd-986e63e82f67895ee8300badee54629b6b445d77a75b5d4bc2d2c221b2cf99d1.scope/memory.limit_in_bytes <==
268435456
```

With cgroups v2, I confirmed that `memory.swap.max` was set to zero for workload containers.
```
$ find /sys/fs/cgroup -mindepth 5 -name memory.swap.max -exec head -v {} \;
==> /sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod4fa0c88a_aaeb_4b63_b2b6_42e1459543c8.slice/cri-containerd-3b5c2ebdb64969a0c4a03e87ef29291a5c2b70c4cf04deb306209430b563b8bf.scope/memory.swap.max <==
0

$ head -v /sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod4fa0c88a_aaeb_4b63_b2b6_42e1459543c8.slice/cri-containerd-3b5c2ebdb64969a0c4a03e87ef29291a5c2b70c4cf04deb306209430b563b8bf.scope/memory.max
268435456
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
