### PR TITLE
Add new command to ghostdog for Infiniband detection and configuration

### DIFF
--- a/packages/rdma-core/Cargo.toml
+++ b/packages/rdma-core/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-rdma/rdma-core/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-rdma/rdma-core/releases/download/v56.0/rdma-core-56.0.tar.gz"
-sha512 = "2f59f70e80d3a93d0159aecf8b1b3c5cfc489661121be06bd1cefe3cda510e63b106b6d19730534150d403c552926c760520b9a848d7ba82f94501ef14d92a63"
+url = "https://github.com/linux-rdma/rdma-core/releases/download/v57.0/rdma-core-57.0.tar.gz"
+sha512 = "4a904d34af6863655545fe720cc25a8800684f63c51cebb67be2058363949217903957dc925c69d41294362ccff75fb0d37f3bc31cd6f6f252a804d6713f62cf"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/rdma-core/rdma-core.spec
+++ b/packages/rdma-core/rdma-core.spec
@@ -1,7 +1,7 @@
-%global abiver rdmav34
+%global abiver 57
 
 Name: %{_cross_os}rdma-core
-Version: 56.0
+Version: 57.0
 Release: 1%{?dist}
 Summary: RDMA core userspace infrastructure, including core libraries and util programs.
 License: Linux-OpenIB AND MIT
@@ -62,17 +62,21 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_datadir}/logdog.d
 %{_cross_factorydir}%{_cross_sysconfdir}/libibverbs.d/efa.driver
 
 # Core RDMA libraries
+%{_cross_libdir}/libibmad.so.*
+%{_cross_libdir}/libibumad.so.*
+%{_cross_libdir}/libibnetdisc.so.*
 %{_cross_libdir}/libibverbs.so.*
 %{_cross_libdir}/librdmacm.so.*
 %dir %{_cross_libdir}/libibverbs
 
 # EFA libraries
 %{_cross_libdir}/libefa.so.*
-%{_cross_libdir}/libibverbs/libefa-%{abiver}.so
+%{_cross_libdir}/libibverbs/libefa-rdmav%{abiver}.so
 
 # Verification tools
 %{_cross_bindir}/ibv_devices
 %{_cross_bindir}/ibv_devinfo
+%{_cross_sbindir}/ibstat
 
 # Exclude the bits that are not needed
 %exclude %{_cross_datadir}/perl5
@@ -80,47 +84,33 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_datadir}/logdog.d
 %exclude %{_cross_libdir}/udev
 %exclude %{_cross_libexecdir}
 %exclude %{_cross_pkgconfigdir}
-%exclude %{_cross_sbindir}
 %exclude %{_cross_sysconfdir}
 %exclude %{_cross_unitdir}
 
 # Exclude all the unused libs
 %exclude %{_cross_libdir}/ibacm*
-%exclude %{_cross_libdir}/libbnxt*
-%exclude %{_cross_libdir}/libcxgb4*
-%exclude %{_cross_libdir}/liberdma*
-%exclude %{_cross_libdir}/libhfi1*
 %exclude %{_cross_libdir}/libhns*
-%exclude %{_cross_libdir}/libibmad*
-%exclude %{_cross_libdir}/libibnetdisc*
-%exclude %{_cross_libdir}/libibumad*
 %exclude %{_cross_libdir}/libmana*
 %exclude %{_cross_libdir}/libmlx*
-%exclude %{_cross_libdir}/libmthca*
-%exclude %{_cross_libdir}/libocrdma*
-%exclude %{_cross_libdir}/libqedr*
-%exclude %{_cross_libdir}/librxe*
-%exclude %{_cross_libdir}/libsiw*
-%exclude %{_cross_libdir}/libvmw*
 %exclude %{_cross_libdir}/rsocket
 
 # Exclude specific RDMA providers (keeping only libefa)
-%exclude %{_cross_libdir}/libibverbs/libbnxt_re-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libcxgb4-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/liberdma-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libhfi1verbs-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libhns-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libipathverbs-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libirdma-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libmana-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libmlx4-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libmlx5-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libmthca-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libocrdma-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libqedr-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/librxe-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libsiw-%{abiver}.so
-%exclude %{_cross_libdir}/libibverbs/libvmw_pvrdma-%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libbnxt_re-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libcxgb4-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/liberdma-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libhfi1verbs-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libhns-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libipathverbs-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libirdma-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libmana-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libmlx4-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libmlx5-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libmthca-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libocrdma-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libqedr-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/librxe-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libsiw-rdmav%{abiver}.so
+%exclude %{_cross_libdir}/libibverbs/libvmw_pvrdma-rdmav%{abiver}.so
 
 # Exclude udev rules
 %exclude %{_cross_udevrulesdir}
@@ -146,14 +136,52 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_datadir}/logdog.d
 %exclude %{_cross_bindir}/ucmatose
 %exclude %{_cross_bindir}/udaddy
 %exclude %{_cross_bindir}/udpong
