### PR TITLE
Migrate ECS to CDI

### DIFF
--- a/packages/docker-engine/daemon-nvidia-json
+++ b/packages/docker-engine/daemon-nvidia-json
@@ -25,5 +25,9 @@ std = { version = "v1", helpers = ["join_array"] }
   {{/if}}
   {{/each}}
   {{/if}}
-  "selinux-enabled": true
+  "selinux-enabled": true,
+  "features": {
+    "cdi": true
+  },
+  "cdi-spec-dirs": ["/etc/cdi/"]
 }

--- a/packages/nvidia-container-toolkit/0001-ldcache-fix-parsing-for-aarch64.patch
+++ b/packages/nvidia-container-toolkit/0001-ldcache-fix-parsing-for-aarch64.patch
@@ -1,0 +1,46 @@
+From 018a8150cab0969c63b82a1e93047599e56de167 Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Wed, 23 Apr 2025 01:09:31 +0000
+Subject: [PATCH] ldcache: fix parsing for aarch64
+
+The architecture flag for aarch64 is currently missing from the
+supported architecture flags list. This omission causes the getEntries
+function to exclude all libraries found on aarch64 hosts. As a result
+helper programs like nvidia-ctk are unable to generate CDI
+specifications for the aarch64 architecture.
+
+This fix adds the missing aarch64 architecture flag, using the same
+value as defined in libnvidia-container[1], which maintains a more
+comprehensive list of supported architectures.
+
+[1]: https://github.com/NVIDIA/libnvidia-container/blob/a198166e1c1166f4847598438115ea97dacc7a92/src/ldcache.h#L21
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ internal/ldcache/ldcache.go | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/internal/ldcache/ldcache.go b/internal/ldcache/ldcache.go
+index 4daf95b..455048c 100644
+--- a/internal/ldcache/ldcache.go
++++ b/internal/ldcache/ldcache.go
+@@ -47,6 +47,7 @@ const (
+ 	flagArchX8664   = 0x0300
+ 	flagArchX32     = 0x0800
+ 	flagArchPpc64le = 0x0500
++	flagArchAarch64 = 0x0a00
+ )
+ 
+ var errInvalidCache = errors.New("invalid ld.so.cache file")
+@@ -195,6 +196,8 @@ func (c *ldcache) getEntries() []entry {
+ 		switch e.Flags & flagArchMask {
+ 		case flagArchX8664:
+ 			fallthrough
++		case flagArchAarch64:
++			fallthrough
+ 		case flagArchPpc64le:
+ 			bits = 64
+ 		case flagArchX32:
+-- 
+2.49.0
+

--- a/packages/nvidia-container-toolkit/generate-cdi-specs.service
+++ b/packages/nvidia-container-toolkit/generate-cdi-specs.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Generate CDI specifications
+# This has to be executed after the kernel modules are loaded
+# otherwise the userspace component of the driver will fail to
+# query the /dev devices
+After=load-tesla-kernel-modules.service load-open-gpu-kernel-modules.service
+# Running this unit after nvidia persistenced ensures that
+# the /dev devices are created and the hardware set to
+# persistence mode.
+Requires=nvidia-persistenced.service
+After=nvidia-persistenced.service
+# Block manual interactions with this service. It doesn't
+# make sense to regenerate CDI specifications as features
+# that might change the GPU (e.g. MIG) are not supported in
+# ECS
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+# Explanation of the options:
+# --format json: to be consistent across Bottlerocket's variants
+# --mode nvml: the default mode ("auto") resolves to this already, make it explicit
+# --device-name-strategy uuid: the ECS agent only supports device UUIDs
+# --output /etc/cdi/nvidia.json: store the CDI specifications at this location
+ExecStart=/usr/bin/nvidia-ctk cdi generate --format json \
+  --mode nvml \
+  --device-name-strategy uuid \
+  --output /etc/cdi/nvidia.json
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-ecs.toml
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit-config-ecs.toml
@@ -3,3 +3,6 @@ root = "/"
 path = "/usr/bin/nvidia-container-cli"
 environment = []
 ldconfig = "@/sbin/ldconfig"
+
+[nvidia-container-runtime]
+mode = "cdi"

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -22,6 +22,7 @@ Source3: nvidia-gpu-devices.rules
 Source4: nvidia-container-toolkit-tmpfiles-ecs.conf
 Source5: nvidia-container-toolkit-tmpfiles-k8s.conf
 Source6: nvidia-container-toolkit-config-k8s
+Source7: generate-cdi-specs.service
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}libnvidia-container
@@ -34,6 +35,7 @@ Requires: (%{name}-k8s if %{_cross_os}variant-family(aws-k8s))
 %package ecs
 Summary: Files specific for the ECS variants
 Requires: %{name}
+Requires: %{name}-cdi-specs
 Conflicts: %{name}-k8s
 
 %description ecs
@@ -45,6 +47,13 @@ Requires: %{name}
 Conflicts: %{name}-ecs
 
 %description k8s
+%{summary}.
+
+%package cdi-specs
+Summary: Tools to generate CDI specifications
+Requires: %{name}
+
+%description cdi-specs
 %{summary}.
 
 %prep
@@ -69,6 +78,7 @@ install -d %{buildroot}%{_cross_bindir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_udevrulesdir}
+install -d %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_datadir}/nvidia-container-toolkit
 install -d %{buildroot}%{_cross_factorydir}/nvidia-container-runtime
 install -d %{buildroot}%{_cross_templatedir}/nvidia-container-runtime
