### PR TITLE
aws-signing-helper: bump version from 1.4.0 to 1.6.0

### DIFF
--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.4.0/rolesanywhere-credential-helper-v1.4.0.tar.gz"
-sha512 = "6da4911c89ea24a1356964f5cedc2cdb06c927a930b189efbf5ccaae60e582714b264fb787b2ed9d575ce5e588d1a057d7f311022c459aca7b7afd9f9c2bc801"
+url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.6.0/rolesanywhere-credential-helper-v1.6.0.tar.gz"
+sha512 = "be0486b7aad0a366835fe65ced3d8ab162866316f7d9c4d0acd11ad67a3d6e922b7890878bb683f625db2a9943d641a67b91bbb189a65ff9e61f13ddd05caa27"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo rolesanywhere-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.4.0
+%global gover 1.6.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/512

**Description of changes:**
Bump `aws-signing-helper` from 1.4.0 to 1.6.0


**Testing done:**
- Built custom k8s AMIs and ran conformance tests:
```
 NAME                                TYPE      STATE      PASSE   FAILE   SKIPPE          
 aarch64-aws-k8s-126-quick           Test      passed         4       0     7068
 aarch64-aws-k8s-132-quick           Test      passed         5       0     6623
 x86-64-aws-k8s-126-quick            Test      passed         4       0     7068 
 x86-64-aws-k8s-132-quick            Test      passed         5       0     6623
```

- Built aws-k8s-130-nvidia variant and ran nvidia-smoke tests. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
