### PR TITLE
selinux: support for soci-snapshotter

### DIFF
--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -58,6 +58,7 @@
 (filecon "/.*/usr(/fips)?/bin/host-ctr" file runtime_exec)
 (filecon "/.*/usr(/fips)?/bin/runc.*" file runtime_exec)
 (filecon "/.*/usr(/fips)?/bin/shibaken" file api_exec)
+(filecon "/.*/usr(/fips)?/bin/soci-snapshotter.*" file runtime_exec)
 
 ; Label local storage mounts.
 (filecon "/local" any local)

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -138,6 +138,11 @@
 (roletype object_r secret_t)
 (context secret (system_u object_r secret_t s0))
 
+; Files for saved system secrets in config files in /etc.
+(type etc_secret_t)
+(roletype object_r etc_secret_t)
+(context etc_secret (system_u object_r etc_secret_t s0))
+
 ; Dynamic objects are files on temporary storage with special rules.
 (typeattribute dynamic_o)
 (typeattributeset dynamic_o (etc_t binfmt_misc_fs_t))
@@ -162,7 +167,7 @@
 ; modified by system-level processes.
 (typeattribute write_restricted_o)
 (typeattributeset write_restricted_o (
-  cache_t csi_exec_t lease_t measure_t secret_t state_t private_t))
+  cache_t csi_exec_t lease_t measure_t secret_t etc_secret_t state_t private_t))
 
 ; Read-restricted objects are files on local storage that can only be
 ; opened by system-level processes.
@@ -210,6 +215,6 @@
   network_exec_t bus_exec_t runtime_exec_t
   mount_exec_t cni_exec_t csi_exec_t
   any_t etc_t proc_t binfmt_misc_fs_t
-  local_t data_t private_t secret_t cache_t
+  local_t data_t private_t secret_t etc_secret_t cache_t
   lease_t measure_t state_t
   api_socket_t))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -221,6 +221,12 @@
 (allow api_s secret_t (files (mutate mount)))
 (allow runtime_s secret_t (files (mutate mount)))
 
+; Trusted components can modify secrets stored in /etc config files.
+(allow trusted_s etc_secret_t (files (mutate)))
+
+; Untrusted components cannot modify secrets stored in /etc config files.
+(neverallow untrusted_s etc_secret_t (files (mutate)))
+
 ; Subjects that control the OS can write to and manage mounts for
 ; "sensitive" files and directories on /local.
 (allow control_s sensitive_o (files (mutate mount)))


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #578 

**Description of changes:**

label the soci-snapshotter-grpc process as `runtime_exec`.

**Testing done:**

On a k8s development variant that includes soci:

```
bash-5.1# ps -eZ | grep soci
system_u:system_r:runtime_t:s0      1482 ?        00:00:00 soci-snapshotter-grpc
```

For the commit to add a label etc_secret_t to be used for configuration files stored under
/etc that include secrets:

**Before the change**: Launch node with userdata to modify the config `/etc/soci-snapshotter/config.toml`:

