### PR TITLE
Update third-party dependencies

### DIFF
--- a/packages/aws-otel-collector/Cargo.toml
+++ b/packages/aws-otel-collector/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws-observability/aws-otel-collector/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.43.1/aws-otel-collector-v0.43.1.tar.gz"
-sha512 = "8c5537c4bbdb661afebb49f0fcd926c7122dbc338394fdb0e695379f709623a7c1854f050bc02e6ab0990d12c4c6e6b0dc4268aa69b4d6e88025f6ec6df75ec7"
+url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.43.2/aws-otel-collector-v0.43.2.tar.gz"
+sha512 = "4352058c8d648b8d6d81148be4ce6f298a3553fdb8d7af311cc90e27de30f84a421950c7f8c9fb313dd4b2686e5ce3db9f69d5523f7d279fb13b20a705d18810"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/aws-otel-collector/aws-otel-collector.spec
+++ b/packages/aws-otel-collector/aws-otel-collector.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}aws-otel-collector
-Version: 0.43.1
+Version: 0.43.2
 Release: 1%{?dist}
 Epoch: 1
 Summary: AWS Distro for OpenTelemetry Collector

--- a/packages/ethtool/Cargo.toml
+++ b/packages/ethtool/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/software/network/ethtool/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.11.tar.xz"
-sha512 = "77f649e1082a164e3627bcb21db1215a89d9a0e984f86516bb05879685aee76b034f6a9e19a499dcdd82883fa003f628b70d27ca8272064df27fe9de67c7a9a7"
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.14.tar.xz"
+sha512 = "05688e41044a3f263f4367149f9d775bc378f0f421685f415b30062ca74fa62acc0d5ee5aa74b2104429b5f1712fc2f12e120af0d5744c775c84fe8e777938a3"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.11.tar.sign"
-sha512 = "9a0ea5a1ab140a69bc13e844e2e919101ea0e3994a503b49ba5009e83ba4609d047c823dbc58b172ca0488591be066f43b66f1eea7597532930a83dddcc5e556"
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.14.tar.sign"
+sha512 = "b52cff3d89cc124549a0cddf5727cec36dd2c46a1cecc4754f8d016035c1d2e455b5fc2f4c86aafa5bb834247778c064dfc6b60eb492442531b3ce1a47a7a696"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ethtool/ethtool.spec
+++ b/packages/ethtool/ethtool.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}ethtool
-Version: 6.11
+Version: 6.14
 Release: 1%{?dist}
 Summary: Settings tool for Ethernet NICs
 License: GPL-2.0-only AND GPL-2.0-or-later
@@ -30,3 +30,4 @@ BuildRequires: %{_cross_os}libmnl-devel
 %{_cross_sbindir}/ethtool
 %exclude %{_cross_datadir}/bash-completion
 %exclude %{_cross_mandir}
+%exclude %{_cross_datadir}/metainfo/org.kernel.software.network.ethtool.metainfo.xml

--- a/packages/grep/Cargo.toml
+++ b/packages/grep/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://mirrors.kernel.org/gnu/grep"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.kernel.org/gnu/grep/grep-3.11.tar.xz"
-sha512 = "f254a1905a08c8173e12fbdd4fd8baed9a200217fba9d7641f0d78e4e002c1f2a621152d67027d9b25f0bb2430898f5233dc70909d8464fd13d7dd9298e65c42"
+url = "https://mirrors.kernel.org/gnu/grep/grep-3.12.tar.xz"
+sha512 = "c54b4db5a8b9afe098c088decd94977746305284d716666a60bac82b4edc0fae4acf828970b5b6fc7d58ecd549f638e17e6958f33a71fedcc7d7415b9228b161"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.kernel.org/gnu/grep/grep-3.11.tar.xz.sig"
-sha512 = "487aba063373ca0594c519991f19b2a6a33b3da0d74735c890f3828fd0880e7e6f64495d2c8f9efa5da53d1eb2d446609bab2399a4b89dcb4510a632e31ffb54"
+url = "https://mirrors.kernel.org/gnu/grep/grep-3.12.tar.xz.sig"
+sha512 = "333755fd9e5879436789a19e9593667d6fb96c2d1b876a1c391eb9cd75d10bb7fbc10215db9838280e6006790c818ef4583b1ae22318a833a5b69264ca15dbf1"
 
 [build-dependencies]
 libpcre = { path = "../libpcre" }

--- a/packages/grep/grep.spec
+++ b/packages/grep/grep.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}grep
-Version: 3.11
+Version: 3.12
 Release: 1%{?dist}
 Epoch: 1
 Summary: GNU grep utility

