### PR TITLE
Third Party package updates

### DIFF
--- a/packages/iputils/Cargo.toml
+++ b/packages/iputils/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://github.com/iputils/iputils/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/iputils/iputils/releases/download/20240905/iputils-20240905.tar.gz"
-sha512 = "ff5ee998c6253d0ceda185d7e266c3126c52acc0fb3ee9f10b9b97aaa7dc839c305d58da7f88697939b6ca3f2c9deab042613c312fd71c248d73ba0616089eda"
+url = "https://github.com/iputils/iputils/releases/download/20250605/iputils-20250605.tar.gz"
+sha512 = "6fa7c2856d5b835e03381b678d87205f3030163de5306db0b5c38dec2203171c958514c561e91aadadb385448905a581e3b8831f8f44b57583b5570e9aac7540"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/iputils/iputils/releases/download/20240905/iputils-20240905.tar.gz.asc"
-sha512 = "8ddd8938c942d50cf4946fcc3e71f1191b0adf568f3c9525f6ab8c9a8e73b15b13aef072bdf533c237bbb6ff8c001f8e282c0b5cc4293a035da19ca39a46bd87"
+url = "https://github.com/iputils/iputils/releases/download/20250605/iputils-20250605.tar.gz.asc"
+sha512 = "f10890ce5498505b8ea635115d540eefd24bc7c8085824e74ff734f679b22fbcb415a9ce42e2100f6381ce03f01bd5942465daac02e4827ac0e311874c42a499"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/iputils/iputils.spec
+++ b/packages/iputils/iputils.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}iputils
-Version: 20240905
+Version: 20250605
 Release: 1%{?dist}
 Summary: A set of network monitoring tools
 License: GPL-2.0-or-later AND BSD-3-Clause

--- a/packages/kexec-tools/Cargo.toml
+++ b/packages/kexec-tools/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/linux/utils/kernel/kexec"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.30.tar.xz"
-sha512 = "4550607ad7eb51d169c2565cfee9195441634624d1c8859e21bca6bd7f15031713c39ba475301c1ef5fc67c009bc6599d254da184be25e68b226155e515e3852"
+url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.31.tar.xz"
+sha512 = "95cb7e7b33685497d72fab74fed2191e476c0574d6ad2333d9e22b95a94543b5fdafe0663282cfaebb8747cf696b7d34c308941ec1074b2b9f1ed440b32d7309"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.30.tar.sign"
-sha512 = "6c326270b34fc805139c548a205a1283e1bf0815507313c5cd1b097ee3b386750634c51008a5c2d61cf58589a1db5976130f4bece5c787ba95b739a21fa24f04"
+url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.31.tar.sign"
+sha512 = "cb964713ed282f575d29823a2110884f052d3b9149c25212a7e4ad3d3023713774a479923af99168db3598ec24480223708c32442555281e6daa42115717260b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kexec-tools/kexec-tools.spec
+++ b/packages/kexec-tools/kexec-tools.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}kexec-tools
-Version: 2.0.30
+Version: 2.0.31
 Release: 1%{?dist}
 Epoch: 1
 Summary: Linux tool to load kernels from the running system

--- a/packages/open-vm-tools/Cargo.toml
+++ b/packages/open-vm-tools/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/vmware/open-vm-tools/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/vmware/open-vm-tools/releases/download/stable-12.5.0/open-vm-tools-12.5.0-24276846.tar.gz"
-sha512 = "068f84192b7056144257a8180884a077fe03e34c441f4eb7729112d3dbd75f70e019d3cdbfe7c25243154d7597f152272efde9417d873a585ec1bfc68f34e234"
+url = "https://github.com/vmware/open-vm-tools/releases/download/stable-13.0.0/open-vm-tools-13.0.0-24696409.tar.gz"
+sha512 = "eacb304f3c00d901ea2afffb09bb26be25b6b10df1de4f1818e7ce07a8c05b5e243c8fbe00a5fbf2680ad5b42727315f5c3fb9af818658ffc2b9425d3f34c37e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/open-vm-tools/open-vm-tools.spec
+++ b/packages/open-vm-tools/open-vm-tools.spec
@@ -1,7 +1,7 @@
-%global buildver 24276846
+%global buildver 24696409
 
 Name: %{_cross_os}open-vm-tools
-Version: 12.5.0
+Version: 13.0.0
 Release: 1%{?dist}
 Summary: Tools for VMware
 License: LGPL-2.1-or-later


### PR DESCRIPTION
**Description of changes:**
- Update `open-vm-tools` v12.5.0  &rarr; v13.0.0
- Update `iputils` v20240905  &rarr; v20250605
- Update `kexec-tools` v2.0.30 &rarr; v2.0.31

**Testing done:**
`iputils`
```
bash-5.1# ping amazon.com
PING amazon.com (54.239.28.85) 56(84) bytes of data.
64 bytes from 54.239.28.85: icmp_seq=1 ttl=249 time=62.8 ms
64 bytes from 54.239.28.85: icmp_seq=2 ttl=249 time=62.9 ms
64 bytes from 54.239.28.85: icmp_seq=3 ttl=249 time=62.8 ms
64 bytes from 54.239.28.85: icmp_seq=4 ttl=249 time=62.8 ms
64 bytes from 54.239.28.85: icmp_seq=5 ttl=249 time=62.8 ms
^C
--- amazon.com ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 4004ms
rtt min/avg/max/mdev = 62.791/62.811/62.863/0.027 ms
```

`kexec-tools` - Tested on vmware instance

![image](https://github.com/user-attachments/assets/c61b43fb-115a-400e-8b38-44c5e2782c84)

`open-vm-tools` - Tested on vmware instance
The VM responded to power off command.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
