### PR TITLE
os: update eni-max-pods

### DIFF
--- a/packages/os/eni-max-pods
+++ b/packages/os/eni-max-pods
@@ -12,12 +12,16 @@
 # permissions and limitations under the License.
 #
 # The regions queried were:
+# - af-south-1
+# - ap-east-1
 # - ap-northeast-1
 # - ap-northeast-2
 # - ap-northeast-3
 # - ap-south-1
+# - ap-south-2
 # - ap-southeast-1
 # - ap-southeast-2
+# - ap-southeast-7
 # - ca-central-1
 # - eu-central-1
 # - eu-north-1
@@ -208,6 +212,8 @@ c7gn.large 29
 c7gn.medium 8
 c7gn.metal 737
 c7gn.xlarge 58
+c7i-flex.12xlarge 234
+c7i-flex.16xlarge 737
 c7i-flex.2xlarge 58
 c7i-flex.4xlarge 234
 c7i-flex.8xlarge 234
@@ -236,6 +242,18 @@ c8g.medium 8
 c8g.metal-24xl 737
 c8g.metal-48xl 737
 c8g.xlarge 58
+c8gd.12xlarge 234
+c8gd.16xlarge 737
+c8gd.24xlarge 737
+c8gd.2xlarge 58
+c8gd.48xlarge 737
+c8gd.4xlarge 234
+c8gd.8xlarge 234
+c8gd.large 29
+c8gd.medium 8
+c8gd.metal-24xl 737
+c8gd.metal-48xl 737
+c8gd.xlarge 58
 cr1.8xlarge 234
 d2.2xlarge 58
 d2.4xlarge 234
@@ -256,10 +274,9 @@ dl2q.24xlarge 737
 f1.16xlarge 394
 f1.2xlarge 58
 f1.4xlarge 234
-g3.16xlarge 737
-g3.4xlarge 234
-g3.8xlarge 234
-g3s.xlarge 58
+f2.12xlarge 234
+f2.48xlarge 737
+f2.6xlarge 234
 g4ad.16xlarge 234
 g4ad.2xlarge 8
 g4ad.4xlarge 29
@@ -353,6 +370,38 @@ i4i.8xlarge 234
 i4i.large 29
 i4i.metal 737
 i4i.xlarge 58
+i7i.12xlarge 234
+i7i.16xlarge 737
+i7i.24xlarge 737
+i7i.2xlarge 58
+i7i.48xlarge 737
+i7i.4xlarge 234
+i7i.8xlarge 234
+i7i.large 29
+i7i.metal-24xl 737
+i7i.metal-48xl 737
+i7i.xlarge 58
+i7ie.12xlarge 394
+i7ie.18xlarge 737
+i7ie.24xlarge 737
+i7ie.2xlarge 58
+i7ie.3xlarge 58
+i7ie.48xlarge 737
+i7ie.6xlarge 234
+i7ie.large 29
+i7ie.metal-24xl 737
+i7ie.metal-48xl 737
+i7ie.xlarge 58
+i8g.12xlarge 234
+i8g.16xlarge 737
+i8g.24xlarge 737
+i8g.2xlarge 58
+i8g.48xlarge 737
+i8g.4xlarge 234
+i8g.8xlarge 234
+i8g.large 29
+i8g.metal-24xl 737
+i8g.xlarge 58
 im4gn.16xlarge 737
 im4gn.2xlarge 58
 im4gn.4xlarge 234
@@ -548,6 +597,8 @@ m7gd.large 29
 m7gd.medium 8
 m7gd.metal 737
 m7gd.xlarge 58
+m7i-flex.12xlarge 234
+m7i-flex.16xlarge 737
 m7i-flex.2xlarge 58
 m7i-flex.4xlarge 234
 m7i-flex.8xlarge 234
@@ -576,14 +627,23 @@ m8g.medium 8
 m8g.metal-24xl 737
 m8g.metal-48xl 737
 m8g.xlarge 58
+m8gd.12xlarge 234
+m8gd.16xlarge 737
+m8gd.24xlarge 737
+m8gd.2xlarge 58
+m8gd.48xlarge 737
+m8gd.4xlarge 234
+m8gd.8xlarge 234
+m8gd.large 29
+m8gd.medium 8
+m8gd.metal-24xl 737
+m8gd.metal-48xl 737
+m8gd.xlarge 58
 mac1.metal 234
 mac2-m1ultra.metal 234
 mac2-m2.metal 234
 mac2-m2pro.metal 234
 mac2.metal 234
-p2.16xlarge 234
-p2.8xlarge 234
-p2.xlarge 58
 p3.16xlarge 234
 p3.2xlarge 58
 p3.8xlarge 234
@@ -592,6 +652,8 @@ p4d.24xlarge 737
 p4de.24xlarge 737
 p5.48xlarge 100
 p5e.48xlarge 100
+p5en.48xlarge 198
+p6-b200.48xlarge 198
 r3.2xlarge 58
 r3.4xlarge 234
 r3.8xlarge 234
@@ -796,6 +858,18 @@ r8g.medium 8
 r8g.metal-24xl 737
 r8g.metal-48xl 737
 r8g.xlarge 58
+r8gd.12xlarge 234
+r8gd.16xlarge 737
+r8gd.24xlarge 737
+r8gd.2xlarge 58
+r8gd.48xlarge 737
+r8gd.4xlarge 234
+r8gd.8xlarge 234
+r8gd.large 29
+r8gd.medium 8
+r8gd.metal-24xl 737
+r8gd.metal-48xl 737
+r8gd.xlarge 58
 t1.micro 4
 t2.2xlarge 44
 t2.large 35
@@ -828,6 +902,7 @@ t4g.xlarge 58
 trn1.2xlarge 58
 trn1.32xlarge 247
 trn1n.32xlarge 247
+trn2.48xlarge 100
 u-12tb1.112xlarge 737
 u-12tb1.metal 147
 u-18tb1.112xlarge 737
@@ -841,6 +916,8 @@ u-6tb1.metal 147
 u-9tb1.112xlarge 737
 u-9tb1.metal 147
 u7i-12tb.224xlarge 737
+u7i-6tb.112xlarge 737
+u7i-8tb.112xlarge 737
 u7in-16tb.224xlarge 394
 u7in-24tb.224xlarge 394
 u7in-32tb.224xlarge 394


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
This pulls in the new instance types to the eni-max-pods mapping file. It adds the max pod values for a new set of published instance types.

Generated content by using the [update script](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/scripts/gen_vpc_ip_limits.go).


**Testing done:**
N/A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
