### PR TITLE
Pass proxy environment variables down to bootstrap containers

### DIFF
--- a/packages/os/bootstrap-containers@.service
+++ b/packages/os/bootstrap-containers@.service
@@ -13,6 +13,7 @@ ConditionPathExists=!/run/bootstrap-containers/%i.ran
 
 [Service]
 Type=oneshot
+EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/bootstrap-containers/%i.env
 # Create a sentinel file to mark that we've run
 ExecStart=/usr/bin/touch /run/bootstrap-containers/%i.ran


### PR DESCRIPTION
**Issue number:**

bottlerocket-os/bottlerocket#4575

**Description of changes:**
This change makes the bootstrap containers systemd services read proxy environment variables so they are used for bootstrap container operations such as image pulls.

This change is identical to the changes in https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/9bbf6220d8163c4b13c7e9a3ac7bc8b2b9c856c6.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
