### PR TITLE
Third Party Package Updates

### DIFF
--- a/packages/chrony/Cargo.toml
+++ b/packages/chrony/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://chrony-project.org/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://chrony-project.org/releases/chrony-4.6.1.tar.gz"
-sha512 = "646ae08f2587366236796f2399d8ab3eb570979e0d82f5d13f5cec49939054c876cc93dc20c8d38e105fd3500e1720d05a223a15076783cd882d0de43afd9c7e"
+url = "https://chrony-project.org/releases/chrony-4.7.tar.gz"
+sha512 = "419594ab8ff0fd42acaf6e4ca1a011d5cf87c8d90ab040e90bb004b43570888329531593f073fb7c5a1093b5754d61c1ae6034d0b86660e4dc37d42ee0f30623"
 
 [[package.metadata.build-package.external-files]]
-url = "https://chrony-project.org/releases/chrony-4.6.1-tar-gz-asc.txt"
-sha512 = "992b706636bf3a7eb6d502562a4990c9d8e20e5f3011d2cdb2ceb32220e9a1c2bfa6eca767212cee49b811823872602dc33f9e7201a7f9a93cc9c90e81b1db49"
+url = "https://chrony-project.org/releases/chrony-4.7-tar-gz-asc.txt"
+sha512 = "c2351e6e624f60e82973bddd5cb1d84c90ee5e862d7d24dfc2b7a8f60a6a948f7446c9b7d68c5e72be4afccbd5d8f572141a4e0bde9cfeefc59aebb7e4fc74e1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/chrony/chrony.spec
+++ b/packages/chrony/chrony.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}chrony
-Version: 4.6.1
+Version: 4.7
 Release: 1%{?dist}
 Summary: A versatile implementation of the Network Time Protocol
 License: GPL-2.0-only

--- a/packages/xfsprogs/Cargo.toml
+++ b/packages/xfsprogs/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://mirrors.edge.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/"
 
 [[package.metadata.build-package.external-files]]
-url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.14.0.tar.xz"
-sha512 = "249a64fb5a92ceb9e58b75a270a90773cfe2c90e863d3f9853c14b3eb0f414bf55b8b67c220a1d7386894ef9295622e224977bd3c6600c9dcba826cb4a634f49"
+url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.15.0.tar.xz"
+sha512 = "975c9c7fe476b02da50da74eb599f804f2b27a638a74b807e1f69d93d0d150d19bf6d5036601b96febe557a6c51065d8cf22eef5fda92a6d7f084ac1d7647496"
 
 [[package.metadata.build-package.external-files]]
-url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.14.0.tar.sign"
-sha512 = "a4fdfaa62a6e404ec709c7b86aa01c37c74de8738d26dc8821add535c61bf31101031e0a5e2962f8bc23957d6183ec8c21d0a114361d7b46e0ecc52337be19b3"
+url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.15.0.tar.sign"
+sha512 = "02c6744de4663a03012c1f07fa6d26244cae3a8c1a1910a72cd7fcde7ba36fb3a8aee8314736bb88943356b6c82cf53712ee0714455351907322cbe033b15d1b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/xfsprogs/xfsprogs.spec
+++ b/packages/xfsprogs/xfsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}xfsprogs
-Version: 6.14.0
+Version: 6.15.0
 Release: 1%{?dist}
 Summary: Utilities for managing the XFS filesystem
 License: GPL-2.0-only AND LGPL-2.1-only


### PR DESCRIPTION
**Description of changes:**
- Update `chrony` v4.6.1 &rarr; v4.7
- Update `xfsprogs` v6.14.0 &rarr; v6.15.0

**Testing done:**
`chrony`
```
bash-5.1# systemctl status chronyd
● chronyd.service - A versatile implementation of the Network Time Protocol
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/chronyd.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Sat 2025-07-12 07:53:25 UTC; 11min ago
       Docs: https://chrony.tuxfamily.org
   Main PID: 1457 (chronyd)
      Tasks: 2 (limit: 4346)
     Memory: 948.0K
        CPU: 19ms
     CGroup: /system.slice/chronyd.service
             ├─1457 /usr/sbin/chronyd -d -F -1
             └─1459 /usr/sbin/chronyd -d -F -1

Jul 12 07:53:25 ip-172-31-26-208.us-west-2.compute.internal systemd[1]: Started A versatile implementation of the Network Time Protocol.
Jul 12 07:53:25 ip-172-31-26-208.us-west-2.compute.internal chronyd[1457]: 2025-07-12T07:53:25Z chronyd version 4.7 starting (+CMDMON +REFCLOCK +RTC +PRIVDR…6 -DEBUG)
Jul 12 07:53:25 ip-172-31-26-208.us-west-2.compute.internal chronyd[1457]: 2025-07-12T07:53:25Z Loaded seccomp filter (level 1)
Jul 12 07:53:30 ip-172-31-26-208.us-west-2.compute.internal chronyd[1457]: 2025-07-12T07:53:30Z Selected source 169.254.169.123
Hint: Some lines were ellipsized, use -l to show in full.
bash-5.1# chronyc
chrony version 4.7
Copyright (C) 1997-2003, 2007, 2009-2025 Richard P. Curnow and others
chrony comes with ABSOLUTELY NO WARRANTY.  This is free software, and
you are welcome to redistribute it under certain conditions.  See the
GNU General Public License version 2 for details.

chronyc> dump
200 OK
```
`xfsprogs`
```
bash-5.1# mkfs.xfs
Parameters parsed from config file /usr/share/xfsprogs/mkfs/default.conf successfully
No device name specified
Usage: mkfs.xfs
/* blocksize */         [-b size=num]
/* config file */       [-c options=xxx]
/* metadata */          [-m crc=0|1,finobt=0|1,uuid=xxx,rmapbt=0|1,reflink=0|1,
                            inobtcount=0|1,bigtime=0|1,autofsck=xxx,
                            metadir=0|1]
/* quota */             [-m uquota|uqnoenforce,gquota|gqnoenforce,
                            pquota|pqnoenforce]
/* data subvol */       [-d agcount=n,agsize=n,file,name=xxx,size=num,
                            (sunit=value,swidth=value|su=num,sw=num|noalign),
                            sectsize=num,concurrency=num]
/* force overwrite */   [-f]
/* inode size */        [-i perblock=n|size=num,maxpct=n,attr=0|1|2,
                            projid32bit=0|1,sparse=0|1,nrext64=0|1,
                            exchange=0|1]
/* no discard */        [-K]
/* log subvol */        [-l agnum=n,internal,size=num,logdev=xxx,version=n
                            sunit=value|su=num,sectsize=num,lazy-count=0|1,
                            concurrency=num]
/* label */             [-L label (maximum 12 characters)]
/* naming */            [-n size=num,version=2|ci,ftype=0|1,parent=0|1]]
/* no-op info only */   [-N]
/* prototype file */    [-p fname]
/* quiet */             [-q]
/* realtime subvol */   [-r extsize=num,size=num,rtdev=xxx,rgcount=n,rgsize=n,
                            concurrency=num,zoned=0|1,start=n,reserved=n]
/* sectorsize */        [-s size=num]
/* version */           [-V]
                        devicename
<devicename> is required unless -d name=xxx is given.
<num> is xxx (bytes), xxxs (sectors), xxxb (fs blocks), xxxk (xxx KiB),
      xxxm (xxx MiB), xxxg (xxx GiB), xxxt (xxx TiB) or xxxp (xxx PiB).
<value> is xxx (512 byte blocks).
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