@@ -82,6 +92,7 @@ install -p -m 0644 %{S:3} %{buildroot}%{_cross_udevrulesdir}/90-nvidia-gpu-devic
 install -m 0644 %{S:4} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolkit-ecs.conf
 install -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolkit-k8s.conf
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/nvidia-container-runtime/
+install -m 0644 %{S:7} %{buildroot}%{_cross_unitdir}/
 
 %files
 %license LICENSE
@@ -100,3 +111,6 @@ install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/nvidia-container-runtim
 %{_cross_factorydir}/nvidia-container-runtime/nvidia-container-toolkit-config-k8s.toml
 %{_cross_templatedir}/nvidia-container-runtime/nvidia-container-toolkit-config-k8s
 %{_cross_tmpfilesdir}/nvidia-container-toolkit-k8s.conf
+
+%files cdi-specs
+%{_cross_unitdir}/generate-cdi-specs.service

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -23,6 +23,7 @@ Source4: nvidia-container-toolkit-tmpfiles-ecs.conf
 Source5: nvidia-container-toolkit-tmpfiles-k8s.conf
 Source6: nvidia-container-toolkit-config-k8s
 Source7: generate-cdi-specs.service
+Patch0001: 0001-ldcache-fix-parsing-for-aarch64.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}libnvidia-container


### PR DESCRIPTION
**Issue number:**

Related to #470 

**Description of changes:**

This series of commits enable CDI for ECS.

A new package `nvidia-container-toolkit-cdi-specs` provides an additional service to generate CDI specifications. This new service can be used by downstream builders that support CDI. This new package is automatically installed for ECS variants.

The `nvidia-container-toolkit` configuration for ECS now forces the cdi mode. The reason for this is twofold:

- This truly enables CDI, and drops the dependency on the prestart hook provided by nvidia-container-toolkit
- This mode allows to use the `NVIDIA_VISIBLE_DEVICES` environment variable, which is what the ECS agent uses to "pass down" the devices that must be configured in the container

The last commit in the series adds a patch for `nvidia-container-toolkit`. The changes in #471 didn't work because `nvidia-ctk` failed to generate the CDI specifications for aarch64 hosts. This is because the module that parses `ldcache` is missing support for aarch64 hosts (see https://github.com/NVIDIA/nvidia-container-toolkit/issues/1045). This is already being fixed upstream (see https://github.com/NVIDIA/nvidia-container-toolkit/pull/1046).

**Testing done:**

With `aws-ecs-2-nvidia` both x86_64 and aarch64 instances (g4dn.2xlarge and g5g.2xlarge):

- Instances booted (previously, aarch64 hosts failed to boot)
- Launched the `nvida-smoke` test defined in testsys:

