### PR TITLE
Always provide service to generate CDI specs

### DIFF
--- a/packages/nvidia-container-toolkit/generate-cdi-specs.service
+++ b/packages/nvidia-container-toolkit/generate-cdi-specs.service
@@ -21,7 +21,9 @@ Type=oneshot
 # Explanation of the options:
 # --format json: to be consistent across Bottlerocket's variants
 # --mode nvml: the default mode ("auto") resolves to this already, make it explicit
-# --device-name-strategy uuid: the ECS agent only supports device UUIDs
+# --device-name-strategy uuid: the ECS agent only supports device UUIDs; for k8s
+#                              this is irrelevant because these specs will be used
+#                              only when NVIDIA_VISIBLE_DEVICES is "all"
 # --output /etc/cdi/nvidia.json: store the CDI specifications at this location
 ExecStart=/usr/bin/nvidia-ctk cdi generate --format json \
   --mode nvml \

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -36,7 +36,6 @@ Requires: (%{name}-k8s if %{_cross_os}variant-family(aws-k8s))
 %package ecs
 Summary: Files specific for the ECS variants
 Requires: %{name}
-Requires: %{name}-cdi-specs
 Conflicts: %{name}-k8s
 
 %description ecs
@@ -48,13 +47,6 @@ Requires: %{name}
 Conflicts: %{name}-ecs
 
 %description k8s
-%{summary}.
-
-%package cdi-specs
-Summary: Tools to generate CDI specifications
-Requires: %{name}
-
-%description cdi-specs
 %{summary}.
 
 %prep
@@ -103,6 +95,7 @@ install -m 0644 %{S:7} %{buildroot}%{_cross_unitdir}/
 %{_cross_bindir}/nvidia-cdi-hook
 %{_cross_bindir}/nvidia-container-runtime
 %{_cross_udevrulesdir}/90-nvidia-gpu-devices.rules
+%{_cross_unitdir}/generate-cdi-specs.service
 
 %files ecs
 %{_cross_factorydir}/nvidia-container-runtime/nvidia-container-toolkit-config-ecs.toml
@@ -112,6 +105,3 @@ install -m 0644 %{S:7} %{buildroot}%{_cross_unitdir}/
 %{_cross_factorydir}/nvidia-container-runtime/nvidia-container-toolkit-config-k8s.toml
 %{_cross_templatedir}/nvidia-container-runtime/nvidia-container-toolkit-config-k8s
 %{_cross_tmpfilesdir}/nvidia-container-toolkit-k8s.conf
-
-%files cdi-specs
-%{_cross_unitdir}/generate-cdi-specs.service


### PR DESCRIPTION
**Description of changes:**

The service to generate the CDI specs is required in both ECS and Kubernetes. For the latter, the CDI specs generated by the service will be used by "privileged" containers that must have access to all the devices.

**Testing done:**

Verified the service is installed in k8s variants and that it is functional:

<details>

```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c0610-dirty",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
bash-5.1# systemctl status generate-cdi-specs.service
● generate-cdi-specs.service - Generate CDI specifications
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/generate-cdi-specs.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (exited) since Wed 2025-05-14 17:47:13 UTC; 53s ago
   Main PID: 1823 (code=exited, status=0/SUCCESS)
        CPU: 64ms

May 14 17:47:13 ip-172-31-20-71.us-west-2.compute.internal nvidia-ctk[1823]: time="2025-05-14T17:47:13Z" level=info msg="Selecting /lib/firmware/nvidia/570.133.20…a10x.bin"
May 14 17:47:13 ip-172-31-20-71.us-west-2.compute.internal nvidia-ctk[1823]: time="2025-05-14T17:47:13Z" level=info msg="Selecting /lib/firmware/nvidia/570.133.20…u10x.bin"
May 14 17:47:13 ip-172-31-20-71.us-west-2.compute.internal nvidia-ctk[1823]: time="2025-05-14T17:47:13Z" level=info msg="Selecting /usr/bin/nvidia-smi as /usr/bin…idia-smi"
May 14 17:47:13 ip-172-31-20-71.us-west-2.compute.internal nvidia-ctk[1823]: time="2025-05-14T17:47:13Z" level=info msg="Selecting /usr/bin/nvidia-debugdump as /u…ebugdump"
May 14 17:47:13 ip-172-31-20-71.us-west-2.compute.internal nvidia-ctk[1823]: time="2025-05-14T17:47:13Z" level=info msg="Selecting /usr/bin/nvidia-persistenced as…istenced"
May 14 17:47:13 ip-172-31-20-71.us-west-2.compute.internal nvidia-ctk[1823]: time="2025-05-14T17:47:13Z" level=warning msg="Could not locate nvidia-cuda-mps-contr…ot found"
May 14 17:47:13 ip-172-31-20-71.us-west-2.compute.internal nvidia-ctk[1823]: time="2025-05-14T17:47:13Z" level=warning msg="Could not locate nvidia-cuda-mps-serve…ot found"
May 14 17:47:13 ip-172-31-20-71.us-west-2.compute.internal nvidia-ctk[1823]: time="2025-05-14T17:47:13Z" level=warning msg="Could not locate nvidia_drv.so: patter…ot found"
May 14 17:47:13 ip-172-31-20-71.us-west-2.compute.internal nvidia-ctk[1823]: time="2025-05-14T17:47:13Z" level=warning msg="Could not locate libglxserver_nvidia.s…ot found"
May 14 17:47:13 ip-172-31-20-71.us-west-2.compute.internal nvidia-ctk[1823]: time="2025-05-14T17:47:13Z" level=info msg="Generated CDI spec with version 0.8.0"
Hint: Some lines were ellipsized, use -l to show in full.
```

</details>




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
