### PR TITLE
Third-party package updates: k8s 

### DIFF
--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/50/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/52/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
 sha512 = "be3d6b527a671eeee59e55e1015a6421b3b3d0f7496451b888a51c960c16441ad02fd0fd98e5bcf1ddead10d14f66ab5316695db2bcf019c41ef62c10821b75d"
 
 [build-dependencies]

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 50
+%global releasever 52
 %global gover 1.28.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/39/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/41/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
 sha512 = "12c73980256a9db6123d67181e7fddd7fa7d18d1f776d586473d967a990844039eb67ed55c40d0dc183dac8526e54ef3326dda63b6849f8079e2ca29dfd71801"
 
 [build-dependencies]

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 39
+%global releasever 41
 %global gover 1.29.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/32/artifacts/kubernetes/v1.30.11/kubernetes-src.tar.gz"
-sha512 = "58af5d6279563f035af3e4ba50ba9d18693bdd9e989c5d23aab3cef91badf95c4cbe7c75606b595b98f7b4d1f707f538424be89547701e8f7a11400a0f12b7e1"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/34/artifacts/kubernetes/v1.30.13/kubernetes-src.tar.gz"
+sha512 = "5d7b13a6535dbf7e89d356efebc684f51eae72c5472a192ab073c13f6f7fe3931e4eaf0fc8c68e30d70369e6e6ba442ed631e4afd9c8f15289bcd8e48bfbda34"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 32
-%global gover 1.30.11
+%global releasever 34
+%global gover 1.30.13
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/21/artifacts/kubernetes/v1.31.7/kubernetes-src.tar.gz"
-sha512 = "404080241bd911ef5afee2eedf962d94893e7a2d8638a46eae8b498a4a74ca9ab5aba25f01199800c02b0d5e33b4f5f042b5e05d2d83f8317b99a64fcb9af6e7"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/23/artifacts/kubernetes/v1.31.9/kubernetes-src.tar.gz"
+sha512 = "9447a3e155c838abf4620ff4e2bac962294a1637f4f38d00a526355103037f4567655767dc0e43fd4f187f0bdd3fe93fa71f325fb2b618bb579979de23791bca"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 21
-%global gover 1.31.7
+%global releasever 23
+%global gover 1.31.9
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.32/Cargo.toml
+++ b/packages/kubernetes-1.32/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.32"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/14/artifacts/kubernetes/v1.32.3/kubernetes-src.tar.gz"
-sha512 = "280ac4c9447d0d2ed404c3b5bf9aae32220655a8160f77056cc96ea4dec2076327ad62aef8aa05f50ce06d38ca31ada6882d5cf736b4eecba610ba2fdeaa9173"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/16/artifacts/kubernetes/v1.32.5/kubernetes-src.tar.gz"
+sha512 = "613445413f80a5ca0a7266bb086830154d77c7f0106e676c6d7d49f2bb9628e6ad8360e5399b02888d2d9a6fa25ea6ef1e4dbc5d690e8a9faa944374d240bfeb"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 14
-%global gover 1.32.3
+%global releasever 16
+%global gover 1.32.5
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.33/Cargo.toml
+++ b/packages/kubernetes-1.33/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.33"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/4/artifacts/kubernetes/v1.33.0/kubernetes-src.tar.gz"
-sha512 = "20de2568ad933bb3a961aa069ab1665f5ebcadbd26b5cb7c7e520200ce588090c6f628a08cb33d302b4cc8bdfbf61bf0703ae6b0773fa916713e9ea552316d33"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/6/artifacts/kubernetes/v1.33.1/kubernetes-src.tar.gz"
+sha512 = "999492d2c48350c424ea8c51f3124d6b36fe325ba5b06c127789a2a6ac0dd5edb7389481bc07c0b34e281063ab072129180e7f0ae93bea89fd8c6630245cce52"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 4
-%global gover 1.33.0
+%global releasever 6
+%global gover 1.33.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/a

**Description of changes:**

- Update  `kubernetes-1.28 - 1.33` to latest

**Testing done:**

