### PR TITLE
packages: update soci-snapshotter to v0.11.1

### DIFF
--- a/packages/soci-snapshotter/Cargo.toml
+++ b/packages/soci-snapshotter/Cargo.toml
@@ -12,15 +12,15 @@ path = "../packages.rs"
 releases-url = "https://github.com/awslabs/soci-snapshotter/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.9.0.tar.gz"
-sha512 = "3f196e20d300ecb585b57810caa19fd7dd715a7215ba2e7e3c49d769bd662b65c40c291e7cd782b53e0203bbbfd20b0238bcf38bf67b19c0fe350ac14843c53c"
-bundle-root-path = "soci-snapshotter-0.9.0/cmd"
+url = "https://github.com/awslabs/soci-snapshotter/archive/v0.11.1/soci-snapshotter-0.11.1.tar.gz"
+sha512 = "f42bf8bf1121cce918ed9cfab542d81e2ee5562fe42ef2d4806b7cf78da2e3e15f830eb86fc1dbc17fc0f1f2566723a4db3feadb473e66c06f2f5bbf21f69588"
+bundle-root-path = "soci-snapshotter-0.11.1/cmd"
 bundle-output-path = "bundled-cmd.tar.gz"
 bundle-modules = [ "go" ]
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v0.9.0.tar.gz"
-sha512 = "3f196e20d300ecb585b57810caa19fd7dd715a7215ba2e7e3c49d769bd662b65c40c291e7cd782b53e0203bbbfd20b0238bcf38bf67b19c0fe350ac14843c53c"
+url = "https://github.com/awslabs/soci-snapshotter/archive/v0.11.1/soci-snapshotter-0.11.1.tar.gz"
+sha512 = "f42bf8bf1121cce918ed9cfab542d81e2ee5562fe42ef2d4806b7cf78da2e3e15f830eb86fc1dbc17fc0f1f2566723a4db3feadb473e66c06f2f5bbf21f69588"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -1,7 +1,7 @@
 %global gorepo soci-snapshotter
-%global gover 0.9.0
+%global gover 0.11.1
 %global rpmver %{gover}
-%global gitrev 737f61a3db40c386f997c1f126344158aa3ad43c
+%global gitrev 28781de6731978b2e2f0f43573a345e9fa14dbd1
 
 Name: %{_cross_os}soci-snapshotter
 Version: %{gover}
@@ -10,8 +10,8 @@ Epoch: 1
 Summary: A containerd snapshotter plugin which enables lazy loading for OCI images.
 License: Apache-2.0
 URL: https://github.com/awslabs/soci-snapshotter
-Source0: https://github.com/awslabs/soci-snapshotter/archive/refs/tags/v%{gover}.tar.gz
-Source1: bundled-v%{gover}.tar.gz
+Source0: https://github.com/awslabs/soci-snapshotter/archive/v%{gover}/soci-snapshotter-%{gover}.tar.gz
+Source1: bundled-soci-snapshotter-%{gover}.tar.gz
 Source2: bundled-cmd.tar.gz
 Source101: soci-snapshotter.service
 Source102: soci-snapshotter.socket


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related https://github.com/bottlerocket-os/bottlerocket/issues/4578

**Description of changes:**

Update soci-snapshotter to v0.11.1

**Testing done:**
```
bash-5.1# soci-snapshotter-grpc --version
soci-snapshotter-grpc version v0.11.1+bottlerocket 28781de6731978b2e2f0f43573a345e9fa14dbd1
```

Built an `aws-dev` AMI with containerd configured to use SOCI as a proxy plugin:

```
bash-5.1# tail -n 5 /etc/containerd/config.toml

[proxy_plugins]
  [proxy_plugins.soci]
    type = "snapshot"
    address = "/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"
```

Pulled example image and confirm snapshots managed by soci:

```
bash-5.1# ctr i pull --snapshotter=soci public.ecr.aws/soci-workshop-examples/ffmpeg:latest

bash-5.1# ls /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/
1  10  11  2  3  4  5  6  7  8  9
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
