### PR TITLE
packages: update kmod to v34.2

### DIFF
--- a/packages/kmod/0001-meson-add-support-for-static-builds.patch
+++ b/packages/kmod/0001-meson-add-support-for-static-builds.patch
@@ -1,0 +1,34 @@
+From b5d3e27e19101712bab37695283c2d8bc3960b28 Mon Sep 17 00:00:00 2001
+From: Piyush Jena <jepiyush@amazon.com>
+Date: Tue, 8 Jul 2025 22:11:12 +0000
+Subject: [PATCH] meson: add support for static builds
+
+Signed-off-by: Piyush Jena <jepiyush@amazon.com>
+---
+ meson.build | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index a0cf675..4b16d6a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -465,10 +465,16 @@ kmod_sources = files(
+   'tools/static-nodes.c',
+ )
+ 
++kmod_link_args = []
++if get_option('default_library') == 'static'
++  kmod_link_args += ['-static']
++endif
++
+ kmod = executable(
+   'kmod',
+   kmod_sources,
+   link_with : [libshared, libkmod_internal],
++  link_args : kmod_link_args,
+   gnu_symbol_visibility : 'hidden',
+   build_by_default : get_option('tools'),
+   install : get_option('tools'),
+-- 
+2.47.1
+

--- a/packages/kmod/0002-meson-create-pkgconfig-files-in-default-path.patch
+++ b/packages/kmod/0002-meson-create-pkgconfig-files-in-default-path.patch
@@ -1,0 +1,25 @@
+From ade8d073f25fd5bbf2ceb2077dec0dd442672144 Mon Sep 17 00:00:00 2001
+From: Piyush Jena <jepiyush@amazon.com>
+Date: Tue, 8 Jul 2025 22:12:47 +0000
+Subject: [PATCH] meson: create pkgconfig files in default path
+
+Signed-off-by: Piyush Jena <jepiyush@amazon.com>
+---
+ meson.build | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 4b16d6a..3b59d5e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -501,7 +501,6 @@ endif
+ pkg.generate(
+   name : 'kmod',
+   description : 'Tools to deal with kernel modules',
+-  install_dir : datadir / 'pkgconfig',
+   unescaped_variables : _kmod_unescaped_variables,
+   variables : _kmod_variables,
+ )
+-- 
+2.47.1
+

--- a/packages/kmod/Cargo.toml
+++ b/packages/kmod/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://www.kernel.org/pub/linux/utils/kernel/kmod"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-33.tar.xz"
-sha512 = "32d79d0bb7e89012f18458d4e88325f8e19a7dba6e1d5cff01aec3e618d1757b0f7c119735bf38d02e0d056a14273fd7522fca7c61a4d12a3ea5854bb662fff8"
+url = "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-34.2.tar.xz"
+sha512 = "0e095c45ad61a6c61ce1ad61b9aa10cf5040e688b749f9a933b0e7d12de493c58027a5068b459cbbce05576fc564a22b83a3dbef1e6511b2a3e27034c88afd33"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-33.tar.sign"
-sha512 = "f84dc40fa1ba7ce858746f1ba9f1da79004c842d6745e9c9777018bea1cfca35e5627f025d320533f822fc61539f6f168d1f000809156d558cc58293a786acb5"
+url = "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-34.2.tar.sign"
+sha512 = "96120097a4e32dd578a9e39b33b78248b4b9e0b56fe5eae8da471942a77ea7e1bf0174b72c550fdcfece3f5f6423436dfc9ca0c9b63acc27abb6c026b616fcc8"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kmod/kmod.spec
+++ b/packages/kmod/kmod.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}kmod
-Version: 33
+Version: 34.2
 Release: 1%{?dist}
 Summary: Tools for kernel module loading and unloading
 License: GPL-2.0-or-later AND LGPL-2.1-or-later
@@ -7,6 +7,8 @@ URL: http://git.kernel.org/?p=utils/kernel/kmod/kmod.git;a=summary
 Source0: https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-%{version}.tar.xz
 Source1: https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-%{version}.tar.sign
 Source2: gpgkey-EAB33C9690013C733916AC839BA2A5A630CBEA53.asc
