### PR TITLE
kubernetes-1.33: Enable DynamicResourceAllocation

### DIFF
--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -207,3 +207,5 @@ memorySwap:
 {{#if settings.kubernetes.single-process-oom-kill}}
 singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
 {{/if}}
+featureGates:
+  DynamicResourceAllocation: true


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/566

**Description of changes:**
EKS has enabled DynamicResourceAllocation for 1.33 and later. This allows Bottlerocket to use DynamicResourceAllocation with ResourceClaims.



**Testing done:**
I build an `aws-k8s-1.33-nvidia` image with this change. 

The validation from https://github.com/kubernetes-sigs/dra-example-driver 

<details>

```
$ kubectl get resourceslice -o yaml
apiVersion: v1
items:
- apiVersion: resource.k8s.io/v1beta1
  kind: ResourceSlice
  metadata:
    creationTimestamp: "2025-07-08T03:27:28Z"
    generateName: ip-192-168-14-244.us-west-2.compute.internal-gpu.example.com-
    generation: 4
    name: ip-192-168-14-244.us-west-2.compute.internal-gpu.example.chk2kl
    ownerReferences:
    - apiVersion: v1
      controller: true
      kind: Node
      name: ip-192-168-14-244.us-west-2.compute.internal
      uid: 59be42b8-1bdc-43cd-9e94-3359fae51576
    resourceVersion: "44608"
    uid: c783b6ce-6ae2-4866-b1a6-40de3a53d6af
  spec:
    devices:
    - basic:
        attributes:
          driverVersion:
            version: 1.0.0
          index:
            int: 4
          model:
            string: LATEST-GPU-MODEL
          uuid:
            string: gpu-a187d9ba-63e4-b674-1de4-42d1a4d73a01
        capacity:
          memory:
            value: 80Gi
      name: gpu-4
    - basic:
        attributes:
          driverVersion:
            version: 1.0.0
          index:
            int: 8
          model:
            string: LATEST-GPU-MODEL
          uuid:
            string: gpu-70426ebe-864a-56d0-ccb9-9c86fb290a52
        capacity:
          memory:
            value: 80Gi
      name: gpu-8
    - basic:
        attributes:
          driverVersion:
            version: 1.0.0
          index:
            int: 5
          model:
            string: LATEST-GPU-MODEL
          uuid:
            string: gpu-b851546f-1079-2930-1c2d-02628c0c88f1
        capacity:
        attributes:
          driverVersion:
            version: 1.0.0
          index:
            int: 3
          model:
            string: LATEST-GPU-MODEL
          uuid:
            string: gpu-639cee7e-5d7c-3342-cf17-3010be70ecd0
        capacity:
          memory:
            value: 80Gi
      name: gpu-3
    - basic:
        attributes:
          driverVersion:
            version: 1.0.0
          index:
            int: 5
          model:
            string: LATEST-GPU-MODEL
          uuid:
            string: gpu-e2e51e4b-a626-04a4-7a91-81d060be8b25
        capacity:
          memory:
            value: 80Gi
      name: gpu-5
    - basic:
        attributes:
          driverVersion:
            version: 1.0.0
          index:
            int: 7
          model:
            string: LATEST-GPU-MODEL
          uuid:
            string: gpu-cf0d3f02-23f8-de95-a3ff-140230bdb8a5
        capacity:
          memory:
            value: 80Gi
      name: gpu-7
    - basic:
        attributes:
          driverVersion:
            version: 1.0.0
          index:
            int: 8
          model:
            string: LATEST-GPU-MODEL
          uuid:
            string: gpu-876d14dd-1b37-8dee-65cc-65de7cbd4049
        capacity:
          memory:
            value: 80Gi
      name: gpu-8
    driver: gpu.example.com
    nodeName: ip-192-168-67-33.us-west-2.compute.internal
    pool:
      generation: 1
      name: ip-192-168-67-33.us-west-2.compute.internal
      resourceSliceCount: 1
kind: List
metadata:
  resourceVersion: ""

$ kubectl apply --filename=demo/gpu-test{1,2,3,4,5}.yaml
namespace/gpu-test1 created
resourceclaimtemplate.resource.k8s.io/single-gpu created
pod/pod0 created
pod/pod1 created
namespace/gpu-test2 created
resourceclaimtemplate.resource.k8s.io/multiple-gpus created
pod/pod0 created
namespace/gpu-test3 created
resourceclaimtemplate.resource.k8s.io/single-gpu created
pod/pod0 created
namespace/gpu-test4 created
resourceclaim.resource.k8s.io/single-gpu created
pod/pod0 created
pod/pod1 created
namespace/gpu-test5 created
resourceclaimtemplate.resource.k8s.io/multiple-gpus created
pod/pod0 created

$ kubectl get pod -A
NAMESPACE            NAME                                       READY   STATUS    RESTARTS   AGE
amazon-guardduty     aws-guardduty-agent-5lkzp                  1/1     Running   0          18m
amazon-guardduty     aws-guardduty-agent-6xp6q                  1/1     Running   0          18m
amazon-guardduty     aws-guardduty-agent-7db65                  1/1     Running   0          4h16m
amazon-guardduty     aws-guardduty-agent-psccp                  1/1     Running   0          4h16m
cert-manager         cert-manager-7774cff9f9-6p9sw              1/1     Running   0          38m
cert-manager         cert-manager-cainjector-5594979f8b-4wsr6   1/1     Running   0          38m
cert-manager         cert-manager-webhook-5645b4cfd5-c8rw6      1/1     Running   0          38m
dra-example-driver   dra-example-driver-kubeletplugin-p494s     1/1     Running   0          56s
dra-example-driver   dra-example-driver-kubeletplugin-wqpqj     1/1     Running   0          56s
gpu-test1            pod0                                       1/1     Running   0          7s
gpu-test1            pod1                                       1/1     Running   0          7s
gpu-test2            pod0                                       1/1     Running   0          7s
gpu-test3            pod0                                       2/2     Running   0          7s
gpu-test4            pod0                                       1/1     Running   0          7s
gpu-test4            pod1                                       1/1     Running   0          7s
gpu-test5            pod0                                       4/4     Running   0          7s
kube-system          aws-node-26qtm                             2/2     Running   0          18m
kube-system          aws-node-h9bkq                             2/2     Running   0          18m
kube-system          aws-node-k4xj7                             2/2     Running   0          4h16m
kube-system          aws-node-ngmmv                             2/2     Running   0          4h16m
kube-system          coredns-7bf648ff5d-hx2jl                   1/1     Running   0          4h19m
kube-system          coredns-7bf648ff5d-xj97g                   1/1     Running   0          4h19m
kube-system          kube-proxy-72xfk                           1/1     Running   0          18m
kube-system          kube-proxy-hf2q4                           1/1     Running   0          4h16m
kube-system          kube-proxy-mwqz6                           1/1     Running   0          4h16m
kube-system          kube-proxy-zxxmt                           1/1     Running   0          18m
kube-system          metrics-server-8b674cb55-mvvb6             1/1     Running   0          4h19m
kube-system          metrics-server-8b674cb55-qxhmk             1/1     Running   0          4h19m
```

</details>

I was getting errors when trying to use DRA plugins which I no longer get:
```
"handling request failed" err="failed registration process: RegisterPlugin error -- no handler registered for plugin type: DRAPlugin at socket /var/lib/kubelet/plugins_registry/compute-domain.nvidia.com.sock" logger="registrar" requestID=14 method="/pluginregistration.Registration/NotifyRegistrationStatus"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
