### PR TITLE
Support Kubelet Config containerLogMaxWorkers and containerLogMonitorInterval

### DIFF
--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -161,6 +161,12 @@ containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
 {{/if}}
+{{#if settings.kubernetes.container-log-max-workers includeZero=true}}
+containerLogMaxWorkers: {{settings.kubernetes.container-log-max-workers}}
+{{/if}}
+{{#if settings.kubernetes.container-log-monitor-interval}}
+containerLogMonitorInterval: {{settings.kubernetes.container-log-monitor-interval}}
+{{/if}}
 {{#if settings.kubernetes.shutdown-grace-period}}
 shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
 {{/if}}

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -161,6 +161,12 @@ containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
 {{/if}}
+{{#if settings.kubernetes.container-log-max-workers includeZero=true}}
+containerLogMaxWorkers: {{settings.kubernetes.container-log-max-workers}}
+{{/if}}
+{{#if settings.kubernetes.container-log-monitor-interval}}
+containerLogMonitorInterval: {{settings.kubernetes.container-log-monitor-interval}}
+{{/if}}
 {{#if settings.kubernetes.shutdown-grace-period}}
 shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
 {{/if}}

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -161,6 +161,12 @@ containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
 {{/if}}
+{{#if settings.kubernetes.container-log-max-workers includeZero=true}}
+containerLogMaxWorkers: {{settings.kubernetes.container-log-max-workers}}
+{{/if}}
+{{#if settings.kubernetes.container-log-monitor-interval}}
+containerLogMonitorInterval: {{settings.kubernetes.container-log-monitor-interval}}
+{{/if}}
 {{#if settings.kubernetes.shutdown-grace-period}}
 shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
 {{/if}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -161,6 +161,12 @@ containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{#if settings.kubernetes.container-log-max-files includeZero=true}}
 containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
 {{/if}}
+{{#if settings.kubernetes.container-log-max-workers includeZero=true}}
+containerLogMaxWorkers: {{settings.kubernetes.container-log-max-workers}}
+{{/if}}
+{{#if settings.kubernetes.container-log-monitor-interval}}
+containerLogMonitorInterval: {{settings.kubernetes.container-log-monitor-interval}}
+{{/if}}
 {{#if settings.kubernetes.shutdown-grace-period}}
 shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
 {{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1257,7 +1257,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-modeled-types"
 version = "0.8.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1325,8 +1325,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.8.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+version = "0.9.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1376,7 +1376,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "serde",
 ]
@@ -1397,7 +1397,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -4569,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4595,7 +4595,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4609,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4622,7 +4622,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4635,7 +4635,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4661,7 +4661,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4687,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4725,8 +4725,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubernetes"
-version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+version = "0.3.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -4765,7 +4765,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4778,7 +4778,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4791,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4804,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4844,7 +4844,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.8.0#c9e5f989c24bea2006527c6f1a4708225ab70cc4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.9.0#0d825fcc0a199e233bed88ea9d9d1685c6d966bc"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -211,13 +211,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.8.0"
+tag = "bottlerocket-settings-models-v0.9.0"
 version = "0.8.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.8.0"
-version = "0.8.0"
+tag = "bottlerocket-settings-models-v0.9.0"
+version = "0.9.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -226,7 +226,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.8.0"
+tag = "bottlerocket-settings-models-v0.9.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Relevant Issue:
bottlerocket-os/bottlerocket#4470

**Description of changes:**
This change is paired with https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/80


Support kubernetes settings:
- `kubernetes.container-log-max-workers` 
- `kubernetes.container-log-monitor-interval` 

Which will be used to render the KubeletConfiguration:
- `containerLogMaxWorkers`
- `containerLogMonitorInterval`

Note that these [two fields are introduced](https://github.com/kubernetes/kubernetes/pull/114301) in k8s 1.30. So we will only render the kubelet config for **1.30+** k8s variants. For k8s variants older than 1.30, the settings will be silently skipped and not rendered to the kubelet config.

**Testing done:**
**Test 1.** Built custom k8s 1.30 variant and set the userdata in my nodegroup spec and deployed via `eksctl`
```
nodeGroups:
  - name: my-ng-bottlerocketv1
    instanceType: m5.large
    ...
    amiFamily: Bottlerocket
    ...
    bottlerocket:
      settings:
        kubernetes:
          container-log-max-workers: 3
          container-log-monitor-interval: 20s
```
The settings were persisted
```
bash-5.1# apiclient get settings.kubernetes
{
  "settings": {
    "kubernetes": {
      ...
      "container-log-max-workers": 3,
      "container-log-monitor-interval": "20s",
      ...
    }
  }
}

```
Kubelet config is properly rendered
```
bash-5.1# cat /etc/kubernetes/kubelet/config | grep containerLog 
containerLogMaxWorkers: 3
containerLogMonitorInterval: 20s
```
Node joined the cluster
```
» k get nodes                                           
NAME                                            STATUS   ROLES    AGE     VERSION
ip-192-168-128-126.us-west-2.compute.internal   Ready    <none>   6m11s   v1.30.10-eks-1a9dacd
```

**Test 2:** Built custom k8s 1.29 ami and set same userdata as Test 1 and verify that the settings will be skipped and not rendered to the kubelet config.
Settings were persisted:
```
bash-5.1# apiclient get settings.kubernetes | grep container
      "container-log-max-workers": 3,
      "container-log-monitor-interval": "20s",
``` 
But we will not apply it to the kubelet config given that the fields are only supported in 1.30+ k8s versions. Below command shows that the relevant fields are not rendered.
```
bash-5.1# cat /etc/kubernetes/kubelet/config | grep container
bash-5.1#
```
Node joined the cluster.

**Test 3:** verify that the change is compatible with older settings sdk
Built a custom k8s 1.30 ami that consumes this core-kit change and use the old settings sdk. Launch the instance without the new settings.

- The node joined the cluster.
- The kubelet config was properly rendered without the new fields.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
