### PR TITLE
Add SBOM generation to Core Kit packages

### DIFF
--- a/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
+++ b/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
@@ -88,6 +88,8 @@ gofips build "${ECS_CNI_BUILD_ARGS[@]}" -o fips/ecs-ipam ./plugins/ipam
 go build "${ECS_CNI_BUILD_ARGS[@]}" -o ecs-bridge ./plugins/ecs-bridge
 gofips build "${ECS_CNI_BUILD_ARGS[@]}" -o fips/ecs-bridge ./plugins/ecs-bridge
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}
 install -D -p -m 0755 ecs-bridge %{buildroot}%{_cross_libexecdir}/cni/ecs/ecs-bridge
@@ -112,9 +114,13 @@ done
 
 %cross_scan_attribution go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %license LICENSE
 
 %files bin

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -108,6 +108,8 @@ go build -ldflags "${GOLDFLAGS}" -o static/ssm-session-worker \
 gofips build -ldflags "${GOLDFLAGS}" -o fips-static/ssm-session-worker \
   ./agent/framework/processor/executer/outofproc/sessionworker/main.go
 
+%cross_generate_sbom
+
 %install
 install -D -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}/amazon-ssm-agent.service
 
@@ -132,10 +134,14 @@ done
 ln -sf %{version} %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/latest
 ln -sf %{version} %{buildroot}%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/latest
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_unitdir}/amazon-ssm-agent.service
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/amazon/ssm
 %{_cross_factorydir}%{_cross_sysconfdir}/amazon/ssm/amazon-ssm-agent.json

--- a/packages/amazon-vpc-cni-plugins/amazon-vpc-cni-plugins.spec
+++ b/packages/amazon-vpc-cni-plugins/amazon-vpc-cni-plugins.spec
@@ -87,6 +87,8 @@ for p in \
   gofips build "${VPC_CNI_BUILD_ARGS[@]}" -mod=vendor -o fips/${p} ./plugins/${p}
 done
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}
 install -D -p -m 0755 aws-appmesh %{buildroot}%{_cross_libexecdir}/cni/vpc/aws-appmesh
@@ -120,9 +122,13 @@ done
 
 %cross_scan_attribution go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %license LICENSE
 
 %files bin

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -56,6 +56,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 export GO_MAJOR="1.24"
 go build -ldflags="${GOLDFLAGS}" -o aws-iam-authenticator ./cmd/aws-iam-authenticator
 gofips build -ldflags="${GOLDFLAGS}" -o fips/aws-iam-authenticator ./cmd/aws-iam-authenticator
+%cross_generate_sbom
 
 %install
 install -d %{buildroot}%{_cross_bindir}
@@ -65,11 +66,14 @@ install -d %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 fips/aws-iam-authenticator %{buildroot}%{_cross_fips_bindir}
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
+%cross_install_sbom
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_bindir}/aws-iam-authenticator

--- a/packages/aws-otel-collector/aws-otel-collector.spec
+++ b/packages/aws-otel-collector/aws-otel-collector.spec
@@ -51,6 +51,8 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 go build -ldflags "${GOLDFLAGS}" -o aws-otel-collector ./cmd/awscollector
 gofips build -ldflags "${GOLDFLAGS}" -o fips/aws-otel-collector ./cmd/awscollector
 
+%cross_generate_sbom
+
 %install
 install -D -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}/aws-otel-collector.service
 
@@ -64,11 +66,15 @@ install -d %{buildroot}{%{_cross_bindir},%{_cross_fips_bindir}}
 install -p -m 0755 aws-otel-collector %{buildroot}%{_cross_bindir}
 install -p -m 0755 fips/aws-otel-collector %{buildroot}%{_cross_fips_bindir}
 
+%cross_install_sbom
+
 %files
 %{_cross_attribution_file}
 %{_cross_unitdir}/aws-otel-collector.service
 %{_cross_tmpfilesdir}/aws-otel-collector-tmpfiles.conf
 %{_cross_factorydir}%{_cross_sysconfdir}/aws-otel-collector.yaml
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_bindir}/aws-otel-collector

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -57,6 +57,8 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 go build -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o aws-signing-helper main.go
 gofips build -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o fips/aws-signing-helper main.go
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 aws-signing-helper %{buildroot}%{_cross_bindir}/aws_signing_helper
@@ -78,12 +80,16 @@ install -d %{buildroot}%{_cross_datadir}/brush
 install -p -m 0755 %{S:2} %{buildroot}%{_cross_datadir}/brush/aws_signing_helper.toml
 ln -sf aws_signing_helper.toml %{buildroot}%{_cross_datadir}/brush/aws-signing-helper.toml
 
+%cross_install_sbom
+
 %cross_scan_attribution go-vendor vendor
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_datadir}/brush/aws_signing_helper.toml
 %{_cross_datadir}/brush/aws-signing-helper.toml
 %{_cross_libexecdir}/brush/allowed-programs/aws_signing_helper

--- a/packages/bash/bash.spec
+++ b/packages/bash/bash.spec
@@ -76,14 +76,18 @@ export \
 )
 
 make "CPPFLAGS=-D_GNU_SOURCE -DRECYCLES_PIDS -DDEFAULT_PATH_VALUE='\"/usr/local/bin:/usr/bin\"'" %{?_smp_mflags}
+%cross_generate_sbom
 
 %install
 %make_install install-headers
 ln -s bash %{buildroot}%{_cross_bindir}/sh
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/bash
 %{_cross_bindir}/sh
 %exclude %{_cross_bindir}/bashbug

--- a/packages/binutils/binutils.spec
+++ b/packages/binutils/binutils.spec
@@ -41,13 +41,17 @@ Requires: %{name}
   --disable-static \
   --disable-gprofng
 %make_build MAKEINFO=true tooldir=%{_cross_prefix}
+%cross_generate_sbom
 
 %install
 %make_install MAKEINFO=true tooldir=%{_cross_prefix}
+%cross_install_sbom
 
 %files
 %license COPYING COPYING3.LIB COPYING3
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/ld
 %{_cross_bindir}/strip
 %dir %{_cross_libdir}/bfd-plugins

--- a/packages/chrony/chrony.spec
+++ b/packages/chrony/chrony.spec
@@ -46,6 +46,7 @@ CC=%{_cross_target}-gcc \
  --enable-scfilter
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
@@ -59,9 +60,13 @@ install -p -m 0644 %{S:13} %{buildroot}%{_cross_sysusersdir}/chrony.conf
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:14} %{buildroot}%{_cross_tmpfilesdir}/chrony.conf
 
+%cross_install_sbom
+
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %dir %{_cross_templatedir}
 %{_cross_sbindir}/chronyd
 %{_cross_templatedir}/chrony-conf

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -53,6 +53,7 @@ for d in $(find plugins -mindepth 2 -maxdepth 2 -type d ! -name windows) ; do
   go build -ldflags="${GOLDFLAGS}" -o "bin/${d##*/}" %{goimport}/${d}
   gofips build -ldflags="${GOLDFLAGS}" -o "fips/bin/${d##*/}" %{goimport}/${d}
 done
+%cross_generate_sbom
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/cni/bin
@@ -65,12 +66,15 @@ install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/cni-plugins.conf
 
 %cross_scan_attribution go-vendor vendor
+%cross_install_sbom
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
 %{_cross_tmpfilesdir}/cni-plugins.conf
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_libexecdir}/cni/bin/loopback

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -32,16 +32,22 @@ Requires: %{_cross_os}iptables
 
 go build -ldflags="${GOLDFLAGS}" -o "bin/cnitool" %{goimport}/cnitool
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}/cni/bin
 install -p -m 0755 bin/cnitool %{buildroot}%{_cross_libexecdir}/cni/bin
 
 %cross_scan_attribution go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
 %{_cross_libexecdir}/cni/bin/cnitool
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %changelog

--- a/packages/conntrack-tools/conntrack-tools.spec
+++ b/packages/conntrack-tools/conntrack-tools.spec
@@ -44,13 +44,17 @@ autoreconf -fi
 %cross_configure
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_sbindir}/conntrack
 %exclude %{_cross_sbindir}/conntrackd
 %exclude %{_cross_sbindir}/nfct

