### PR TITLE
systemd: backport fix for daemon-reload and stop using isolate

### DIFF
--- a/packages/release/activate-configured.service
+++ b/packages/release/activate-configured.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=Isolates configured.target
+Description=Activate configured.target
 After=preconfigured.target
 Requires=preconfigured.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/systemctl set-default configured
-ExecStart=/usr/bin/systemctl isolate default --no-block
+ExecStart=/usr/bin/systemctl set-default configured.target
+ExecStart=/usr/bin/systemctl start configured.target --no-block
 RemainAfterExit=true
 StandardError=journal+console
 

--- a/packages/release/activate-multi-user.service
+++ b/packages/release/activate-multi-user.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=Isolates multi-user.target
+Description=Activate multi-user.target
 After=configured.target reboot-if-required.service
 Requires=configured.target reboot-if-required.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/systemctl set-default multi-user
-ExecStart=/usr/bin/systemctl isolate default --no-block
+ExecStart=/usr/bin/systemctl set-default multi-user.target
+ExecStart=/usr/bin/systemctl start multi-user.target --no-block
 RemainAfterExit=true
 StandardError=journal+console
 

--- a/packages/release/activate-preconfigured.service
+++ b/packages/release/activate-preconfigured.service
@@ -1,13 +1,13 @@
 [Unit]
-Description=Isolates preconfigured.target
+Description=Activate preconfigured.target
 DefaultDependencies=no
 After=fipscheck.target
 Requires=fipscheck.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/systemctl set-default preconfigured
-ExecStart=/usr/bin/systemctl isolate default --no-block
+ExecStart=/usr/bin/systemctl set-default preconfigured.target
+ExecStart=/usr/bin/systemctl start preconfigured.target --no-block
 RemainAfterExit=true
 StandardOutput=tty
 StandardError=inherit

--- a/packages/systemd/1003-serialize-don-t-allocate-1M-on-the-stack-just-like-t.patch
+++ b/packages/systemd/1003-serialize-don-t-allocate-1M-on-the-stack-just-like-t.patch
@@ -1,0 +1,82 @@
+From 714fc5c244cd9e83e6c82b87ff032de41fe86faf Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Mon, 11 Sep 2023 12:21:14 +0200
+Subject: [PATCH] serialize: don#t allocate 1M on the stack just like that
+
+Prompted by: https://github.com/systemd/systemd/pull/27890#issuecomment-1712841117
+---
+ src/shared/serialize.c | 36 +++++++++++++++++++++++++++---------
+ 1 file changed, 27 insertions(+), 9 deletions(-)
+
+diff --git a/src/shared/serialize.c b/src/shared/serialize.c
+index cd48286355..a1fc2429ae 100644
+--- a/src/shared/serialize.c
++++ b/src/shared/serialize.c
+@@ -23,10 +23,8 @@ int serialize_item(FILE *f, const char *key, const char *value) {
+ 
+         /* Make sure that anything we serialize we can also read back again with read_line() with a maximum line size
+          * of LONG_LINE_MAX. This is a safety net only. All code calling us should filter this out earlier anyway. */
+-        if (strlen(key) + 1 + strlen(value) + 1 > LONG_LINE_MAX) {
+-                log_warning("Attempted to serialize overly long item '%s', refusing.", key);
+-                return -EINVAL;
+-        }
++        if (strlen(key) + 1 + strlen(value) + 1 > LONG_LINE_MAX)
++                return log_warning_errno(SYNTHETIC_ERRNO(EINVAL), "Attempted to serialize overly long item '%s', refusing.", key);
+ 
+         fputs(key, f);
+         fputc('=', f);
+@@ -53,7 +51,10 @@ int serialize_item_escaped(FILE *f, const char *key, const char *value) {
+ }
+ 
+ int serialize_item_format(FILE *f, const char *key, const char *format, ...) {
+-        char buf[LONG_LINE_MAX];
++        _cleanup_free_ char *allocated = NULL;
++        char buf[256]; /* Something resonably short that fits nicely on any stack (i.e. is considerably less
++                        * than LONG_LINE_MAX (1MiB!) */
++        const char *b;
+         va_list ap;
+         int k;
+ 
+@@ -61,18 +62,35 @@ int serialize_item_format(FILE *f, const char *key, const char *format, ...) {
+         assert(key);
+         assert(format);
+ 
++        /* First, let's try to format this into a stack buffer */
+         va_start(ap, format);
+         k = vsnprintf(buf, sizeof(buf), format, ap);
+         va_end(ap);
+ 
+-        if (k < 0 || (size_t) k >= sizeof(buf) || strlen(key) + 1 + k + 1 > LONG_LINE_MAX) {
+-                log_warning("Attempted to serialize overly long item '%s', refusing.", key);
+-                return -EINVAL;
++        if (k < 0)
++                return log_warning_errno(errno, "Failed to serialize item '%s', ignoring: %m", key);
++        if (strlen(key) + 1 + k + 1 > LONG_LINE_MAX) /* See above */
++                return log_warning_errno(SYNTHETIC_ERRNO(EINVAL), "Attempted to serialize overly long item '%s', refusing.", key);
++
++        if ((size_t) k < sizeof(buf))
++                b = buf; /* Yay, it fit! */
++        else {
++                /* So the string didn't fit in the short buffer above, but was not above our total limit,
++                 * hence let's format it via dynamic memory */
++
++                va_start(ap, format);
++                k = vasprintf(&allocated, format, ap);
++                va_end(ap);
++
++                if (k < 0)
++                        return log_warning_errno(errno, "Failed to serialize item '%s', ignoring: %m", key);
++
++                b = allocated;
+         }
+ 
+         fputs(key, f);
+         fputc('=', f);
+-        fputs(buf, f);
++        fputs(b, f);
+         fputc('\n', f);
+ 
+         return 1;
+-- 
+2.47.0
+

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -24,6 +24,9 @@ Source6: systemd-sysusers.conf
 Patch1001: 1001-sd-netlink-make-calc_elapse-return-USEC_INFINITY-whe.patch
 Patch1002: 1002-sd-netlink-make-the-default-timeout-configurable-by-.patch
 
+# Backport of upstream patch to speed up `systemctl daemon-reload`.
+Patch1003: 1003-serialize-don-t-allocate-1M-on-the-stack-just-like-t.patch
+
 # Local patch to work around the fact that /var is a bind mount from
 # /local/var, and we want the /local/var/run symlink to point to /run.
 Patch9001: 9001-use-absolute-path-for-var-run-symlink.patch


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/276

**Description of changes:**
Guard against a potential regression from adding `-ftrivial-auto-var-init=zero` to the default compiler flags by backporting a `systemd` patch to avoid a 1M stack allocation. As a bonus, this should speed up `systemctl daemon-reload` which is now one of the most expensive parts of our boot sequence.

Replace uses of `systemctl isolate` with `systemctl start`. Upstream calls `isolate` ["a bad idea"](https://github.com/systemd/systemd/issues/26364#issuecomment-1424900066) and suggests `start` instead, which works fine for our purposes.

Note that we rely on the implicit reload that happens when the target is changed to find the units for host and bootstrap containers. This could be an explicit reload, but that would leave the target at its default value - either `preconfigured.target` or `fipscheck.target` - which changes the output that `systemd-analyze` reports.

**Testing done:**
Verified that the system comes up correctly, and that both bootstrap containers and host containers run as expected. 



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
