### PR TITLE
Configure soci-snapshotter for containerd and kubernetes

### DIFF
--- a/packages/containerd-1.7/1003-config-change-Plugins-type-from-toml.Tree-to-interfa.patch
+++ b/packages/containerd-1.7/1003-config-change-Plugins-type-from-toml.Tree-to-interfa.patch
@@ -1,0 +1,55 @@
+From dd3763194ff68b597bc8079ab21ffa60489e0c0b Mon Sep 17 00:00:00 2001
+From: Gavin Inglis <giinglis@amazon.com>
+Date: Tue, 22 Jul 2025 23:49:53 +0000
+Subject: [PATCH] config: change Plugins type from toml.Tree to interface{}
+
+In order to bring 2.0 config parsing parity to containerd-1.7 in terms
+of merge behavior, the type of Plugins must be made a generic
+interface{} and unmarshalling adjust accordingly. This tree structure
+resulted in higher level nodes being affected by changes to children and
+leaves and reset to their defaults.
+
+Signed-off-by: Gavin Inglis <giinglis@amazon.com>
+---
+ services/server/config/config.go | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/services/server/config/config.go b/services/server/config/config.go
+index e3fac1d82..1c663d99a 100644
+--- a/services/server/config/config.go
++++ b/services/server/config/config.go
+@@ -18,6 +18,7 @@ package config
+ 
+ import (
+ 	"fmt"
++	"io"
+ 	"path/filepath"
+ 	"strings"
+ 
+@@ -58,7 +59,7 @@ type Config struct {
+ 	// required plugin doesn't exist or fails to be initialized or started.
+ 	RequiredPlugins []string `toml:"required_plugins"`
+ 	// Plugins provides plugin specific configuration for the initialization of a plugin
+-	Plugins map[string]toml.Tree `toml:"plugins"`
++	Plugins map[string]interface{} `toml:"plugins"`
+ 	// OOMScore adjust the containerd's oom score
+ 	OOMScore int `toml:"oom_score"`
+ 	// Cgroup specifies cgroup information for the containerd daemon process
+@@ -187,7 +188,13 @@ func (c *Config) Decode(p *plugin.Registration) (interface{}, error) {
+ 	if !ok {
+ 		return p.Config, nil
+ 	}
+-	if err := data.Unmarshal(p.Config); err != nil {
++	r, w := io.Pipe()
++	go func() {
++		err := toml.NewEncoder(w).Encode(data)
++		w.CloseWithError(err)
++	}()
++
++	if err := toml.NewDecoder(r).Decode(p.Config); err != nil {
+ 		return nil, err
+ 	}
+ 	return p.Config, nil
+-- 
+2.47.1
+

--- a/packages/containerd-1.7/1004-Allow-sections-of-Plugins-to-be-merged-and-not-overw.patch
+++ b/packages/containerd-1.7/1004-Allow-sections-of-Plugins-to-be-merged-and-not-overw.patch
@@ -1,0 +1,31 @@
+From a21e379b69916558c1771b086a4a17b0a58f7cc1 Mon Sep 17 00:00:00 2001
+From: Ray Burgemeestre <rayb@nvidia.com>
+Date: Thu, 21 Mar 2024 12:00:24 +0100
+Subject: [PATCH] Allow sections of Plugins to be merged, and not overwritten
+ as entire sections.
+
+See for rationale the Pull Request description. Added unit test to
+demonstrate the difference of this change.
+
+Signed-off-by: Ray Burgemeestre <rayb@nvidia.com>
+Signed-off-by: Gavin Inglis <giinglis@amazon.com>
+---
+ services/server/config/config.go      |  4 --
+ services/server/config/config_test.go | 73 +++++++++++++++++++++
+ 2 files changed, 73 insertions(+), 4 deletions(-)
+
+diff --git a/services/server/config/config.go b/services/server/config/config.go
+index c77f165e4..24687b873 100644
+--- a/services/server/config/config.go
++++ b/services/server/config/config.go
+@@ -412,10 +412,6 @@ func mergeConfig(to, from *Config) error {
+ 	}
+ 
+ 	// Replace entire sections instead of merging map's values.
+-	for k, v := range from.Plugins {
+-		to.Plugins[k] = v
+-	}
+-
+ 	for k, v := range from.StreamProcessors {
+ 		to.StreamProcessors[k] = v
+ 	}

--- a/packages/containerd-1.7/containerd-1.7.spec
+++ b/packages/containerd-1.7/containerd-1.7.spec
@@ -23,6 +23,7 @@ Source3: containerd-config-toml_basic
 Source4: containerd-config-toml_k8s_nvidia_containerd_sock
 Source5: containerd-tmpfiles.conf
 Source6: containerd-cri-base-json
+Source7: snapshotter-toml
 
 # Mount for writing containerd configuration
 Source100: etc-containerd.mount
@@ -39,6 +40,10 @@ Source1000: clarify.toml
 # Backport of upstream patches for igzip support.
 Patch1001: 1001-Use-Intel-ISA-L-s-igzip-if-available.patch
 Patch1002: 1002-Skip-exec.LookPath-if-a-specific-gzip-implementation.patch
+# Patch to modify type of Plugins for config merge behavior.
+Patch1003: 1003-config-change-Plugins-type-from-toml.Tree-to-interfa.patch
+# Backport of upstream patch for config merge behavior.
+Patch1004: 1004-Allow-sections-of-Plugins-to-be-merged-and-not-overw.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
@@ -141,7 +146,7 @@ install -p -m 0644 %{S:1} %{S:100} %{S:110} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/containerd
-install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{S:7} %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
@@ -162,6 +167,7 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/0
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/containerd
 %{_cross_templatedir}/containerd-config-toml*
 %{_cross_templatedir}/containerd-cri-base-json
+%{_cross_templatedir}/snapshotter-toml
 %{_cross_tmpfilesdir}/containerd.conf
 
 %files bin

--- a/packages/containerd-1.7/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-1.7/containerd-config-toml_k8s_containerd_sock
@@ -15,6 +15,8 @@ disabled_plugins = [
     "io.containerd.snapshotter.v1.zfs",
 ]
 
+imports = ["/etc/containerd/config.d/*.toml"]
+
 [grpc]
 address = "/run/containerd/containerd.sock"
 

--- a/packages/containerd-1.7/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-1.7/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -15,6 +15,8 @@ disabled_plugins = [
     "io.containerd.snapshotter.v1.zfs",
 ]
 
+imports = ["/etc/containerd/config.d/*.toml"]
+
 [grpc]
 address = "/run/containerd/containerd.sock"
 

--- a/packages/containerd-1.7/containerd-tmpfiles.conf
+++ b/packages/containerd-1.7/containerd-tmpfiles.conf
@@ -1,1 +1,2 @@
 d /etc/cni/net.d - - - -
+d /etc/containerd/config.d - - - -

--- a/packages/containerd-1.7/snapshotter-toml
+++ b/packages/containerd-1.7/snapshotter-toml
@@ -1,0 +1,20 @@
+[required-extensions]
+container-runtime = "v1"
+std = { version = "v1" }
++++
+{{#if settings.container-runtime.snapshotter}}
+{{#if (eq settings.container-runtime.snapshotter "soci" )}}
+[plugins."io.containerd.grpc.v1.cri".containerd]
+snapshotter = "soci"
+disable_snapshot_annotations = false
+# Plug soci snapshotter into containerd
+[proxy_plugins.soci]
+type = "snapshot"
+address = "/run/soci-snapshotter/soci-snapshotter.sock"
+[proxy_plugins.soci.exports]
+root = "/var/lib/soci-snapshotter"
+{{else}}
+[plugins."io.containerd.grpc.v1.cri".containerd]
+snapshotter = "overlayfs"
+{{/if}}
+{{/if}}

--- a/packages/containerd-2.0/containerd-2.0.spec
+++ b/packages/containerd-2.0/containerd-2.0.spec
@@ -23,6 +23,7 @@ Source3: containerd-config-toml_basic
 Source4: containerd-config-toml_k8s_nvidia_containerd_sock
 Source5: containerd-tmpfiles.conf
 Source6: containerd-cri-base-json
+Source7: snapshotter-toml
 
 # Mount for writing containerd configuration
 Source100: etc-containerd.mount
@@ -136,7 +137,7 @@ install -p -m 0644 %{S:1} %{S:100} %{S:110} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/containerd
-install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{S:7} %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
@@ -157,6 +158,7 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/0
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/containerd
 %{_cross_templatedir}/containerd-config-toml*
 %{_cross_templatedir}/containerd-cri-base-json
+%{_cross_templatedir}/snapshotter-toml
 %{_cross_tmpfilesdir}/containerd.conf
 
 %files bin

--- a/packages/containerd-2.0/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.0/containerd-config-toml_k8s_containerd_sock
@@ -14,6 +14,8 @@ disabled_plugins = [
     "io.containerd.snapshotter.v1.zfs",
 ]
 
+imports = ["/etc/containerd/config.d/*.toml"]
+
 [grpc]
 address = "/run/containerd/containerd.sock"
 

--- a/packages/containerd-2.0/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.0/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -14,6 +14,8 @@ disabled_plugins = [
     "io.containerd.snapshotter.v1.zfs",
 ]
 
+imports = ["/etc/containerd/config.d/*.toml"]
+
 [grpc]
 address = "/run/containerd/containerd.sock"
 

--- a/packages/containerd-2.0/containerd-tmpfiles.conf
+++ b/packages/containerd-2.0/containerd-tmpfiles.conf
@@ -1,1 +1,2 @@
 d /etc/cni/net.d - - - -
+d /etc/containerd/config.d - - - -

--- a/packages/containerd-2.0/snapshotter-toml
+++ b/packages/containerd-2.0/snapshotter-toml
@@ -1,0 +1,20 @@
+[required-extensions]
+container-runtime = "v1"
+std = { version = "v1" }
++++
+{{#if settings.container-runtime.snapshotter}}
+{{#if (eq settings.container-runtime.snapshotter "soci" )}}
+[plugins."io.containerd.cri.v1.images"]
+snapshotter = "soci"
+disable_snapshot_annotations = false
+# Plug soci snapshotter into containerd
+[proxy_plugins.soci]
+type = "snapshot"
+address = "/run/soci-snapshotter/soci-snapshotter.sock"
+[proxy_plugins.soci.exports]
+root = "/var/lib/soci-snapshotter"
+{{else}}
+[plugins."io.containerd.cri.v1.images"]
+snapshotter = "overlayfs"
+{{/if}}
+{{/if}}

--- a/packages/kubernetes-1.28/kubelet-env
+++ b/packages/kubernetes-1.28/kubelet-env
@@ -5,3 +5,4 @@ std = { version = "v1", helpers = ["join_map"] }
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
 NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}
+KUBELET_CONFIG_DROPIN_DIR_ALPHA=1

--- a/packages/kubernetes-1.28/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.28/kubelet-exec-start-conf
@@ -34,5 +34,6 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
+    --config-dir=/etc/kubernetes/kubelet/config.d \
     --pod-infra-container-image localhost/kubernetes/pause:0.1.0 \
     --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.28/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.28/kubernetes-tmpfiles.conf
@@ -5,3 +5,4 @@ r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
 d /opt/csi/mountpoint-s3 - - - -
 L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3
+d /etc/kubernetes/kubelet/config.d - - - -

--- a/packages/kubernetes-1.29/kubelet-env
+++ b/packages/kubernetes-1.29/kubelet-env
@@ -5,3 +5,4 @@ std = { version = "v1", helpers = ["join_map"] }
 NODE_IP={{settings.kubernetes.node-ip}}
 NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
 NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}
+KUBELET_CONFIG_DROPIN_DIR_ALPHA=1

--- a/packages/kubernetes-1.29/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.29/kubelet-exec-start-conf
@@ -34,5 +34,6 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
+    --config-dir=/etc/kubernetes/kubelet/config.d \
     --pod-infra-container-image localhost/kubernetes/pause:0.1.0 \
     --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.29/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.29/kubernetes-tmpfiles.conf
@@ -5,3 +5,4 @@ r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
 d /opt/csi/mountpoint-s3 - - - -
 L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3
+d /etc/kubernetes/kubelet/config.d - - - -

--- a/packages/kubernetes-1.30/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.30/kubelet-exec-start-conf
@@ -34,5 +34,6 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
+    --config-dir=/etc/kubernetes/kubelet/config.d \
     --pod-infra-container-image localhost/kubernetes/pause:0.1.0 \
     --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.30/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.30/kubernetes-tmpfiles.conf
@@ -5,3 +5,4 @@ r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
 d /opt/csi/mountpoint-s3 - - - -
 L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3
+d /etc/kubernetes/kubelet/config.d - - - -

--- a/packages/kubernetes-1.31/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.31/kubelet-exec-start-conf
@@ -34,5 +34,6 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
+    --config-dir=/etc/kubernetes/kubelet/config.d \
     --pod-infra-container-image localhost/kubernetes/pause:0.1.0 \
     --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.31/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.31/kubernetes-tmpfiles.conf
@@ -5,3 +5,4 @@ r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
 d /opt/csi/mountpoint-s3 - - - -
 L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3
+d /etc/kubernetes/kubelet/config.d - - - -

--- a/packages/kubernetes-1.32/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.32/kubelet-exec-start-conf
@@ -34,5 +34,6 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
+    --config-dir=/etc/kubernetes/kubelet/config.d \
     --pod-infra-container-image localhost/kubernetes/pause:0.1.0 \
     --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.32/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.32/kubernetes-tmpfiles.conf
@@ -5,3 +5,4 @@ r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
 d /opt/csi/mountpoint-s3 - - - -
 L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3
+d /etc/kubernetes/kubelet/config.d - - - -

--- a/packages/kubernetes-1.33/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.33/kubelet-exec-start-conf
@@ -34,5 +34,6 @@ ExecStart=/usr/bin/kubelet \
 {{#if settings.kubernetes.log-level includeZero=true}}
     -v {{settings.kubernetes.log-level}} \
 {{/if}}
+    --config-dir=/etc/kubernetes/kubelet/config.d \
     --pod-infra-container-image localhost/kubernetes/pause:0.1.0 \
     --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.33/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.33/kubernetes-tmpfiles.conf
@@ -5,3 +5,4 @@ r! /var/lib/kubelet/cpu_manager_state
 L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
 d /opt/csi/mountpoint-s3 - - - -
 L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3
+d /etc/kubernetes/kubelet/config.d - - - -


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #575

**Description of changes:**

* Configure containerd-1.7 and containerd-2.0 to include the soci-snapshotter plugin and set `snapshotter` to `"soci"` when `settings.container-runtime.snapshotter="soci"`
  * Backport patch from containerd 2.x and transform commit https://github.com/containerd/containerd/commit/b5615caf118da4e96104004e11132d9d0ad08a87 to bring parity to import config merge behavior for `containerd-1.7`
* Configure kubernetes-* packages
  * kubernetes-1.27 excluded as these variants are reaching EOL https://github.com/bottlerocket-os/bottlerocket/issues/4580
  * set `KUBELET_CONFIG_DROPIN_DIR_ALPHA` for k8s-1.28 and k8s-1.29 as support for the drop-in configuration dir reached beta in k8s-1.30: https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/

Changing snapshotter at runtime can lead to inconsistent state between content of respective snapshotters. The drop in configuration files provided in this PR are rendered only on boot with the new `overwrite-if-path-present` option added in #548.

**Testing done:**


* Created aws-k8s-* variants with:
  * https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/91
  * https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/569
  * https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/571
  * SELinux policy changes: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/579
  * Bottlerocket variant changes (https://github.com/bottlerocket-os/bottlerocket/pull/4593) to include soci-snapshotter, render templates, etc.
* Launched variants in EKS clusters

More details can be found in https://github.com/bottlerocket-os/bottlerocket/pull/4593

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