--- a/packages/containerd-1.7/containerd-1.7.spec
+++ b/packages/containerd-1.7/containerd-1.7.spec
@@ -123,6 +123,8 @@ do
   gofips build "${BUILD_ARGS[@]}" -o fips/${bin} %{goimport}/cmd/${bin}
 done
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}{%{_cross_bindir},%{_cross_fips_bindir}}
 for bin in \
@@ -152,10 +154,14 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/0
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE NOTICE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_unitdir}/containerd.service
 %{_cross_unitdir}/etc-containerd.mount
 %{_cross_unitdir}/prepare-var-lib-containerd.service

--- a/packages/containerd-2.0/containerd-2.0.spec
+++ b/packages/containerd-2.0/containerd-2.0.spec
@@ -120,6 +120,8 @@ do
   gofips build "${BUILD_ARGS[@]}" -o fips/${bin} ./cmd/${bin}
 done
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}{%{_cross_bindir},%{_cross_fips_bindir}}
 for bin in \
@@ -147,10 +149,14 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/0
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE NOTICE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_unitdir}/containerd.service
 %{_cross_unitdir}/etc-containerd.mount
 %{_cross_unitdir}/prepare-var-lib-containerd.service

--- a/packages/coreutils/coreutils.spec
+++ b/packages/coreutils/coreutils.spec
@@ -37,13 +37,17 @@ Requires: %{_cross_os}libxcrypt
   --without-openssl \
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/[
 %{_cross_bindir}/b2sum
 %{_cross_bindir}/base32

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -43,6 +43,7 @@ CONFIGURE_OPTS=(
 
 %cross_meson "${CONFIGURE_OPTS[@]}"
 %cross_meson_build
+%cross_generate_sbom
 
 %install
 %cross_meson_install
@@ -56,9 +57,13 @@ install -p -m 0644 %{S:12} %{buildroot}%{_cross_datadir}/dbus-1/system.conf
 install -d %{buildroot}%{_cross_sysusersdir}
 install -p -m 0644 %{S:13} %{buildroot}%{_cross_sysusersdir}/dbus.conf
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/dbus-broker
 %{_cross_bindir}/dbus-broker-launch
 %dir %{_cross_datadir}/dbus-1

--- a/packages/docker-cli/docker-cli.spec
+++ b/packages/docker-cli/docker-cli.spec
@@ -64,6 +64,8 @@ BUILD_ARGS=(
 go build "${BUILD_ARGS[@]}" -o docker %{goimport}/cmd/docker
 gofips build "${BUILD_ARGS[@]}" -o fips/docker %{goimport}/cmd/docker
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 docker %{buildroot}%{_cross_bindir}
@@ -73,10 +75,14 @@ install -p -m 0755 fips/docker %{buildroot}%{_cross_fips_bindir}
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE NOTICE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_bindir}/docker

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -94,6 +94,8 @@ go build "${BUILD_ARGS[@]}" -o docker-proxy %{goimport}/cmd/docker-proxy
 gofips build "${BUILD_ARGS[@]}" -o fips/dockerd %{goimport}/cmd/dockerd
 gofips build "${BUILD_ARGS[@]}" -o fips/docker-proxy %{goimport}/cmd/docker-proxy
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 dockerd %{buildroot}%{_cross_bindir}
@@ -116,9 +118,13 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/docker-daemon-nvidia
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_unitdir}/docker.service
 %{_cross_unitdir}/docker.socket
 %{_cross_unitdir}/prepare-var-lib-docker.service

--- a/packages/docker-init/docker-init.spec
+++ b/packages/docker-init/docker-init.spec
@@ -21,14 +21,18 @@ BuildRequires: %{_cross_os}glibc-devel
 %build
 %{cross_cmake} .
 %make_build tini-static
+%cross_generate_sbom
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 tini-static %{buildroot}%{_cross_bindir}/docker-init
+%cross_install_sbom
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_bindir}/docker-init
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %changelog

--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -62,6 +62,8 @@ Requires: %{_cross_os}e2fsprogs-libs
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install install-libs \
   root_sbindir=%{_cross_sbindir} \
@@ -75,9 +77,13 @@ install -p -m 0644 %{S:10} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:11} %{buildroot}%{_cross_tmpfilesdir}/e2fsprogs.conf
 
+%cross_install_sbom
+
 %files
 %license debian/copyright
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_sbindir}/badblocks
 %{_cross_sbindir}/dumpe2fs
 %{_cross_sbindir}/e2fsck

--- a/packages/early-boot-config/early-boot-config.spec
+++ b/packages/early-boot-config/early-boot-config.spec
@@ -70,6 +70,8 @@ Requires: %{name}-local
 %endif
     %{nil}
 
+%cross_generate_sbom
+
 %global early_boot_config_bindir %{_cross_libexecdir}/early-boot-config/bin
 %global early_boot_config_provider_dir %{_cross_libexecdir}/early-boot-config/data-providers.d
 
@@ -128,10 +130,14 @@ ln -rs \
   %{buildroot}%{early_boot_config_provider_dir}/40-vmware-guestinfo
 %endif
 
+%cross_install_sbom
+
 %files
 %{_cross_bindir}/early-boot-config
 %{_cross_unitdir}/early-boot-config.service
 %dir %{early_boot_config_provider_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files local
 %{early_boot_config_bindir}/local-defaults-user-data-provider

--- a/packages/ecr-credential-provider-1.27/ecr-credential-provider-1.27.spec
+++ b/packages/ecr-credential-provider-1.27/ecr-credential-provider-1.27.spec
@@ -57,6 +57,8 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
@@ -66,10 +68,14 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.28/ecr-credential-provider-1.28.spec
+++ b/packages/ecr-credential-provider-1.28/ecr-credential-provider-1.28.spec
@@ -57,6 +57,8 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
@@ -66,10 +68,14 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.29/ecr-credential-provider-1.29.spec
+++ b/packages/ecr-credential-provider-1.29/ecr-credential-provider-1.29.spec
@@ -57,6 +57,8 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
@@ -66,10 +68,14 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
+++ b/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
@@ -59,6 +59,8 @@ export GO_MAJOR="1.23"
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
@@ -68,10 +70,14 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
+++ b/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
@@ -59,6 +59,8 @@ export GO_MAJOR="1.23"
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
@@ -68,10 +70,14 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
+++ b/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
@@ -59,6 +59,8 @@ export GO_MAJOR="1.24"
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
@@ -68,10 +70,14 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
+++ b/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
@@ -59,6 +59,8 @@ export GO_MAJOR="1.24"
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
@@ -68,10 +70,14 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -152,6 +152,8 @@ gofips build "${ECS_AGENT_BUILD_ARGS[@]}" -o fips/amazon-ecs-agent ./agent
   %tar_cf ../../amazon-ecs-pause.tar -C image .
 )
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -D -p -m 0755 amazon-ecs-agent %{buildroot}%{_cross_bindir}/amazon-ecs-agent
@@ -198,10 +200,14 @@ ln -rs %{buildroot}%{_cross_sysconfdir}/pki/tls/certs/ca-bundle.crt %{buildroot}
 install -d %{buildroot}%{_cross_datadir}/logdog.d
 install -p -m 0644 %{S:300} %{buildroot}%{_cross_datadir}/logdog.d
 
+%cross_install_sbom
+
 %files
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
 %license LICENSE NOTICE ecs-agent/THIRD_PARTY.md
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %{_cross_libexecdir}/amazon-ecs-agent/managed-agents
 %{_cross_unitdir}/ecs.service

