### PR TITLE
Provide additional CRI runtimes for NVIDIA

### DIFF
--- a/packages/containerd-1.7/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-1.7/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -21,6 +21,7 @@ address = "/run/containerd/containerd.sock"
 [plugins."io.containerd.grpc.v1.cri"]
 device_ownership_from_security_context = {{default false settings.kubernetes.device-ownership-from-security-context}}
 enable_selinux = true
+enable_cdi = true
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
 sandbox_image = "localhost/kubernetes/pause:0.1.0"
 {{#if settings.container-runtime.max-container-log-line-size}}
@@ -43,9 +44,29 @@ default_runtime_name = "nvidia"
 runtime_type = "io.containerd.runc.v2"
 base_runtime_spec = "/etc/containerd/cri-base.json"
 
+# cdi only nvidia container runtime
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-cdi]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+# legacy only nvidia container runtime
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-legacy]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
 SystemdCgroup = true
 BinaryName = "nvidia-container-runtime"
+
+# cdi only nvidia container runtime
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-cdi.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime.cdi"
+
+# legacy only nvidia container runtime
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia-legacy.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime.legacy"
 
 [plugins."io.containerd.grpc.v1.cri".cni]
 bin_dir = "/opt/cni/bin"

--- a/packages/containerd-2.0/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.0/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -45,9 +45,27 @@ default_runtime_name = "nvidia"
 runtime_type = "io.containerd.runc.v2"
 base_runtime_spec = "/etc/containerd/cri-base.json"
 
+# CDI only nvidia container runtime
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-cdi]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+# legacy only nvidia container runtime
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-legacy]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
 [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia.options]
 SystemdCgroup = true
 BinaryName = "nvidia-container-runtime"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-cdi.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime.cdi"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-legacy.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime.legacy"
 
 [plugins."io.containerd.cri.v1.runtime".cni]
 bin_dir = "/opt/cni/bin"


### PR DESCRIPTION
**Issue number:**

Closes #510 

**Description of changes:**

The GPU Operator provides additional runtime classes to allow selecting the NVIDIA stack for the pods. Provide the same runtimes the GPU Operator provides for compatibility.

**Testing done:**

As part of: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/459

In variants: `aws-k8s-1.29`, `aws-k8s-1.31`, `aws-k8s-1.32`, `aws-k8s-1.33` for x86_64 and aarch64:

- Verified that all the containerd runtimes are functional


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