```
[root@a8bd83522145 /]# uname -a
Linux a8bd83522145 6.1.132 #1 SMP Mon Apr 21 16:58:15 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux

[root@a8bd83522145 /]# find /samples -mindepth 1 -exec {} \;
GPU Device 0: "Turing" with compute capability 7.5

Running ........................................................

Overall Time For matrixMultiplyPerf

Printing Average of 20 measurements in (ms)
Size_KB  UMhint UMhntAs  UMeasy   0Copy MemCopy CpAsync CpHpglk CpPglAs
4         0.180   0.209   0.312   0.018   0.032   0.029   0.037   0.029
16        0.206   0.241   0.406   0.042   0.055   0.046   0.061   0.057
64        0.346   0.354   0.694   0.135   0.142   0.132   0.142   0.132
256       0.849   0.793   1.196   0.744   0.529   0.506   0.493   0.489
1024      2.961   2.679   3.433   4.777   2.129   2.077   1.912   1.899
4096     11.248  10.239  13.502  35.709   8.743   8.661   8.548   8.512
16384    50.874  48.221  60.778 334.087  42.651  42.575  42.570  42.579

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.
/samples/deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA T4G"
  CUDA Driver Version / Runtime Version          12.2 / 11.4
  CUDA Capability Major/Minor version number:    7.5
  Total amount of global memory:                 14931 MBytes (15655829504 bytes)
  (040) Multiprocessors, (064) CUDA Cores/MP:    2560 CUDA Cores
  GPU Max Clock rate:                            1590 MHz (1.59 GHz)
  Memory Clock rate:                             5001 Mhz
  Memory Bus Width:                              256-bit
  L2 Cache Size:                                 4194304 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        65536 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1024
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 3 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 31
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.2, CUDA Runtime Version = 11.4, NumDevs = 1
Result = PASS
[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Turing" with compute capability 7.5

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 336.17 GFlop/s, Time= 12.477 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.
Initializing...
GPU Device 0: "Turing" with compute capability 7.5

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 5.052672 ms
TOPS: 27.20
reductionMultiBlockCG Starting...

GPU Device 0: "Turing" with compute capability 7.5

33554432 elements
numThreads: 1024
numBlocks: 40

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 0.917629 ms
Bandwidth:    146.265758 GB/s

GPU result = 1.992401361465
CPU result = 1.992401361465
Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.024288
65536 elements scanned in 0.024288 ms -> 2698.287109 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.053610 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.051968 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.110240 ms
CheckSum: 2073600, (expect 1920x1080=2073600)
/samples/simpleAWBarrier starting...
GPU Device 0: "Turing" with compute capability 7.5

Launching normVecByDotProductAWBarrier kernel with numBlocks = 40 blockSize = 1024
Result = PASSED
/samples/simpleAWBarrier completed, returned OK
simpleAtomicIntrinsics starting...
GPU Device 0: "Turing" with compute capability 7.5

Processing time: 115.209999 (ms)
simpleAtomicIntrinsics completed, returned OK
[simpleVoteIntrinsics]
GPU Device 0: "Turing" with compute capability 7.5

> GPU device has 40 Multi-Processors, SM 7.5 compute capabilities

[VOTE Kernel Test 1/3]
        Running <<Vote.Any>> kernel1 ...
        OK

[VOTE Kernel Test 2/3]
        Running <<Vote.All>> kernel2 ...
        OK

[VOTE Kernel Test 3/3]
        Running <<Vote.Any>> kernel3 ...
        OK
        Shutting down...
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done
GPU Device 0: "Turing" with compute capability 7.5

CPU max matches GPU max

Warp Aggregated Atomics PASSED
[root@a8bd83522145 /]#
```

As an extra precaution, I diffed the libraries and binaries mounted on the containers, to make sure we aren't missing any library with the migration. I confirmed that the libraries are the same. Left CDI, Right Legacy:

```
/aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/nvidia-debug	/aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/nvidia-debug
/aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/nvidia-persi	/aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/nvidia-persi
/aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/nvidia-smi	/aarch64-bottlerocket-linux-gnu/sys-root/usr/bin/nvidia-smi
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/firmware/nvi |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/firmware/nvi
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/firmware/nvi |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/firmware/nvi
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/driver/nvidia/gpus/0000:00:1f.0
/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla |	/nvidia0
							      >	/nvidiactl
							      >	/nvidia-modeset
/nvidia-persistenced/socket					/nvidia-persistenced/socket
							      >	/nvidia-uvm
							      >	/nvidia-uvm-tools
``` 

Reviewers will notice the missing `/driver/nvidia/gpus/0000:00:1f.0`, `/nvidia0`, `/nvidiactl`, `/nvidia-modeset`, `/nvidia-uvm`, `/nvidia-uvm-tools` mounts in CDI. This is because instead of mounting the devices, in CDI the devices are actually passed as Linux devices configured in the OCI specification. So instead of mounts, the devices are created by the container runtime under `/dev` :

```
[root@a8bd83522145 /]# ls -la /dev/ | grep nvidia
crw-rw-rw-. 1 root root 195, 254 Apr 24 02:25 nvidia-modeset
crw-rw-rw-. 1 root root 240,   0 Apr 24 02:25 nvidia-uvm
crw-rw-rw-. 1 root root 240,   1 Apr 24 02:25 nvidia-uvm-tools
crw-rw-rw-. 1 root root 195,   0 Apr 24 02:25 nvidia0
crw-rw-rw-. 1 root root 195, 255 Apr 24 02:25 nvidiactl
[root@a8bd83522145 /]#
```

Without these devices, workloads that depend on `cuda` wouldn't run (see [this comment])

[this comment]: https://forums.developer.nvidia.com/t/rootless-docker-error-no-supported-gpu-s-detected-to-run-this-container/210593/2

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
