### PR TITLE
add zramctl to util-linux package

### DIFF
--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -273,6 +273,7 @@ done
 %{_cross_sbindir}/resizepart
 %{_cross_sbindir}/switch_root
 %{_cross_sbindir}/wipefs
+%{_cross_sbindir}/zramctl
 %exclude %{_cross_sbindir}/hwclock
 %exclude %{_cross_sbindir}/cfdisk
 %exclude %{_cross_sbindir}/ctrlaltdel
@@ -292,7 +293,6 @@ done
 %exclude %{_cross_sbindir}/uuidd
 %exclude %{_cross_sbindir}/vigr
 %exclude %{_cross_sbindir}/vipw
-%exclude %{_cross_sbindir}/zramctl
 %exclude %{_cross_sbindir}/blkpr
 
 %exclude %{_cross_bashdir}


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/4075

**Description of changes:**
Add `zramctl` to the `util-linux` package, instead of excluding it. This can be used to set up zram-backed swap devices, in conjunction with the `mkswap` and `swapon` commands that are already included.


**Testing done:**
Set up a swap device:
```
modprobe zram
zramctl /dev/zram0 --size 1G
mkswap --uuid clear /dev/zram0
swapon --discard --priority 1024 /dev/zram0
```

Verified that swap is active:
```
# free -m
               total        used        free      shared  buff/cache   available
Mem:            7761        1046        2632           4        4286        6714
Swap:           1023           0        1023
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
