### PR TITLE
nvidia-k8s-device-plugin: add ldcache parsing for aarch64 patch

### DIFF
--- a/packages/nvidia-k8s-device-plugin/0001-fix-ldcache-parsing-for-aarch64.patch
+++ b/packages/nvidia-k8s-device-plugin/0001-fix-ldcache-parsing-for-aarch64.patch
@@ -1,0 +1,49 @@
+From be4ba83b821eea9050eefdb7e67df2d757c3795a Mon Sep 17 00:00:00 2001
+From: Jingwei Wang <jweiw@amazon.com>
+Date: Wed, 23 Apr 2025 17:17:35 +0000
+Subject: [PATCH] fix ldcache parsing for aarch64
+
+k8s-device-plugin carries its own nvidia-container-toolkit and uses
+nvidia-ctk to generate the CDI specifications.
+
+The architecture flag for aarch64 is currently missing from the
+supported architecture flags list. This omission causes the getEntries
+function to exclude all libraries found on aarch64 hosts. As a result
+helper programs like nvidia-ctk are unable to generate CDI
+specifications for the aarch64 architecture.
+
+This fix adds the missing aarch64 architecture flag, using the same
+value as defined in libnvidia-container[1], which maintains a more
+comprehensive list of supported architectures.
+
+[1]: https://github.com/NVIDIA/libnvidia-container/blob/a198166e1c1166f4847598438115ea97dacc7a92/src/ldcache.h#L21
+
+Signed-off-by: Jingwei Wang <jweiw@amazon.com>
+---
+ .../nvidia-container-toolkit/internal/ldcache/ldcache.go       | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/ldcache/ldcache.go b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/ldcache/ldcache.go
+index 4daf95b..455048c 100644
+--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/ldcache/ldcache.go
++++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/ldcache/ldcache.go
+@@ -47,6 +47,7 @@ const (
+ 	flagArchX8664   = 0x0300
+ 	flagArchX32     = 0x0800
+ 	flagArchPpc64le = 0x0500
++	flagArchAarch64 = 0x0a00
+ )
+ 
+ var errInvalidCache = errors.New("invalid ld.so.cache file")
+@@ -195,6 +196,8 @@ func (c *ldcache) getEntries() []entry {
+ 		switch e.Flags & flagArchMask {
+ 		case flagArchX8664:
+ 			fallthrough
++		case flagArchAarch64:
++			fallthrough
+ 		case flagArchPpc64le:
+ 			bits = 64
+ 		case flagArchX32:
+-- 
+2.47.0
+

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -18,6 +18,7 @@ Source2: nvidia-k8s-device-plugin-conf
 Source3: nvidia-k8s-device-plugin-exec-start-conf
 Source4: nvidia-k8s-device-plugin-mig-conf
 
+Patch0001: 0001-fix-ldcache-parsing-for-aarch64.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{name}(binaries)


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
add patch to fix ldcache parsing for aarch64

k8s-device-plugin carries its own nvidia-container-toolkit for now and uses nvidia-ctk to generate the CDI specifications.

The architecture flag for aarch64 is currently missing from the supported architecture flags list. This omission causes the getEntries function to exclude all libraries found on aarch64 hosts. As a result helper programs like nvidia-ctk are unable to generate CDI specifications for the aarch64 architecture.

**Testing done:**
- testing with part of this [PR](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/459)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