+Patch1001: 0001-meson-add-support-for-static-builds.patch
+Patch1002: 0002-meson-create-pkgconfig-files-in-default-path.patch
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libz-devel
 BuildRequires: %{_cross_os}libzstd-devel
@@ -19,6 +21,8 @@ Requires: %{_cross_os}libzstd
 %package devel
 Summary: Files for development using the tools for kernel module loading and unloading
 Requires: %{name}
+Requires: %{_cross_os}libz-devel
+Requires: %{_cross_os}libzstd-devel
 
 %description devel
 %{summary}.
@@ -30,43 +34,42 @@ cp COPYING COPYING.LGPL
 cp tools/COPYING COPYING.GPL
 
 %build
+CONFIGURE_OPTS=(
+  -Dzlib=enabled
+  -Dzstd=enabled
+  -Dopenssl=disabled
+  -Dmanpages=false
+  -Dxz=disabled
+  -Dfishcompletiondir=no
+  -Dbashcompletiondir=no
+  -Dzshcompletiondir=no
+)
 
-%define _configure ../configure
-
-mkdir static-build
-pushd static-build
-%cross_configure \
-  --with-noarch-pkgconfigdir=%{_cross_pkgconfigdir} \
-  --with-zlib \
-  --with-zstd \
-  --without-openssl \
-  --disable-manpages
-
-%make_build LDFLAGS="-all-static"
-
-popd
-
+%global _cross_vpath_builddir dynamic-build
 mkdir dynamic-build
-pushd dynamic-build
+%cross_meson \
+  --sbindir=%{_cross_bindir} \
+  "${CONFIGURE_OPTS[@]}"
+%cross_meson_build
 
-%cross_configure \
-  --with-noarch-pkgconfigdir=%{_cross_pkgconfigdir} \
-  --with-zlib \
-  --with-zstd \
-  --without-openssl \
-  --disable-manpages
-
-%make_build
-
-popd
+%global _cross_vpath_builddir static-build
+mkdir static-build
+%{cross_meson} \
+  --default-library=static \
+  --sbindir=%{_cross_bindir} \
+  --prefer-static \
+  "${CONFIGURE_OPTS[@]}"
+export LDFLAGS="-all-static"
+%cross_meson_build
 
 %install
 pushd dynamic-build
-%make_install
+%ninja_install
 popd
 
 pushd static-build
-install -p tools/kmod %{buildroot}%{_cross_bindir}
+install -d %{buildroot}%{_cross_bindir}
+install -p kmod %{buildroot}%{_cross_bindir}
 
 install -d %{buildroot}%{_cross_sbindir}
 ln -s ../bin/kmod %{buildroot}%{_cross_sbindir}/modprobe
@@ -84,7 +87,6 @@ popd
 %{_cross_bindir}/rmmod
 %{_cross_sbindir}/modprobe
 %{_cross_libdir}/*.so.*
-%exclude %{_cross_datadir}/bash-completion
 
 %files devel
 %{_cross_libdir}/*.so


### PR DESCRIPTION
**Description of changes:**
1. Updates `kmod` package to v34.2.
2. Modify spec file to support `meson` build.
  - The first patch adds support for static builds.
  - The second patch creates the pkgconfig files in `/usr/lib/pkgconfig` instead of `/usr/share/pkgconfig`

**Testing done:**
1. `aws-dev` and `vmware-dev` instances boot.
2. Made sure that kmod is statically linked
```
  #12 9.747 + readelf -d /home/builder/rpmbuild/BUILD/bottlerocket-kmod-34.2-build/BUILDROOT/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/kmod
  #12 9.747 ~/rpmbuild/BUILD/bottlerocket-kmod-34.2-build/kmod-34.2
  #12 9.753 
  #12 9.753 There is no dynamic section in this file.
  #12 9.754 + exit 1
```
    

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