--- a/packages/iproute/Cargo.toml
+++ b/packages/iproute/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "http://kernel.org/pub/linux/utils/net/iproute2"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.12.0.tar.xz"
-sha512 = "dbd6afb8162a6086e4be9045b8dc53aa563bd4b7abaf43ee13cd7d493730ff0b90e6985f68c6f42d64f4af6a692d0589e0cefd2f24045ec1c10418cfb73940b2"
+url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.15.0.tar.xz"
+sha512 = "1a438941cd939e1c8e32cfe8c40e6fd826c89185f1bb0c623eaad7380a66afd9fa9e0d7cdc5e5b193d2761b7dbdc78fd0811537eecc500be633730c32ff55ad4"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.12.0.tar.sign"
-sha512 = "dcb949462629523d8abccd4cd41966fc3ab38f9c16f9d7da986489d4bf184bf4623426dda8d4b15f8fa7cf75c21df4661376f47ff299649abaa3af464f84b325"
+url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.15.0.tar.sign"
+sha512 = "5a1159f926c1543ac01d7981f87a66c9715ebecffe37bd3954aebfe9499db8591ca26448322a60c55fd4d48564f63730732c80f010c7da1268dc9db1e089b48e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/iproute/iproute.spec
+++ b/packages/iproute/iproute.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}iproute
-Version: 6.12.0
+Version: 6.15.0
 Release: 1%{?dist}
 Summary: Tools for advanced IP routing and network device configuration
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/libnvme/Cargo.toml
+++ b/packages/libnvme/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-nvme/libnvme/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-nvme/libnvme/archive/v1.13/libnvme-1.13.tar.gz"
-sha512 = "7c56cb4a531c77e7024126c3dde4ffe629944be93a3102b09bc7a16031bdd64dac5cb19834c586609c5e3c186f805532d739f960abc4ba22114f36c6bc710264"
+url = "https://github.com/linux-nvme/libnvme/archive/v1.14/libnvme-1.14.tar.gz"
+sha512 = "96a1bbd6cea1e77381254e242e781b023416abfbf44c82a0aa6eb0b316b30316d32d0b91f441089a317cbae5b511f6b3eaab570624cbda2178f9dce4cb5dd288"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnvme/libnvme.spec
+++ b/packages/libnvme/libnvme.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libnvme
-Version: 1.13
+Version: 1.14
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for NVM Express

--- a/packages/makedumpfile/Cargo.toml
+++ b/packages/makedumpfile/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/makedumpfile/makedumpfile/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/makedumpfile/makedumpfile/archive/1.7.6/makedumpfile-1.7.6.tar.gz"
-sha512 = "2436bbc5ced82e95e1c528cc63c6d71b5a386f34623f2f3cf6050019d21e6e81a15ddb5aa50cbec33b86228d2ba622f3ff37989b7cbeb6e66c94380380518f60"
+url = "https://github.com/makedumpfile/makedumpfile/archive/1.7.7/makedumpfile-1.7.7.tar.gz"
+sha512 = "530dff86f00bfda529926baf71012d865dab517c749837eb51f8b06145922f64a00dcbf6632c1ef7cd286072ae01243011ab70d67ab8e63ebb8657f2c2f5c4b5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/makedumpfile/makedumpfile.spec
+++ b/packages/makedumpfile/makedumpfile.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}makedumpfile
-Version: 1.7.6
+Version: 1.7.7
 Release: 1%{?dist}
 Epoch: 1
 Summary: Tool to create dumps from kernel memory images

--- a/packages/nvme-cli/Cargo.toml
+++ b/packages/nvme-cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-nvme/nvme-cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-nvme/nvme-cli/archive/v2.13/nvme-cli-2.13.tar.gz"
-sha512 = "71ade7b97354bf70e4909d85265db157715c1afe52fba6d1e2aa614900a8059830e85029f71680884966476363e8846d6cfbc1dcfe57330c749775acc39df6e7"
+url = "https://github.com/linux-nvme/nvme-cli/archive/v2.14/nvme-cli-2.14.tar.gz"
+sha512 = "7f600ee719f06283e136427a0f9eb0b22412f7f4549c774768caff54150207ba87e2a431ea1569e5ed86a554aecd23c00c4e8c351aa0168a81807c86a0cb2edc"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvme-cli/nvme-cli.spec
+++ b/packages/nvme-cli/nvme-cli.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}nvme-cli
-Version: 2.13
+Version: 2.14
 Release: 1%{?dist}
 Epoch: 1
 Summary: CLI to interact with NVMe devices

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://strace.io/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.13/strace-6.13.tar.xz"
-sha512 = "e702238f32882f92a2b2834fb853b5fa3d81decb441b69f0e74ba0205f6a586bfe698e34bfbac6d4f766ebd25d0b99d4679d9eb27845e5129cfd4e34ced6a8d2"
+url = "https://strace.io/files/6.15/strace-6.15.tar.xz"
+sha512 = "5bb21b55d52aab6883821d4aea9449138d5efafac99f72b3831de710ed1ece11bb4a21b16fab97d772397213f43d06072e1d467ae03c38198ead0e65ddcd6ab5"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.13/strace-6.13.tar.xz.asc"
-sha512 = "a59e4aeff491ad62603b0591653e7da5e8a4ef0fedcf2faad3f485993b37b738c0809cefa5753ab7d1b85f3b6c87b423b6416dea36def65e220548ee0b4afb46"
+url = "https://strace.io/files/6.15/strace-6.15.tar.xz.asc"
+sha512 = "c2c0098d9b415950c6f0591e2b8c59b96bb929df9270f5e256078d27e93b791f3bca2bf52f36d8ddf3b7354e711a94b4588b78a94da3327a35777c859808d993"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 6.13
+Version: 6.15
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Updates the following packages to latest versions:
- `ethtool`
- `grep`
- `iproute`
- `strace`
- `aws-otel-collector`: unable to update to latest upstream since that requires golang v1.24.3 which will require an sdk update
- `makedumpfile`
- `nvme-cli`
- `libnvme`


**Testing done:**
Built and launched an AMI and tested the functionality for all the updated packages. (eg. running `ethtool eth0` to get stats and so on)


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
