### PR TITLE
sources: fix clippy warnings for Rust 1.87.0

### DIFF
--- a/sources/api/apiclient/src/exec.rs
+++ b/sources/api/apiclient/src/exec.rs
@@ -694,7 +694,10 @@ mod error {
 
         // This is from our own module which includes enough context.
         #[snafu(display("{}", source))]
-        Connect { source: connect::Error },
+        Connect {
+            #[snafu(source(from(connect::Error, Box::new)))]
+            source: Box<connect::Error>,
+        },
 
         #[snafu(display("Failed to deserialize message from server: {}", source))]
         Deserialize { source: serde_json::Error },
@@ -707,7 +710,8 @@ mod error {
 
         #[snafu(display("Failed to read from WebSocket: {}", source))]
         ReadWebSocket {
-            source: tokio_tungstenite::tungstenite::Error,
+            #[snafu(source(from(tokio_tungstenite::tungstenite::Error, Box::new)))]
+            source: Box<tokio_tungstenite::tungstenite::Error>,
         },
 
         #[snafu(display("Failed to send {} message to server: {}", kind, source))]

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -912,9 +912,9 @@ impl ResponseError for error::Error {
             // 404 Not Found
             MissingData { .. } => StatusCode::NOT_FOUND,
             ListKeys { .. } => StatusCode::NOT_FOUND,
-            UpdateDoesNotExist { .. } => StatusCode::NOT_FOUND,
-            NoStagedImage { .. } => StatusCode::NOT_FOUND,
-            UninitializedUpdateStatus { .. } => StatusCode::NOT_FOUND,
+            UpdateDoesNotExist => StatusCode::NOT_FOUND,
+            NoStagedImage => StatusCode::NOT_FOUND,
+            UninitializedUpdateStatus => StatusCode::NOT_FOUND,
 
             // 422 Unprocessable Entity
             CommitWithNoPending => StatusCode::UNPROCESSABLE_ENTITY,
@@ -922,10 +922,10 @@ impl ResponseError for error::Error {
 
             // 423 Locked
             UpdateShareLock { .. } => StatusCode::LOCKED,
-            UpdateLockHeld { .. } => StatusCode::LOCKED,
+            UpdateLockHeld => StatusCode::LOCKED,
 
             // 409 Conflict
-            DisallowCommand { .. } => StatusCode::CONFLICT,
+            DisallowCommand => StatusCode::CONFLICT,
 
             // 500 Internal Server Error
             DataStoreLock => StatusCode::INTERNAL_SERVER_ERROR,
@@ -947,7 +947,7 @@ impl ResponseError for error::Error {
             ConfigApplierWait { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ConfigApplierWrite { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             SystemdNotify { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-            SystemdNotifyStatus {} => StatusCode::INTERNAL_SERVER_ERROR,
+            SystemdNotifyStatus => StatusCode::INTERNAL_SERVER_ERROR,
             SetPermissions { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             SetGroup { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             SettingsToJson { .. } => StatusCode::INTERNAL_SERVER_ERROR,
@@ -955,7 +955,7 @@ impl ResponseError for error::Error {
             Shutdown { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Reboot { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             UpdateDispatcher { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-            UpdateError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            UpdateError => StatusCode::INTERNAL_SERVER_ERROR,
             UpdateStatusParse { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             UpdateInfoParse { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             UpdateLockOpen { .. } => StatusCode::INTERNAL_SERVER_ERROR,

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -617,7 +617,7 @@ mod error {
 
         #[snafu(display("Failed to execute '{:?}': {}", command, source))]
         ExecutionFailure {
-            command: Command,
+            command: Box<Command>,
             source: std::io::Error,
         },
 

--- a/sources/api/host-containers/src/main.rs
+++ b/sources/api/host-containers/src/main.rs
@@ -68,7 +68,7 @@ mod error {
 
         #[snafu(display("Failed to execute '{:?}': {}", command, source))]
         ExecutionFailure {
-            command: Command,
+            command: Box<Command>,
             source: std::io::Error,
         },
 

--- a/sources/api/migration/migrator/src/main.rs
+++ b/sources/api/migration/migrator/src/main.rs
@@ -35,7 +35,6 @@ use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 use std::env;
-use std::io::ErrorKind;
 use std::os::unix::fs::symlink;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -401,7 +400,7 @@ where
             })?
             .map(|entry| {
                 let annotated: std::result::Result<bytes::Bytes, tough::error::Error> = entry;
-                annotated.map_err(|tough_error| std::io::Error::new(ErrorKind::Other, tough_error))
+                annotated.map_err(std::io::Error::other)
             });
 
         // Convert the stream to a blocking Read object.
@@ -672,7 +671,7 @@ async fn load_manifest(repository: tough::Repository) -> Result<Manifest> {
         .context(error::ManifestNotFoundSnafu)?
         .map(|entry| {
             let annotated: std::result::Result<bytes::Bytes, tough::error::Error> = entry;
-            annotated.map_err(|tough_error| std::io::Error::new(ErrorKind::Other, tough_error))
+            annotated.map_err(std::io::Error::other)
         });
 
     // Convert the stream to a blocking Read object.

--- a/sources/api/pluto/src/ec2.rs
+++ b/sources/api/pluto/src/ec2.rs
@@ -23,8 +23,11 @@ pub(super) enum Error {
     ))]
     DescribeInstances {
         instance_id: String,
-        source: aws_sdk_eks::error::SdkError<
-            aws_sdk_ec2::operation::describe_instances::DescribeInstancesError,
+        #[snafu(source(from(aws_sdk_ec2::error::SdkError<aws_sdk_ec2::operation::describe_instances::DescribeInstancesError>, Box::new)))]
+        source: Box<
+            aws_sdk_ec2::error::SdkError<
+                aws_sdk_ec2::operation::describe_instances::DescribeInstancesError,
+            >,
         >,
     },
 

--- a/sources/api/pluto/src/eks.rs
+++ b/sources/api/pluto/src/eks.rs
@@ -14,8 +14,11 @@ pub(crate) type ClusterNetworkConfig = KubernetesNetworkConfigResponse;
 pub(super) enum Error {
     #[snafu(display("Error describing cluster: {}", source))]
     DescribeCluster {
-        source: aws_sdk_eks::error::SdkError<
-            aws_sdk_eks::operation::describe_cluster::DescribeClusterError,
+        #[snafu(source(from(aws_sdk_eks::error::SdkError<aws_sdk_eks::operation::describe_cluster::DescribeClusterError>, Box::new)))]
+        source: Box<
+            aws_sdk_eks::error::SdkError<
+                aws_sdk_eks::operation::describe_cluster::DescribeClusterError,
+            >,
         >,
     },
 

--- a/sources/api/prairiedog/src/error.rs
+++ b/sources/api/prairiedog/src/error.rs
@@ -13,7 +13,7 @@ pub(super) enum Error {
 
     #[snafu(display("Failed to execute '{:?}': {}", command, source))]
     ExecutionFailure {
-        command: Command,
+        command: Box<Command>,
         source: std::io::Error,
     },
 

--- a/sources/api/schnauzer/src/helpers/mod.rs
+++ b/sources/api/schnauzer/src/helpers/mod.rs
@@ -1360,7 +1360,7 @@ pub fn oci_defaults(
     // Extract the last part of the settings path, which is the OCI spec section we want to render.
     let oci_spec_section = settings_path
         .split('.')
-        .last()
+        .next_back()
         .expect("did not find (got None for) an oci_spec_section");
 
     // Render the requested OCI spec section

--- a/sources/api/thar-be-updates/src/main.rs
+++ b/sources/api/thar-be-updates/src/main.rs
@@ -363,8 +363,8 @@ fn match_error_to_exit_status(err: Error) -> i32 {
     match err {
         Error::UpdateLockHeld { .. } => TbuErrorStatus::UpdateLockHeld,
         Error::DisallowCommand { .. } => TbuErrorStatus::DisallowCommand,
-        Error::UpdateDoesNotExist { .. } => TbuErrorStatus::UpdateDoesNotExist,
-        Error::StagingPartition { .. } => TbuErrorStatus::NoStagedImage,
+        Error::UpdateDoesNotExist => TbuErrorStatus::UpdateDoesNotExist,
+        Error::StagingPartition => TbuErrorStatus::NoStagedImage,
         _ => TbuErrorStatus::OtherError,
     }
     .to_i32()

--- a/sources/bootstrap-commands/src/main.rs
+++ b/sources/bootstrap-commands/src/main.rs
@@ -251,7 +251,7 @@ mod error {
 
         #[snafu(display("Failed to execute '{:?}': {}", command, source))]
         ExecutionFailure {
-            command: Command,
+            command: Box<Command>,
             source: std::io::Error,
         },
 

--- a/sources/cfsignal/src/error.rs
+++ b/sources/cfsignal/src/error.rs
@@ -35,8 +35,11 @@ pub enum Error {
 
     #[snafu(display("SignalResource request failed: {}", source))]
     SignalResource {
-        source: aws_sdk_cloudformation::error::SdkError<
-            aws_sdk_cloudformation::operation::signal_resource::SignalResourceError,
+        #[snafu(source(from(aws_sdk_cloudformation::error::SdkError<aws_sdk_cloudformation::operation::signal_resource::SignalResourceError>, Box::new)))]
+        source: Box<
+            aws_sdk_cloudformation::error::SdkError<
+                aws_sdk_cloudformation::operation::signal_resource::SignalResourceError,
+            >,
         >,
     },
 }

--- a/sources/driverdog/src/main.rs
+++ b/sources/driverdog/src/main.rs
@@ -495,7 +495,7 @@ mod error {
 
         #[snafu(display("Failed to execute '{:?}': {}", command, source))]
         ExecutionFailure {
-            command: Command,
+            command: Box<Command>,
             source: std::io::Error,
         },
 

--- a/sources/metricdog/src/metricdog.rs
+++ b/sources/metricdog/src/metricdog.rs
@@ -101,11 +101,11 @@ impl Metricdog {
     /// # Parameters
     ///
     /// * `sender`:          This is the name of the application sending the metrics e.g.
-    ///                      `metricdog` or `updog`.
+    ///   `metricdog` or `updog`.
     /// * `event`:           The metrics event that is being sent. For example `BootSuccess` or
-    ///                      `HealthPing`.
+    ///   `HealthPing`.
     /// * `timeout_seconds`: The timeout setting for the HTTP client. Defaults to
-    ///                      `DEFAULT_TIMEOUT_SECONDS` when `None` is passed.
+    ///   `DEFAULT_TIMEOUT_SECONDS` when `None` is passed.
     pub(crate) fn send<S1>(
         &self,
         sender: S1,

--- a/sources/netdog/src/net_config/mod.rs
+++ b/sources/netdog/src/net_config/mod.rs
@@ -39,6 +39,7 @@ pub(crate) trait Interfaces {
     /// Does the config contain any interfaces?
     fn has_interfaces(&self) -> bool;
 
+    #[cfg(not(feature = "wicked"))]
     fn interfaces(&self) -> Vec<InterfaceId>;
 
     /// Converts the network config into a list of `WickedInterface` structs, suitable for writing
@@ -59,6 +60,7 @@ impl<I: Interfaces> Interfaces for Box<I> {
         (**self).has_interfaces()
     }
 
+    #[cfg(not(feature = "wicked"))]
     fn interfaces(&self) -> Vec<InterfaceId> {
         (**self).interfaces()
     }

--- a/sources/netdog/src/net_config/v1.rs
+++ b/sources/netdog/src/net_config/v1.rs
@@ -53,6 +53,7 @@ impl Interfaces for NetConfigV1 {
         !self.interfaces.is_empty()
     }
 
+    #[cfg(not(feature = "wicked"))]
     fn interfaces(&self) -> Vec<InterfaceId> {
         self.interfaces
             .keys()

--- a/sources/netdog/src/net_config/v2.rs
+++ b/sources/netdog/src/net_config/v2.rs
@@ -37,6 +37,7 @@ impl Interfaces for NetConfigV2 {
         !self.interfaces.is_empty()
     }
 
+    #[cfg(not(feature = "wicked"))]
     fn interfaces(&self) -> Vec<InterfaceId> {
         self.interfaces
             .keys()

--- a/sources/netdog/src/net_config/v3.rs
+++ b/sources/netdog/src/net_config/v3.rs
@@ -36,6 +36,7 @@ impl Interfaces for NetConfigV3 {
         !self.net_devices.is_empty()
     }
 
+    #[cfg(not(feature = "wicked"))]
     fn interfaces(&self) -> Vec<InterfaceId> {
         self.net_devices.keys().cloned().collect()
     }

--- a/sources/updater/update_metadata/src/lib.rs
+++ b/sources/updater/update_metadata/src/lib.rs
@@ -311,7 +311,7 @@ impl Update {
             .waves
             .range((Included(0), Excluded(seed)))
             .map(|(k, v)| (*k, *v))
-            .last();
+            .next_back();
         let end_wave = self
             .waves
             .range((Included(seed), Included(MAX_SEED)))

--- a/sources/updater/updog/src/transport.rs
+++ b/sources/updater/updog/src/transport.rs
@@ -4,7 +4,7 @@ use futures::StreamExt;
 use futures::TryStreamExt;
 use futures_core::Stream;
 use log::error;
-use std::io::{ErrorKind, Read};
+use std::io::Read;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
@@ -92,7 +92,7 @@ pub(crate) fn reader_from_stream<S>(stream: S) -> impl Read
 where
     S: Stream<Item = Result<Bytes, tough::error::Error>> + Send + Unpin,
 {
-    let mapped_err = stream.map(|next| next.map_err(|e| std::io::Error::new(ErrorKind::Other, e)));
+    let mapped_err = stream.map(|next| next.map_err(std::io::Error::other));
     let async_read = mapped_err.into_async_read().compat();
     SyncIoBridge::new(async_read)
 }

--- a/sources/xfscli/src/bin/fsck_xfs/error.rs
+++ b/sources/xfscli/src/bin/fsck_xfs/error.rs
@@ -86,7 +86,7 @@ impl Error {
             Error::DirtyLogs => ExitCode::from(4),
             Error::MakeDir { .. } => ExitCode::from(1),
             Error::Mount => ExitCode::from(1),
-            Error::RepairFailure { .. } => ExitCode::from(4),
+            Error::RepairFailure => ExitCode::from(4),
             Error::UnrecognizedExitCode { .. } => ExitCode::from(4),
 
             // Return 8 when device argument is not provided


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/275

**Description of changes:**
Fix clippy warnings for Rust 1.87.0. Also, fix unused code warnings for `netdog` when the "wicked" feature flag is enabled.


**Testing done:**
`make twoliter check-clippy` passes, and the `netdog` package builds with no warnings logged.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
