### PR TITLE
Soci snapshotter change service

### DIFF
--- a/packages/containerd-1.7/containerd.service
+++ b/packages/containerd-1.7/containerd.service
@@ -3,6 +3,7 @@ Description=containerd container runtime
 Documentation=https://containerd.io
 After=network-online.target configured.target
 Wants=network-online.target configured.target
+Requires=configure-snapshotter.service
 
 [Service]
 Slice=runtime.slice

--- a/packages/containerd-2.0/containerd.service
+++ b/packages/containerd-2.0/containerd.service
@@ -3,6 +3,7 @@ Description=containerd container runtime
 Documentation=https://containerd.io
 After=network-online.target configured.target
 Wants=network-online.target configured.target
+Requires=configure-snapshotter.service
 
 [Service]
 Slice=runtime.slice

--- a/packages/release/configure-snapshotter.service
+++ b/packages/release/configure-snapshotter.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Configure Snapshotter
+Before=containerd.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/containerd/selected-snapshotter
+EnvironmentFile=-/var/cache/containerd/active-snapshotter
+# Skip cleanup if either snapshotter variable is empty
+ExecCondition=[ -n "${ACTIVE_SNAPSHOTTER}" ]
+ExecCondition=[ -n "${SELECTED_SNAPSHOTTER}" ]
+# Check if the active snapshotter has changed
+ExecCondition=[ "${SELECTED_SNAPSHOTTER}" != "${ACTIVE_SNAPSHOTTER}" ]
+# Don't error if the directories don't exist.
+ExecStart=-/usr/bin/find /var/lib/soci-snapshotter -mindepth 1 -delete -true
+ExecStart=-/usr/bin/find /var/lib/containerd -mindepth 1 -delete -true
+ExecStart=/usr/bin/truncate -s0 /var/cache/containerd/active-snapshotter
+ExecStart=/usr/bin/echo 'ACTIVE_SNAPSHOTTER="${SELECTED_SNAPSHOTTER}"'
+
+# Set the ACTIVE_SNAPSHOTTER regardless of if conditions are met for cleanup.
+# This mitigates the behavior that an unmet ExecCondition will truncate the active-snapshotter EnvironmentFile.
+ExecStopPost=/usr/bin/truncate -s0 /var/cache/containerd/active-snapshotter
+ExecStopPost=/usr/bin/echo 'ACTIVE_SNAPSHOTTER="${SELECTED_SNAPSHOTTER}"'
+
+RemainAfterExit=true
+# Write the active snapshotter.
+StandardOutput=file:/var/cache/containerd/active-snapshotter
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/release/release-snapshotter-tmpfiles.conf
+++ b/packages/release/release-snapshotter-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /var/cache/containerd 0755 - - -
+f /var/cache/containerd/active-snapshotter 0644 - - - ACTIVE_SNAPSHOTTER="overlayfs"

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -17,6 +17,7 @@ Source96: release-repart-local.conf
 Source97: release-sysctl.conf
 Source98: release-systemd-system.conf
 Source99: release-ca-certificates-tmpfiles.conf
+Source100: release-snapshotter-tmpfiles.conf
 
 Source200: motd.template
 Source201: proxy-env
@@ -28,6 +29,7 @@ Source206: aws-config
 Source207: aws-credentials
 Source208: modules-load.template
 Source209: log4j-hotpatch-enabled
+Source210: selected-snapshotter-template
 
 # Core targets, services, and slices.
 Source1001: multi-user.target
@@ -73,6 +75,7 @@ Source1064: deprecation-warning@.timer
 Source1065: check-kernel-integrity.service
 Source1066: check-fips-modules.service
 Source1067: fips-modprobe@.service
+Source1068: configure-snapshotter.service
 
 # Mounts that require build-time edits.
 Source1080: var-lib-kernel-devel-lower.mount.in
@@ -161,6 +164,7 @@ install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:93} %{buildroot}%{_cross_tmpfilesdir}/release.conf
 install -p -m 0644 %{S:99} %{buildroot}%{_cross_tmpfilesdir}/release-ca-certificates.conf
 install -p -m 0644 %{S:94} %{buildroot}%{_cross_tmpfilesdir}/release-fips.conf
+install -p -m 0644 %{S:100} %{buildroot}%{_cross_tmpfilesdir}/release-snapshotter.conf
 
 install -d %{buildroot}%{_cross_libdir}/systemd/networkd.conf.d
 install -p -m 0644 %{S:95} %{buildroot}%{_cross_libdir}/systemd/networkd.conf.d/80-release.conf
