### PR TITLE
configuration-files: add option for write-once on boot

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -3431,6 +3431,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
+ "tempfile",
  "toml",
 ]
 
@@ -5236,6 +5237,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
+ "tempfile",
  "tokio",
 ]
 

--- a/sources/api/apiserver/src/server/controller.rs
+++ b/sources/api/apiserver/src/server/controller.rs
@@ -1053,6 +1053,7 @@ mod test {
                 path: "file".try_into().unwrap(),
                 template_path: "template".try_into().unwrap(),
                 mode: None,
+                overwrite_path_if_present: None
             })
         );
 

--- a/sources/api/thar-be-settings/Cargo.toml
+++ b/sources/api/thar-be-settings/Cargo.toml
@@ -29,3 +29,4 @@ generate-readme.workspace = true
 
 [dev-dependencies]
 maplit.workspace = true
+tempfile.workspace = true

--- a/sources/api/thar-be-settings/src/config.rs
+++ b/sources/api/thar-be-settings/src/config.rs
@@ -61,6 +61,13 @@ pub async fn render_config_files(
     // Go write all the configuration files from template
     let mut rendered_configs = Vec::new();
     for (name, metadata) in config_files {
+        if !metadata.should_render() {
+            info!(
+                "File {} already exists and overwrite-path-if-present=false, skipping render of config file",
+                &metadata.path,
+            );
+            continue;
+        }
         debug!("Rendering {}", &name);
 
         let try_rendered =

--- a/sources/models/Cargo.toml
+++ b/sources/models/Cargo.toml
@@ -19,6 +19,9 @@ bottlerocket-settings-plugin.workspace = true
 bottlerocket-settings-models.workspace = true
 serde_plain.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [build-dependencies]
 generate-readme.workspace = true
 

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -31,7 +31,7 @@ use bottlerocket_release::BottlerocketRelease;
 use bottlerocket_settings_models::model_derive::model;
 use bottlerocket_settings_plugin::BottlerocketSettings;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, path::Path};
 
 use bottlerocket_settings_models::modeled_types::SingleLineString;
 
@@ -77,6 +77,16 @@ struct ConfigurationFile {
     template_path: SingleLineString,
     #[serde(skip_serializing_if = "Option::is_none")]
     mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    overwrite_path_if_present: Option<bool>,
+}
+
+impl ConfigurationFile {
+    /// Checks whether the configuration file should be written if the path is present.
+    /// and overwrite_path_if_present is set.
+    pub fn should_render(&self) -> bool {
+        self.overwrite_path_if_present != Some(false) || !Path::new(&self.path.as_ref()).exists()
+    }
 }
 
 ///// Metadata
@@ -92,4 +102,86 @@ struct Metadata {
 struct Report {
     name: String,
     description: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_should_render_with_existing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+        let existing_file_path = temp_path.join("existing_file.conf");
+
+        // Create an existing file.
+        fs::write(&existing_file_path, "existing content").unwrap();
+
+        // Test case 1: overwrite_path_if_present = Some(false) with existing file
+        // Should return false (don't overwrite)
+        let config_file_no_overwrite = ConfigurationFile {
+            path: existing_file_path.to_str().unwrap().try_into().unwrap(),
+            template_path: "/mock/template.toml".try_into().unwrap(),
+            mode: None,
+            overwrite_path_if_present: Some(false),
+        };
+        assert!(!config_file_no_overwrite.should_render());
+
+        // Test case 2: overwrite_path_if_present = Some(true) with existing file
+        // Should return true (do overwrite)
+        let config_file_overwrite = ConfigurationFile {
+            path: existing_file_path.to_str().unwrap().try_into().unwrap(),
+            template_path: "/mock/template.toml".try_into().unwrap(),
+            mode: None,
+            overwrite_path_if_present: Some(true),
+        };
+        assert!(config_file_overwrite.should_render());
+
+        // Test case 3: overwrite_path_if_present = None with existing file
+        // Should return true (default behavior is to overwrite)
+        let config_file_default = ConfigurationFile {
+            path: existing_file_path.to_str().unwrap().try_into().unwrap(),
+            template_path: "/mock/template.toml".try_into().unwrap(),
+            mode: None,
+            overwrite_path_if_present: None,
+        };
+        assert!(config_file_default.should_render());
+    }
+
+    #[test]
+    fn test_should_render_with_non_existing_file() {
+        let non_existing_file_path = "fake_file.conf";
+
+        // Test case 1: overwrite_path_if_present = Some(false) with non-existing file
+        // Should return true (file doesn't exist, so create it)
+        let config_file_no_overwrite = ConfigurationFile {
+            path: non_existing_file_path.try_into().unwrap(),
+            template_path: "/mock/template.toml".try_into().unwrap(),
+            mode: None,
+            overwrite_path_if_present: Some(false),
+        };
+        assert!(config_file_no_overwrite.should_render());
+
+        // Test case 2: overwrite_path_if_present = Some(true) with non-existing file
+        // Should return true (do overwrite/create)
+        let config_file_overwrite = ConfigurationFile {
+            path: non_existing_file_path.try_into().unwrap(),
+            template_path: "/mock/template.toml".try_into().unwrap(),
+            mode: None,
+            overwrite_path_if_present: Some(true),
+        };
+        assert!(config_file_overwrite.should_render());
+
+        // Test case 3: overwrite_path_if_present = None with non-existing file
+        // Should return true (default behavior is to create)
+        let config_file_default = ConfigurationFile {
+            path: non_existing_file_path.try_into().unwrap(),
+            template_path: "/mock/template.toml".try_into().unwrap(),
+            mode: None,
+            overwrite_path_if_present: None,
+        };
+        assert!(config_file_default.should_render());
+    }
 }


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #547 

**Description of changes:**

Add a new option for configuration-files to be written only once (on boot). Changes to settings rendered in these files will reflect in Bottlerocket's datastore but will not take effect until reboot.

**Testing done:**

Built an aws-dev variant with `motd`'s configuration file set to write once:

```
[configuration-files.motd]
path = "/etc/motd"
template-path = "/usr/share/templates/motd"
write-mode = "once"
```

Launch an instance with userdata:

```
[settings]
motd = "only once"
```

Setting was rendered:

```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "82b61407-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-dev)",
    "variant_id": "aws-dev",
    "version_id": "1.40.0"
  }
}
bash-5.1# apiclient get settings.motd
{
  "settings": {
    "motd": "only once"
  }
}
bash-5.1# cat /etc/motd
only once
```

Modify setting, ensure `/etc/motd` was not changed, reboot, ensure `/etc/motd` has the new setting value:

```
bash-5.1# apiclient set settings.motd="not until reboot"
bash-5.1# apiclient get settings.motd
{
  "settings": {
    "motd": "not until reboot"
  }
}
# Actual configuration file still reflects original value
bash-5.1# cat /etc/motd
only once

bash-5.1# apiclient reboot

...

bash-5.1# apiclient get settings.motd
{
  "settings": {
    "motd": "not until reboot"
  }
}
# Actual configuration file still reflects original value
bash-5.1# cat /etc/motd
not until reboot
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
