### PR TITLE
Add k8s-1.33 and ecr-credential-provider-1.33 pkgs with pre-release sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "ecr-credential-provider-1_30",
  "ecr-credential-provider-1_31",
  "ecr-credential-provider-1_32",
+ "ecr-credential-provider-1_33",
  "ecs-agent",
  "ecs-gpu-init",
  "ethtool",
@@ -356,6 +357,13 @@ dependencies = [
 
 [[package]]
 name = "ecr-credential-provider-1_32"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "ecr-credential-provider-1_33"
 version = "0.1.0"
 dependencies = [
  "glibc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "kubernetes-1_30",
  "kubernetes-1_31",
  "kubernetes-1_32",
+ "kubernetes-1_33",
  "libacl",
  "libaio",
  "libattr",
@@ -525,6 +526,13 @@ dependencies = [
 
 [[package]]
 name = "kubernetes-1_32"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "kubernetes-1_33"
 version = "0.1.0"
 dependencies = [
  "glibc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
   "packages/kubernetes-1.30",
   "packages/kubernetes-1.31",
   "packages/kubernetes-1.32",
+  "packages/kubernetes-1.33",
   "packages/libacl",
   "packages/libaio",
   "packages/libattr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "packages/ecr-credential-provider-1.30",
   "packages/ecr-credential-provider-1.31",
   "packages/ecr-credential-provider-1.32",
+  "packages/ecr-credential-provider-1.33",
   "packages/ecs-agent",
   "packages/ecs-gpu-init",
   "packages/ethtool",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -41,6 +41,7 @@ ecr-credential-provider-1_29 = { path = "../../packages/ecr-credential-provider-
 ecr-credential-provider-1_30 = { path = "../../packages/ecr-credential-provider-1.30" }
 ecr-credential-provider-1_31 = { path = "../../packages/ecr-credential-provider-1.31" }
 ecr-credential-provider-1_32 = { path = "../../packages/ecr-credential-provider-1.32" }
+ecr-credential-provider-1_33 = { path = "../../packages/ecr-credential-provider-1.33" }
 ecs-agent = { path = "../../packages/ecs-agent" }
 ecs-gpu-init = { path = "../../packages/ecs-gpu-init" }
 ethtool = { path = "../../packages/ethtool" }

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -64,6 +64,7 @@ kubernetes-1_29 = { path = "../../packages/kubernetes-1.29" }
 kubernetes-1_30 = { path = "../../packages/kubernetes-1.30" }
 kubernetes-1_31 = { path = "../../packages/kubernetes-1.31" }
 kubernetes-1_32 = { path = "../../packages/kubernetes-1.32" }
+kubernetes-1_33 = { path = "../../packages/kubernetes-1.33" }
 libacl = { path = "../../packages/libacl" }
 libaio = { path = "../../packages/libaio" }
 libattr = { path = "../../packages/libattr" }

--- a/packages/ecr-credential-provider-1.33/Cargo.toml
+++ b/packages/ecr-credential-provider-1.33/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+# "." is not allowed in crate names, but we want a friendlier name for the
+# directory and spec file, so we override it below.
+name = "ecr-credential-provider-1_33"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+package-name = "ecr-credential-provider-1.33"
+releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.33.0-rc.0.tar.gz"
+path = "cloud-provider-aws-1.33.0.tar.gz"
+sha512 = "a923071b95174ad96bf78e3c255e0b7682fe1f896d7399abdcacdde82df808aec026c350e443f8612f98048ca6b51d77208d55f34fae9167a2ccf01b83e20071"
+bundle-modules = [ "go" ]
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/ecr-credential-provider-1.33/clarify.toml
+++ b/packages/ecr-credential-provider-1.33/clarify.toml
@@ -1,0 +1,8 @@
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT AND BSD-3-Clause AND Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x617d80bc },
+    { path = "goyaml.v2/LICENSE", hash = 0xe569d630 },
+    { path = "goyaml.v2/LICENSE.libyaml", hash = 0xa2e4ce3 },
+    { path = "goyaml.v2/NOTICE", hash = 0x49bceeb9 },
+]

--- a/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
+++ b/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
@@ -1,0 +1,80 @@
+%global goproject github.com/kubernetes
+%global gorepo cloud-provider-aws
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 1.33.0
+%global rpmver %{gover}
+
+%global _dwz_low_mem_die_limit 0
+
+Name: %{_cross_os}ecr-credential-provider-1.33
+Version: %{rpmver}
+Release: 0.rc0%{?dist}
+Summary: Amazon ECR credential provider
+License: Apache-2.0
+URL: https://github.com/kubernetes/cloud-provider-aws
+
+Source: cloud-provider-aws-%{gover}.tar.gz
+Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
+Source1000: clarify.toml
+
+BuildRequires: %{_cross_os}glibc-devel
+Requires: %{name}(binaries)
+
+# For IAM Roles Anywhere, the signing helper might be set as the credential
+# process.
+Requires: %{_cross_os}aws-signing-helper
+
+%description
+%{summary}.
+
+%package bin
+Summary: Amazon ECR credential provider binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: Amazon ECR credential provider binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
+%{summary}.
+
+%prep
+%setup -n %{gorepo}-%{gover}-rc.0 -q
+%setup -T -D -n %{gorepo}-%{gover}-rc.0 -b 1 -q
+
+%build
+%set_cross_go_flags
+
+export GOTOOLCHAIN=local
+export GO_MAJOR="1.24"
+
+go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
+gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
+install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
+
+install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
+install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
+
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+
+%files bin
+%{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
+
+%files fips-bin
+%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/kubernetes-1.33/.gitignore
+++ b/packages/kubernetes-1.33/.gitignore
@@ -1,0 +1,1 @@
+/*-EKS-PATCH-*.patch

--- a/packages/kubernetes-1.33/Cargo.toml
+++ b/packages/kubernetes-1.33/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+# "." is not allowed in crate names, but we want a friendlier name for the
+# directory and spec file, so we override it below.
+name = "kubernetes-1_33"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+package-name = "kubernetes-1.33"
+
+[[package.metadata.build-package.external-files]]
+url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/1/artifacts/kubernetes/v1.33.0-beta.0/kubernetes-src.tar.gz"
+sha512 = "45c059166c0d24ba928c446c32e766b77e24e40c61ac4bb54b28725f220793b33ff7d2f04cc355db077cdbd146041ae927cd0c87889ff4b835b9b6faa7a9a09c"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.33/clarify.toml
+++ b/packages/kubernetes-1.33/clarify.toml
@@ -1,0 +1,67 @@
+[clarify."github.com/JeffAshton/win_pdh"]
+expression = "BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0xb221dcc9 },
+]
+
+[clarify."github.com/daviddengcn/go-colortext"]
+expression = "BSD-3-Clause AND MIT"
+license-files = [
+    { path = "LICENSE", hash = 0x9769fae1 },
+]
+
+[clarify."github.com/ghodss/yaml"]
+expression = "MIT AND BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0xcdf3ae00 },
+]
+
+[clarify."github.com/heketi/heketi"]
+# kubernetes only uses code that is under LGPLv3+/Apache 2.0, not the code that is GPLv2+/LGPLv3+
+expression = "LGPL-3.0-or-later OR Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x3c4b96d1 },
+    { path = "LICENSE-APACHE2", hash = 0x438c8616 },
+    { path = "COPYING-LGPLV3", hash = 0xf0bccb3a },
+]
+skip-files = [ "COPYING-GPLV2" ]
+
+[clarify."github.com/go-bindata/go-bindata"]
+expression = "CC0-1.0"
+license-files = [
+    { path = "LICENSE", hash = 0x393fafd6 },
+]
+
+[clarify."github.com/miekg/dns"]
+expression = "BSD-3-Clause"
+license-files = [
+    { path = "COPYRIGHT", hash = 0xe41dd36c },
+    { path = "LICENSE", hash = 0xfc8f12ff },
+]
+
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT AND BSD-3-Clause AND Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x617d80bc },
+    { path = "goyaml.v2/LICENSE", hash = 0xe569d630 },
+    { path = "goyaml.v2/LICENSE.libyaml", hash = 0xa2e4ce3 },
+    { path = "goyaml.v2/NOTICE", hash = 0x49bceeb9 },
+    { path = "goyaml.v3/LICENSE", hash = 0x176b1f44 },
+    { path = "goyaml.v3/NOTICE", hash = 0x49bceeb9 },
+]
+
+[clarify."honnef.co/go/tools"]
+expression = "MIT AND BSD-3-Clause AND Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xad378ed2 },
+    { path = "LICENSE-THIRD-PARTY", hash = 0x546425eb },
+    { path = "lint/LICENSE", hash = 0xc6b58232 },
+    { path = "ssa/LICENSE", hash = 0xe656fb62 },
+]
+
+[clarify."github.com/storageos/go-api"]
+expression = "MIT AND BSD-2-Clause"
+license-files = [
+    { path = "LICENCE", hash = 0x67a6861e },
+]
+skip-files = ["licence.go", "types/licence.go"]

--- a/packages/kubernetes-1.33/credential-provider-config-yaml
+++ b/packages/kubernetes-1.33/credential-provider-config-yaml
@@ -1,0 +1,42 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes  = "v1"
+std = { version = "v1", helpers = ["default"] }
++++
+apiVersion: kubelet.config.k8s.io/v1
+kind: CredentialProviderConfig
+providers:
+{{#if settings.kubernetes.credential-providers}}
+{{#each settings.kubernetes.credential-providers}}
+{{#if this.enabled}}
+  - name: {{@key}}
+    matchImages:
+{{#each this.image-patterns}}
+      - "{{this}}"
+{{/each}}
+    defaultCacheDuration: "{{default "12h" this.cache-duration}}"
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
+{{#if (eq @key "ecr-credential-provider")}}
+    env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
+{{#if this.environment}}
+{{#each this.environment}}
+      - name: {{@key}}
+        value: '{{this}}'
+{{/each}}
+{{/if}}
+{{#if (eq @key "ecr-credential-provider")}}
+      - name: HOME
+        value: '/root'
+{{#if @root.settings.aws.profile}}
+      - name: AWS_PROFILE
+        value: '{{@root.settings.aws.profile}}'
+{{/if}}
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}

--- a/packages/kubernetes-1.33/dockershim-symlink.conf
+++ b/packages/kubernetes-1.33/dockershim-symlink.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock

--- a/packages/kubernetes-1.33/etc-kubernetes-pki-private.mount
+++ b/packages/kubernetes-1.33/etc-kubernetes-pki-private.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Kubernetes PKI private directory (/etc/kubernetes/pki/private)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/etc/kubernetes/pki/private
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=0700
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/kubernetes-1.33/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.33/kubelet-bootstrap-kubeconfig
@@ -1,0 +1,25 @@
+[required-extensions]
+kubernetes = "v1"
++++
+---
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+{{#if settings.kubernetes.api-server}}
+    certificate-authority: "/etc/kubernetes/pki/ca.crt"
+    server: "{{settings.kubernetes.api-server}}"
+{{/if}}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+{{#if settings.kubernetes.bootstrap-token}}
+  user:
+    token: "{{settings.kubernetes.bootstrap-token}}"
+{{/if}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -1,0 +1,196 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["any_enabled", "default"] }
++++
+---
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+{{#if settings.kubernetes.standalone-mode}}
+address: 127.0.0.1
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
+{{else}}
+address: 0.0.0.0
+authentication:
+  anonymous:
+    enabled: false
+  webhook:
+    cacheTTL: 2m0s
+    enabled: true
+  x509:
+    clientCAFile: "/etc/kubernetes/pki/ca.crt"
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 5m0s
+    cacheUnauthorizedTTL: 30s
+{{/if}}
+clusterDomain: {{settings.kubernetes.cluster-domain}}
+{{#if settings.kubernetes.cluster-dns-ip}}
+clusterDNS:
+{{#each settings.kubernetes.cluster-dns-ip}}
+- {{this}}
+{{else}}
+- {{settings.kubernetes.cluster-dns-ip}}
+{{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-soft}}
+evictionSoft:
+  {{#each settings.kubernetes.eviction-soft}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-soft-grace-period}}
+evictionSoftGracePeriod:
+  {{#each settings.kubernetes.eviction-soft-grace-period}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-max-pod-grace-period}}
+evictionMaxPodGracePeriod: {{settings.kubernetes.eviction-max-pod-grace-period}}
+{{/if}}
+{{#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{/if}}
+{{#if settings.kubernetes.registry-qps includeZero=true}}
+registryPullQPS: {{settings.kubernetes.registry-qps}}
+{{/if}}
+{{#if settings.kubernetes.registry-burst includeZero=true}}
+registryBurst: {{settings.kubernetes.registry-burst}}
+{{/if}}
+{{#if settings.kubernetes.event-qps includeZero=true}}
+eventRecordQPS: {{settings.kubernetes.event-qps}}
+{{/if}}
+{{#if settings.kubernetes.event-burst includeZero=true}}
+eventBurst: {{settings.kubernetes.event-burst}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-qps includeZero=true}}
+kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-burst includeZero=true}}
+kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
+{{/if}}
+kubeReserved:
+  cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  {{#if settings.kubernetes.kube-reserved.memory}}
+  memory: "{{settings.kubernetes.kube-reserved.memory}}"
+  {{else}}
+  {{#if settings.kubernetes.max-pods}}
+  memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  {{/if}}
+  {{/if}}
+  ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+{{#unless settings.kubernetes.reserved-cpus}}
+kubeReservedCgroup: "/runtime"
+{{/unless}}
+{{#if settings.kubernetes.system-reserved}}
+systemReserved:
+  {{#each settings.kubernetes.system-reserved}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{#unless settings.kubernetes.reserved-cpus}}
+systemReservedCgroup: "/system"
+{{/unless}}
+{{/if}}
+cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
+cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
+{{#if settings.kubernetes.cpu-manager-reconcile-period}}
+cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
+{{/if}}
+{{#if settings.kubernetes.cpu-manager-policy-options}}
+cpuManagerPolicyOptions:
+{{#each settings.kubernetes.cpu-manager-policy-options}}
+    {{this}}: "true"
+{{/each}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-scope}}
+topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-policy}}
+topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
+{{/if}}
+podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
+{{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
+imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
+{{/if}}
+{{#if settings.kubernetes.image-gc-low-threshold-percent includeZero=true}}
+imageGCLowThresholdPercent: {{settings.kubernetes.image-gc-low-threshold-percent}}
+{{/if}}
+{{#if settings.kubernetes.provider-id}}
+providerID: {{settings.kubernetes.provider-id}}
+{{/if}}
+resolvConf: "/run/netdog/resolv.conf"
+hairpinMode: hairpin-veth
+readOnlyPort: 0
+cgroupDriver: systemd
+cgroupRoot: "/"
+runtimeRequestTimeout: 15m
+protectKernelDefaults: true
+serializeImagePulls: false
+seccompDefault: {{default false settings.kubernetes.seccomp-default}}
+{{#if (and (default "" settings.kubernetes.server-certificate) (default "" settings.kubernetes.server-key))}}
+tlsCertFile: "/etc/kubernetes/pki/kubelet-server.crt"
+tlsPrivateKeyFile: "/etc/kubernetes/pki/private/kubelet-server.key"
+{{else}}
+serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
+{{/if}}
+tlsCipherSuites:
+- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
+maxPods: {{default 110 settings.kubernetes.max-pods}}
+staticPodPath: "/etc/kubernetes/static-pods/"
+{{#if settings.kubernetes.container-log-max-size includeZero=true}}
+containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
+{{/if}}
+{{#if settings.kubernetes.container-log-max-files includeZero=true}}
+containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
+{{/if}}
+{{#if settings.kubernetes.shutdown-grace-period}}
+shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
+{{/if}}
+{{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+{{/if}}
+{{#if settings.kubernetes.memory-manager-reserved-memory}}
+{{#if (any_enabled settings.kubernetes.memory-manager-reserved-memory)}}
+{{#if settings.kubernetes.memory-manager-policy}}
+memoryManagerPolicy: {{settings.kubernetes.memory-manager-policy}}
+{{/if}}
+reservedMemory:
+{{#each settings.kubernetes.memory-manager-reserved-memory}}
+{{#if this.enabled}}
+  - numaNode: {{@key}}
+    limits:
+{{#if this.memory}}
+      memory: {{this.memory}}
+{{/if}}
+{{#if this.hugepages-1Gi}}
+      hugepages-1Gi: {{this.hugepages-1Gi}}
+{{/if}}
+{{#if this.hugepages-2Mi}}
+      hugepages-2Mi: {{this.hugepages-2Mi}}
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}
+{{/if}}
+{{#if settings.kubernetes.reserved-cpus}}
+reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
+{{/if}}
+failSwapOn: false

--- a/packages/kubernetes-1.33/kubelet-env
+++ b/packages/kubernetes-1.33/kubelet-env
@@ -1,0 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["join_node_taints"] }
+std = { version = "v1", helpers = ["join_map"] }
++++
+NODE_IP={{settings.kubernetes.node-ip}}
+NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
+NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}

--- a/packages/kubernetes-1.33/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.33/kubelet-exec-start-conf
@@ -1,0 +1,38 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["any_enabled", "default"] }
++++
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet \
+{{#unless settings.kubernetes.standalone-mode}}
+    --cloud-provider {{default "external" settings.kubernetes.cloud-provider}} \
+    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
+    --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
+{{/if}}
+{{else}}
+    --cloud-provider "" \
+{{/unless}}
+    --config /etc/kubernetes/kubelet/config \
+    --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+    --containerd=/run/containerd/containerd.sock \
+    --root-dir /var/lib/kubelet \
+    --cert-dir /var/lib/kubelet/pki \
+{{#if settings.kubernetes.credential-providers}}
+{{#if (any_enabled settings.kubernetes.credential-providers)}}
+    --image-credential-provider-bin-dir /usr/libexec/kubernetes/kubelet/plugins \
+    --image-credential-provider-config /etc/kubernetes/kubelet/credential-provider-config.yaml \
+{{/if}}
+{{/if}}
+{{#if settings.kubernetes.hostname-override}}
+    --hostname-override {{settings.kubernetes.hostname-override}} \
+{{/if}}
+    --node-ip ${NODE_IP} \
+    --node-labels "${NODE_LABELS}" \
+    --register-with-taints "${NODE_TAINTS}" \
+{{#if settings.kubernetes.log-level includeZero=true}}
+    -v {{settings.kubernetes.log-level}} \
+{{/if}}
+    --pod-infra-container-image localhost/kubernetes/pause:0.1.0 \
+    --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.33/kubelet-kubeconfig
+++ b/packages/kubernetes-1.33/kubelet-kubeconfig
@@ -1,0 +1,43 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes = "v1"
++++
+---
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+{{#if settings.kubernetes.api-server}}
+    certificate-authority: "/etc/kubernetes/pki/ca.crt"
+    server: "{{settings.kubernetes.api-server}}"
+{{/if}}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+{{#if (eq settings.kubernetes.authentication-mode "aws")}}
+{{#if settings.kubernetes.cluster-name}}
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: "/usr/bin/aws-iam-authenticator"
+      args:
+      - token
+      - "-i"
+      - "{{settings.kubernetes.cluster-name}}"
+      {{#if settings.aws.region}}
+      - "--region"
+      - "{{settings.aws.region}}"
+      {{/if}}
+{{/if}}
+{{/if}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
+  user:
+    client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
+    client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
+{{/if}}

--- a/packages/kubernetes-1.33/kubelet-server-crt
+++ b/packages/kubernetes-1.33/kubelet-server-crt
@@ -1,0 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
+{{~#if settings.kubernetes.server-certificate~}}
+{{base64_decode settings.kubernetes.server-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.33/kubelet-server-key
+++ b/packages/kubernetes-1.33/kubelet-server-key
@@ -1,0 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
+{{~#if settings.kubernetes.server-key~}}
+{{base64_decode settings.kubernetes.server-key}}
+{{~/if~}}

--- a/packages/kubernetes-1.33/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.33/kubelet-sysctl.conf
@@ -1,0 +1,2 @@
+# Overcommit handling mode - 1: Always overcommit
+vm.overcommit_memory = 1

--- a/packages/kubernetes-1.33/kubelet.service
+++ b/packages/kubernetes-1.33/kubelet.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Kubelet
+Documentation=https://github.com/kubernetes/kubernetes
+After=containerd.service configured.target
+Wants=configured.target
+BindsTo=containerd.service
+
+[Service]
+Slice=runtime.slice
+Type=notify
+EnvironmentFile=/etc/network/proxy.env
+EnvironmentFile=/etc/kubernetes/kubelet/env
+ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
+# Must be overridden by a drop-in file or `kubelet` won't start
+ExecStart=/usr/bin/false
+
+Restart=always
+RestartForceExitStatus=SIGPIPE
+RestartSec=5
+Delegate=yes
+KillMode=process
+CPUAccounting=true
+MemoryAccounting=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -1,0 +1,277 @@
+# After this upstream change, the linker flags `-s -w` are always added unless
+# DBG=1 is set in the environment, which would set compiler flags to disable
+# optimizations and inlining:
+#  https://github.com/kubernetes/kubernetes/pull/108371
+#
+# For now, work around this by indicating that no debug package is expected.
+%global debug_package %{nil}
+
+%global goproject github.com/kubernetes
+%global gorepo kubernetes
+%global goimport %{goproject}/%{gorepo}
+
+%global releasever 1
+%global gover 1.33.0
+%global rpmver %{gover}
+
+%global _dwz_low_mem_die_limit 0
+
+# Construct reproducible tar archives
+# See https://reproducible-builds.org/docs/archives/
+%global source_date_epoch 1234567890
+%global tar_cf tar --sort=name --mtime="@%{source_date_epoch}" --owner=0 --group=0 --numeric-owner -cf
+
+# The kubernetes build process expects the cross-compiler to be specified via `KUBE_*_CC`
+# Here we generate that variable to use bottlerocket-specific compile aliases
+# Examples of the generated variable:
+# KUBE_LINUX_AMD64_CC=x86_64-bottlerocket-linux-gnu-gcc
+# KUBE_LINUX_ARM64_CC=aarch64-bottlerocket-linux-gnu-gcc
+%global kube_cc %{shrink: \
+  %{lua: print(string.upper( \
+     rpm.expand("KUBE_%{_cross_go_os}_%{_cross_go_arch}_CC=")) .. \
+     rpm.expand("%{_cross_target}-gcc")) }}
+
+Name: %{_cross_os}%{gorepo}
+Version: %{rpmver}
+Release: 0.beta0%{?dist}
+Summary: Container cluster management
+# base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
+License: Apache-2.0 AND BSD-3-Clause
+URL: https://%{goimport}
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-33/releases/%{releasever}/artifacts/kubernetes/v1.33.0-beta.0/kubernetes-src.tar.gz
+Source1: kubelet.service
+Source2: kubelet-env
+Source3: kubelet-config
+Source4: kubelet-kubeconfig
+Source5: kubernetes-ca-crt
+Source6: kubelet-exec-start-conf
+Source7: kubelet-bootstrap-kubeconfig
+Source8: kubernetes-tmpfiles.conf
+Source9: kubelet-sysctl.conf
+Source10: prepare-var-lib-kubelet.service
+Source11: kubelet-server-crt
+Source12: kubelet-server-key
+Source13: etc-kubernetes-pki-private.mount
+Source14: credential-provider-config-yaml
+Source15: logdog.kubelet.conf
+
+# ExecStartPre drop-ins
+Source20: prestart-load-pause-ctr.conf
+Source21: dockershim-symlink.conf
+Source22: make-kubelet-dirs.conf
+
+# pause image components
+Source100: pause-config.json
+Source101: pause-manifest.json
+Source102: pod-infra-container-image
+
+Source1000: clarify.toml
+
+BuildRequires: git
+BuildRequires: rsync
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.33
+Summary: Container cluster node agent
+Requires: %{_cross_os}conntrack-tools
+Requires: %{_cross_os}containerd
+Requires: %{_cross_os}findutils
+Requires: %{_cross_os}ecr-credential-provider-1.33
+Requires: %{_cross_os}aws-iam-authenticator
+Requires: %{_cross_os}static-pods
+Requires: %{_cross_os}kubelet-1.33(binaries)
+
+%description -n %{_cross_os}kubelet-1.33
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.33-bin
+Summary: Container cluster node agent binaries
+Provides: %{_cross_os}kubelet-1.33(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.33)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.33-fips-bin)
+
+%description -n %{_cross_os}kubelet-1.33-bin
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.33-fips-bin
+Summary: Container cluster node agent binaries, FIPS edition
+Provides: %{_cross_os}kubelet-1.33(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.33)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.33-bin)
+
+%description -n %{_cross_os}kubelet-1.33-fips-bin
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.33
+Summary: Container cluster node proxy
+Requires: %{_cross_os}kubelet-1.33
+Requires: %{_cross_os}kube-proxy-1.33(binaries)
+
+%description -n %{_cross_os}kube-proxy-1.33
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.33-bin
+Summary: Container cluster node proxy binaries
+Provides: %{_cross_os}kube-proxy-1.33(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.33)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.33-fips-bin)
+
+%description -n %{_cross_os}kube-proxy-1.33-bin
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.33-fips-bin
+Summary: Container cluster node proxy binaries, FIPS edition
+Provides: %{_cross_os}kube-proxy-1.33(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.33)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.33-bin)
+
+%description -n %{_cross_os}kube-proxy-1.33-fips-bin
+%{summary}.
+
+%prep
+%autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
+
+# third_party licenses
+# multiarch/qemu-user-static ignored, we're not using it
+cp third_party/forked/gonum/graph/LICENSE LICENSE.gonum.graph
+cp third_party/forked/shell2junit/LICENSE LICENSE.shell2junit
+cp third_party/forked/golang/LICENSE LICENSE.golang
+cp third_party/forked/golang/PATENTS PATENTS.golang
+
+%build
+export FORCE_HOST_GO=1
+
+export GO_MAJOR="1.24"
+
+# Build codegen programs with the host toolchain.
+make hack/update-codegen.sh
+
+# Build kubelet and kube-proxy with the target toolchain.
+%set_cross_go_flags
+unset CC
+export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
+export %{kube_cc}
+export GOFLAGS="${GOFLAGS} -tags=dockerless"
+export GOLDFLAGS="${GOLDFLAGS}"
+# don't build kube-proxy statically as we use linkermode=external which requires CGO
+export KUBE_CGO_OVERRIDES="kube-proxy"
+make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
+
+export KUBE_OUTPUT_SUBPATH="_fips_output/local"
+export GOEXPERIMENT="boringcrypto"
+make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
+
+# build the pause container
+cd build/pause/linux/
+
+# Build static pause executable for container image.
+mkdir -p rootfs/usr/bin
+%{_cross_triple}-musl-gcc %{_cross_cflags} %{_cross_ldflags} -static-pie pause.c -o rootfs/pause
+
+# Construct container image.
+mkdir -p image/rootfs
+%tar_cf image/rootfs/layer.tar -C rootfs .
+DIGEST=$(sha256sum image/rootfs/layer.tar | sed -e 's/ .*//')
+install -m 0644 %{S:100} image/config.json
+sed -i "s/~~digest~~/${DIGEST}/" image/config.json
+install -m 0644 %{S:101} image/manifest.json
+
+%tar_cf ../../../_output/local/bin/linux/%{_cross_go_arch}/kubernetes-pause.tar -C image .
+
+%install
+output="./_output/local/bin/linux/%{_cross_go_arch}"
+install -d %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
+
+fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
+install -d %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
+
+install -d %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
+
+install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+
+mkdir -p %{buildroot}%{_cross_templatedir}
+install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
+install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
+install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
+install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
+install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
+install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
+install -m 0644 %{S:11} %{buildroot}%{_cross_templatedir}/kubelet-server-crt
+install -m 0644 %{S:12} %{buildroot}%{_cross_templatedir}/kubelet-server-key
+install -m 0644 %{S:14} %{buildroot}%{_cross_templatedir}/credential-provider-config-yaml
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+
+install -d %{buildroot}%{_cross_sysctldir}
+install -p -m 0644 %{S:9} %{buildroot}%{_cross_sysctldir}/90-kubelet.conf
+
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes
+ln -rs \
+  %{buildroot}%{_sharedstatedir}/kubelet/plugins \
+  %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
+
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
+
+install -d %{buildroot}%{_cross_datadir}/logdog.d
+install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
+
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes
+install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
+install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
+
+%files -n %{_cross_os}kubelet-1.33
+%license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+%{_cross_unitdir}/kubelet.service
+%{_cross_unitdir}/prepare-var-lib-kubelet.service
+%{_cross_unitdir}/etc-kubernetes-pki-private.mount
+%dir %{_cross_unitdir}/kubelet.service.d
+%{_cross_unitdir}/kubelet.service.d/prestart-load-pause-ctr.conf
+%{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
+%{_cross_unitdir}/kubelet.service.d/dockershim-symlink.conf
+%dir %{_cross_templatedir}
+%{_cross_templatedir}/kubelet-env
+%{_cross_templatedir}/kubelet-config
+%{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
+%{_cross_templatedir}/kubelet-exec-start-conf
+%{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_templatedir}/kubelet-server-crt
+%{_cross_templatedir}/kubelet-server-key
+%{_cross_templatedir}/credential-provider-config-yaml
+%{_cross_tmpfilesdir}/kubernetes.conf
+%{_cross_sysctldir}/90-kubelet.conf
+%dir %{_cross_libexecdir}/kubernetes
+%{_cross_libexecdir}/kubernetes/kubelet-plugins
+%{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
+%{_cross_templatedir}/pod-infra-container-image
+%{_cross_datadir}/logdog.d/logdog.kubelet.conf
+
+%files -n %{_cross_os}kubelet-1.33-bin
+%{_cross_bindir}/kubelet
+
+%files -n %{_cross_os}kubelet-1.33-fips-bin
+%{_cross_fips_bindir}/kubelet
+
+%files -n %{_cross_os}kube-proxy-1.33
+
+%files -n %{_cross_os}kube-proxy-1.33-bin
+%{_cross_bindir}/kube-proxy
+
+%files -n %{_cross_os}kube-proxy-1.33-fips-bin
+%{_cross_fips_bindir}/kube-proxy
+
+%changelog

--- a/packages/kubernetes-1.33/kubernetes-ca-crt
+++ b/packages/kubernetes-1.33/kubernetes-ca-crt
@@ -1,0 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
+{{~#if settings.kubernetes.cluster-certificate~}}
+{{base64_decode settings.kubernetes.cluster-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.33/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.33/kubernetes-tmpfiles.conf
@@ -1,0 +1,7 @@
+d /etc/kubernetes/static-pods - - - -
+L /etc/kubernetes/manifests - - - - static-pods
+L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
+r! /var/lib/kubelet/cpu_manager_state
+L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
+d /opt/csi/mountpoint-s3 - - - -
+L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3

--- a/packages/kubernetes-1.33/logdog.kubelet.conf
+++ b/packages/kubernetes-1.33/logdog.kubelet.conf
@@ -1,0 +1,3 @@
+exec kube-status systemctl status kube* -l --no-pager
+file ipamd.log /var/log/aws-routed-eni/ipamd.log
+file plugin.log /var/log/aws-routed-eni/plugin.log

--- a/packages/kubernetes-1.33/make-kubelet-dirs.conf
+++ b/packages/kubernetes-1.33/make-kubelet-dirs.conf
@@ -1,0 +1,5 @@
+[Service]
+# Create the backing directories for symlinks in /etc
+ExecStartPre=/usr/bin/mkdir -p \
+    /var/lib/kubelet/providers/secrets-store \
+    /var/lib/kubelet/node-feature-discovery/features.d

--- a/packages/kubernetes-1.33/pause-config.json
+++ b/packages/kubernetes-1.33/pause-config.json
@@ -1,0 +1,1 @@
+{"author":"Bottlerocket","config":{"Cmd":["/pause"],"ArgsEscaped":true},"created":"2014-12-12T01:12:53.332832423Z","history":[{"created":"2014-12-12T01:12:53.332832423Z","author":"Bottlerocket","created_by":"Bottlerocket","empty_layer":true}],"os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:~~digest~~"]}}

--- a/packages/kubernetes-1.33/pause-manifest.json
+++ b/packages/kubernetes-1.33/pause-manifest.json
@@ -1,0 +1,1 @@
+[{"Config":"config.json","RepoTags":["localhost/kubernetes/pause:0.1.0"],"Layers":["rootfs/layer.tar"]}]

--- a/packages/kubernetes-1.33/pod-infra-container-image
+++ b/packages/kubernetes-1.33/pod-infra-container-image
@@ -1,0 +1,6 @@
+[required-extensions]
+kubernetes = { version = "v1", optional = true }
++++
+{{~#if settings.kubernetes.pod-infra-container-image~}}
+DEPRECATED_SETTING=settings.kubernetes.pod-infra-container-image
+{{~/if~}}

--- a/packages/kubernetes-1.33/prepare-var-lib-kubelet.service
+++ b/packages/kubernetes-1.33/prepare-var-lib-kubelet.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Prepare Kubelet Directory (/var/lib/kubelet)
+DefaultDependencies=no
+RequiresMountsFor=/var
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+
+# Remove an existing symlink, if present. Intentionally not recursive!
+ExecStartPre=-/usr/bin/rm -f /var/lib/kubelet
+
+# Create /var/lib/kubelet so it is available for bind mounts.
+ExecStart=/usr/bin/mkdir -p /var/lib/kubelet
+
+# Suppress warning if directory exists.
+StandardError=null
+
+RemainAfterExit=true
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/kubernetes-1.33/prestart-load-pause-ctr.conf
+++ b/packages/kubernetes-1.33/prestart-load-pause-ctr.conf
@@ -1,0 +1,14 @@
+[Service]
+# load the built-in pause image
+ExecStartPre=/usr/bin/ctr \
+    --namespace=k8s.io \
+    image import \
+    --all-platforms \
+    /usr/libexec/kubernetes/kubernetes-pause.tar
+
+# label it to prevent it from being removed
+ExecStartPre=/usr/bin/ctr \
+    --namespace=k8s.io \
+    image label \
+    localhost/kubernetes/pause:0.1.0 \
+    io.cri-containerd.pinned=pinned


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket/issues/4477

**Description of changes:**

Initial set of changes for kubernetes 1.33 support:
- Add a kubernetes-1.33 pkg with the EKS-D k8s-1.33-beta.0 source
- Add a ecr-credential-provider-1.33 pkg with the 1.33-rc.0 source (which is [the current latest](https://github.com/kubernetes/cloud-provider-aws/releases))

**Testing done:**

- Core-kit builds with the new packages
- Instance using the 1.33-beta.0 kubelet boots
- RPM info to verify `rpmvercmp`:
```
$  rpm -qpi build/rpms/kubernetes-1.33/bottlerocket-kubelet-1.33-1.33.0-0.beta0.1744782134.eaa3fa49.br1.x86_64.rpm 
Name        : bottlerocket-kubelet-1.33
Version     : 1.33.0
Release     : 0.beta0.1744782134.eaa3fa49.br1
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 1547763
License     : Apache-2.0 AND BSD-3-Clause
Signature   : (none)
Source RPM  : bottlerocket-kubernetes-1.33.0-0.beta0.1744782134.eaa3fa49.br1.src.rpm
Build Date  : Wed Apr 16 06:18:51 2025
Build Host  : localhost
URL         : https://github.com/kubernetes/kubernetes
Summary     : Container cluster node agent
Description :
Container cluster node agent.

$ rpm -qpi build/rpms/ecr-credential-provider-1.33/bottlerocket-ecr-credential-provider-1.33-1.33.0-0.rc0.1744782134.eaa3fa49.br1.x86_64.rpm 
Name        : bottlerocket-ecr-credential-provider-1.33
Version     : 1.33.0
Release     : 0.rc0.1744782134.eaa3fa49.br1
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 1030683
License     : Apache-2.0
Signature   : (none)
Source RPM  : bottlerocket-ecr-credential-provider-1.33-1.33.0-0.rc0.1744782134.eaa3fa49.br1.src.rpm
Build Date  : Wed Apr 16 06:22:36 2025
Build Host  : localhost
URL         : https://github.com/kubernetes/cloud-provider-aws
Summary     : Amazon ECR credential provider
Description :
Amazon ECR credential provider.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
