### PR TITLE
Third party package updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## OS Changes
 * Third party package updates ([#494], [#498], [#513], [#514])
 * Extend `ghostdog` for Infiniband detection and configuration ([#499])
-
 * Enable `cryptsetup` and `tpm2` functionality for systemd ([#518])
 
 ## Build Changes

--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.6.30/aws-iam-authenticator-0.6.30.tar.gz"
-sha512 = "b2292f1078c7cbc4a6b49115af85bc747db4e2b4afd9bdb0808f40ffa48e3bcebfc76ab5973873ae9781167a91c4c4bfa899d1e7226eccb61fee808a91980164"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.7.2/aws-iam-authenticator-0.7.2.tar.gz"
+sha512 = "a37950bb08d7b0e175880126381167fd69172c398e8a5993b72a2b199147cfb6e6827666fe9415c6d6dcdc5e0d4600981113f32e1f1285d91635d3da44461d5e"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.6.30
+%global gover 0.7.2
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -53,7 +53,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 
 %build
 %set_cross_go_flags
-export GO_MAJOR="1.23"
+export GO_MAJOR="1.24"
 go build -ldflags="${GOLDFLAGS}" -o aws-iam-authenticator ./cmd/aws-iam-authenticator
 gofips build -ldflags="${GOLDFLAGS}" -o fips/aws-iam-authenticator ./cmd/aws-iam-authenticator
 

--- a/packages/ecr-credential-provider-1.31/Cargo.toml
+++ b/packages/ecr-credential-provider-1.31/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.31"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.31.5"
-path = "cloud-provider-aws-1.31.5.tar.gz"
-sha512 = "a2fefd9be3106d373ac0fb4547008b19442f056676c876cb9c08b5d9f2674435456393da531ac1ffe90e814c636e70c9f2a720140857cf639d420507322a59b3"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.31.6.tar.gz"
+path = "cloud-provider-aws-1.31.6.tar.gz"
+sha512 = "0b0c17be6ed98a6e116cf1b988ad6d511302585c491b34ca965fcf5eb7315c90b485613cd549df3babb2b49dc50abde61adc3b65247be9c64444122689f3331e"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
+++ b/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.31.5
+%global gover 1.31.6
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.32/Cargo.toml
+++ b/packages/ecr-credential-provider-1.32/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.32"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.32.2.tar.gz"
-path = "cloud-provider-aws-1.32.2.tar.gz"
-sha512 = "2ea6038125044850960207d509b779e439eb1325b2f4a260a8d2cfd9e9c7229a977681d4048bd06855ddaf21b985868d7da0242684a3b8706b6260430454a27b"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.32.3.tar.gz"
+path = "cloud-provider-aws-1.32.3.tar.gz"
+sha512 = "c0ceb88e18b2589d0c8291c5c4955adda9e6d44b134de8b92b9bf35182787609613328d3b00a6624d8f916e202a63328cb1fe6f03d3aeeb3ba23f912054badf4"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
+++ b/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.32.2
+%global gover 1.32.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -54,7 +54,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %set_cross_go_flags
 
 export GOTOOLCHAIN=local
-export GO_MAJOR="1.23"
+export GO_MAJOR="1.24"
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go

--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/49/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/50/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
 sha512 = "be3d6b527a671eeee59e55e1015a6421b3b3d0f7496451b888a51c960c16441ad02fd0fd98e5bcf1ddead10d14f66ab5316695db2bcf019c41ef62c10821b75d"
 
 [build-dependencies]

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 49
+%global releasever 50
 %global gover 1.28.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/38/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/39/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
 sha512 = "12c73980256a9db6123d67181e7fddd7fa7d18d1f776d586473d967a990844039eb67ed55c40d0dc183dac8526e54ef3326dda63b6849f8079e2ca29dfd71801"
 
 [build-dependencies]

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 38
+%global releasever 39
 %global gover 1.29.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/31/artifacts/kubernetes/v1.30.11/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/32/artifacts/kubernetes/v1.30.11/kubernetes-src.tar.gz"
 sha512 = "58af5d6279563f035af3e4ba50ba9d18693bdd9e989c5d23aab3cef91badf95c4cbe7c75606b595b98f7b4d1f707f538424be89547701e8f7a11400a0f12b7e1"
 
 [build-dependencies]

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 31
+%global releasever 32
 %global gover 1.30.11
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/20/artifacts/kubernetes/v1.31.7/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/21/artifacts/kubernetes/v1.31.7/kubernetes-src.tar.gz"
 sha512 = "404080241bd911ef5afee2eedf962d94893e7a2d8638a46eae8b498a4a74ca9ab5aba25f01199800c02b0d5e33b4f5f042b5e05d2d83f8317b99a64fcb9af6e7"
 
 [build-dependencies]

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 20
+%global releasever 21
 %global gover 1.31.7
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.32/Cargo.toml
+++ b/packages/kubernetes-1.32/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.32"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/13/artifacts/kubernetes/v1.32.3/kubernetes-src.tar.gz"
-sha512 = "841167a4aef240ef347408d519673d1d3225b35a42b91850cd1964ed69bd0191623cac9376f56e6d0973b38217c1b076c00d01ab9d7e04763342f0fbfebaf37d"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/14/artifacts/kubernetes/v1.32.3/kubernetes-src.tar.gz"
+sha512 = "280ac4c9447d0d2ed404c3b5bf9aae32220655a8160f77056cc96ea4dec2076327ad62aef8aa05f50ce06d38ca31ada6882d5cf736b4eecba610ba2fdeaa9173"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 13
+%global releasever 14
 %global gover 1.32.3
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.33/Cargo.toml
+++ b/packages/kubernetes-1.33/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.33"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/3/artifacts/kubernetes/v1.33.0/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/4/artifacts/kubernetes/v1.33.0/kubernetes-src.tar.gz"
 sha512 = "20de2568ad933bb3a961aa069ab1665f5ebcadbd26b5cb7c7e520200ce588090c6f628a08cb33d302b4cc8bdfbf61bf0703ae6b0773fa916713e9ea552316d33"
 
 [build-dependencies]

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 1
+%global releasever 4
 %global gover 1.33.0
 %global rpmver %{gover}
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

**Description of changes:**
- fix a spacing error in CHANGELOG
- update `aws-iam-authenticator` to v0.7.2
- update `ecr-credential-provider-1.31` to v1.31.6
- update `ecr-credential-provider-1.32` to v1.32.3
- update `kubernetes-1.28 - 1.32` to latest

**Testing done:**
-  [x] `aws-iam-authenticator`
The node joins the cluster in the tests below which is a sufficient test. Skipping!

-  [x] `ecr-credential-provider`
1. Run a container from a private registry. It will fail unless you are using an image from the same account.
```
[fedora@ip-xxxxx Repositories]$ kubectl get pods -A
NAMESPACE     NAME                              READY   STATUS         RESTARTS   AGE
default       hello-nodejs                      0/1     ErrImagePull   0          3s
kube-system   aws-node-lntkq                    2/2     Running        0          27m
kube-system   coredns-5449774944-lpqqk          1/1     Running        0          30m
kube-system   coredns-5449774944-xwfn6          1/1     Running        0          30m
kube-system   kube-proxy-gbrwj                  1/1     Running        0          27m
kube-system   metrics-server-76dfb8cb4b-5b4jn   1/1     Running        0          30m
kube-system   metrics-server-76dfb8cb4b-gc8rw   1/1     Running        0          30m
```
2. Base64 encode aws credentials of the above account in this format
```
[default]
use_fips_endpoint=false

[profile ecr]
use_fips_endpoint=false
aws_access_key_id=xxxxx
aws_secret_access_key=yyyyy
aws_session_token=zzzzz
```
3. Apply the above settings in the bottlerocket instance
```
apiclient apply <<EOF
[settings.kubernetes.credential-providers.ecr-credential-provider]
enabled = true
cache-duration = "30m"
image-patterns = [
  "*.dkr.ecr.us-east-2.amazonaws.com",
  "*.dkr.ecr.us-west-2.amazonaws.com"
]

[settings.aws]
profile = "ecr"
config = "{base64 encoding of the above}"
EOF
```
4. Run the same container from a private registry. It should work now.
```
[fedora@ip-xxxxx Repositories]$ kubectl delete pod hello-nodejs
pod "hello-nodejs" deleted
[fedora@ip-xxxxx Repositories]$ kubectl apply -f hello-nodejs.yaml 
pod/hello-nodejs created
[fedora@ip-xxxxx Repositories]$ kubectl get pods -A
NAMESPACE     NAME                              READY   STATUS      RESTARTS   AGE
default       hello-nodejs                      0/1     Completed   0          4s
kube-system   aws-node-lntkq                    2/2     Running     0          37m
kube-system   coredns-5449774944-lpqqk          1/1     Running     0          40m
kube-system   coredns-5449774944-xwfn6          1/1     Running     0          40m
kube-system   kube-proxy-gbrwj                  1/1     Running     0          37m
kube-system   metrics-server-76dfb8cb4b-5b4jn   1/1     Running     0          40m
kube-system   metrics-server-76dfb8cb4b-gc8rw   1/1     Running     0          40m
```

-  [x] `kubernetes-1.28-1.33`
```
 NAME                                                         TYPE                        STATE                                        PASSED                   FAILED                   SKIPPED   BUILD ID                         LAST UPDATE
 aarch64-aws-k8s-128-conformance                              Test                        passed                                          384                        0                      7012   0968c061-dirty                   2025-06-04T22:47:19Z
 aarch64-aws-k8s-128-nvidia-conformance                       Test                        passed                                          384                        0                      7012   0968c061-dirty                   2025-06-04T20:35:04Z
 aarch64-aws-k8s-128-nvidia-quick                             Test                        passed                                            5                        0                      7391   0968c061-dirty                   2025-06-04T21:03:45Z
 aarch64-aws-k8s-128-quick                                    Test                        passed                                            5                        0                      7391   0968c061-dirty                   2025-06-04T21:02:25Z
 aarch64-aws-k8s-129-conformance                              Test                        passed                                          392                        0                      7023   0968c061-dirty                   2025-06-04T22:57:25Z
 aarch64-aws-k8s-129-nvidia-conformance                       Test                        passed                                          392                        0                      7023   0968c061-dirty                   2025-06-04T20:33:40Z
 aarch64-aws-k8s-129-nvidia-quick                             Test                        passed                                            5                        0                      7410   0968c061-dirty                   2025-06-04T23:43:12Z
 aarch64-aws-k8s-129-quick                                    Test                        passed                                            5                        0                      7410   0968c061-dirty                   2025-06-04T21:03:25Z
 aarch64-aws-k8s-130-conformance                              Test                        passed                                          406                        0                      6801   0968c061-dirty                   2025-06-04T22:51:26Z
 aarch64-aws-k8s-130-nvidia-conformance                       Test                        passed                                          406                        0                      6801   0968c061-dirty                   2025-06-04T20:33:40Z
 aarch64-aws-k8s-130-nvidia-quick                             Test                        passed                                            5                        0                      7202   0968c061-dirty                   2025-06-04T21:02:44Z
 aarch64-aws-k8s-130-quick                                    Test                        passed                                            5                        0                      7202   0968c061-dirty                   2025-06-04T21:03:06Z
 aarch64-aws-k8s-131-conformance                              Test                        passed                                          408                        0                      6204   0968c061-dirty                   2025-06-05T01:26:41Z
 aarch64-aws-k8s-131-nvidia-conformance                       Test                        passed                                          408                        0                      6204   0968c061-dirty                   2025-06-04T22:58:19Z
 aarch64-aws-k8s-131-nvidia-quick                             Test                        passed                                            5                        0                      6607   0968c061-dirty                   2025-06-04T21:04:03Z
 aarch64-aws-k8s-131-quick                                    Test                        passed                                            5                        0                      6607   0968c061-dirty                   2025-06-05T01:30:18Z
 aarch64-aws-k8s-132-conformance                              Test                        passed                                          415                        0                      6214   0968c061-dirty                   2025-06-04T23:03:05Z
 aarch64-aws-k8s-132-nvidia-conformance                       Test                        passed                                          415                        0                      6214   0968c061-dirty                   2025-06-05T01:36:27Z
 aarch64-aws-k8s-132-nvidia-quick                             Test                        passed                                            5                        0                      6624   0968c061-dirty                   2025-06-04T23:44:43Z
 aarch64-aws-k8s-132-quick                                    Test                        passed                                            5                        0                      6624   0968c061-dirty                   2025-06-04T21:05:34Z
 x86-64-aws-k8s-128-conformance                               Test                        passed                                          384                        0                      7012   0968c061-dirty                   2025-06-04T18:36:39Z
 x86-64-aws-k8s-128-nvidia-conformance                        Test                        passed                                          384                        0                      7012   0968c061-dirty                   2025-06-04T18:37:42Z
 x86-64-aws-k8s-128-nvidia-quick                              Test                        passed                                            5                        0                      7391   0968c061-dirty                   2025-06-04T16:49:55Z
 x86-64-aws-k8s-128-quick                                     Test                        passed                                            5                        0                      7391   0968c061-dirty                   2025-06-04T16:51:45Z
 x86-64-aws-k8s-129-conformance                               Test                        passed                                          392                        0                      7023   0968c061-dirty                   2025-06-04T18:42:41Z
 x86-64-aws-k8s-129-nvidia-conformance                        Test                        passed                                          392                        0                      7023   0968c061-dirty                   2025-06-04T18:42:47Z
 x86-64-aws-k8s-129-nvidia-quick                              Test                        passed                                            5                        0                      7410   0968c061-dirty                   2025-06-04T16:49:49Z
 x86-64-aws-k8s-129-quick                                     Test                        passed                                            5                        0                      7410   0968c061-dirty                   2025-06-04T16:53:28Z
 x86-64-aws-k8s-130-conformance                               Test                        passed                                          406                        0                      6801   0968c061-dirty                   2025-06-04T18:43:49Z
 x86-64-aws-k8s-130-nvidia-conformance                        Test                        passed                                          406                        0                      6801   0968c061-dirty                   2025-06-04T18:41:03Z
 x86-64-aws-k8s-130-nvidia-quick                              Test                        passed                                            5                        0                      7202   0968c061-dirty                   2025-06-04T16:51:54Z
 x86-64-aws-k8s-130-quick                                     Test                        passed                                            5                        0                      7202   0968c061-dirty                   2025-06-04T16:54:37Z
 x86-64-aws-k8s-131-conformance                               Test                        passed                                          408                        0                      6204   0968c061-dirty                   2025-06-04T18:42:40Z
 x86-64-aws-k8s-131-nvidia-conformance                        Test                        passed                                          408                        0                      6204   0968c061-dirty                   2025-06-04T18:38:49Z
 x86-64-aws-k8s-131-nvidia-quick                              Test                        passed                                            5                        0                      6607   0968c061-dirty                   2025-06-04T16:51:59Z
 x86-64-aws-k8s-131-quick                                     Test                        passed                                            5                        0                      6607   0968c061-dirty                   2025-06-04T16:55:04Z
 x86-64-aws-k8s-132-conformance                               Test                        passed                                          415                        0                      6214   0968c061-dirty                   2025-06-04T20:29:59Z
 x86-64-aws-k8s-132-nvidia-conformance                        Test                        passed                                          415                        0                      6214   0968c061-dirty                   2025-06-05T02:03:23Z
 x86-64-aws-k8s-132-nvidia-quick                              Test                        passed                                            5                        0                      6624   0968c061-dirty                   2025-06-05T00:09:07Z
 x86-64-aws-k8s-132-quick                                     Test                        passed                                            5                        0                      6624   0968c061-dirty                   2025-06-04T16:57:24Z
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
