### PR TITLE
ephemeral storage: allow soci-snapshotter path

### DIFF
--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -297,6 +297,7 @@ pub fn allowed_bind_dirs(variant: &str) -> BindDirs {
     if variant.contains("k8s") {
         allowed_exact.insert("/var/lib/kubelet");
         allowed_exact.insert("/var/log/pods");
+        allowed_exact.insert("/var/lib/soci-snapshotter");
     }
     if variant.contains("ecs") {
         allowed_exact.insert("/var/lib/docker");


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #570 

**Description of changes:**

Add `/var/lib/soci-snapshotter-grpc` to the allowlisted paths that can bind to ephemeral storage.

**Testing done:**

On a custom dev `aws-k8s-1.33` variant that includes `soci-snapshotter`, launched with userdata:

```
[settings.bootstrap-commands.k8s-ephemeral-storage]
commands = [
    ["apiclient", "ephemeral-storage", "init"],
    ["apiclient", "ephemeral-storage" ,"bind", "--dirs", "/var/lib/containerd", "/var/lib/kubelet", "/var/log/pods", "/var/lib/soci-snapshotter-grpc"]
]
essential = true
mode = "always"
```

lsblk output:
```
...
nvme3n1      259:16   0  6.8T  0 disk
`-md127        9:127  0 54.6T  0 raid0 /var/lib/soci-snapshotter-grpc
                                       /var/log/pods
                                       /var/lib/kubelet
                                       /var/lib/containerd
                                       /mnt/.ephemeral
...
```

And successfully ran pods.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
