### PR TITLE
feat: k8s: support setting the `memorySwap.swapBehavior` kubelet config

### DIFF
--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -200,3 +200,7 @@ reservedMemory:
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
+{{#if settings.kubernetes.memory-swap-behavior}}
+memorySwap:
+  swapBehavior: {{settings.kubernetes.memory-swap-behavior}}
+{{/if}}

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -200,3 +200,7 @@ reservedMemory:
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
+{{#if settings.kubernetes.memory-swap-behavior}}
+memorySwap:
+  swapBehavior: {{settings.kubernetes.memory-swap-behavior}}
+{{/if}}

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -200,6 +200,10 @@ reservedMemory:
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
+{{#if settings.kubernetes.memory-swap-behavior}}
+memorySwap:
+  swapBehavior: {{settings.kubernetes.memory-swap-behavior}}
+{{/if}}
 {{#if settings.kubernetes.single-process-oom-kill}}
 singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
 {{/if}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -200,6 +200,10 @@ reservedMemory:
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
+{{#if settings.kubernetes.memory-swap-behavior}}
+memorySwap:
+  swapBehavior: {{settings.kubernetes.memory-swap-behavior}}
+{{/if}}
 {{#if settings.kubernetes.single-process-oom-kill}}
 singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
 {{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1256,8 +1256,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.9.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+version = "0.10.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1325,8 +1325,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.10.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+version = "0.11.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1376,7 +1376,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "serde",
 ]
@@ -1397,7 +1397,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -4570,7 +4570,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4583,7 +4583,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4596,7 +4596,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4610,7 +4610,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4636,7 +4636,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4662,7 +4662,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4675,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4688,7 +4688,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4714,7 +4714,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4726,8 +4726,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubernetes"
-version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+version = "0.4.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4741,7 +4741,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -4766,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4779,7 +4779,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4792,7 +4792,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4819,7 +4819,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4832,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.10.0#eb08efb19615dd2ea12e32a9eeac65eef03cb15c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.11.0#4afbab74e41c12d097976c713cf6153ac2e3e49f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -211,13 +211,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.10.0"
-version = "0.9.0"
+tag = "bottlerocket-settings-models-v0.11.0"
+version = "0.10.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.10.0"
-version = "0.10.0"
+tag = "bottlerocket-settings-models-v0.11.0"
+version = "0.11.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -226,7 +226,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.10.0"
+tag = "bottlerocket-settings-models-v0.11.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
**Issue number:**

Part of https://github.com/bottlerocket-os/bottlerocket/issues/4547

**Description of changes:**

This PR adds support for setting the `memorySwap.swapBehavior` kubelet config through the `Kubernetes.memory-swap.swap-behavior` setting.

The first EKS version in which the `NodeSwap` feature is enabled by default is 1.30, so this is the first version I've made configurable with the new setting. Older versions will simply ignore it.

**Testing done:**

* **Test 1.** Built custom k8s-1.33-eks variant deployed via `eksctl` and this config:
    ```yaml
    ---
    apiVersion: eksctl.io/v1alpha5
    kind: ClusterConfig

    metadata:
      name: bottlerocket-test-133
      region: us-east-1
      version: "1.33"

    nodeGroups:
      - name: ng-bottlerocket-test
        instanceType: m8g.large
        desiredCapacity: 1
        amiFamily: Bottlerocket
        ami: ami-<...>
        iam: <...>
        bottlerocket:
          settings:
            kubernetes:
              memory-swap-behavior: LimitedSwap
    ```

    * Results:
        * Settings are persisted:
        ```
        bash-5.1# apiclient get settings.kubernetes.memory-swap-behavior
        {
          "settings": {
            "kubernetes": {
              "memory-swap-behavior": "LimitedSwap"
            }
          }
        }
        ```
        * Settings are applied to the kubelet config:
        ```
        bash-5.1# cat /etc/kubernetes/kubelet/config | tail -2
        memorySwap:
          swapBehavior: LimitedSwap
        ```
        * Node joins the cluster.

* **Test 2.** Same as Test 1 but with k8s 1.30.

    Results: Same as Test 1.

* **Test 3.** Same as Test 1 but with k8s 1.29.

    Results: Settings are persisted but not applied to the kubelet config. Node joins the cluster.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