- Core kit builds on both platforms
- Quick + conformance tests pass on all k8s-1.28+ variants and nvidia smoke tests pass on all k8s-1.28+ nvidia variants
```
NAME                                            TYPE      STATE       PASSED    FAILED    SKIPPED    BUILD ID          LAST UPDATE
aarch64-aws-k8s-128-conformance                 Test      passed      384       0         7012       a46c292c-dirty    2025-06-19T04:55:27Z
aarch64-aws-k8s-128-ipv6-conformance            Test      passed      384       0         7012       a46c292c-dirty    2025-06-19T05:07:47Z
aarch64-aws-k8s-128-ipv6-quick                  Test      passed      5         0         7391       a46c292c-dirty    2025-06-19T03:11:22Z
aarch64-aws-k8s-128-nvidia-conformance          Test      passed      384       0         7012       a46c292c-dirty    2025-06-19T08:42:23Z
aarch64-aws-k8s-128-nvidia-quick                Test      passed      5         0         7391       a46c292c-dirty    2025-06-19T03:10:35Z
aarch64-aws-k8s-128-nvidia-test                 Test      passed      11        0         0          a46c292c-dirty    2025-06-19T12:12:03Z
aarch64-aws-k8s-128-quick                       Test      passed      5         0         7391       a46c292c-dirty    2025-06-19T03:11:27Z

aarch64-aws-k8s-129-conformance                 Test      passed      392       0         7023       a46c292c-dirty    2025-06-19T05:02:25Z
aarch64-aws-k8s-129-ipv6-conformance            Test      passed      392       0         7023       a46c292c-dirty    2025-06-19T05:12:47Z
aarch64-aws-k8s-129-ipv6-quick                  Test      passed      5         0         7410       a46c292c-dirty    2025-06-19T03:13:28Z
aarch64-aws-k8s-129-nvidia-conformance          Test      passed      392       0         7023       a46c292c-dirty    2025-06-19T11:10:24Z
aarch64-aws-k8s-129-nvidia-quick                Test      passed      5         0         7410       a46c292c-dirty    2025-06-19T03:11:06Z
aarch64-aws-k8s-129-nvidia-test                 Test      passed      11        0         0          a46c292c-dirty    2025-06-19T11:18:58Z
aarch64-aws-k8s-129-quick                       Test      passed      5         0         7410       a46c292c-dirty    2025-06-19T03:11:46Z

aarch64-aws-k8s-130-conformance                 Test      passed      406       0         6801       a46c292c-dirty    2025-06-19T04:59:06Z
aarch64-aws-k8s-130-ipv6-conformance            Test      passed      406       0         6801       a46c292c-dirty    2025-06-19T05:07:09Z
aarch64-aws-k8s-130-ipv6-quick                  Test      passed      5         0         7202       a46c292c-dirty    2025-06-19T03:13:13Z
aarch64-aws-k8s-130-nvidia-conformance          Test      passed      406       0         6801       a46c292c-dirty    2025-06-19T11:02:29Z
aarch64-aws-k8s-130-nvidia-quick                Test      passed      5         0         7202       a46c292c-dirty    2025-06-19T03:11:30Z
aarch64-aws-k8s-130-nvidia-test                 Test      passed      11        0         0          a46c292c-dirty    2025-06-19T11:10:42Z
aarch64-aws-k8s-130-quick                       Test      passed      5         0         7202       a46c292c-dirty    2025-06-19T03:13:02Z

aarch64-aws-k8s-131-conformance                 Test      passed      408       0         6204       a46c292c-dirty    2025-06-19T04:53:31Z
aarch64-aws-k8s-131-ipv6-conformance            Test      passed      408       0         6204       a46c292c-dirty    2025-06-19T13:48:39Z
aarch64-aws-k8s-131-ipv6-quick                  Test      passed      5         0         6607       a46c292c-dirty    2025-06-19T09:44:40Z
aarch64-aws-k8s-131-nvidia-conformance          Test      passed      408       0         6204       a46c292c-dirty    2025-06-19T11:14:25Z
aarch64-aws-k8s-131-nvidia-quick                Test      passed      5         0         6607       a46c292c-dirty    2025-06-19T03:12:39Z
aarch64-aws-k8s-131-nvidia-test                 Test      passed      11        0         0          a46c292c-dirty    2025-06-19T11:22:24Z
aarch64-aws-k8s-131-quick                       Test      passed      5         0         6607       a46c292c-dirty    2025-06-19T09:44:43Z

aarch64-aws-k8s-132-conformance                 Test      passed      415       0         6214       a46c292c-dirty    2025-06-19T05:01:32Z
aarch64-aws-k8s-132-ipv6-conformance            Test      passed      415       0         6214       a46c292c-dirty    2025-06-19T13:44:47Z
aarch64-aws-k8s-132-ipv6-quick                  Test      passed      5         0         6624       a46c292c-dirty    2025-06-19T09:44:32Z
aarch64-aws-k8s-132-nvidia-conformance          Test      passed      415       0         6214       a46c292c-dirty    2025-06-19T11:13:03Z
aarch64-aws-k8s-132-nvidia-quick                Test      passed      5         0         6624       a46c292c-dirty    2025-06-19T03:11:11Z
aarch64-aws-k8s-132-nvidia-test                 Test      passed      11        0         0          a46c292c-dirty    2025-06-19T11:21:47Z
aarch64-aws-k8s-132-quick                       Test      passed      5         0         6624       a46c292c-dirty    2025-06-19T09:44:14Z

aarch64-aws-k8s-133-conformance                 Test      passed      423       0         6312       a46c292c-dirty    2025-06-19T04:57:55Z
aarch64-aws-k8s-133-ipv6-conformance            Test      passed      423       0         6312       a46c292c-dirty    2025-06-19T19:34:14Z
aarch64-aws-k8s-133-ipv6-quick                  Test      passed      5         0         6730       a46c292c-dirty    2025-06-19T17:37:16Z
aarch64-aws-k8s-133-nvidia-conformance          Test      passed      423       0         6312       a46c292c-dirty    2025-06-19T11:09:56Z
aarch64-aws-k8s-133-nvidia-quick                Test      passed      5         0         6730       a46c292c-dirty    2025-06-19T03:12:32Z
aarch64-aws-k8s-133-nvidia-test                 Test      passed      11        0         0          a46c292c-dirty    2025-06-19T11:18:11Z
aarch64-aws-k8s-133-quick                       Test      passed      5         0         6730       a46c292c-dirty    2025-06-19T09:44:17Z

x86-64-aws-k8s-128-conformance                  Test      passed      384       0         7012       a46c292c-dirty    2025-06-19T04:53:16Z
x86-64-aws-k8s-128-ipv6-conformance             Test      passed      384       0         7012       a46c292c-dirty    2025-06-19T05:05:34Z
x86-64-aws-k8s-128-ipv6-quick                   Test      passed      5         0         7391       a46c292c-dirty    2025-06-19T03:10:30Z
x86-64-aws-k8s-128-nvidia-conformance           Test      passed      384       0         7012       a46c292c-dirty    2025-06-19T05:00:17Z
x86-64-aws-k8s-128-nvidia-quick                 Test      passed      5         0         7391       a46c292c-dirty    2025-06-19T03:10:20Z
x86-64-aws-k8s-128-nvidia-test                  Test      passed      11        0         0          a46c292c-dirty    2025-06-19T05:08:40Z
x86-64-aws-k8s-128-quick                        Test      passed      5         0         7391       a46c292c-dirty    2025-06-19T03:10:26Z

x86-64-aws-k8s-129-conformance                  Test      passed      392       0         7023       a46c292c-dirty    2025-06-19T05:00:18Z
x86-64-aws-k8s-129-ipv6-conformance             Test      passed      392       0         7023       a46c292c-dirty    2025-06-19T05:18:46Z
x86-64-aws-k8s-129-ipv6-quick                   Test      passed      5         0         7410       a46c292c-dirty    2025-06-19T03:11:12Z
x86-64-aws-k8s-129-nvidia-conformance           Test      passed      392       0         7023       a46c292c-dirty    2025-06-19T05:07:50Z
x86-64-aws-k8s-129-nvidia-quick                 Test      passed      5         0         7410       a46c292c-dirty    2025-06-19T03:09:55Z
x86-64-aws-k8s-129-nvidia-test                  Test      passed      11        0         0          a46c292c-dirty    2025-06-19T09:32:13Z
x86-64-aws-k8s-129-quick                        Test      passed      5         0         7410       a46c292c-dirty    2025-06-19T03:09:12Z

x86-64-aws-k8s-130-conformance                  Test      passed      406       0         6801       a46c292c-dirty    2025-06-19T04:57:34Z
x86-64-aws-k8s-130-ipv6-conformance             Test      passed      406       0         6801       a46c292c-dirty    2025-06-19T05:11:24Z
x86-64-aws-k8s-130-ipv6-quick                   Test      passed      5         0         7202       a46c292c-dirty    2025-06-19T03:11:36Z
x86-64-aws-k8s-130-nvidia-conformance           Test      passed      406       0         6801       a46c292c-dirty    2025-06-19T04:59:33Z
x86-64-aws-k8s-130-nvidia-quick                 Test      passed      5         0         7202       a46c292c-dirty    2025-06-19T03:09:54Z
x86-64-aws-k8s-130-nvidia-test                  Test      passed      11        0         0          a46c292c-dirty    2025-06-19T09:32:16Z
x86-64-aws-k8s-130-quick                        Test      passed      5         0         7202       a46c292c-dirty    2025-06-19T03:08:45Z

x86-64-aws-k8s-131-conformance                  Test      passed      408       0         6204       a46c292c-dirty    2025-06-19T11:18:20Z
x86-64-aws-k8s-131-ipv6-conformance             Test      passed      408       0         6204       a46c292c-dirty    2025-06-19T11:20:44Z
x86-64-aws-k8s-131-ipv6-quick                   Test      passed      5         0         6607       a46c292c-dirty    2025-06-19T03:13:15Z
x86-64-aws-k8s-131-nvidia-conformance           Test      passed      408       0         6204       a46c292c-dirty    2025-06-19T11:05:44Z
x86-64-aws-k8s-131-nvidia-quick                 Test      passed      5         0         6607       a46c292c-dirty    2025-06-19T03:10:02Z
x86-64-aws-k8s-131-nvidia-test                  Test      passed      11        0         0          a46c292c-dirty    2025-06-19T11:14:36Z
x86-64-aws-k8s-131-quick                        Test      passed      5         0         6607       a46c292c-dirty    2025-06-19T03:09:41Z

x86-64-aws-k8s-132-conformance                  Test      passed      415       0         6214       a46c292c-dirty    2025-06-19T04:55:35Z
x86-64-aws-k8s-132-ipv6-conformance             Test      passed      415       0         6214       a46c292c-dirty    2025-06-19T05:13:07Z
x86-64-aws-k8s-132-ipv6-quick                   Test      passed      5         0         6624       a46c292c-dirty    2025-06-19T03:13:48Z
x86-64-aws-k8s-132-nvidia-conformance           Test      passed      415       0         6214       a46c292c-dirty    2025-06-19T05:00:01Z
x86-64-aws-k8s-132-nvidia-quick                 Test      passed      5         0         6624       a46c292c-dirty    2025-06-19T03:09:55Z
x86-64-aws-k8s-132-nvidia-test                  Test      passed      11        0         0          a46c292c-dirty    2025-06-19T09:32:22Z
x86-64-aws-k8s-132-quick                        Test      passed      5         0         6624       a46c292c-dirty    2025-06-19T03:10:15Z

x86-64-aws-k8s-133-conformance                  Test      passed      423       0         6312       a46c292c-dirty    2025-06-19T04:58:29Z
x86-64-aws-k8s-133-ipv6-conformance             Test      passed      423       0         6312       a46c292c-dirty    2025-06-19T13:48:02Z
x86-64-aws-k8s-133-ipv6-quick                   Test      passed      5         0         6730       a46c292c-dirty    2025-06-19T03:12:07Z
x86-64-aws-k8s-133-nvidia-conformance           Test      passed      423       0         6312       a46c292c-dirty    2025-06-19T11:13:11Z
x86-64-aws-k8s-133-nvidia-quick                 Test      passed      5         0         6730       a46c292c-dirty    2025-06-19T03:10:17Z
x86-64-aws-k8s-133-nvidia-test                  Test      passed      11        0         0          a46c292c-dirty    2025-06-19T11:21:41Z
x86-64-aws-k8s-133-quick                        Test      passed      5         0         6730       a46c292c-dirty    2025-06-19T03:10:25Z
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
