### PR TITLE
ghostdog: add grid driver to options

### DIFF
--- a/sources/ghostdog/src/main.rs
+++ b/sources/ghostdog/src/main.rs
@@ -21,7 +21,22 @@ use std::process::Command;
 const NVME_CLI_PATH: &str = "/sbin/nvme";
 const NVME_IDENTIFY_DATA_SIZE: usize = 4096;
 const NVIDIA_VENDOR_ID: &str = "10de";
+const NVIDIA_GRID_DEVICE_ID: &str = "27b8";
 const OPEN_GPU_SUPPORTED_DEVICES_PATH: &str = "/usr/share/nvidia/open-gpu-supported-devices.json";
+
+// Generate a list of Subdevice IDs that match the format of the file at OPEN_GPU_SUPPORTED_DEVICES_PATH
+// but are instead sourced here. The format in the JSON file has each ID starting with `0x` and are all upper
+// case where `pciclient` will provide just the 4 character ID with no prefix. `pciclient` output has to be
+// prepended and moved to uppercase to match these just as if they were sourced from the JSON file.
+lazy_static! {
+    static ref NVIDIA_GRID_SUBDEVICES: HashSet<&'static str> = {
+        let mut m = HashSet::new();
+        m.insert("0x1733");
+        m.insert("0x1735");
+        m.insert("0x1737");
+        m
+    };
+}
 
 #[derive(FromArgs, PartialEq, Debug)]
 /// Manage ephemeral disks.
@@ -217,7 +232,7 @@ fn read_supported_devices_file(path: PathBuf) -> Result<SupportedDevicesConfigur
     Ok(device_configuration)
 }
 
-/// Search the Open GPU Supported Devices File to determine if the Open GPU Driver should be used based upon PCI devices present
+/// Search the Open GPU Supported Devices File to determine which driver should be used based upon PCI devices present
 fn find_preferred_driver() -> Result<String> {
     let open_gpu_devices = read_supported_devices_file(OPEN_GPU_SUPPORTED_DEVICES_PATH.into())?;
     let list_input = pciclient::ListDevicesParam::builder()
@@ -239,6 +254,27 @@ fn find_preferred_driver() -> Result<String> {
             .map(|x| &x.device_id)
             .collect::<HashSet<_>>(),
     };
+
+    // If the PCI device ID is one that could potentially use GRID, collect the Subdevice IDs
+    let mut subdevice_ids = present_devices
+        .iter()
+        .filter(|x| x.device().starts_with(NVIDIA_GRID_DEVICE_ID))
+        .map(|x| {
+            format!(
+                "0x{}",
+                x.subsystem_device()
+                    .as_ref()
+                    .unwrap_or(&"".to_string())
+                    .to_uppercase()
+            )
+            .clone()
+        })
+        .collect::<HashSet<_>>()
+        .into_iter();
+    // Return early with grid if a match is made for these subdevices
+    if subdevice_ids.any(|subdevice| NVIDIA_GRID_SUBDEVICES.contains(subdevice.as_str())) {
+        return Ok("grid".to_string());
+    }
 
     if unique_ids.any(|input_device| open_gpu_device_set.contains(&input_device)) {
         Ok("open-gpu".to_string())


### PR DESCRIPTION


**Issue number:** Related to https://github.com/bottlerocket-os/bottlerocket/issues/4441


**Description of changes:**
Bottlerocket needs to use GRID drivers for some EC2 instances. This adds the logic to provide GRID as an option based upon PCI Subdevice ID. These IDs are known ahead of time so we create a list that can be referenced upon boot to add one more additional option (`grid`) when these devices are explicitly found.  

**Testing done:**
Validated with draft changes that include GRID drivers that when these subdevice IDs match, they choose GRID:

<details>

```
         Starting User Login Management...
[  OK  ] Finished Disable kexec load syscalls.
[  OK  ] Started User Login Management.
[   14.949740] ghostdog[1943]: open-gpu is not preferred driver: grid
[   15.060421] ghostdog[1945]: tesla is not preferred driver: grid
         Starting Load open GPU kernel modules...
         Starting Load Tesla kernel modules...
[  OK  ] Finished Generate network configuration.
[  OK  ] Reached target Preparation for Network.
[   15.067668] ghostdog[1982]: open-gpu is not preferred driver: grid
         Starting Network Configuration...
[   15.070212] ghostdog[1983]: tesla is not preferred driver: grid
[  OK  ] Started Network Configuration.
[  OK  ] Reached target Network.
         Starting Wait for Network to be Configured...
[   15.617122] migrator[1947]: Data store does not exist at given path, exiting (/var/lib/bottlerocket/datastore/current)
[  OK  ] Finished Bottlerocket data store migrator.
         Starting Call signpost to mark the …r all required targets are met....
         Starting Datastore creator...
[  OK  ] Finished Call signpost to mark the …ter all required targets are met..
[  OK  ] Finished Datastore creator.
         Starting Bottlerocket API server...
[  OK  ] Finished Wait for Network to be Configured.
         Starting Write network status...
[  OK  ] Finished Write network status.
[  OK  ] Reached target Network is Online.
[  OK  ] Started Bottlerocket API server.
         Starting Bottlerocket userdata configuration system...
[  OK  ] Finished Bottlerocket userdata configuration system.
         Starting User-specified setting generators...
[  OK  ] Finished Copy GRID kernel modules.
         Starting Load GRID kernel modules...
```

</details>

When on instances that have similar PCI Device IDs but not subdevice IDs, the `open-gpu` driver is still recommended:

<details>

```
[   22.529857] ghostdog[2058]: grid is not preferred driver: open-gpu
         Starting Link Tesla kernel modules...
[  OK  ] Started NVIDIA fabric manager service.
         Starting Reboot system if needed fo…guration changes to take effect...
         Starting Send boot success...
[   22.540520] ghostdog[2067]: tesla is not preferred driver: open-gpu
         Starting Wait for the instance to be in service...
[  OK  ] Finished Wait for the instance to be in service.
         Starting Load GRID kernel modules...
         Starting Load Tesla kernel modules...
[  OK  ] Finished Isolates multi-user.target.
[   22.559612] ghostdog[2081]: grid is not preferred driver: open-gpu
[   22.566336] ghostdog[2083]: tesla is not preferred driver: open-gpu
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
