### PR TITLE
Support for singleProcessOOMKill in Kubernetes 1.32 and 1.33

### DIFF
--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -200,3 +200,6 @@ reservedMemory:
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
+{{#if settings.kubernetes.single-process-oom-kill}}
+singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
+{{/if}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -200,3 +200,6 @@ reservedMemory:
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
+{{#if settings.kubernetes.single-process-oom-kill}}
+singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
+{{/if}}


### PR DESCRIPTION
**Description of changes:**

This adds support for the singleProcessOOMKill [[1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md)] flag used by the kubelet starting with version 1.32.

**Testing done:**

In combination with https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/81 and a local change to the Bottlerocket repo I confirmed that I can set the setting:

```bash
[root@admin]# apiclient get settings.kubernetes.single
{
  "settings": {
    "kubernetes": {
      "single-process-oom-kill": true
    }
  }
}
```

Confirmed that the setting was rendered:

```
staticPodPath: "/etc/kubernetes/static-pods/"
failSwapOn: false
singleProcessOOMKill: true
```

Confirmed that the cgroup for the pod was configured:

```
# With singleProcessOOMKill: false
bash-5.1# find /sys -name "*memory.oom*" -exec cat {} \; | grep 1
1

# With singleProcessOOMKill: true
bash-5.1# find /sys -name "*memory.oom*" -exec cat {} \; | grep 1
# Nothing is returned
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