--- a/packages/ecs-gpu-init/ecs-gpu-init.spec
+++ b/packages/ecs-gpu-init/ecs-gpu-init.spec
@@ -28,6 +28,8 @@ export CGO_LDFLAGS="-Wl,-z,relro -Wl,--export-dynamic"
 export GOLDFLAGS="-compressdwarf=false -linkmode=external -extldflags '${CGO_LDFLAGS}'"
 go build -ldflags="${GOLDFLAGS}" -o ecs-gpu-init ./cmd/ecs-gpu-init
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ecs-gpu-init %{buildroot}%{_cross_bindir}
@@ -39,10 +41,14 @@ install -D -p -m 0644 %{S:2} %{buildroot}%{_cross_tmpfilesdir}/ecs-gpu-init.conf
 
 %cross_scan_attribution go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %{_cross_attribution_vendor_dir}
 %{_cross_bindir}/ecs-gpu-init
 %{_cross_unitdir}/ecs-gpu-init.service
 %{_cross_tmpfilesdir}/ecs-gpu-init.conf
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %changelog

--- a/packages/ethtool/ethtool.spec
+++ b/packages/ethtool/ethtool.spec
@@ -20,14 +20,18 @@ BuildRequires: %{_cross_os}libmnl-devel
 %build
 %cross_configure
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING LICENSE
 %{_cross_attribution_file}
 %{_cross_sbindir}/ethtool
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_datadir}/bash-completion
 %exclude %{_cross_mandir}
 %exclude %{_cross_datadir}/metainfo/org.kernel.software.network.ethtool.metainfo.xml

--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -24,6 +24,7 @@ Conflicts: %{_cross_os}image-feature(no-fips)
 %prep
 
 %build
+%cross_generate_sbom
 
 %install
 mkdir -p %{buildroot}%{_cross_rootdir}
@@ -54,11 +55,15 @@ ln -s lib %{buildroot}%{_cross_prefix}/lib64
 ln -s .%{_bindir} %{buildroot}/bin
 ln -s .%{_sbindir} %{buildroot}/sbin
 
