### PR TITLE
packages: update kubernetes-1.26

### DIFF
--- a/packages/kubernetes-1.26/Cargo.toml
+++ b/packages/kubernetes-1.26/Cargo.toml
@@ -86,8 +86,8 @@ url = "https://raw.githubusercontent.com/aws/eks-distro/93c82ae30d0c044196bd0b0b
 sha512 = "d26e1886dc8661666fd7469b469a1cbd24d4f4d7d240c56d6d6d2148abe5e4bc278cb00f288bec9c7a0f6458a3eb857e4a1a2571c635ab4d83b347eac81d5eab"
 
 [[package.metadata.build-package.external-files]]
-url = "https://raw.githubusercontent.com/aws/eks-distro/259009b1eefaed4a7be4df2ec1d12a280b4c28e2/projects/kubernetes/kubernetes/1-26/patches/0020-EKS-PATCH-Update-the-goversion-to-1.23.patch"
-sha512 = "22f6634afe74d3753561b1e1a3dae66ee4a532b683d38ac8d22a7bdda8f562f94ff9cc2560b12e5b5e03816b79a849d301345177a9452501b44c214e7c2264d3"
+url = "https://raw.githubusercontent.com/aws/eks-distro/588c0674ceb8721d8ee83d6818c63eb9e5ec6f44/projects/kubernetes/kubernetes/1-26/patches/0020-EKS-PATCH-Update-the-goversion-to-1.23.patch"
+sha512 = "c4566589f855a02577d81a63e96c89dc9961b2f2871a963c7fd8c168661dd0d380830d0021a39eec83914278c3a5f09628a0cd7ba1cff2504a81bb3f318247b3"
 
 [build-dependencies]
 glibc = { path = "../glibc" }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Minor update was made to the previous k8 1.26 patch https://github.com/aws/eks-distro/pull/3761/commits/17b468b3363e618f7e9c74c23b5e2abbdb4dbfce to fix a patch issue which only appears to effect upstreams publishing-bot. Taking it none the less to stay on the latest.

**Testing done:**
```
 aarch64-aws-k8s-126-conformance                           Test                     passed                                     371                      0                    6701   0968c061-dirty                 2025-05-19T17:03:14Z
 aarch64-aws-k8s-126-nvidia-conformance                    Test                     passed                                     371                      0                    6701   0968c061-dirty                 2025-05-19T17:09:26Z
 aarch64-aws-k8s-126-quick                                 Test                     passed                                       4                      0                    7068   0968c061-dirty                 2025-05-19T15:27:07Z
 x86-64-aws-k8s-126-conformance                            Test                     passed                                     371                      0                    6701   0968c061-dirty                 2025-05-19T17:07:13Z
 x86-64-aws-k8s-126-nvidia-conformance                     Test                     passed                                     371                      0                    6701   0968c061-dirty                 2025-05-19T21:15:55Z
 ```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
