### PR TITLE
sync glibc build flags

### DIFF
--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -127,6 +127,7 @@ git diff --quiet
 # for the C.UTF-8 locale, which we need `localedef` to generate.
 mkdir build
 pushd build
+CC="%{_cross_target}-gcc %{?_cross_arch_cflags}" CXX="%{_cross_target}-g++ %{?_cross_arch_cflags}" \
 %glibc_configure \
   --target="%{_cross_target}" \
   --host="%{_cross_target}" \

--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -83,7 +83,7 @@ Requires: %{name}
 %autosetup -Sgit -n glibc-%{version} -p1
 
 %global glibc_configure %{shrink: \
-BUILDFLAGS="-O2 -g -Wp,-D_GLIBCXX_ASSERTIONS -fstack-clash-protection" \
+BUILDFLAGS="-O2 -g -Wp,-D_GLIBCXX_ASSERTIONS -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" \
 CFLAGS="${BUILDFLAGS}" CPPFLAGS="" CXXFLAGS="${BUILDFLAGS}" \
 ../configure \
   --prefix="%{_cross_prefix}" \


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/276

**Description of changes:**
Build `glibc` with frame pointers. This should've happened around the time of https://github.com/bottlerocket-os/bottlerocket-sdk/pull/206, but was missed since `glibc` doesn't use the standard compiler and linker flags.

A forthcoming SDK will also set `%{_cross_arch_cflags}`, so use those flags too if the macro is defined.


**Testing done:**
Verified in the build logs that the frame pointer and arch-specific flags are passed to compiler invocations.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