+%exclude %{_cross_sbindir}/check_lft_balance.pl
+%exclude %{_cross_sbindir}/dump_fts
+%exclude %{_cross_sbindir}/dump_lfts.sh
+%exclude %{_cross_sbindir}/dump_mfts.sh
+%exclude %{_cross_sbindir}/ibacm
+%exclude %{_cross_sbindir}/ibaddr
+%exclude %{_cross_sbindir}/ibcacheedit
+%exclude %{_cross_sbindir}/ibccconfig
+%exclude %{_cross_sbindir}/ibccquery
+%exclude %{_cross_sbindir}/ibfindnodesusing.pl
+%exclude %{_cross_sbindir}/ibhosts
+%exclude %{_cross_sbindir}/ibidsverify.pl
+%exclude %{_cross_sbindir}/iblinkinfo
+%exclude %{_cross_sbindir}/ibnetdiscover
+%exclude %{_cross_sbindir}/ibnodes
+%exclude %{_cross_sbindir}/ibping
+%exclude %{_cross_sbindir}/ibportstate
+%exclude %{_cross_sbindir}/ibqueryerrors
+%exclude %{_cross_sbindir}/ibroute
+%exclude %{_cross_sbindir}/ibrouters
+%exclude %{_cross_sbindir}/ibsrpdm
+%exclude %{_cross_sbindir}/ibstatus
+%exclude %{_cross_sbindir}/ibswitches
+%exclude %{_cross_sbindir}/ibsysstat
+%exclude %{_cross_sbindir}/ibtracert
+%exclude %{_cross_sbindir}/iwpmd
+%exclude %{_cross_sbindir}/perfquery
+%exclude %{_cross_sbindir}/run_srp_daemon
+%exclude %{_cross_sbindir}/saquery
+%exclude %{_cross_sbindir}/sminfo
+%exclude %{_cross_sbindir}/smpdump
+%exclude %{_cross_sbindir}/smpquery
+%exclude %{_cross_sbindir}/srp_daemon
+%exclude %{_cross_sbindir}/srp_daemon.sh
+%exclude %{_cross_sbindir}/vendstat
 
 %files devel
 %dir %{_cross_includedir}/infiniband
 %dir %{_cross_includedir}/rdma
 %{_cross_includedir}/infiniband/*
 %{_cross_includedir}/rdma/*
-%{_cross_libdir}/libefa*
-%{_cross_libdir}/libibverbs*
-%{_cross_libdir}/librdmacm*
+%{_cross_libdir}/libefa.so
+%{_cross_libdir}/libibmad.so
+%{_cross_libdir}/libibnetdisc.so
+%{_cross_libdir}/libibumad.so
+%{_cross_libdir}/libibverbs.so
+%{_cross_libdir}/librdmacm.so
 
 %changelog

--- a/packages/rdma-core/rdma-core.spec
+++ b/packages/rdma-core/rdma-core.spec
@@ -38,6 +38,7 @@ Requires: %{name}
   -DCMAKE_INSTALL_BINDIR:PATH=%{_cross_bindir} \
   -DCMAKE_INSTALL_SBINDIR:PATH=%{_cross_sbindir} \
   -DCMAKE_INSTALL_SYSCONFDIR:PATH=%{_cross_sysconfdir} \
+  -DCMAKE_INSTALL_UDEV_RULESDIR:PATH=%{_cross_udevrulesdir} \
 
 %make_build
 
@@ -78,10 +79,21 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_datadir}/logdog.d
 %{_cross_bindir}/ibv_devinfo
 %{_cross_sbindir}/ibstat
 
+# udev rule for renaming to persistent names
+%{_cross_libdir}/udev/rdma_rename
+%{_cross_udevrulesdir}/60-rdma-persistent-naming.rules
+%{_cross_udevrulesdir}/90-rdma-umad.rules
+
+# Exclude the other udev rules we don't want
+%exclude %{_cross_udevrulesdir}/60-srp_daemon.rules
+%exclude %{_cross_udevrulesdir}/75-rdma-description.rules
+%exclude %{_cross_udevrulesdir}/90-iwpmd.rules
+%exclude %{_cross_udevrulesdir}/90-rdma-hw-modules.rules
+%exclude %{_cross_udevrulesdir}/90-rdma-ulp-modules.rules
+
 # Exclude the bits that are not needed
 %exclude %{_cross_datadir}/perl5
 %exclude %{_cross_docdir}
-%exclude %{_cross_libdir}/udev
 %exclude %{_cross_libexecdir}
 %exclude %{_cross_pkgconfigdir}
 %exclude %{_cross_sysconfdir}
@@ -111,9 +123,6 @@ install -p -m 0644 %{S:200} %{buildroot}%{_cross_datadir}/logdog.d
 %exclude %{_cross_libdir}/libibverbs/librxe-rdmav%{abiver}.so
 %exclude %{_cross_libdir}/libibverbs/libsiw-rdmav%{abiver}.so
 %exclude %{_cross_libdir}/libibverbs/libvmw_pvrdma-rdmav%{abiver}.so
-
-# Exclude udev rules
-%exclude %{_cross_udevrulesdir}
 
 # Exclude all the unused binaries
 %exclude %{_cross_bindir}/cmtime

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2444,6 +2444,7 @@ dependencies = [
  "serde_json",
  "signpost",
  "snafu",
+ "tempfile",
 ]
 
 [[package]]

--- a/sources/ghostdog/Cargo.toml
+++ b/sources/ghostdog/Cargo.toml
@@ -18,6 +18,7 @@ signpost.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
+tempfile.workspace = true
 
 [build-dependencies]
 generate-readme.workspace = true

--- a/sources/ghostdog/src/error.rs
+++ b/sources/ghostdog/src/error.rs
@@ -1,4 +1,6 @@
 /// Potential errors during `ghostdog` execution.
+use std::{io, path::PathBuf};
+
 use snafu::Snafu;
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(super)))]
@@ -15,6 +17,17 @@ pub(super) enum Error {
     },
     #[snafu(display("Invalid device info for device '{}'", path.display()))]
     InvalidDeviceInfo { path: std::path::PathBuf },
+    #[snafu(display("Unable to read infiniband devices from sysfs: {}", source))]
+    InfinibandSysDevices { source: std::io::Error },
+    #[snafu(display("Unable to read device file from sysfs: {}", source))]
+    InfinibandDevice { source: std::io::Error },
+    #[snafu(display("Could not get hex value from '{}': {}", mask, source))]
+    CapabilityCheck {
+        mask: String,
+        source: std::num::ParseIntError,
+    },
+    #[snafu(display("Found invalid GUID '{}'", guid))]
+    InvalidPortGuidString { guid: String },
     #[snafu(display("Failed to check if EFA device is attached: {}", source))]
     CheckEfaFailure { source: pciclient::PciClientError },
     #[snafu(display("Failed to check if Neuron device is attached: {}", source))]
@@ -23,6 +36,8 @@ pub(super) enum Error {
     NoEfaPresent,
     #[snafu(display("Did not detect Neuron"))]
     NoNeuronPresent,
+    #[snafu(display("'{}' has no parent directory", path.display()))]
+    NoParentDirectory { path: std::path::PathBuf },
     #[snafu(display("Failed to open '{}': {}", path.display(), source))]
     OpenFile {
         path: std::path::PathBuf,
@@ -32,6 +47,15 @@ pub(super) enum Error {
     ReadFile {
         path: std::path::PathBuf,
         source: std::io::Error,
+    },
+    #[snafu(display("Failed to create temporary file in {}: {}", path.display(), source))]
+    CreateTempFile { path: PathBuf, source: io::Error },
+    #[snafu(display("Failed to write temporary file: {}", source))]
+    WriteTempFile { source: io::Error },
+    #[snafu(display("Failed to move temporary file to {}: {}", path.display(), source))]
+    PersistTempFile {
+        path: PathBuf,
+        source: tempfile::PersistError,
     },
     #[snafu(display("Couldn't parse the GPU Devices File: {}", source))]
     ParseGpuDevicesFile { source: serde_json::Error },

--- a/sources/ghostdog/src/error.rs
+++ b/sources/ghostdog/src/error.rs
@@ -1,0 +1,47 @@
+/// Potential errors during `ghostdog` execution.
+use snafu::Snafu;
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(super)))]
+pub(super) enum Error {
+    #[snafu(display("Failed to open '{}': {}", path.display(), source))]
+    DeviceOpen {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[snafu(display("Failed to execute NVMe command for device '{}': {}", path.display(), source))]
+    NvmeCommand {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[snafu(display("Invalid device info for device '{}'", path.display()))]
+    InvalidDeviceInfo { path: std::path::PathBuf },
+    #[snafu(display("Failed to check if EFA device is attached: {}", source))]
+    CheckEfaFailure { source: pciclient::PciClientError },
+    #[snafu(display("Failed to check if Neuron device is attached: {}", source))]
+    CheckNeuronFailure { source: pciclient::PciClientError },
+    #[snafu(display("Did not detect EFA"))]
+    NoEfaPresent,
+    #[snafu(display("Did not detect Neuron"))]
+    NoNeuronPresent,
+    #[snafu(display("Failed to open '{}': {}", path.display(), source))]
+    OpenFile {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[snafu(display("Failed to read '{}': {}", path.display(), source))]
+    ReadFile {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+    #[snafu(display("Couldn't parse the GPU Devices File: {}", source))]
+    ParseGpuDevicesFile { source: serde_json::Error },
+    #[snafu(display("Failed to list PCI devices: {}", source))]
+    ListPciDevices { source: pciclient::PciClientError },
+    #[snafu(display("{} is not preferred driver: {}", requested, preferred))]
+    DriverMismatch {
+        requested: String,
+        preferred: String,
+    },
+}
+
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/sources/ghostdog/src/infiniband.rs
+++ b/sources/ghostdog/src/infiniband.rs
@@ -1,0 +1,317 @@
+use crate::error;
+use crate::error::Result;
+use snafu::{ensure, ResultExt};
+use std::ffi::OsString;
+use std::ops::Deref;
+use std::path::Path;
+use std::str::FromStr;
+use std::{fs, str, vec};
+
+const SYS_CLASS_DIR: &str = "/sys/class";
+const INFINIBAND_CLASS_NAME: &str = "infiniband";
+const SW_MNG_VALUE: &str = "SW_MNG";
+
+/// Generic device struct found from sysfs
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct InfinibandDevice {
+    pub(crate) name: OsString,
+    pub(crate) ports: Vec<InfinibandPort>,
+}
+
+/// Finds all the devices in sysfs for a given class sorted by name
+pub(crate) fn find_infiniband_devices() -> Result<Vec<InfinibandDevice>> {
+    let devices_path = Path::new(SYS_CLASS_DIR).join(INFINIBAND_CLASS_NAME);
+    let mut found_devices: Vec<InfinibandDevice> = vec![];
+    if !devices_path.exists() {
+        // Nothing to do since no devices detected
+        return Ok(found_devices);
+    }
+
+    let sys_devices_dirs = fs::read_dir(devices_path).context(error::InfinibandSysDevicesSnafu)?;
+    for device in sys_devices_dirs {
+        let device = device.context(error::InfinibandDeviceSnafu)?;
+        let device_name: OsString = device.file_name();
+        found_devices.push(InfinibandDevice {
+            name: device_name,
+            ports: vec![],
+        })
+    }
+
+    found_devices.sort();
+    Ok(found_devices)
+}
+
+impl InfinibandDevice {
+    /// Returns true if the SW_MNG_VALUE is found in the Vital Product Data file for given sysfs device
+    pub(crate) fn is_device_sw_mng(&self) -> Result<bool> {
+        let vpd_file = Path::new(SYS_CLASS_DIR)
+            .join(INFINIBAND_CLASS_NAME)
+            .join(self.name.as_os_str())
+            .join("device")
+            .join("vpd");
+        if vpd_file.exists() {
+            let vpd_file_bytes: &[u8] =
+                &std::fs::read(vpd_file.as_path()).context(error::ReadFileSnafu {
+                    path: vpd_file.as_path(),
+                })?;
+            let needle = SW_MNG_VALUE.as_bytes();
+            if vpd_file_bytes
+                .windows(needle.len())
+                .any(|window| window == needle)
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    // Given a device in sysfs, iterate over the known paths where ports are defined
+    // Iterate over the ports and read in the capability mask and Port GUID for each port
+    pub(crate) fn find_ports_for_device(self) -> Result<Vec<InfinibandPort>> {
+        let mut found_ports: Vec<InfinibandPort> = vec![];
+        let ports_path = Path::new(SYS_CLASS_DIR)
+            .join(INFINIBAND_CLASS_NAME)
+            .join(self.name)
+            .join("ports");
+
+        let port_directories =
+            fs::read_dir(ports_path).context(error::InfinibandSysDevicesSnafu)?;
+        for port in port_directories {
+            let port = port.context(error::InfinibandSysDevicesSnafu)?;
+            let capability_mask_path = port.path().join("cap_mask");
+            if !capability_mask_path.exists() {
+                continue;
+            }
+            let capability_mask = std::fs::read_to_string(capability_mask_path.as_path()).context(
+                error::ReadFileSnafu {
+                    path: capability_mask_path.as_path(),
+                },
+            )?;
+            let first_guid_path = port.path().join("gids").join("0");
+            if !first_guid_path.exists() {
+                continue;
+            }
+            let first_guid = std::fs::read_to_string(first_guid_path.as_path()).context(
+                error::ReadFileSnafu {
+                    path: first_guid_path.as_path(),
+                },
+            )?;
+
+            // If a capability mask and port guid have been read, create the Infiniband Port
+            found_ports.push(InfinibandPort {
+                capability_mask: CapabilityMask::from_str(capability_mask.as_str())?,
+                port_guid: PortGuid::from_str(first_guid.as_str())?,
+            });
+        }
+        Ok(found_ports)
+    }
+}
+
+/// Struct that holds the two important values for an Infiniband Port when checking for
+/// Subnet Management capabilties.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct InfinibandPort {
+    /// Capability Mask is read in as a string such as 0xa751e848
+    pub(crate) capability_mask: CapabilityMask,
+    /// Primary(first enumerated) PortGuid for a Port
+    pub(crate) port_guid: PortGuid,
+}
+
+impl InfinibandPort {
+    /// is_sm_enabled checks the specific capability bit for Subnet Management means its enabled
+    // The actual bit means `isSMDisabled`, so check if its not zero
+    pub(crate) fn is_sm_enabled(&self) -> bool {
+        // SM is enabled if the eleventh bit ("SM disabled") is clear
+        (*self.capability_mask & (1 << 10)) == 0
+    }
+}
+
+/// Port GUID is a u64 that is read in as a string with : separting 8 sections but is written out in a form such as 0x
+///
+/// For example "fe80:0000:0000:0000:e09d:7303:003f:3bf8" will be stored and displayed as "0xe09d7303003f3bf8"
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct PortGuid(String);
+
+impl FromStr for PortGuid {
+    type Err = error::Error;
+    /// String is expected to look like "fe80:0000:0000:0000:e09d:7303:003f:3bf8"
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let potential_guid = s.trim().to_string();
+        ensure!(
+            potential_guid.starts_with("fe80"),
+            error::InvalidPortGuidStringSnafu {
+                guid: potential_guid
+            }
+        );
+        let parts: Vec<&str> = potential_guid.split(":").collect();
+        ensure!(
+            parts.len() == 8,
+            error::InvalidPortGuidStringSnafu {
+                guid: potential_guid
+            }
+        );
+        for part in parts.iter() {
+            ensure!(
+                part.len() == 4,
+                error::InvalidPortGuidStringSnafu {
+                    guid: potential_guid
+                }
+            );
+        }
+
+        Ok(PortGuid(format!(
+            "0x{}{}{}{}",
+            parts[4], parts[5], parts[6], parts[7]
+        )))
+    }
+}
+
+impl Deref for PortGuid {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Capability Mask struct to help with FromStr and bit masking
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct CapabilityMask(u32);
+
+impl FromStr for CapabilityMask {
+    type Err = error::Error;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let mask = hex_string_to_u32(s.trim()).context(error::CapabilityCheckSnafu { mask: s })?;
+        Ok(CapabilityMask(mask))
+    }
+}
+
+impl Deref for CapabilityMask {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// Helper function to take the string Capability mask and convert to u32
+fn hex_string_to_u32(hex: &str) -> std::result::Result<u32, std::num::ParseIntError> {
+    let hex_str = hex.strip_prefix("0x").unwrap_or(hex);
+    u32::from_str_radix(hex_str, 16)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hex_to_u32_valid_hex_with_prefix() {
+        assert_eq!(hex_string_to_u32("0xa750e84a").unwrap(), 0xa750e84a);
+        assert_eq!(hex_string_to_u32("0xffff").unwrap(), 0xffff);
+        assert_eq!(hex_string_to_u32("abcdef12").unwrap(), 0xABCDEF12);
+        assert_eq!(hex_string_to_u32("0x0").unwrap(), 0x0);
+    }
+
+    #[test]
+    fn test_hex_to_u32_valid_hex_without_prefix() {
+        assert_eq!(hex_string_to_u32("a750e84a").unwrap(), 0xa750e84a);
+        assert_eq!(hex_string_to_u32("ffff").unwrap(), 0xffff);
+        assert_eq!(hex_string_to_u32("0").unwrap(), 0x0);
+    }
+
+    #[test]
+    fn test_hex_to_u32_invalid_hex() {
+        assert!(hex_string_to_u32("invalid").is_err());
+        assert!(hex_string_to_u32("0xgggg").is_err());
+        assert!(hex_string_to_u32("").is_err());
+    }
+
+    #[test]
+    fn test_hex_to_u32_overflow() {
+        // Value larger than u32::MAX
+        assert!(hex_string_to_u32("0xffffffffff").is_err());
+    }
+
+    #[test]
+    fn test_valid_guid_creation() {
+        let valid_guid = "fe80:0000:0000:0000:e09d:7303:003f:3bf8";
+        let result = PortGuid::from_str(valid_guid);
+        assert!(result.is_ok());
+        assert_eq!(result.as_ref().unwrap().0, "0xe09d7303003f3bf8");
+        assert_eq!(*result.unwrap(), "0xe09d7303003f3bf8");
+    }
+
+    #[test]
+    fn test_valid_guid_with_whitespace() {
+        let valid_guid = "  fe80:0000:0000:0000:e09d:7303:003f:3bf8  ";
+        let result = PortGuid::from_str(valid_guid);
+        assert!(result.is_ok());
+        assert_eq!(*result.unwrap(), "0xe09d7303003f3bf8");
+    }
+
+    #[test]
+    fn test_invalid_guid_prefix() {
+        let invalid_guids = [
+            "abcd:0000:0000:0000:e09d:7303:003f:3bf8",
+            "fe81:0000:0000:0000:e09d:7303:003f:3bf8",
+            "",
+            "fe",
+            "fe8",
+        ];
+
+        for invalid_guid in invalid_guids.iter() {
+            let result = PortGuid::from_str(invalid_guid);
+            assert!(result.is_err());
+
+            match result {
+                Err(e) => {
+                    assert!(matches!(e, error::Error::InvalidPortGuidString { .. }));
+                }
+                Ok(_) => panic!("Expected error for invalid GUID"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_guid_clone() {
+        let guid = PortGuid::from_str("fe80:0000:0000:0000:e09d:7303:003f:3bf8").unwrap();
+        let cloned_guid = guid.clone();
+        assert_eq!(guid.0, cloned_guid.0);
+    }
+
+    #[test]
+    fn test_guid_debug() {
+        let guid = PortGuid::from_str("fe80:0000:0000:0000:e09d:7303:003f:3bf8").unwrap();
+        let debug_output = format!("{:?}", guid);
+        assert!(debug_output.contains("0xe09d7303003f3bf8"));
+    }
+
+    #[test]
+    fn test_is_sm_enabled() {
+        let test_cases = vec![
+            // SM enabled cases (bit 10 is 0)
+            ("0x00000000", true), // All bits 0
+            ("0xa750e84a", true), // Expected mask that passes
+            ("0xfffffbff", true), // Only bit 10 is 0
+            ("0x00000001", true), // Only first bit set
+            // SM disabled cases (bit 10 is 1)
+            ("0x00000400", false), // Only bit 10 set
+            ("0xffffffff", false), // All bits set
+            ("0x00000401", false), // Bit 10 and first bit set
+        ];
+
+        for (capability_mask, expected) in test_cases {
+            let port = InfinibandPort {
+                capability_mask: CapabilityMask::from_str(capability_mask).unwrap(),
+                port_guid: PortGuid::from_str("fe80:0000:0000:0000:e09d:7303:003f:3bf8").unwrap(),
+            };
+
+            assert_eq!(
+                port.is_sm_enabled(),
+                expected,
+                "Failed for capability_mask: {}",
+                capability_mask
+            );
+        }
+    }
+}

--- a/sources/ghostdog/src/main.rs
+++ b/sources/ghostdog/src/main.rs
@@ -6,9 +6,11 @@ It can also check if devices on the PCI bus match a particular NVIDIA driver.
 */
 
 mod error;
