### PR TITLE
soci-snapshotter: use socket activation, embed build commit

### DIFF
--- a/packages/soci-snapshotter/soci-snapshotter.service
+++ b/packages/soci-snapshotter/soci-snapshotter.service
@@ -7,10 +7,6 @@ Before=containerd.service
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/soci-snapshotter-grpc
+ExecStart=/usr/bin/soci-snapshotter-grpc --address fd://
 Restart=always
 RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-RequiredBy=containerd.service

--- a/packages/soci-snapshotter/soci-snapshotter.socket
+++ b/packages/soci-snapshotter/soci-snapshotter.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=soci snapshotter containerd plugin (socket)
+PartOf=soci-snapshotter.service
+Documentation=https://github.com/awslabs/soci-snapshotter
+
+[Socket]
+ListenStream=/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -13,6 +13,7 @@ Source0: https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v%{gover}
 Source1: bundled-v%{gover}.tar.gz
 Source2: bundled-cmd.tar.gz
 Source101: soci-snapshotter.service
+Source102: soci-snapshotter.socket
 Source1000: clarify.toml
 
 BuildRequires: %{_cross_os}glibc-devel
@@ -63,12 +64,14 @@ install -p -m 0755 out/soci %{buildroot}%{_cross_bindir}
 install -p -m 0755 out/fips/soci-snapshotter-grpc %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 out/fips/soci %{buildroot}%{_cross_fips_bindir}
 install -D -p -m 0644 %{S:101} %{buildroot}%{_cross_unitdir}
+install -D -p -m 0644 %{S:102} %{buildroot}%{_cross_unitdir}
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files
 %license LICENSE NOTICE.md
 %{_cross_unitdir}/soci-snapshotter.service
+%{_cross_unitdir}/soci-snapshotter.socket
 %{_cross_attribution_vendor_dir}
 %{_cross_attribution_file}
 

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -1,6 +1,7 @@
 %global gorepo soci-snapshotter
 %global gover 0.9.0
 %global rpmver %{gover}
+%global gitrev 737f61a3db40c386f997c1f126344158aa3ad43c
 
 Name: %{_cross_os}soci-snapshotter
 Version: %{gover}
@@ -49,11 +50,14 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %build
 %set_cross_go_flags
 
-go build -C cmd -ldflags="${GOLDFLAGS}" -o "../out/soci-snapshotter-grpc" ./soci-snapshotter-grpc
-go build -C cmd -ldflags="${GOLDFLAGS}" -o "../out/soci" ./soci
+export LD_VERSION="-X github.com/awslabs/soci-snapshotter/version.Version=v%{gover}+bottlerocket"
+export LD_REVISION="-X github.com/awslabs/soci-snapshotter/version.Revision=%{gitrev}"
 
-gofips build -C cmd -ldflags="${GOLDFLAGS}" -o "../out/fips/soci-snapshotter-grpc" ./soci-snapshotter-grpc
-gofips build -C cmd -ldflags="${GOLDFLAGS}" -o "../out/fips/soci" ./soci
+go build -C cmd -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}" -o "../out/soci-snapshotter-grpc" ./soci-snapshotter-grpc
+go build -C cmd -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}" -o "../out/soci" ./soci
+
+gofips build -C cmd -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}" -o "../out/fips/soci-snapshotter-grpc" ./soci-snapshotter-grpc
+gofips build -C cmd -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}" -o "../out/fips/soci" ./soci
 
 %install
 install -d %{buildroot}%{_cross_bindir}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #530 

**Description of changes:**

Start the soci-snapshotter service with systemd socket activation and use its git revision as build metadata embedded in binaries


**Testing done:**

Testing `gitrev` on an `aws-dev` variant:

```
bash-5.1# soci-snapshotter-grpc --version
soci-snapshotter-grpc version v0.9.0+bottlerocket 737f61a3db40c386f997c1f126344158aa3ad43c
```

Testing socket activation on `aws-dev` variant with containerd configured to load soci:

```
bash-5.1# systemctl status soci-snapshotter
● soci-snapshotter.service - soci snapshotter containerd plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/soci-snapshotter.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Fri 2025-05-30 00:53:42 UTC; 8min ago
TriggeredBy: ● soci-snapshotter.socket
       Docs: https://github.com/awslabs/soci-snapshotter
   Main PID: 1230 (soci-snapshotte)
      Tasks: 40 (limit: 8934)
     Memory: 717.8M
        CPU: 6.301s
     CGroup: /system.slice/soci-snapshotter.service
             └─1230 /usr/bin/soci-snapshotter-grpc --address fd://
```

Configured containerd:

```
bash-5.1# tail -n 5 /etc/containerd/config.toml

[proxy_plugins]
  [proxy_plugins.soci]
    type = "snapshot"
    address = "/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"
```

Pulled example image:

```
ctr i pull --snapshotter=soci public.ecr.aws/soci-workshop-examples/ffmpeg:latest
```

On an `aws-dev` instance without containerd configured with soci:

```
bash-5.1# systemctl status soci-snapshotter
○ soci-snapshotter.service - soci snapshotter containerd plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/soci-snapshotter.service; static)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: inactive (dead)
TriggeredBy: ● soci-snapshotter.socket
       Docs: https://github.com/awslabs/soci-snapshotter
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
