### PR TITLE
Containerd-2.0 bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v8.1.1 (2025-05-14)
+
+## OS Changes
+* Fix `containerd-2.0` settings for `container-registry` ([#504])
+
+[#504] : https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/504
+
 # v8.1.0 (2025-05-05)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "8.1.0"
+release-version = "8.1.1"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/packages/containerd-2.0/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.0/containerd-config-toml_k8s_containerd_sock
@@ -49,9 +49,10 @@ SystemdCgroup = true
 bin_dir = "/opt/cni/bin"
 conf_dir = "/etc/cni/net.d"
 
+[plugins."io.containerd.cri.v1.images".registry]
 {{#if settings.container-registry.mirrors}}
 {{#each settings.container-registry.mirrors}}
-[plugins."io.containerd.cri.v1.runtime".registry.mirrors."{{registry}}"]
+[plugins."io.containerd.cri.v1.images".registry.mirrors."{{registry}}"]
 endpoint = [{{join_array ", " endpoint }}]
 {{/each}}
 {{/if}}
@@ -59,9 +60,9 @@ endpoint = [{{join_array ", " endpoint }}]
 {{#if settings.container-registry.credentials}}
 {{#each settings.container-registry.credentials}}
 {{#if (eq registry "docker.io" )}}
-[plugins."io.containerd.cri.v1.runtime".registry.configs."registry-1.docker.io".auth]
+[plugins."io.containerd.cri.v1.images".registry.configs."registry-1.docker.io".auth]
 {{else}}
-[plugins."io.containerd.cri.v1.runtime".registry.configs."{{registry}}".auth]
+[plugins."io.containerd.cri.v1.images".registry.configs."{{registry}}".auth]
 {{/if}}
 {{#if username}}
 username = "{{{username}}}"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket/issues/4520

**Description of changes:**

Update the containerd-2.0 k8s config template to use the correct path container-registry settings. Similar to what is defined in the [nvidia config template](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/6f014eb46c57d83368faa8dad97b39b817f31682/packages/containerd-2.0/containerd-config-toml_k8s_nvidia_containerd_sock#L56)


**Testing done:**

- validated that the generated config is as expected
-  tested by pulling an image from a private repo without issue


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