+%cross_install_sbom
+
 %files
 %dir %{_cross_rootdir}
 %{_cross_rootdir}/*
 %dir %{_cross_sysconfdir}
 %dir %{_cross_localstatedir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %{_prefix}
 /bin

--- a/packages/findutils/findutils.spec
+++ b/packages/findutils/findutils.spec
@@ -21,13 +21,17 @@ Requires: %{_cross_os}libselinux
 %build
 %cross_configure
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/find
 %{_cross_bindir}/xargs
 %exclude %{_cross_bindir}/locate

--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -137,6 +137,8 @@ CC="%{_cross_target}-gcc %{?_cross_arch_cflags}" CXX="%{_cross_target}-g++ %{?_c
 make %{?_smp_mflags} -O -r
 popd
 
+%cross_generate_sbom
+
 %install
 pushd build
 make -j1 install_root=%{buildroot} install
@@ -168,9 +170,13 @@ chmod 644 %{buildroot}%{_cross_datadir}/locale/locale.alias
 install -d %{buildroot}%{_cross_datadir}/zoneinfo
 base64 --decode %{S:14} > %{buildroot}%{_cross_datadir}/zoneinfo/UTC
 
+%cross_install_sbom
+
 %files
 %license COPYING COPYING.LIB LICENSES
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_tmpfilesdir}/glibc.conf
 %exclude %{_cross_sysconfdir}/rpc
 

--- a/packages/grep/grep.spec
+++ b/packages/grep/grep.spec
@@ -22,14 +22,18 @@ Requires: %{_cross_os}libpcre
 %build
 %cross_configure --without-included-regex --disable-silent-rules
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_bindir}/grep
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 # Exclude fgrep and egrep because they are shell scripts
 %exclude %{_cross_bindir}/fgrep
 %exclude %{_cross_bindir}/egrep

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -50,6 +50,7 @@ export GO_MAJOR="1.23"
 %set_cross_go_flags
 go build -ldflags="${GOLDFLAGS}" -o host-ctr ./cmd/host-ctr
 gofips build -ldflags="${GOLDFLAGS}" -o fips/host-ctr ./cmd/host-ctr
+%cross_generate_sbom
 
 %install
 install -d %{buildroot}%{_cross_bindir}
@@ -70,6 +71,7 @@ install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/host-containerd
 install -p -m 0644 %{S:12} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/host-containerd/config.toml
 
 %cross_scan_attribution go-vendor vendor
+%cross_install_sbom
 
 %files
 %{_cross_attribution_vendor_dir}
@@ -77,6 +79,8 @@ install -p -m 0644 %{S:12} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/
 %{_cross_unitdir}/*.mount
 %{_cross_tmpfilesdir}/host-containerd.conf
 %{_cross_factorydir}%{_cross_sysconfdir}/host-containerd/config.toml
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_bindir}/host-ctr

--- a/packages/iproute/iproute.spec
+++ b/packages/iproute/iproute.spec
@@ -43,14 +43,18 @@ export PKG_CONFIG_PATH='%{_cross_pkgconfigdir}' \\\
 %set_cross_build_flags
 ./configure --libdir '%{_cross_libdir}'
 %make_build
+%cross_generate_sbom
 
 %install
 %set_env
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_sbindir}/bridge
 %{_cross_sbindir}/ctstat
 %{_cross_sbindir}/dcb

--- a/packages/iptables/iptables.spec
+++ b/packages/iptables/iptables.spec
@@ -49,6 +49,8 @@ Requires: %{name}
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
 
@@ -57,9 +59,13 @@ ln -srnf \
   %{buildroot}%{_cross_sbindir}/xtables-legacy-multi \
   %{buildroot}%{_cross_bindir}/iptables-xml
 
+%cross_install_sbom
+
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_sbindir}/xtables-legacy-multi
 %{_cross_sbindir}/iptables
 %{_cross_sbindir}/iptables-legacy

--- a/packages/iputils/iputils.spec
+++ b/packages/iputils/iputils.spec
@@ -37,13 +37,17 @@ CONFIGURE_OPTS=(
 
 %cross_meson "${CONFIGURE_OPTS[@]}"
 %cross_meson_build
+%cross_generate_sbom
 
 %install
 %cross_meson_install
+%cross_install_sbom
 
 %files
 %license LICENSE Documentation/LICENSE.GPL2 Documentation/LICENSE.BSD3
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %attr(0755,root,root) %caps(cap_net_raw=p) %{_cross_bindir}/arping
 %attr(0755,root,root) %caps(cap_net_raw=p cap_net_admin=p) %{_cross_bindir}/ping
 %{_cross_bindir}/tracepath

--- a/packages/kexec-tools/kexec-tools.spec
+++ b/packages/kexec-tools/kexec-tools.spec
@@ -22,13 +22,17 @@ rm -f kexec-tools.spec.in
 %build
 %cross_configure
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_sbindir}/kexec
 %exclude %{_cross_mandir}
 %exclude %{_cross_sbindir}/vmcore-dmesg

--- a/packages/keyutils/keyutils.spec
+++ b/packages/keyutils/keyutils.spec
@@ -47,6 +47,7 @@ export CC=%{_cross_target}-gcc ; \
 
 %build
 %keyutilsmake
+%cross_generate_sbom
 
 %install
 %keyutilsmake install
@@ -61,6 +62,8 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/r
 ln -snf libkeyutils.so.? \
   %{buildroot}%{_cross_libdir}/libkeyutils.so
 
+%cross_install_sbom
+
 %files
 %{_cross_attribution_file}
 %license LICENCE.GPL LICENCE.LGPL
@@ -71,6 +74,8 @@ ln -snf libkeyutils.so.? \
 %{_cross_datadir}/keyutils
 %{_cross_libdir}/libkeyutils.so.*
 %{_cross_factorydir}%{_cross_sysconfdir}/request-key.conf
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %exclude %{_cross_mandir}
 %exclude %{_cross_sysconfdir}/request-key.conf

--- a/packages/kmod/kmod.spec
+++ b/packages/kmod/kmod.spec
@@ -60,6 +60,8 @@ pushd dynamic-build
 
 popd
 
+%cross_generate_sbom
+
 %install
 pushd dynamic-build
 %make_install
@@ -72,9 +74,13 @@ install -d %{buildroot}%{_cross_sbindir}
 ln -s ../bin/kmod %{buildroot}%{_cross_sbindir}/modprobe
 popd
 
+%cross_install_sbom
+
 %files
 %license COPYING.LGPL COPYING.GPL
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/kmod
 %{_cross_bindir}/depmod
 %{_cross_bindir}/insmod

--- a/packages/kubernetes-1.27/kubernetes-1.27.spec
+++ b/packages/kubernetes-1.27/kubernetes-1.27.spec
@@ -197,6 +197,8 @@ install -m 0644 %{S:101} image/manifest.json
 
 %tar_cf ../../../_output/local/bin/linux/%{_cross_go_arch}/kubernetes-pause.tar -C image .
 
+%cross_generate_sbom
+
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
@@ -245,10 +247,14 @@ install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
 
+%cross_install_sbom
+
 %files -n %{_cross_os}kubelet-1.27
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -181,6 +181,8 @@ install -m 0644 %{S:101} image/manifest.json
 
 %tar_cf ../../../_output/local/bin/linux/%{_cross_go_arch}/kubernetes-pause.tar -C image .
 
+%cross_generate_sbom
+
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
@@ -229,6 +231,8 @@ install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
 
+%cross_install_sbom
+
 %files -n %{_cross_os}kubelet-1.28
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
@@ -257,6 +261,8 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files -n %{_cross_os}kubelet-1.28-bin
 %{_cross_bindir}/kubelet

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -181,6 +181,8 @@ install -m 0644 %{S:101} image/manifest.json
 
 %tar_cf ../../../_output/local/bin/linux/%{_cross_go_arch}/kubernetes-pause.tar -C image .
 
+%cross_generate_sbom
+
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
@@ -229,6 +231,8 @@ install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
 
+%cross_install_sbom
+
 %files -n %{_cross_os}kubelet-1.29
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
@@ -257,6 +261,8 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files -n %{_cross_os}kubelet-1.29-bin
 %{_cross_bindir}/kubelet

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -182,6 +182,8 @@ install -m 0644 %{S:101} image/manifest.json
 
 %tar_cf ../../../_output/local/bin/linux/%{_cross_go_arch}/kubernetes-pause.tar -C image .
 
+%cross_generate_sbom
+
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
@@ -230,10 +232,14 @@ install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
 
+%cross_install_sbom
+
 %files -n %{_cross_os}kubelet-1.30
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -184,6 +184,8 @@ install -m 0644 %{S:101} image/manifest.json
 
 %tar_cf ../../../_output/local/bin/linux/%{_cross_go_arch}/kubernetes-pause.tar -C image .
 
+%cross_generate_sbom
+
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
@@ -232,6 +234,8 @@ install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
 
+%cross_install_sbom
+
 %files -n %{_cross_os}kubelet-1.31
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
@@ -260,6 +264,8 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files -n %{_cross_os}kubelet-1.31-bin
 %{_cross_bindir}/kubelet

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -183,6 +183,8 @@ install -m 0644 %{S:101} image/manifest.json
 
 %tar_cf ../../../_output/local/bin/linux/%{_cross_go_arch}/kubernetes-pause.tar -C image .
 
+%cross_generate_sbom
+
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
@@ -231,10 +233,14 @@ install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
 
+%cross_install_sbom
+
 %files -n %{_cross_os}kubelet-1.32
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -183,6 +183,8 @@ install -m 0644 %{S:101} image/manifest.json
 
 %tar_cf ../../../_output/local/bin/linux/%{_cross_go_arch}/kubernetes-pause.tar -C image .
 
+%cross_generate_sbom
+
 %install
 output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
@@ -231,10 +233,14 @@ install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
 
+%cross_install_sbom
+
 %files -n %{_cross_os}kubelet-1.33
 %license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_unitdir}/kubelet.service
 %{_cross_unitdir}/prepare-var-lib-kubelet.service
 %{_cross_unitdir}/etc-kubernetes-pki-private.mount

--- a/packages/libacl/libacl.spec
+++ b/packages/libacl/libacl.spec
@@ -35,13 +35,19 @@ Requires: %{name}
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
+
+%cross_install_sbom
 
 %files
 %license doc/COPYING.LGPL
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_bindir}
 %exclude %{_cross_docdir}
 %exclude %{_cross_mandir}

--- a/packages/libaio/libaio.spec
+++ b/packages/libaio/libaio.spec
@@ -27,6 +27,7 @@ Requires: %{name}
 %build
 %set_cross_build_flags
 %make_build CC="%{_cross_target}-gcc"
+%cross_generate_sbom
 
 %install
 make \
@@ -36,11 +37,14 @@ make \
   usrlibdir=%{_cross_libdir} \
   includedir=%{_cross_includedir} \
   install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/libaio.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/libaio.a

--- a/packages/libattr/libattr.spec
+++ b/packages/libattr/libattr.spec
@@ -29,13 +29,17 @@ Requires: %{name}
 %force_disable_rpath
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license doc/COPYING.LGPL
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_sysconfdir}/xattr.conf
 %exclude %{_cross_bindir}

--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -52,6 +52,7 @@ autoreconf -fi
 %force_disable_rpath
 
 %make_build
+%cross_generate_sbom
 
 %install
 make DESTDIR=%{buildroot} -C lib install
@@ -69,11 +70,15 @@ install -p -m 0644 %{S:10} %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_datadir}/audit
 install -p -m 0644 %{S:11} %{buildroot}%{_cross_datadir}/audit
 
+%cross_install_sbom
+
 
 %files
 %license COPYING COPYING.LIB
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.a

--- a/packages/libbpf/libbpf.spec
+++ b/packages/libbpf/libbpf.spec
@@ -34,14 +34,18 @@ make -s \\\
 
 %build
 %kmake -C src
+%cross_generate_sbom
 
 %install
 %kmake -C src install
+%cross_install_sbom
 
 %files
 %license LICENSE LICENSE.BSD-2-Clause LICENSE.LGPL-2.1
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.a

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -53,15 +53,19 @@ make\\\
 
 %build
 %{cross_make}
+%cross_generate_sbom
 
 %install
 %{cross_make} install
 
 chmod +x %{buildroot}%{_cross_libdir}/*.so.*
+%cross_install_sbom
 
 %files
 %license License
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_mandir}
 %exclude %{_cross_sbindir}

--- a/packages/libcrypto/libcrypto.spec
+++ b/packages/libcrypto/libcrypto.spec
@@ -84,13 +84,19 @@ Requires: %{_cross_os}libssl-devel
 
 %ninja_build
 
+%cross_generate_sbom
+
 %install
 %ninja_install
+
+%cross_install_sbom
 
 %files
 %license LICENSE NOTICE
 %{_cross_attribution_file}
 %{_cross_libdir}/libcrypto.so
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files -n %{_cross_os}libssl
 %{_cross_libdir}/libssl.so

--- a/packages/libcryptsetup/libcryptsetup.spec
+++ b/packages/libcryptsetup/libcryptsetup.spec
@@ -87,12 +87,18 @@ autoreconf -fi
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
+
+%cross_install_sbom
 
 %files
 %license COPYING COPYING.LGPL
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_libdir}/*.so.*
 %{_cross_tmpfilesdir}/cryptsetup.conf
 %exclude %{_cross_mandir}

--- a/packages/libdbus/libdbus.spec
+++ b/packages/libdbus/libdbus.spec
@@ -59,16 +59,20 @@ CONFIGURE_OPTS=(
 
 %cross_meson "${CONFIGURE_OPTS[@]}"
 %cross_meson_build
+%cross_generate_sbom
 
 %install
 %cross_meson_install
 
 rm -rf %{buildroot}%{_cross_docdir}/dbus/examples
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_datadir}/doc
 %exclude %{_cross_datadir}/xml
 

--- a/packages/libdevmapper/libdevmapper.spec
+++ b/packages/libdevmapper/libdevmapper.spec
@@ -69,15 +69,19 @@ Requires: %{name}
   %{nil}
 
 %make_build device-mapper
+%cross_generate_sbom
 
 %install
 make install_device-mapper DESTDIR=%{buildroot} INSTALL="/usr/bin/install -p"
 find %{buildroot} -type f -executable -exec chmod u+w {} +
+%cross_install_sbom
 
 %files
 %license COPYING.LIB
 %{_cross_attribution_file}
 %{_cross_libdir}/libdevmapper.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_mandir}
 
 %files devel

--- a/packages/libelf/libelf.spec
+++ b/packages/libelf/libelf.spec
@@ -39,9 +39,11 @@ Requires: %{_cross_os}libz-devel
   --disable-libdebuginfod \
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING-GPLV2 COPYING-LGPLV3
@@ -50,6 +52,8 @@ Requires: %{_cross_os}libz-devel
 %{_cross_libdir}/libelf-*.so
 %{_cross_libdir}/libdw-*.so
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_mandir}
 %exclude %{_cross_bindir}
 

--- a/packages/libexpat/libexpat.spec
+++ b/packages/libexpat/libexpat.spec
@@ -32,14 +32,18 @@ Requires: %{name}
   --without-xmlwf \
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_docdir}
 
 %files devel

--- a/packages/libffi/libffi.spec
+++ b/packages/libffi/libffi.spec
@@ -27,14 +27,18 @@ Requires: %{name}
   --disable-multi-os-directory \
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_mandir}
 
 %files devel

--- a/packages/libgcc/libgcc.spec
+++ b/packages/libgcc/libgcc.spec
@@ -29,6 +29,7 @@ cp %{_cross_licensedir}/gcc/COPYING{3,.RUNTIME} .
 %build
 install -p -m0755 %{_cross_libdir}/libgcc_s.so.1 .
 install -p -m0755 %{_cross_libdir}/libstdc++.so.6.* .
+%cross_generate_sbom
 
 %install
 mkdir -p %{buildroot}%{_cross_libdir}
@@ -37,11 +38,14 @@ install -p -m0755 libstdc++.so.6.* %{buildroot}%{_cross_libdir}
 for lib in $(find %{buildroot}%{_cross_libdir} -name 'libstdc++.so.6.*') ; do
   ln -s "${lib##*/}" %{buildroot}%{_cross_libdir}/libstdc++.so.6
 done
