### PR TITLE
netdog: look for net.toml under /usr

### DIFF
--- a/sources/netdog/src/cli/mod.rs
+++ b/sources/netdog/src/cli/mod.rs
@@ -9,6 +9,7 @@ use crate::net_config::{self, Interfaces};
 use crate::{
     DEFAULT_NET_CONFIG_FILE, KERNEL_CMDLINE, OVERRIDE_NET_CONFIG_FILE, PRIMARY_INTERFACE,
     PRIMARY_MAC_ADDRESS, PRIMARY_SYSCTL_CONF, SYSCTL_MARKER_FILE, SYSTEMD_SYSCTL, SYS_CLASS_NET,
+    USR_NET_CONFIG_FILE,
 };
 pub(crate) use generate_hostname::GenerateHostnameArgs;
 pub(crate) use generate_net_config::GenerateNetConfigArgs;
@@ -166,9 +167,10 @@ where
 fn fetch_net_config() -> Result<(Option<Box<dyn Interfaces>>, PathBuf)> {
     let override_path = PathBuf::from(OVERRIDE_NET_CONFIG_FILE);
     let default_path = PathBuf::from(DEFAULT_NET_CONFIG_FILE);
+    let usr_path = PathBuf::from(USR_NET_CONFIG_FILE);
     let cmdline = PathBuf::from(KERNEL_CMDLINE);
 
-    for path in [override_path, default_path] {
+    for path in [override_path, default_path, usr_path] {
         if Path::exists(&path) {
             return Ok((
                 net_config::from_path(&path).context(error::NetConfigParseSnafu { path: &path })?,

--- a/sources/netdog/src/main.rs
+++ b/sources/netdog/src/main.rs
@@ -49,6 +49,7 @@ static PRIMARY_INTERFACE: &str = "/var/lib/netdog/primary_interface";
 static PRIMARY_MAC_ADDRESS: &str = "/var/lib/netdog/primary_mac_address";
 static DEFAULT_NET_CONFIG_FILE: &str = "/var/lib/bottlerocket/net.toml";
 static OVERRIDE_NET_CONFIG_FILE: &str = "/var/lib/netdog/net.toml";
+static USR_NET_CONFIG_FILE: &str = "/usr/share/bottlerocket/net.toml";
 static PRIMARY_SYSCTL_CONF: &str = "/etc/sysctl.d/90-primary_interface.conf";
 static SYSCTL_MARKER_FILE: &str = "/run/netdog/primary_sysctls_set";
 static SYS_CLASS_NET: &str = "/sys/class/net";


### PR DESCRIPTION
Look for net.toml also under /usr/share/bottlerocket. The previous locations in /var have higher priority.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

I didn't know I had to open an issue yet, will remember for next time.

**Description of changes:**

Currently netdog boot parameters only allow a single interface. For bottlerocket variants that will have multiple interfaces this is not sufficient and complicates the booting process. netdog already allows multiple interfaces via a `net.toml` file, but only [when provisioning as a metal](https://github.com/bottlerocket-os/bottlerocket/blob/develop/PROVISIONING-METAL.md#network-interface-configuration).

This change allows using `net.toml` in other configurations and thus enable a bottlerocket instance to configure multiple interfaces at boot.

**Testing done:**

`cargo test`. 

I haven't been able to use this in an actual instance yet.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
