### PR TITLE
soci-snapshotter: inherit proxy env vars

### DIFF
--- a/packages/soci-snapshotter/soci-snapshotter.service
+++ b/packages/soci-snapshotter/soci-snapshotter.service
@@ -7,6 +7,7 @@ Before=containerd.service
 
 [Service]
 Type=notify
+EnvironmentFile=/etc/network/proxy.env
 ExecStart=/usr/bin/soci-snapshotter-grpc --address fd://
 Restart=always
 RestartSec=5


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #583

**Description of changes:**

Provide proxy environment variables to soci-snapshotter's systemd so these variables can be used for image pulls.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