+%cross_install_sbom
 
 %files
 %license COPYING3 COPYING.RUNTIME
 %{_cross_attribution_file}
 %{_cross_libdir}/libgcc_s.so.1
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files -n %{_cross_os}libstdc++
 %{_cross_libdir}/libstdc++.so.6

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -53,12 +53,16 @@ CONFIGURE_OPTS=(
 
 %cross_meson "${CONFIGURE_OPTS[@]}"
 %cross_meson_build
+%cross_generate_sbom
 
 %install
 %cross_meson_install
+%cross_install_sbom
 
 %files
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_datadir}
 %exclude %{_cross_libexecdir}

--- a/packages/libinih/libinih.spec
+++ b/packages/libinih/libinih.spec
@@ -29,14 +29,18 @@ CONFIGURE_OPTS=(
 
 %cross_meson "${CONFIGURE_OPTS[@]}"
 %cross_meson_build
+%cross_generate_sbom
 
 %install
 %cross_meson_install
+%cross_install_sbom
 
 %files
 %license LICENSE.txt
 %{_cross_attribution_file}
 %{_cross_libdir}/libinih.so.0
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_pkgconfigdir}/inih.pc

--- a/packages/libisal/libisal.spec
+++ b/packages/libisal/libisal.spec
@@ -45,13 +45,19 @@ autoreconf -fi
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
+
+%cross_install_sbom
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_mandir}
 
 %files devel

--- a/packages/libiw/libiw.spec
+++ b/packages/libiw/libiw.spec
@@ -29,16 +29,22 @@ make \
   LDFLAGS="%{_cross_ldflags}" \
   BUILD_SHARED=1 \
 
+%cross_generate_sbom
+
 %install
 make \
   INSTALL_INC=%{buildroot}/%{_cross_includedir} \
   INSTALL_LIB=%{buildroot}/%{_cross_libdir} \
   install-dynamic install-hdr
 
+%cross_install_sbom
+
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.so

--- a/packages/libjson-c/libjson-c.spec
+++ b/packages/libjson-c/libjson-c.spec
@@ -37,14 +37,18 @@ Requires: %{name}
   -G Ninja
 
 cmake --build .
+%cross_generate_sbom
 
 %install
 DESTDIR="%{buildroot}" cmake --install .
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_libdir}/cmake
 
 %files devel

--- a/packages/libmnl/libmnl.spec
+++ b/packages/libmnl/libmnl.spec
@@ -29,14 +29,18 @@ Requires: %{name}
   --enable-static
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.a

--- a/packages/libncurses/libncurses.spec
+++ b/packages/libncurses/libncurses.spec
@@ -65,6 +65,8 @@ Requires: %{name}
 
 make %{?_smp_mflags} libs
 
+%cross_generate_sbom
+
 %install
 make DESTDIR=%{buildroot} install.{libs,data,includes}
 chmod 755 %{buildroot}%{_cross_libdir}/lib*.so.*.*
@@ -97,9 +99,13 @@ do
 done
 rm -rf "%{buildroot}%{_cross_datadir}/terminfo.bak"
 
