### PR TITLE
nvidia-container-toolkit: provide additional container runtimes

### DIFF
--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -72,6 +72,8 @@ go build -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime-hook ./cmd/nvidia-c
 go build -ldflags="${GOLDFLAGS}" -o nvidia-ctk ./cmd/nvidia-ctk
 go build -ldflags="${GOLDFLAGS}" -o nvidia-cdi-hook ./cmd/nvidia-cdi-hook
 go build -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime ./cmd/nvidia-container-runtime
+go build -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime.cdi ./cmd/nvidia-container-runtime.cdi
+go build -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime.legacy ./cmd/nvidia-container-runtime.legacy
 
 %install
 install -d %{buildroot}%{_cross_bindir}
@@ -86,6 +88,8 @@ install -p -m 0755 nvidia-container-runtime-hook %{buildroot}%{_cross_bindir}/
 install -p -m 0755 nvidia-ctk %{buildroot}%{_cross_bindir}/
 install -p -m 0755 nvidia-cdi-hook %{buildroot}%{_cross_bindir}/
 install -p -m 0755 nvidia-container-runtime %{buildroot}%{_cross_bindir}/
+install -p -m 0755 nvidia-container-runtime.cdi %{buildroot}%{_cross_bindir}/
+install -p -m 0755 nvidia-container-runtime.legacy %{buildroot}%{_cross_bindir}/
 install -m 0644 %{S:1} %{buildroot}%{_cross_factorydir}/nvidia-container-runtime/
 install -m 0644 %{S:2} %{buildroot}%{_cross_factorydir}/nvidia-container-runtime/
 install -p -m 0644 %{S:3} %{buildroot}%{_cross_udevrulesdir}/90-nvidia-gpu-devices.rules
@@ -101,6 +105,8 @@ install -m 0644 %{S:7} %{buildroot}%{_cross_unitdir}/
 %{_cross_bindir}/nvidia-ctk
 %{_cross_bindir}/nvidia-cdi-hook
 %{_cross_bindir}/nvidia-container-runtime
+%{_cross_bindir}/nvidia-container-runtime.cdi
+%{_cross_bindir}/nvidia-container-runtime.legacy
 %{_cross_udevrulesdir}/90-nvidia-gpu-devices.rules
 
 %files ecs


### PR DESCRIPTION
**Issue**
Closes #508


**Description of changes:**
provide nvidia-container-runtime.cdi and nvidia-container-runtime.legacy binaries.

```
Found existing alias for "ls -lah". You should use: "lsa"
total 39M
drwxr-xr-x. 1 jweiw jweiw  274 May 12 15:56 .
drwxr-xr-x. 1 jweiw jweiw   22 May 12 15:56 ..
-rwxr-xr-x. 1 jweiw jweiw 5.9M May  5 22:57 nvidia-cdi-hook
-rwxr-xr-x. 1 jweiw jweiw 6.1M May  5 22:57 nvidia-container-runtime
-rwxr-xr-x. 1 jweiw jweiw 6.1M May  5 22:57 nvidia-container-runtime.cdi
-rwxr-xr-x. 1 jweiw jweiw 4.5M May  5 22:57 nvidia-container-runtime-hook
-rwxr-xr-x. 1 jweiw jweiw 6.1M May  5 22:57 nvidia-container-runtime.legacy
-rwxr-xr-x. 1 jweiw jweiw  10M May  5 22:57 nvidia-ctk
```
this is the size after provide these two binaries, it doesn't use all the storage for the nvidia variant. 
**Testing done:**
Build the package and extract RPM


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