@@ -197,7 +201,7 @@ install -p -m 0644 \
   %{S:1040} %{S:1041} %{S:1042} %{S:1043} %{S:1044} \
   %{S:1045} %{S:1046} %{S:1047} %{S:1048} %{S:1049} \
   %{S:1060} %{S:1061} %{S:1062} %{S:1063} %{S:1064} \
-  %{S:1065} %{S:1066} %{S:1067} \
+  %{S:1065} %{S:1066} %{S:1067} %{S:1068} \
   %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_unitdir}/systemd-tmpfiles-setup.service.d
@@ -256,6 +260,7 @@ install -p -m 0644 %{S:206} %{buildroot}%{_cross_templatedir}/aws-config
 install -p -m 0644 %{S:207} %{buildroot}%{_cross_templatedir}/aws-credentials
 install -p -m 0644 %{S:208} %{buildroot}%{_cross_templatedir}/modules-load
 install -p -m 0644 %{S:209} %{buildroot}%{_cross_templatedir}/log4j-hotpatch-enabled
+install -p -m 0644 %{S:210} %{buildroot}%{_cross_templatedir}/selected-snapshotter
 
 install -d %{buildroot}%{_cross_unitdir}/systemd-udev-trigger.service.d/
 install -p -m 0644 %{S:1105} %{buildroot}%{_cross_unitdir}/systemd-udev-trigger.service.d/00-selinux.conf
@@ -342,6 +347,9 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_templatedir}/log4j-hotpatch-enabled
 %{_cross_udevrulesdir}/61-mount-cdrom.rules
 %{_cross_datadir}/logdog.d/logdog.common.conf
+%{_cross_unitdir}/configure-snapshotter.service
+%{_cross_templatedir}/selected-snapshotter
+%{_cross_tmpfilesdir}/release-snapshotter.conf
 
 %files fips
 %{_cross_bootconfigdir}/10-fips.conf

--- a/packages/release/selected-snapshotter-template
+++ b/packages/release/selected-snapshotter-template
@@ -1,0 +1,5 @@
+[required-extensions]
+container-runtime = "v1"
+std = { version = "v1" }
++++
+SELECTED_SNAPSHOTTER="{{#if settings.container-runtime.snapshotter}}{{settings.container-runtime.snapshotter}}{{else}}overlayfs{{/if}}"

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -251,7 +251,7 @@
 (allow api_s private_t (files (mutate)))
 (allow clock_s measure_t (files (mutate)))
 (allow network_s lease_t (files (mutate)))
-(allow runtime_s cache_t (files (mutate)))
+(allow trusted_s cache_t (files (mutate)))
 
 ; Other components should not be permitted to modify these files,
 ; or to manage mounts for these directories.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #580

**Description of changes:**

Bottlerocket will allow users to modify the snapshotter configured for containerd via settings.container-runtime.snapshotter. Switching snapshotters requires the clean state of containerd, meaning no active
running containers or existing images. Bottlerocket should only make the change to configured snapshotter at boot of an instance and not do so at runtime.

This commit  adds a service to configure snapshotter selection change on reboot of an instance. When settings.container-runtime.snapshotter is modified, it will only take effect at reboot. Change in containerd's underlying snapshotter can lead to dangling content, so when such a change is detected, reset respective snapshotter state directories /var/lib/containerd and /var/lib/soci-snapshotter-grpc.

**Testing done:**

In each case, launch the same pod listed below. Chosen variant: `aws-k8s-1.33-x86_64`.

<details>

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: djl-deployment
  labels:
    app: djl-soci
spec:
  replicas: 1
  selector:
    matchLabels:
      app: djl-soci
  template:
    metadata:
      labels:
        app: djl-soci
    spec:
      containers:
      - name: djl-container
        #image: deepjavalibrary/djl-serving:0.26.0-deepspeed
        image: 763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.22.1-deepspeed0.9.2-cu118
        command: ["sleep"]
        args: ["inf"]
```

</details>

- [x] Reboot an instance with no change in snapshotter selection
  * 1x for soci and 1x for overlay configured
  * ensure all pods come back up
- [x] Boot with soci. Run some pods with example images. change snapshotter. reboot
  * ensure pods come back up to `Running`
  * ensure `ls -lR /var/lib/soci-snapshotter` is empty
- [x] Boot with overlay. Run some pods. change snapshotter. reboot.
  * ensure pods come back up to `Running`
  * ensure content via `ls -lR /var/lib/soci-snapshotter`
* **RESULTS: https://gist.github.com/ginglis13/cfc7d1d907e65d889af9b55923476e12**

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
