### PR TITLE
add two capability markers to SELinux policy

### DIFF
--- a/packages/selinux-policy/base.cil
+++ b/packages/selinux-policy/base.cil
@@ -66,3 +66,7 @@
 ; operations can be carried out via fcntl, and are always allowed
 ; through that path.
 (policycap "ioctl_skip_cloexec")
+
+; The policy provides the intended label for any userspace processes
+; executed before the SELinux policy is loaded.
+(policycap "userspace_initial_context")

--- a/packages/selinux-policy/base.cil
+++ b/packages/selinux-policy/base.cil
@@ -61,3 +61,8 @@
 ; Enable policy to label symlinks on kernel file systems using
 ; "genfscon" statements, as with directories and files.
 (policycap "genfs_seclabel_symlinks")
+
+; Always allow FIOCLEX and FIONCLEX ioctls, since the equivalent
+; operations can be carried out via fcntl, and are always allowed
+; through that path.
+(policycap "ioctl_skip_cloexec")

--- a/packages/selinux-policy/sid.cil
+++ b/packages/selinux-policy/sid.cil
@@ -47,6 +47,10 @@
 (sidcontext unlabeled local)
 (sidcontext file local)
 
+; Apply the "init" context for userspace processes started before the
+; SELinux policy is loaded.
+(sidcontext init init)
+
 ; Apply the "any" context for entities like sockets, ports, and
 ; network interfaces if they are otherwise unlabeled.
 (sidcontext any_socket any)


### PR DESCRIPTION
**Issue number:**
Fixes #533

**Description of changes:**
Add two new capability markers to the SELinux policy.

`ioctl_skip_cloexec` is supported in kernel 5.15, and `userspace_initial_context` is new in 6.12.


**Testing done:**
Verified that the SELinux policy loads and that PID 1 is labeled as `init_t` on all three kernels.

kernel 5.15 and 6.1 reports one new capability, and one unknown capability:
```
[    5.665924] SELinux:  policy capability genfs_seclabel_symlinks=1
[    5.665925] SELinux:  policy capability ioctl_skip_cloexec=1
[    5.665926] SELinux:  unknown policy capability 8
```

The "unknown" message is harmless.

kernel 6.12 reports both new capabilities:
```
[    0.326664] SELinux:  policy capability genfs_seclabel_symlinks=1
[    0.326665] SELinux:  policy capability ioctl_skip_cloexec=1
[    0.326665] SELinux:  policy capability userspace_initial_context=1
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
