### PR TITLE
Bloodhound: Add warning for 3.4.1.1 check fail in K8s

### DIFF
--- a/sources/bloodhound/src/output.rs
+++ b/sources/bloodhound/src/output.rs
@@ -43,7 +43,13 @@ impl ReportWriter for TextReportWriter {
         writeln!(output, "{:17}{}", "Skipped:", report.skipped)?;
         writeln!(output, "{:17}{}", "Total checks:", report.total)?;
         writeln!(output)?;
-        writeln!(output, "Compliance check result: {}", report.status)
+        if report.contain_known_fail_check("3.4.1.1".to_string()) {
+            writeln!(
+                output,
+                "\x1b[93m WARNING: For Kubernetes Variants, DROP will be unconditionally overwritten. If this applies to you, work with your auditor for an exception. See https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/540 for more details.\x1b[0m"
+            )?;
+        }
+        writeln!(output, "Compliance check result: {} ", report.status)
     }
 }
 

--- a/sources/bloodhound/src/results.rs
+++ b/sources/bloodhound/src/results.rs
@@ -180,4 +180,10 @@ impl ReportResults {
         self.results
             .insert(metadata.name.clone(), IndividualResult { metadata, result });
     }
+
+    pub fn contain_known_fail_check(&self, target_id: String) -> bool {
+        self.results.values().any(|result| {
+            result.metadata.id == target_id && result.result.status == CheckStatus::FAIL
+        })
+    }
 }


### PR DESCRIPTION
This test is expected to fail on Kubernetes variants as Kubernetes needs the iptables rule -P FORWARD ACCEPT for its operation and it is not recommended to modify this rule as it could lead to adverse effects of service operation. This rule exists in Bottlerocket because it is possible to run Bottlerocket with default deny (on ECS for instance).

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** 

Closes # 540

**Description of changes:**
- Add a warning in the CIS benchmark check text output only for the 3.4.1.1 check.

**Testing done:**
```
apiclient report cis -l 2
Benchmark name:  CIS Bottlerocket Benchmark
Version:         v1.0.0
Reference:       https://www.cisecurity.org/benchmark/bottlerocket
Benchmark level: 2
Start time:      2025-06-24T00:20:14.551028115Z

[PASS] 1.1.1.1   Ensure mounting of udf filesystems is disabled (Automatic)
[SKIP] 1.2.1     Ensure software update repositories are configured (Manual)
[PASS] 1.3.1     Ensure dm-verity is configured (Automatic)
[PASS] 1.4.1     Ensure setuid programs do not create core dumps (Automatic)
[PASS] 1.4.2     Ensure address space layout randomization (ASLR) is enabled (Automatic)
[PASS] 1.4.3     Ensure unprivileged eBPF is disabled (Automatic)
[PASS] 1.4.4     Ensure user namespaces are disabled (Automatic)
[PASS] 1.5.1     Ensure SELinux is configured (Automatic)
[PASS] 1.5.2     Ensure Lockdown is configured (Automatic)
[SKIP] 1.6       Ensure updates, patches, and additional security software are installed (Manual)
[PASS] 2.1.1.1   Ensure chrony is configured (Automatic)
[PASS] 3.1.1     Ensure packet redirect sending is disabled (Automatic)
[PASS] 3.2.1     Ensure source routed packets are not accepted (Automatic)
[PASS] 3.2.2     Ensure ICMP redirects are not accepted (Automatic)
[PASS] 3.2.3     Ensure secure ICMP redirects are not accepted (Automatic)
[PASS] 3.2.4     Ensure suspicious packets are logged (Automatic)
[PASS] 3.2.5     Ensure broadcast ICMP requests are ignored (Automatic)
[PASS] 3.2.6     Ensure bogus ICMP responses are ignored (Automatic)
[PASS] 3.2.7     Ensure TCP SYN Cookies is enabled (Automatic)
[PASS] 3.3.1     Ensure SCTP is disabled (Automatic)
[FAIL] 3.4.1.1   Ensure IPv4 default deny firewall policy (Automatic)
[PASS] 3.4.1.2   Ensure IPv4 loopback traffic is configured (Automatic)
[SKIP] 3.4.1.3   Ensure IPv4 outbound and established connections are configured (Manual)
[PASS] 3.4.2.1   Ensure IPv6 default deny firewall policy (Automatic)
[PASS] 3.4.2.2   Ensure IPv6 loopback traffic is configured (Automatic)
[SKIP] 3.4.2.3   Ensure IPv6 outbound and established connections are configured (Manual)
[PASS] 4.1.1.1   Ensure journald is configured to write logs to persistent disk (Automatic)
[PASS] 4.1.2     Ensure permissions on journal files are configured (Automatic)

Passed:          23
Failed:          1
Skipped:         4
Total checks:    28

Check 3.4.1.1 fails in Kubernetes Variants due to a known issue(https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/540 ). Please work with your auditor to log an exception.
Compliance check result: FAIL
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
