### PR TITLE
Update k8s-1.33 related packages to v1.33.0

### DIFF
--- a/packages/ecr-credential-provider-1.33/Cargo.toml
+++ b/packages/ecr-credential-provider-1.33/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.33"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.33.0-rc.0.tar.gz"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.33.0.tar.gz"
 path = "cloud-provider-aws-1.33.0.tar.gz"
-sha512 = "a923071b95174ad96bf78e3c255e0b7682fe1f896d7399abdcacdde82df808aec026c350e443f8612f98048ca6b51d77208d55f34fae9167a2ccf01b83e20071"
+sha512 = "8ad66c67b68b2f51e814094b53574f1a2ab9c91f2e08e99e7175acb5a82049f6a4922edf52ba1474d62035a4f25aaebc0c26c4a32c839cc2e7fbf6f5951cca9b"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
+++ b/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
@@ -9,7 +9,7 @@
 
 Name: %{_cross_os}ecr-credential-provider-1.33
 Version: %{rpmver}
-Release: 0.rc0%{?dist}
+Release: 1%{?dist}
 Summary: Amazon ECR credential provider
 License: Apache-2.0
 URL: https://github.com/kubernetes/cloud-provider-aws
@@ -47,8 +47,8 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{summary}.
 
 %prep
-%setup -n %{gorepo}-%{gover}-rc.0 -q
-%setup -T -D -n %{gorepo}-%{gover}-rc.0 -b 1 -q
+%setup -n %{gorepo}-%{gover} -q
+%setup -T -D -n %{gorepo}-%{gover} -b 1 -q
 
 %build
 %set_cross_go_flags

--- a/packages/kubernetes-1.33/Cargo.toml
+++ b/packages/kubernetes-1.33/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.33"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/1/artifacts/kubernetes/v1.33.0-beta.0/kubernetes-src.tar.gz"
-sha512 = "45c059166c0d24ba928c446c32e766b77e24e40c61ac4bb54b28725f220793b33ff7d2f04cc355db077cdbd146041ae927cd0c87889ff4b835b9b6faa7a9a09c"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/3/artifacts/kubernetes/v1.33.0/kubernetes-src.tar.gz"
+sha512 = "20de2568ad933bb3a961aa069ab1665f5ebcadbd26b5cb7c7e520200ce588090c6f628a08cb33d302b4cc8bdfbf61bf0703ae6b0773fa916713e9ea552316d33"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -33,7 +33,7 @@
 
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
-Release: 0.beta0%{?dist}
+Release: 1%{?dist}
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket/issues/4477

**Description of changes:**

Update `kubernetes-1.33` and `ecr-credential-provider-1.33` pkgs to v1.33.0

**Testing done:**

- [x] Verified `gp3` is used for device volumes
- [x] Verified `containerd` version is 2.0+
- [x] Verified kernel version is 6.12 on non-fips and 6.1 on fips
- [x] Verified new 570 drivers are used on nvidia variants

- [x] Conformance tests
```
NAME                                                  TYPE      STATE      PASSE   FAILE   SKIPPE   BUILD I   LAST UPDATE  
 final-aarch64-aws-k8s-133-conformance-test             Test   passed      423        0      6312              2025-05-02T04:14:37Z
 final-aarch64-aws-k8s-133-fips-conformance-test        Test   passed      423        0      6312              2025-05-02T04:14:50Z
 final-aarch64-aws-k8s-133-fips-ipv6-conformance-test   Test   passed      423        0      6312              2025-05-02T04:27:54Z
 final-aarch64-aws-k8s-133-ipv6-conformance-test        Test   passed      423        0      6312              2025-05-02T04:26:44Z
 final-aarch64-aws-k8s-133-nvidia-conformance-test      Test   passed      423        0      6312              2025-05-02T04:11:22Z

 final-x86-64-aws-k8s-133-conformance-test              Test   passed      423        0      6312              2025-05-02T04:12:24Z
 final-x86-64-aws-k8s-133-fips-conformance-test         Test   passed      423        0      6312              2025-05-02T04:14:50Z
 final-x86-64-aws-k8s-133-fips-ipv6-conformance-test    Test   passed      423        0      6312              2025-05-02T04:25:13Z
 final-x86-64-aws-k8s-133-ipv6-conformance-test         Test   passed      423        0      6312              2025-05-02T04:19:56Z
 final-x86-64-aws-k8s-133-nvidia-conformance-test       Test   passed      423        0      6312              2025-05-02T04:09:04Z
```

- [x] Nvidia smoke tests
```
% kubectl --kubeconfig final-x86-64-aws-k8s-133-nvidia.kubeconfig get job                        
NAME                STATUS     COMPLETIONS   DURATION   AGE
nvidia-smoke-test   Complete   1/1           31s        44s

kubectl --kubeconfig final-aarch64-aws-k8s-133-nvidia.kubeconfig get job
NAME                STATUS     COMPLETIONS   DURATION   AGE
nvidia-smoke-test   Complete   1/1           45s        45s
```

-  [x] EBS driver testing
```
$ kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-ebs-csi-driver
NAME                                 READY   STATUS    RESTARTS   AGE
ebs-csi-controller-7cb87fdf6-v8l89   5/5     Running   0          21s
ebs-csi-controller-7cb87fdf6-vwcs6   5/5     Running   0          21s
ebs-csi-node-48x5r                   3/3     Running   0          21s

$ kubectl apply -f manifests
persistentvolumeclaim/block-claim created
pod/app created
storageclass.storage.k8s.io/ebs-sc created
[fedora@ip-172-31-48-208 block-volume]$ kubectl get pvc block-claim
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
block-claim   Bound    pvc-28ebb702-019b-4488-8ba4-fe438c5dfdc1   4Gi        RWO            ebs-sc         <unset>                 17s
```

- [x] cloud-provider-credential test
```
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  39s   default-scheduler  Successfully assigned default/hello-nodejs-2 to ip-192-168-237-48.us-west-2.compute.internal
  Normal  Pulling    38s   kubelet            Pulling image "533267423195.dkr.ecr.us-west-2.amazonaws.com/hello-nodejs:latest"
  Normal  Pulled     33s   kubelet            Successfully pulled image "533267423195.dkr.ecr.us-west-2.amazonaws.com/hello-nodejs:latest" in 4.661s (4.661s including waiting). Image size: 124978258 bytes.
  Normal  Created    33s   kubelet            Created container: hello-nodejs-2
  Normal  Started    33s   kubelet            Started container hello-nodejs-2
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
