### PR TITLE
expand support for efficient relabeling in SELinux policy

### DIFF
--- a/packages/selinux-policy/mcs.cil
+++ b/packages/selinux-policy/mcs.cil
@@ -50,12 +50,13 @@
           (or (eq t2 all_s)
               (eq t2 unconstrained_o)))))
 
-; Restrict file writes unless one of these conditions is met:
+; Restrict file writes (and mounts) unless one of these conditions is
+; met:
 ; * the source dominates the target
 ; * the source context is for a privileged subject (e.g. `control_t`)
 ; * the target context is for an unconstrained object
 
-(mlsconstrain (files (mutate))
+(mlsconstrain (files (mutate mount))
   (or (dom h1 h2)
       (or (eq t1 privileged_s)
           (eq t2 unconstrained_o))))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -271,8 +271,12 @@
 (allow container_s constrained_o (files (relabel)))
 
 ; Containers are also allowed to "relabel" filesystems at mount time
-; using "*context=" options, but only to and from "local_t".
+; using "*context=" options, but only to and from the "local_t" and
+; "data_t" types. This enables CSI drivers to mount filesystems on
+; behalf of containers with the appropriate label, so the container
+; runtime does not need to relabel all files.
 (allow container_s local_t (filesystems (relabel)))
+(allow container_s data_t (filesystems (relabel)))
 
 ; Untrusted components are not allowed to relabel most files, and
 ; cannot use "*context=" options to impose arbitrary labels.


### PR DESCRIPTION
**Issue number:**
Fixes #544

**Description of changes:**
Add `data_t` to the labels that containers are allowed to use in the `context=*` option when mounting filesystems. This enables CSI drivers to utilize [efficient SELinux relabeling](https://kubernetes.io/blog/2023/04/18/kubernetes-1-27-efficient-selinux-relabeling-beta/), while also providing the pod's MCS pair to configure the volume with `ReadWriteOncePod` semantics.

**Testing done:**
I verified that [a valkey deployment](https://gist.github.com/bcressey/c49ea00bfca33cd633f5ab4d3a5ae265) with two PVCs - one with the `ReadWriteOncePod` access mode, one with `ReadWriteOnce` - was able to start successfully, and the `context` option was set as expected.

I enabled the `SELinuxMount` feature gate in the `kubelet` config to verify that the same policy change will cover this behavior when that feature gate is enabled by default in the future.

The `context=*` option is applied at mount time by the CSI driver:
```
bash-5.1# mount | grep globalmount
/dev/nvme5n1 on /var/lib/kubelet/plugins/kubernetes.io/csi/ebs.csi.aws.com/fd9c17b3da5c184ccd2bce72d1db0e6e963a5c32ef5fba2f7dbd4bfb0597ba46/globalmount type ext4 (rw,relatime,context="system_u:object_r:data_t:s0:c1,c22,c333")
/dev/nvme4n1 on /var/lib/kubelet/plugins/kubernetes.io/csi/ebs.csi.aws.com/9d555ea631f871502d4769e525bec811bafa2e70d5f4f870870538112d317b5d/globalmount type ext4 (rw,relatime,context="system_u:object_r:data_t:s0:c1,c22,c333")
```

I also created test cases for privileged and unprivileged container mount operations to validate that the MCS constraints are working as expected.

Process labels:
* `system_u:system_r:control_t:s0-s0:c0.c1023` (privileged)
* `system_u:system_r:container_t:s0:c0.c2` (unprivileged)

The privileged container can override the effective context, for example by mounting a `c3.c5` filesystem on a `c0.c2` directory (or vice versa). The unprivileged container can only adjust the context to the same or more open permissions.

| Context Option | Mount Point Label | Privileged | Unprivileged |
| - | - | - | - |
| `system_u:object_r:local_t:s0` | `system_u:object_r:local_t:s0` | ✅ | ✅ |
| `system_u:object_r:data_t:s0` | `system_u:object_r:local_t:s0` | ✅ | ✅ |
| `system_u:object_r:data_t:s0:c0.c2` | `system_u:object_r:local_t:s0` | ✅ | ✅ |
| `system_u:object_r:data_t:s0:c3.c5` | `system_u:object_r:local_t:s0` | ✅ | ❌ |
| `system_u:object_r:local_t:s0` | `system_u:object_r:data_t:s0:c0.c2` | ✅ | ✅ |
| `system_u:object_r:data_t:s0` | `system_u:object_r:data_t:s0:c0.c2` | ✅ | ✅ |
| `system_u:object_r:data_t:s0:c0.c2` | `system_u:object_r:data_t:s0:c0.c2` | ✅ | ✅ |
| `system_u:object_r:data_t:s0:c3.c5` | `system_u:object_r:data_t:s0:c0.c2` | ✅ | ❌ |
| `system_u:object_r:local_t:s0` | `system_u:object_r:data_t:s0:c3.c5` | ✅ | ❌ |
| `system_u:object_r:data_t:s0` | `system_u:object_r:data_t:s0:c3.c5` | ✅ | ❌ |
| `system_u:object_r:data_t:s0:c0.c2` | `system_u:object_r:data_t:s0:c3.c5` | ✅ | ❌ |
| `system_u:object_r:data_t:s0:c3.c5` | `system_u:object_r:data_t:s0:c3.c5` | ✅ | ❌ |

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