```
[settings.bootstrap-containers.set-soci-config]
   mode = "always"
   essential = false
   user-data = "IyEvYmluL2Jhc2gKCiMgU2NyaXB0IHRvIGNvbmZpZ3VyZSBTT0NJIHNldHRpbmdzIGluIGNvbnRhaW5lcmQgY29uZmlnCiMgU2V0cyBwdWxsX21vZGVzLnNvY2lfdjEgZW5hYmxlID0gdHJ1ZSBhbmQgcHVsbF9tb2Rlcy5wYXJhbGxlbF9wdWxsX3VucGFjayBlbmFibGUgPSBmYWxzZQojCiMKIyBiNjQ6IEl5RXZZbWx1TDJKaGMyZ0tDaU1nVTJOeWFYQjBJSFJ2SUdOdmJtWnBaM1Z5WlNCVFQwTkpJSE5sZEhScGJtZHpJR2x1SUdOdmJuUmhhVzVsY21RZ1kyOXVabWxuQ2lNZ1UyVjBjeUJ3ZFd4c1gyMXZaR1Z6TG5OdlkybGZkakVnWlc1aFlteGxJRDBnZEhKMVpTQmhibVFnY0hWc2JGOXRiMlJsY3k1d1lYSmhiR3hsYkY5d2RXeHNYM1Z1Y0dGamF5QmxibUZpYkdVZ1BTQm1ZV3h6WlFvS0NrTlBUa1pKUjE5R1NVeEZQUzh1WW05MGRHeGxjbTlqYTJWMEwzSnZiM1JtY3k5bGRHTXZjMjlqYVMxemJtRndjMmh2ZEhSbGNpOWpiMjVtYVdjdWRHOXRiQW9LYVdZZ1d5QWhJQzFtSUNJa1EwOU9Sa2xIWDBaSlRFVWlJRjA3SUhSb1pXNEtJQ0FnSUdWamFHOGdJa1Z5Y205eU9pQkRiMjVtYVdjZ1ptbHNaU0FrUTA5T1JrbEhYMFpKVEVVZ2JtOTBJR1p2ZFc1a0lnb2dJQ0FnWlhocGRDQXhDbVpwQ2dvaklGTmxkQ0J6YjJOcFgzWXhJR1Z1WVdKc1pTQTlJSFJ5ZFdVS2MyVmtJQzFwSUNjdlhseGJjSFZzYkY5dGIyUmxjMXd1YzI5amFWOTJNVnhkTHl3dlhseGJMeUI3Q2lBZ0lDQXZYbVZ1WVdKc1pTQTlJR1poYkhObEwyTmNDbVZ1WVdKc1pTQTlJSFJ5ZFdVS2ZTY2dJaVJEVDA1R1NVZGZSa2xNUlNJS0NpTWdVMlYwSUhCaGNtRnNiR1ZzWDNCMWJHeGZkVzV3WVdOcklHVnVZV0pzWlNBOUlHWmhiSE5sQ25ObFpDQXRhU0FuTDE1Y1czQjFiR3hmYlc5a1pYTmNMbkJoY21Gc2JHVnNYM0IxYkd4ZmRXNXdZV05yWEYwdkxDOWVYRnN2SUhzS0lDQWdJQzllWlc1aFlteGxJRDBnZEhKMVpTOWpYQXBsYm1GaWJHVWdQU0JtWVd4elpRcDlKeUFpSkVOUFRrWkpSMTlHU1V4Rklnb0taV05vYnlBaVUwOURTU0JqYjI1bWFXZDFjbUYwYVc5dUlIVndaR0YwWldRZ2MzVmpZMlZ6YzJaMWJHeDVJZ3BsWTJodklDSXRJSEIxYkd4ZmJXOWtaWE11YzI5amFWOTJNU0JsYm1GaWJHVWdQU0IwY25WbElncGxZMmh2SUNJdElIQjFiR3hmYlc5a1pYTXVjR0Z5WVd4c1pXeGZjSFZzYkY5MWJuQmhZMnNnWlc1aFlteGxJRDBnWm1Gc2MyVWlDZz09CgoKQ09ORklHX0ZJTEU9Ly5ib3R0bGVyb2NrZXQvcm9vdGZzL2V0Yy9zb2NpLXNuYXBzaG90dGVyL2NvbmZpZy50b21sCgppZiBbICEgLWYgIiRDT05GSUdfRklMRSIgXTsgdGhlbgogICAgZWNobyAiRXJyb3I6IENvbmZpZyBmaWxlICRDT05GSUdfRklMRSBub3QgZm91bmQiCiAgICBleGl0IDEKZmkKCiMgU2V0IHNvY2lfdjEgZW5hYmxlID0gdHJ1ZQpzZWQgLWkgJy9eXFtwdWxsX21vZGVzXC5zb2NpX3YxXF0vLC9eXFsvIHsKICAgIC9eZW5hYmxlID0gZmFsc2UvY1wKZW5hYmxlID0gdHJ1ZQp9JyAiJENPTkZJR19GSUxFIgoKIyBTZXQgcGFyYWxsZWxfcHVsbF91bnBhY2sgZW5hYmxlID0gZmFsc2UKc2VkIC1pICcvXlxbcHVsbF9tb2Rlc1wucGFyYWxsZWxfcHVsbF91bnBhY2tcXS8sL15cWy8gewogICAgL15lbmFibGUgPSB0cnVlL2NcCmVuYWJsZSA9IGZhbHNlCn0nICIkQ09ORklHX0ZJTEUiCgplY2hvICJTT0NJIGNvbmZpZ3VyYXRpb24gdXBkYXRlZCBzdWNjZXNzZnVsbHkiCmVjaG8gIi0gcHVsbF9tb2Rlcy5zb2NpX3YxIGVuYWJsZSA9IHRydWUiCmVjaG8gIi0gcHVsbF9tb2Rlcy5wYXJhbGxlbF9wdWxsX3VucGFjayBlbmFibGUgPSBmYWxzZSIK"
```

And confirm that `/etc/soci-snapshotter/config.toml` is modified to include:

```
[pull_modes.soci_v1]
enable = true
[pull_modes.soci_v2]
enable = false

[pull_modes.parallel_pull_unpack]
enable = false
```



**After the change**:
* In combination with #569, update the mount for soci configuration to label as `etc_secret_t`:
```
...
Options=nosuid,nodev,noexec,noatime,mode=0750,context=system_u:object_r:etc_secret_t:s0
...
```
* Launch node with same userdata as above to modify the config `/etc/soci-snapshotter/config.toml`
* Confirm that no change is made to `/etc/soci-snapshotter/config.toml`
* Confirm denials via `dmesg`:
```
[   24.461641] audit: type=1400 audit(1752601422.928:8): avc:  denied  { write } for  pid=14230 comm="sed" name="soci-snapshotter" dev="tmpfs" ino=197 scontext=system_u:system_r:control_t:s0-s0:c0.c1023 tcontext=system_u:object_r:etc_t:s0 tclass=dir permissive=0
[   24.462615] audit: type=1400 audit(1752601422.928:9): avc:  denied  { write } for  pid=14231 comm="sed" name="soci-snapshotter" dev="tmpfs" ino=197 scontext=system_u:system_r:control_t:s0-s0:c0.c1023 tcontext=system_u:object_r:etc_t:s0 tclass=dir permissive=0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