+%cross_install_sbom
+
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_libdir}/lib*.so.6*
 %dir %{_cross_datadir}/terminfo
 %{_cross_datadir}/terminfo/*

--- a/packages/libnetfilter_conntrack/libnetfilter_conntrack.spec
+++ b/packages/libnetfilter_conntrack/libnetfilter_conntrack.spec
@@ -35,14 +35,18 @@ Requires: %{name}
   --enable-static
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.a

--- a/packages/libnetfilter_cthelper/libnetfilter_cthelper.spec
+++ b/packages/libnetfilter_cthelper/libnetfilter_cthelper.spec
@@ -31,14 +31,18 @@ Requires: %{name}
   --enable-static
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.a

--- a/packages/libnetfilter_cttimeout/libnetfilter_cttimeout.spec
+++ b/packages/libnetfilter_cttimeout/libnetfilter_cttimeout.spec
@@ -31,14 +31,18 @@ Requires: %{name}
   --enable-static
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.a

--- a/packages/libnetfilter_queue/libnetfilter_queue.spec
+++ b/packages/libnetfilter_queue/libnetfilter_queue.spec
@@ -33,14 +33,18 @@ Requires: %{name}
   --enable-static
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.a

--- a/packages/libnfnetlink/libnfnetlink.spec
+++ b/packages/libnfnetlink/libnfnetlink.spec
@@ -29,14 +29,18 @@ Requires: %{name}
   --enable-static
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.a

--- a/packages/libnftnl/libnftnl.spec
+++ b/packages/libnftnl/libnftnl.spec
@@ -33,14 +33,18 @@ Requires: %{name}
   --without-json-parsing \
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.a

--- a/packages/libnl/libnl.spec
+++ b/packages/libnl/libnl.spec
@@ -36,12 +36,18 @@ autoreconf -fi
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
+
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_mandir}
 %exclude %{_cross_sysconfdir}

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -65,12 +65,14 @@ export LIB_VERSION=%{version} \\\
 %build
 %set_env
 %make_build
+%cross_generate_sbom
 
 %install
 %set_env
 %make_install
 install -d %{buildroot}%{_cross_sysctldir}
 install -p -m 0644 %{S:2} %{buildroot}%{_cross_sysctldir}/90-libnvidia-container.conf
+%cross_install_sbom
 
 %files
 %license NOTICE LICENSE
@@ -81,6 +83,8 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_sysctldir}/90-libnvidia-container
 %{_cross_libdir}/libnvidia-container-go.so.*
 %{_cross_bindir}/nvidia-container-cli
 %{_cross_sysctldir}/90-libnvidia-container.conf
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_docdir}
 
 %files devel

--- a/packages/libnvme/libnvme.spec
+++ b/packages/libnvme/libnvme.spec
@@ -36,14 +36,18 @@ CONFIGURE_OPTS=(
 
 %cross_meson "${CONFIGURE_OPTS[@]}"
 %cross_meson_build
+%cross_generate_sbom
 
 %install
 %cross_meson_install
+%cross_install_sbom
 
 %files
 %license COPYING ccan/licenses/BSD-MIT ccan/licenses/CC0
 %{_cross_libdir}/*.so.*
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_includedir}/*.h

--- a/packages/libpcre/libpcre.spec
+++ b/packages/libpcre/libpcre.spec
@@ -46,13 +46,19 @@ Requires: %{name}
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
+
+%cross_install_sbom
 
 %files
 %license LICENCE
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_bindir}
 %exclude %{_cross_docdir}
 %exclude %{_cross_mandir}

--- a/packages/libpopt/libpopt.spec
+++ b/packages/libpopt/libpopt.spec
@@ -29,14 +29,18 @@ Requires: %{name}
   %{nil}
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/libpopt.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_mandir}
 
 %files devel

--- a/packages/libseccomp/libseccomp.spec
+++ b/packages/libseccomp/libseccomp.spec
@@ -30,13 +30,19 @@ Requires: %{name}
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
+
+%cross_install_sbom
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_bindir}/scmp_sys_resolver
 %exclude %{_cross_mandir}
 

--- a/packages/libselinux/libselinux.spec
+++ b/packages/libselinux/libselinux.spec
@@ -51,15 +51,19 @@ export USE_PCRE2='y' \\\
 %build
 %set_env
 %make_build
+%cross_generate_sbom
 
 %install
 %set_env
 %make_install
+%cross_install_sbom
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_mandir}
 
 %files utils

--- a/packages/libsemanage/libsemanage.spec
+++ b/packages/libsemanage/libsemanage.spec
@@ -42,15 +42,19 @@ export PREFIX='%{_cross_prefix}' \\\
 %build
 %set_env
 %make_build
+%cross_generate_sbom
 
 %install
 %set_env
 %make_install
+%cross_install_sbom
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_libexecdir}
 %exclude %{_cross_mandir}
 %exclude %{_cross_sysconfdir}

--- a/packages/libsepol/libsepol.spec
+++ b/packages/libsepol/libsepol.spec
@@ -35,15 +35,19 @@ export SHLIBDIR='%{_cross_libdir}' \\\
 %build
 %set_env
 %make_build
+%cross_generate_sbom
 
 %install
 %set_env
 %make_install
+%cross_install_sbom
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_bindir}
 %exclude %{_cross_mandir}
 

--- a/packages/libstd-rust/libstd-rust.spec
+++ b/packages/libstd-rust/libstd-rust.spec
@@ -20,14 +20,18 @@ cp /usr/share/licenses/rust/* .
 
 %build
 install -p -m0755 %{_libexecdir}/rust/lib/rustlib/%{__cargo_target}/lib/libstd-*.so .
+%cross_generate_sbom
 
 %install
 mkdir -p %{buildroot}%{_cross_libdir}
 install -p -m0755 libstd-*.so %{buildroot}%{_cross_libdir}
+%cross_install_sbom
 
 %files
 %license COPYRIGHT LICENSE-APACHE LICENSE-MIT
 %{_cross_attribution_file}
 %{_cross_libdir}/libstd-*.so
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %changelog

--- a/packages/libtirpc/libtirpc.spec
+++ b/packages/libtirpc/libtirpc.spec
@@ -28,14 +28,18 @@ Requires: %{name}
   --disable-gssapi \
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_mandir}
 %exclude %{_cross_sysconfdir}
 

--- a/packages/libtss2/libtss2.spec
+++ b/packages/libtss2/libtss2.spec
@@ -71,15 +71,21 @@ CONFIGURE_OPTS=(
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
 
 install -d %{buildroot}%{_cross_sysusersdir}
 install -p -m 0644 %{S:10} %{buildroot}%{_cross_sysusersdir}/tss.conf
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_libdir}/libtss2-esys.so.*
 %{_cross_libdir}/libtss2-rc.so.*
 %{_cross_libdir}/libtss2-mu.so.*

--- a/packages/liburcu/liburcu.spec
+++ b/packages/liburcu/liburcu.spec
@@ -34,12 +34,18 @@ autoreconf -fi
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
+
+%cross_install_sbom
 
 %files
 %license LICENSE.md lgpl-relicensing.md
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %{_cross_libdir}/liburcu.so.8*
 %{_cross_libdir}/liburcu-common.so.8*

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -36,13 +36,17 @@ Requires: %{name}
   --with-pkgconfigdir=%{_cross_pkgconfigdir} \
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license LICENSING COPYING.LIB
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_mandir}
 

--- a/packages/libz/libz.spec
+++ b/packages/libz/libz.spec
@@ -35,16 +35,20 @@ export CROSS_PREFIX="%{_cross_target}-" \\\
   --without-new-strategies \
   --zlib-compat
 %make_build
+%cross_generate_sbom
 
 %install
 %set_env
 %make_install
+%cross_install_sbom
 
 %files
 %license LICENSE.md
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
 %exclude %{_cross_mandir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/*.so

--- a/packages/libzstd/libzstd.spec
+++ b/packages/libzstd/libzstd.spec
@@ -34,15 +34,19 @@ export DESTDIR=%{buildroot}%{_cross_rootdir} \\\
 %build
 %set_env
 %make_build
+%cross_generate_sbom
 
 %install
 %set_env
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_libdir}/*.so.*
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_bindir}
 %exclude %{_cross_mandir}
 

--- a/packages/login/login.spec
+++ b/packages/login/login.spec
@@ -20,6 +20,7 @@ Source1: getty.drop-in.conf
 %prep
 
 %build
+%cross_generate_sbom
 
 %install
 install -d %{buildroot}%{_cross_bindir}
@@ -31,9 +32,13 @@ ln -s ../bin/login %{buildroot}%{_cross_sbindir}/sulogin
 install -d %{buildroot}%{_cross_unitdir}/getty.target.d
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}/getty.target.d/001-login.conf
 
+%cross_install_sbom
+
 %files
 %{_cross_bindir}/login
 %{_cross_sbindir}/sulogin
 %{_cross_unitdir}/getty.target.d/001-login.conf
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %changelog

--- a/packages/makedumpfile/makedumpfile.spec
+++ b/packages/makedumpfile/makedumpfile.spec
@@ -36,15 +36,19 @@ export USESNAPPY="off" \\\
 %build
 %set_env
 %make_build
+%cross_generate_sbom
 
 %install
 %set_env
 make install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_sbindir}/makedumpfile
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_mandir}
 %exclude %{_cross_sbindir}/makedumpfile-R.pl
 %exclude %{_cross_prefix}/share/makedumpfile

--- a/packages/mdadm/mdadm.spec
+++ b/packages/mdadm/mdadm.spec
@@ -26,6 +26,7 @@ CXFLAGS="%{_cross_cflags} -DNO_COROSYNC -DNO_DLM" \
 %build
 %set_env
 make LDFLAGS="%{_cross_ldflags}"
+%cross_generate_sbom
 
 %install
 %set_env
@@ -35,10 +36,13 @@ make install-systemd DESTDIR= SYSTEMD_DIR=%{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:100} %{buildroot}%{_cross_tmpfilesdir}/mdadm.conf
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %{_cross_sbindir}/mdadm
 %{_cross_sbindir}/mdmon

--- a/packages/netdog/netdog.spec
+++ b/packages/netdog/netdog.spec
@@ -77,6 +77,8 @@ echo "** Build Netdog Binaries"
     --features wicked \
     --target-dir=${HOME}/.cache/wicked
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_libexecdir}/hostname-detectors
 install -p -m 0755 ${HOME}/.cache/dogtag/%{__cargo_target}/release/20-imds %{buildroot}%{_cross_libexecdir}/hostname-detectors/20-imds
@@ -96,6 +98,8 @@ install -d %{buildroot}%{_cross_libdir}
 install -d %{buildroot}%{_cross_libdir}/systemd/resolved.conf.d
 install -p -m 0644 %{S:20} %{buildroot}%{_cross_libdir}/systemd/resolved.conf.d
 
+%cross_install_sbom
+
 %post wicked -p <lua>
 posix.symlink("netdog-wicked", "%{_cross_bindir}/netdog")
 
@@ -107,6 +111,8 @@ posix.symlink("netdog-systemd-networkd", "%{_cross_bindir}/netdog")
 %{_cross_unitdir}/generate-network-config.service
 %{_cross_unitdir}/disable-udp-offload.service
 %{_cross_unitdir}/run-netdog.mount
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files -n %{_cross_os}hostname-reverse-dns
 %{_cross_libexecdir}/hostname-detectors/10-reverse-dns

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -67,6 +67,8 @@ go build -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime ./cmd/nvidia-contai
 go build -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime.cdi ./cmd/nvidia-container-runtime.cdi
 go build -ldflags="${GOLDFLAGS}" -o nvidia-container-runtime.legacy ./cmd/nvidia-container-runtime.legacy
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -d %{buildroot}%{_cross_tmpfilesdir}
@@ -90,9 +92,13 @@ install -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/nvidia-container-toolki
 install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/nvidia-container-runtime/
 install -m 0644 %{S:7} %{buildroot}%{_cross_unitdir}/
 
+%cross_install_sbom
+
 %files
 %license LICENSE
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/nvidia-container-runtime-hook
 %{_cross_bindir}/nvidia-ctk
 %{_cross_bindir}/nvidia-cdi-hook

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -58,6 +58,8 @@ export GOLDFLAGS="-compressdwarf=false -linkmode=external -extldflags '${CGO_LDF
 go build -ldflags="${GOLDFLAGS}" -o nvidia-device-plugin ./cmd/nvidia-device-plugin/
 gofips build -ldflags="${GOLDFLAGS}" -o fips/nvidia-device-plugin ./cmd/nvidia-device-plugin/
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 nvidia-device-plugin %{buildroot}%{_cross_bindir}
@@ -72,10 +74,14 @@ install -D -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-pl
 install -D -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-exec-start-conf
 install -D -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-mig-conf
 
+%cross_install_sbom
+
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_unitdir}/nvidia-k8s-device-plugin.service
 %dir %{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
 %{_cross_templatedir}/nvidia-k8s-device-plugin-conf

--- a/packages/nvme-cli/nvme-cli.spec
+++ b/packages/nvme-cli/nvme-cli.spec
@@ -29,17 +29,21 @@ CONFIGURE_OPTS=(
 
 %cross_meson "${CONFIGURE_OPTS[@]}"
 %cross_meson_build
+%cross_generate_sbom
 
 %install
 %cross_meson_install
 # This is an empty configuration file with comments with examples of how to
 # configure the systemd services
 rm %{buildroot}%{_sysconfdir}/nvme/discovery.conf
+%cross_install_sbom
 
 %files
 %license LICENSE ccan/licenses/LGPL-2.1 ccan/licenses/BSD-MIT ccan/licenses/CC0
 %{_cross_attribution_file}
 %{_cross_sbindir}/nvme
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_udevrulesdir}
 %exclude %{_cross_unitdir}
 %exclude %{_cross_datadir}

--- a/packages/open-vm-tools/open-vm-tools.spec
+++ b/packages/open-vm-tools/open-vm-tools.spec
@@ -67,6 +67,8 @@ autoreconf -fi
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
 
@@ -79,9 +81,13 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/v
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:3} %{buildroot}%{_cross_tmpfilesdir}/open-vm-tools.conf
 
+%cross_install_sbom
+
 %files
 %license COPYING LICENSE
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/vmtoolsd
 %{_cross_bindir}/vmware-toolbox-cmd
 %{_cross_unitdir}/vmtoolsd.service

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -589,6 +589,8 @@ if [ "${aws_sdk_rc}" -ne 0 ]; then
    exit "${aws_sdk_rc}"
 fi
 
+%cross_generate_sbom
+
 
 %install
 install -d %{buildroot}%{_cross_bindir}
@@ -735,11 +737,15 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_udevrulesdir}/82-supplemental-s
 install -d %{buildroot}%{_cross_licensedir}
 install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 
+%cross_install_sbom
+
 %files
 %{_cross_attribution_vendor_dir}
 %{_cross_licensedir}/COPYRIGHT
 %{_cross_licensedir}/LICENSE-MIT
 %{_cross_licensedir}/LICENSE-APACHE
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files -n %{_cross_os}apiserver
 %{_cross_bindir}/apiserver

--- a/packages/pciutils/pciutils.spec
+++ b/packages/pciutils/pciutils.spec
@@ -34,15 +34,19 @@ make\\\
 
 %build
 %pciutils_make
+%cross_generate_sbom
 
 %install
 %pciutils_make install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_bindir}/lspci
 %{_cross_datadir}/pci.ids
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_sbindir}/pcilmr
 %exclude %{_cross_sbindir}/setpci
 %exclude %{_cross_sbindir}/update-pciids

--- a/packages/pigz/pigz.spec
+++ b/packages/pigz/pigz.spec
@@ -26,14 +26,18 @@ export CC=%{_cross_target}-gcc \\\
 %build
 %set_env
 %make_build CC="${CC}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+%cross_generate_sbom
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 unpigz %{buildroot}%{_cross_bindir}
+%cross_install_sbom
 
 %files
 %license README zopfli/COPYING
 %{_cross_bindir}/unpigz
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %changelog

--- a/packages/policycoreutils/policycoreutils.spec
+++ b/packages/policycoreutils/policycoreutils.spec
@@ -38,6 +38,7 @@ export LOCALEDIR='%{_cross_localedir}' \\\
 for dir in load_policy semodule sestatus setfiles ; do
   %make_build -C ${dir}
 done
+%cross_generate_sbom
 
 %install
 %set_env
@@ -46,10 +47,13 @@ for dir in load_policy semodule sestatus setfiles ; do
 done
 # remove unneeded compatibility symlink
 rm %{buildroot}%{_cross_sbindir}/sestatus
+%cross_install_sbom
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_sbindir}/load_policy
 %{_cross_sbindir}/semodule
 %{_cross_bindir}/sestatus

--- a/packages/procps/procps.spec
+++ b/packages/procps/procps.spec
@@ -45,6 +45,8 @@ Requires: %{name}
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
 
@@ -64,9 +66,13 @@ for a in ${!aliases[*]} ; do
 done
 popd
 
+%cross_install_sbom
+
 %files
 %license COPYING COPYING.LIB
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/free
 %{_cross_bindir}/pgrep
 %{_cross_bindir}/pidof

--- a/packages/rdma-core/rdma-core.spec
+++ b/packages/rdma-core/rdma-core.spec
@@ -42,6 +42,8 @@ Requires: %{name}
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
 
@@ -54,9 +56,13 @@ install -p %{buildroot}%{_cross_sysconfdir}/libibverbs.d/efa.driver %{buildroot}
 install -d %{buildroot}%{_cross_datadir}/logdog.d
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_datadir}/logdog.d
 
+%cross_install_sbom
+
 %files
 %license COPYING.md COPYING.BSD_MIT ccan/LICENSE.MIT
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_datadir}/logdog.d/logdog.rdma.conf
 %{_cross_tmpfilesdir}/rdma-core.conf
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/libibverbs.d

--- a/packages/readline/readline.spec
+++ b/packages/readline/readline.spec
@@ -29,14 +29,18 @@ Requires: %{name}
 %build
 %cross_configure --with-curses --disable-install-examples
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
 %{_cross_libdir}/*.so.*
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %exclude %{_cross_infodir}
 %exclude %{_cross_mandir}
 %exclude %{_cross_datadir}/doc/readline/*

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -152,6 +152,7 @@ Requires: %{_cross_os}libkcapi
 %prep
 
 %build
+%cross_generate_sbom
 
 %install
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
@@ -271,6 +272,8 @@ install -p -m 0644 %{S:1500} %{buildroot}%{_cross_bootconfigdir}/10-fips.conf
 
 ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 
+%cross_install_sbom
+
 %files
 %{_cross_factorydir}%{_cross_sysconfdir}/nsswitch.conf
 %{_cross_sysctldir}/80-release.conf
@@ -342,6 +345,8 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_templatedir}/log4j-hotpatch-enabled
 %{_cross_udevrulesdir}/61-mount-cdrom.rules
 %{_cross_datadir}/logdog.d/logdog.common.conf
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files fips
 %{_cross_bootconfigdir}/10-fips.conf

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -67,6 +67,8 @@ BUILD_ARGS=(
 go build "${BUILD_ARGS[@]}" -o bin/runc .
 gofips build "${BUILD_ARGS[@]}" -o fips/bin/runc .
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 bin/runc %{buildroot}%{_cross_bindir}
@@ -76,10 +78,14 @@ install -p -m 0755 fips/bin/runc %{buildroot}%{_cross_fips_bindir}
 
 %cross_scan_attribution go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE NOTICE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_bindir}/runc

--- a/packages/selinux-policy/selinux-policy.spec
+++ b/packages/selinux-policy/selinux-policy.spec
@@ -51,6 +51,7 @@ cp -p \
 %build
 %{_sourcedir}/catgen.sh > category.cil
 secilc --policyvers=31 *.cil
+%cross_generate_sbom
 
 %install
 poldir="%{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/selinux"
@@ -78,6 +79,8 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_unitdir}/selinux-policy-files.s
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:103} %{buildroot}%{_cross_tmpfilesdir}/selinux-policy.conf
 
+%cross_install_sbom
+
 %files
 %{_cross_factorydir}%{_cross_sysconfdir}/selinux/config
 %{_cross_factorydir}%{_cross_sysconfdir}/selinux/%{policytype}/contexts/files/file_contexts
@@ -87,5 +90,7 @@ install -p -m 0644 %{S:103} %{buildroot}%{_cross_tmpfilesdir}/selinux-policy.con
 %{_cross_sysconfdir}/selinux
 %{_cross_tmpfilesdir}/selinux-policy.conf
 %{_cross_unitdir}/selinux-policy-files.service
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %changelog

--- a/packages/socat/socat.spec
+++ b/packages/socat/socat.spec
@@ -67,12 +67,18 @@ BuildRequires: %{_cross_os}glibc-devel
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
+
+%cross_install_sbom
 
 %files
 %license COPYING
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/socat
 %{_cross_bindir}/socat1
 %exclude %{_cross_bindir}/filan

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -59,6 +59,8 @@ go build -C cmd -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}" -o "../out/
 gofips build -C cmd -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}" -o "../out/fips/soci-snapshotter-grpc" ./soci-snapshotter-grpc
 gofips build -C cmd -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}" -o "../out/fips/soci" ./soci
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -d %{buildroot}%{_cross_fips_bindir}
@@ -72,12 +74,16 @@ install -D -p -m 0644 %{S:102} %{buildroot}%{_cross_unitdir}
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
+%cross_install_sbom
+
 %files
 %license LICENSE NOTICE.md
 %{_cross_unitdir}/soci-snapshotter.service
 %{_cross_unitdir}/soci-snapshotter.socket
 %{_cross_attribution_vendor_dir}
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files bin
 %{_cross_bindir}/soci-snapshotter-grpc

--- a/packages/static-pods/static-pods.spec
+++ b/packages/static-pods/static-pods.spec
@@ -27,6 +27,8 @@ echo "** Compile static-pods agent"
 %cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
     -p static-pods
 
+%cross_generate_sbom
+
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/static-pods %{buildroot}%{_cross_bindir}
@@ -34,6 +36,10 @@ install -p -m 0755 ${HOME}/.cache/%{__cargo_target}/release/static-pods %{buildr
 install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:0} %{buildroot}%{_cross_templatedir}
 
+%cross_install_sbom
+
 %files
 %{_cross_bindir}/static-pods
 %{_cross_templatedir}/static-pods-toml
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -21,13 +21,17 @@ BuildRequires: %{_cross_os}glibc-devel
   --disable-mpers \
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license COPYING LGPL-2.1-or-later
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/strace
 %exclude %{_cross_bindir}/strace-log-merge
 %exclude %{_cross_mandir}/*

--- a/packages/systemd/systemd.spec
+++ b/packages/systemd/systemd.spec
@@ -317,6 +317,8 @@ CONFIGURE_OPTS=(
 %cross_meson "${CONFIGURE_OPTS[@]}"
 %cross_meson_build
 
+%cross_generate_sbom
+
 %install
 %cross_meson_install
 
@@ -358,9 +360,13 @@ install -p -m 0644 %{S:4} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/i
 # Remove any README files.
 find %{buildroot} -type f -name README -print -delete
 
+%cross_install_sbom
+
 %files
 %license LICENSE.GPL2 LICENSE.LGPL2.1
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/busctl
 %{_cross_bindir}/journalctl
 %{_cross_bindir}/systemctl

--- a/packages/tpm2-tools/tpm2-tools.spec
+++ b/packages/tpm2-tools/tpm2-tools.spec
@@ -39,13 +39,17 @@ CONFIGURE_OPTS=(
 %cross_configure "${CONFIGURE_OPTS[@]}"
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
+%cross_install_sbom
 
 %files
 %license docs/LICENSE
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/tpm2
 %{_cross_bindir}/tpm2_activatecredential
 %{_cross_bindir}/tpm2_certify

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -138,6 +138,8 @@ cp Documentation/licenses/COPYING.* .
 
 %make_build
 
+%cross_generate_sbom
+
 %install
 %make_install
 
@@ -162,9 +164,13 @@ for lib in libuuid; do
     cp -a COPYING.BSD-3-Clause %{buildroot}%{_cross_licensedir}/${lib}
 done
 
+%cross_install_sbom
+
 %files
 %license COPYING.BSD-3-Clause COPYING.BSD-4-Clause-UC COPYING.GPL-2.0-or-later COPYING.LGPL-2.1-or-later
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_bindir}/chmem
 %{_cross_bindir}/choom
 %{_cross_bindir}/chrt

--- a/packages/wicked/wicked.spec
+++ b/packages/wicked/wicked.spec
@@ -91,6 +91,7 @@ autoreconf -fi
 %force_disable_rpath
 
 %make_build
+%cross_generate_sbom
 
 %install
 %make_install
@@ -116,6 +117,8 @@ install -p -m 0644 %{S:99} %{buildroot}%{_cross_datadir}/wicked/schema/constants
 # install logdog configuration file
 install -d %{buildroot}%{_cross_datadir}/logdog.d
 install -p -m 0644 %{S:30} %{buildroot}%{_cross_datadir}/logdog.d
+
+%cross_install_sbom
 
 %files
 %license COPYING
@@ -155,6 +158,8 @@ install -p -m 0644 %{S:30} %{buildroot}%{_cross_datadir}/logdog.d
 %{_cross_factorydir}%{_cross_sysconfdir}/wicked/server.xml
 %{_cross_tmpfilesdir}/wicked.conf
 %{_cross_datadir}/logdog.d/logdog.wicked.conf
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 
 %files devel
 %{_cross_libdir}/libwicked.so

--- a/packages/xfsprogs/xfsprogs.spec
+++ b/packages/xfsprogs/xfsprogs.spec
@@ -40,16 +40,20 @@ Requires: %{name}
   --enable-scrub=no
 
 %make_build
+%cross_generate_sbom
 
 %install
 make DIST_ROOT=%{buildroot} install install-dev \
   PKG_ROOT_SBIN_DIR=%{_cross_sbindir} PKG_ROOT_LIB_DIR=%{_cross_libdir}
 
 rm -f %{buildroot}/%{_cross_libdir}/*.{la,a}
+%cross_install_sbom
 
 %files
 %license LICENSES/GPL-2.0 LICENSES/LGPL-2.1
 %{_cross_attribution_file}
+%{_cross_sbom_package_dir}/%{name}-spdx.json
+%{_cross_sbom_package_dir}/%{name}-cyclonedx.json
 %{_cross_libdir}/*.so.*
 %{_cross_sbindir}/mkfs.xfs
 %{_cross_sbindir}/xfs_copy


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
Adds macros required to generate SBOMs to each package in the core kit. Must not be merged until the updated SDK containing the new macro is also merged.


**Testing done:**
ran `make` locally and validated the presence of the new SBOM files.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