+mod infiniband;
 
+use crate::error::Result;
+use crate::infiniband::find_infiniband_devices;
 use argh::FromArgs;
-use error::Result;
 use gptman::GPT;
 use hex_literal::hex;
 use lazy_static::lazy_static;
@@ -16,10 +18,11 @@ use serde::Deserialize;
 use signpost::uuid_to_guid;
 use snafu::{ensure, ResultExt};
 use std::collections::HashSet;
-use std::fs;
-use std::io::{Read, Seek};
-use std::path::PathBuf;
+use std::io::{Read, Seek, Write};
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::{fs, str};
+use tempfile::NamedTempFile;
 
 const NVME_CLI_PATH: &str = "/sbin/nvme";
 const NVME_IDENTIFY_DATA_SIZE: usize = 4096;
@@ -56,6 +59,7 @@ enum SubCommand {
     EfaPresent(EfaPresentArgs),
     NeuronPresent(NeuronPresentArgs),
     MatchNvidiaDriver(MatchNvidiaDriverArgs),
+    WriteInfinibandGuid(WriteInfinibandGuidArgs),
 }
 
 #[derive(FromArgs, PartialEq, Debug)]
@@ -92,6 +96,14 @@ struct MatchNvidiaDriverArgs {
     driver_name: String,
 }
 
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "write-infiniband-primary-guid")]
+/// Detect if Infiniband devices are attached and write the primary port guid to an env file if detected
+struct WriteInfinibandGuidArgs {
+    #[argh(positional)]
+    env_file: PathBuf,
+}
+
 #[derive(Deserialize)]
 /// Open GPU struct for comparing PCI ID's to a known list of supported devices.
 enum SupportedDevicesConfiguration {
@@ -119,7 +131,8 @@ struct GpuDeviceData {
 }
 
 // Main entry point.
-fn run() -> Result<()> {
+#[snafu::report]
+fn main() -> Result<()> {
     let args: Args = argh::from_env();
     match args.subcommand {
         SubCommand::Scan(scan_args) => {
@@ -143,6 +156,9 @@ fn run() -> Result<()> {
             let driver_name = driver.driver_name;
             nvidia_driver_supported(&driver_name)?;
         }
+        SubCommand::WriteInfinibandGuid(envfile) => {
+            find_and_write_infiniband_guid(envfile.env_file)?;
+        }
     }
     Ok(())
 }
@@ -161,6 +177,40 @@ fn is_neuron_attached() -> Result<()> {
     } else {
         Err(error::Error::NoNeuronPresent)
     }
+}
+
+/// Detects if infiniband is present. If not, return early. If it does find Infiniband devices,
+/// find if they match specific capabilities to be used for communication between NVIDIA Fabric
+/// Manger and NVLSM, then write the guid to an env file for use by those services.
+fn find_and_write_infiniband_guid(env_file: PathBuf) -> Result<()> {
+    let devices = find_infiniband_devices()?;
+
+    // Return early if no devices are found
+    if devices.is_empty() {
+        return Ok(());
+    }
+
+    // For each device, confirm if SW_MNG is present, then find the first port of the device. If that
+    // device has the correct capability mask, then get the GUID. The first device to be found in this
+    // search is the correct GUID for the configuration file.
+    for device in devices {
+        if device.is_device_sw_mng()? {
+            let ports = device.find_ports_for_device()?;
+            for port in ports {
+                if port.is_sm_enabled() {
+                    // NVIDIA Fabric Manager or NVLSM use -g to configure a Port GUID, use this as input
+                    // to those services
+                    write_config_string(
+                        env_file.clone(),
+                        format!("GUID_ARG=\"-g {}\"", *port.port_guid).as_str(),
+                    )?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+    // If no suitable GUIDs were found, return without writing to the file
+    Ok(())
 }
 
 /// Find the device type by examining the partition table, if present.
@@ -322,14 +372,35 @@ lazy_static! {
     ].iter().copied().collect();
 }
 
-// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
-// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
-// https://github.com/shepmaster/snafu/issues/110
-fn main() {
-    if let Err(e) = run() {
-        eprintln!("{}", e);
-        std::process::exit(1);
+/// write_config_string will write the provided string to the provided path
+fn write_config_string(config_path: PathBuf, content_string: &str) -> Result<()> {
+    // Create a temporary file in the desired config directory
+    // Check that a path was specified and isn't /
+    let env_directory = config_path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty() && *p != Path::new("/"))
+        .ok_or_else(|| error::Error::NoParentDirectory {
+            path: config_path.clone(),
+        })?;
+
+    let mut tempfile =
+        NamedTempFile::new_in(env_directory).context(error::CreateTempFileSnafu {
+            path: PathBuf::from(env_directory),
+        })?;
+
+    // Write the config to the temporary file
+    if !content_string.is_empty() {
+        writeln!(tempfile, "{}", content_string).context(error::WriteTempFileSnafu)?;
     }
+
+    // Construct the final path and atomically move the temporary file to it
+    tempfile
+        .persist(&config_path)
+        .context(error::PersistTempFileSnafu {
+            path: config_path.clone(),
+        })?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -338,7 +409,8 @@ mod test {
 
     use gptman::{GPTPartitionEntry, GPT};
     use signpost::uuid_to_guid;
-    use std::io::Cursor;
+    use std::{env, io::Cursor};
+    use tempfile::TempDir;
 
     fn test_data() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/tests")
@@ -428,5 +500,78 @@ mod test {
                 assert!(data.len() == 6);
             }
         }
+    }
+
+    #[test]
+    fn test_write_config_string_success() -> Result<()> {
+        // Create a temporary directory for testing
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.txt");
+        let test_content = "test content";
+
+        // Write content to file
+        write_config_string(config_path.clone(), test_content)?;
+
+        // Verify the content was written correctly
+        let read_content = fs::read_to_string(&config_path).unwrap();
+        assert_eq!(read_content, format!("{}\n", test_content));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_config_string_no_parent_directory() {
+        // Try to write to a path without a parent directory
+        let result = write_config_string(PathBuf::from("file.txt"), "content");
+        println!("{:?}", result);
+        assert!(matches!(
+            result.unwrap_err(),
+            error::Error::NoParentDirectory { path: _ }
+        ));
+        // Try to write to /
+        let result = write_config_string(PathBuf::from("/file.txt"), "content");
+
+        assert!(matches!(
+            result.unwrap_err(),
+            error::Error::NoParentDirectory { path: _ }
+        ));
+    }
+
+    #[test]
+    fn test_write_config_string_empty_content() -> Result<()> {
+        // Create a temporary directory for testing
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.txt");
+        let empty_content = "";
+
+        // Write empty content to file
+        write_config_string(config_path.clone(), empty_content)?;
+
+        // Verify the content was written correctly
+        let read_content = fs::read_to_string(&config_path).unwrap();
+        assert_eq!(read_content, ""); // Note: writeln! adds a newline
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_config_string_overwrite_existing() -> Result<()> {
+        // Create a temporary directory for testing
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.txt");
+
+        // Write initial content
+        let initial_content = "initial content";
+        write_config_string(config_path.clone(), initial_content)?;
+
+        // Write new content
+        let new_content = "new content";
+        write_config_string(config_path.clone(), new_content)?;
+
+        // Verify the content was overwritten correctly
+        let read_content = fs::read_to_string(&config_path).unwrap();
+        assert_eq!(read_content, format!("{}\n", new_content));
+
+        Ok(())
     }
 }

--- a/sources/ghostdog/src/main.rs
+++ b/sources/ghostdog/src/main.rs
@@ -5,7 +5,10 @@ It can also be called for EFA device detection which can be used for ExecConditi
 It can also check if devices on the PCI bus match a particular NVIDIA driver.
 */
 
+mod error;
+
 use argh::FromArgs;
+use error::Result;
 use gptman::GPT;
 use hex_literal::hex;
 use lazy_static::lazy_static;
@@ -328,56 +331,6 @@ fn main() {
         std::process::exit(1);
     }
 }
-
-/// Potential errors during `ghostdog` execution.
-mod error {
-    use snafu::Snafu;
-    #[derive(Debug, Snafu)]
-    #[snafu(visibility(pub(super)))]
-    pub(super) enum Error {
-        #[snafu(display("Failed to open '{}': {}", path.display(), source))]
-        DeviceOpen {
-            path: std::path::PathBuf,
-            source: std::io::Error,
-        },
-        #[snafu(display("Failed to execute NVMe command for device '{}': {}", path.display(), source))]
-        NvmeCommand {
-            path: std::path::PathBuf,
-            source: std::io::Error,
-        },
-        #[snafu(display("Invalid device info for device '{}'", path.display()))]
-        InvalidDeviceInfo { path: std::path::PathBuf },
-        #[snafu(display("Failed to check if EFA device is attached: {}", source))]
-        CheckEfaFailure { source: pciclient::PciClientError },
-        #[snafu(display("Failed to check if Neuron device is attached: {}", source))]
-        CheckNeuronFailure { source: pciclient::PciClientError },
-        #[snafu(display("Did not detect EFA"))]
-        NoEfaPresent,
-        #[snafu(display("Did not detect Neuron"))]
-        NoNeuronPresent,
-        #[snafu(display("Failed to open '{}': {}", path.display(), source))]
-        OpenFile {
-            path: std::path::PathBuf,
-            source: std::io::Error,
-        },
-        #[snafu(display("Failed to read '{}': {}", path.display(), source))]
-        ReadFile {
-            path: std::path::PathBuf,
-            source: std::io::Error,
-        },
-        #[snafu(display("Couldn't parse the GPU Devices File: {}", source))]
-        ParseGpuDevicesFile { source: serde_json::Error },
-        #[snafu(display("Failed to list PCI devices: {}", source))]
-        ListPciDevices { source: pciclient::PciClientError },
-        #[snafu(display("{} is not preferred driver: {}", requested, preferred))]
-        DriverMismatch {
-            requested: String,
-            preferred: String,
-        },
-    }
-}
-
-type Result<T> = std::result::Result<T, error::Error>;
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
**Description of changes:**
This change is related to and required for https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/142

This adds an additional sub command to `ghostdog`: `write-infiniband-sw-mng-guid` which matches similar other detection subcommands. Its first role is to detect the correct hardware needed for NVLSM. If this hardware is not detected it exits early. If the hardware is detected, it finds the appropriate Port GUID needed for communication between Fabric Manager and NVLSM. Once it finds this, it writes the GUID to the specified (via an argument to the command) file in the format of `GUID_ARGS="-g 0xffffff.."` which can then be read in by systemd as an environment variables for starting NVLSM and Fabric Manager. 

**Testing done:**
See the testing in https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/142. I built an `aws-k8s-1.32-nvidia` variant with both this and the kernel kit changes and confirmed that Fabric Manager works both with and without this Infiniband hardware.

On `p4d.24xlarge`, the hardware doesn't exist and so nvlsm skips due to the non-zero exit:

<details>

```
bash-5.1# systemctl status nvidia-fabricmanager
● nvidia-fabricmanager.service - NVIDIA fabric manager service
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-fabricmanager.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Fri 2025-05-16 18:56:29 UTC; 2min 18s ago
   Main PID: 15988 (nv-fabricmanage)
      Tasks: 19 (limit: 629145)
     Memory: 26.0M
        CPU: 18.245s
     CGroup: /system.slice/nvidia-fabricmanager.service
             └─15988 /usr/bin/nv-fabricmanager -c /etc/nvidia/fabricmanager.cfg

May 16 18:56:40 ip-192-168-32-119.us-west-2.compute.internal nv-fabricmanager[15988]: [May 16 2025 18:56:40] [INFO] [tid 15988] GPU with nodeId = 0, gpuId =…nfigured
May 16 18:56:40 ip-192-168-32-119.us-west-2.compute.internal nv-fabricmanager[15988]: [May 16 2025 18:56:40] [INFO] [tid 15988] GPU with nodeId = 0, gpuId =…nfigured
May 16 18:56:40 ip-192-168-32-119.us-west-2.compute.internal nv-fabricmanager[15988]: [May 16 2025 18:56:40] [INFO] [tid 15988] GPU with nodeId = 0, gpuId =…nfigured
May 16 18:56:40 ip-192-168-32-119.us-west-2.compute.internal nv-fabricmanager[15988]: [May 16 2025 18:56:40] [INFO] [tid 15988] GPU with nodeId = 0, gpuId =…nfigured
May 16 18:56:40 ip-192-168-32-119.us-west-2.compute.internal nv-fabricmanager[15988]: [May 16 2025 18:56:40] [INFO] [tid 15988] GPU with nodeId = 0, gpuId =…nfigured
May 16 18:56:40 ip-192-168-32-119.us-west-2.compute.internal nv-fabricmanager[15988]: [May 16 2025 18:56:40] [INFO] [tid 15988] GPU with nodeId = 0, gpuId =…nfigured
May 16 18:56:40 ip-192-168-32-119.us-west-2.compute.internal nv-fabricmanager[15988]: [May 16 2025 18:56:40] [INFO] [tid 15988] GPU with nodeId = 0, gpuId =…nfigured
May 16 18:56:40 ip-192-168-32-119.us-west-2.compute.internal nv-fabricmanager[15988]: [May 16 2025 18:56:40] [INFO] [tid 15988] Multi node HA error handling disabled
May 16 18:56:40 ip-192-168-32-119.us-west-2.compute.internal nv-fabricmanager[15988]: [May 16 2025 18:56:40] [INFO] [tid 15988] Successfully configured all …traffic.
May 16 18:56:40 ip-192-168-32-119.us-west-2.compute.internal nv-fabricmanager[15988]: [May 16 2025 18:56:40] [INFO] [tid 15988] FM starting NvLink Inband messages
Hint: Some lines were ellipsized, use -l to show in full.
bash-5.1# systemctl status nvlsm
○ nvlsm.service - Start NVLink Subnet Manager
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvlsm.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: inactive (dead) (Result: exec-condition) since Fri 2025-05-16 18:56:29 UTC; 2min 30s ago
  Condition: start condition failed at Fri 2025-05-16 18:56:29 UTC; 2min 30s ago
    Process: 15966 ExecCondition=[ -s /etc/nvidia/nvlsm.env ] (code=exited, status=1/FAILURE)
        CPU: 1ms

May 16 18:56:29 ip-192-168-32-119.us-west-2.compute.internal systemd[1]: Starting Start NVLink Subnet Manager...
May 16 18:56:29 ip-192-168-32-119.us-west-2.compute.internal systemd[1]: nvlsm.service: Skipped due to 'exec-condition'.
May 16 18:56:29 ip-192-168-32-119.us-west-2.compute.internal systemd[1]: Condition check resulted in Start NVLink Subnet Manager being skipped.
bash-5.1# systemctl status nvlsm-online
○ nvlsm-online.service - Start NVLink Subnet Manager Online Service
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvlsm-online.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: inactive (dead) (Result: exec-condition) since Fri 2025-05-16 18:56:29 UTC; 2min 34s ago
  Condition: start condition failed at Fri 2025-05-16 18:56:29 UTC; 2min 34s ago
    Process: 15972 ExecCondition=[ -s /etc/nvidia/nvlsm.env ] (code=exited, status=1/FAILURE)
        CPU: 1ms

May 16 18:56:29 ip-192-168-32-119.us-west-2.compute.internal systemd[1]: Starting Start NVLink Subnet Manager Online Service...
May 16 18:56:29 ip-192-168-32-119.us-west-2.compute.internal systemd[1]: nvlsm-online.service: Skipped due to 'exec-condition'.
May 16 18:56:29 ip-192-168-32-119.us-west-2.compute.internal systemd[1]: Condition check resulted in Start NVLink Subnet Manager Online Service being skipped.
bash-5.1# systemd-analyze critical-chain
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

multi-user.target @33.290s
└─nvidia-k8s-device-plugin.service @33.053s +223ms
  └─kubelet.service @31.682s +1.238s
    └─containerd.service @31.625s +52ms
      └─runtime.slice @31.621s
        └─-.slice @1.416s
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
