### PR TITLE
add release subpackage to enable swap

### DIFF
--- a/packages/release/prepare-swap.service
+++ b/packages/release/prepare-swap.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Prepare Swap
+RefuseManualStart=true
+RefuseManualStop=true
+DefaultDependencies=no
+Wants=modprobe@zram.service
+After=modprobe@zram.service dev-zram0.device
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/zramctl /dev/zram0 --size 1G
+ExecStart=/usr/sbin/mkswap --uuid clear /dev/zram0
+ExecStart=/usr/sbin/swapon --discard --priority 1024 /dev/zram0
+RemainAfterExit=true
+StandardError=journal+console
+SyslogIdentifier=prepare-swap
+
+[Install]
+WantedBy=sysinit.target

--- a/packages/release/release-swap-sysctl.conf
+++ b/packages/release/release-swap-sysctl.conf
@@ -1,0 +1,5 @@
+# In-memory swap I/O should always be faster than filesystem I/O.
+vm.swappiness = 200
+
+# Disable readahead since there are no I/O delays for in-memory swap.
+vm.page-cluster = 0

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -9,15 +9,22 @@ Summary: Bottlerocket release
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket
 
+# Core config files.
 Source11: nsswitch.conf
+
+# Sysctl drop-ins.
+Source80: release-sysctl.conf
+Source81: release-swap-sysctl.conf
+
+# Other drop-ins.
 Source93: release-tmpfiles.conf
 Source94: release-fips-tmpfiles.conf
 Source95: release-systemd-networkd.conf
 Source96: release-repart-local.conf
-Source97: release-sysctl.conf
 Source98: release-systemd-system.conf
 Source99: release-ca-certificates-tmpfiles.conf
 
+# Templates for the settings API.
 Source200: motd.template
 Source201: proxy-env
 Source202: hostname-env
@@ -63,6 +70,7 @@ Source1046: mask-local-var.service
 Source1047: repart-data-preferred.service
 Source1048: repart-data-fallback.service
 Source1049: prepare-local-fs.service
+Source1050: prepare-swap.service
 
 # Feature-specific units.
 Source1060: capture-kernel-dump.service
@@ -149,6 +157,14 @@ Requires: %{_cross_os}libkcapi
 %description fips
 %{summary}.
 
+%package swap
+Summary: Bottlerocket release, with zram-based swap
+Requires: %{name}
+Requires: (%{name}-fips if %{_cross_os}image-feature(fips))
+
+%description swap
+%{summary}.
+
 %prep
 
 %build
@@ -169,7 +185,8 @@ install -d %{buildroot}%{_cross_libdir}/repart.d/
 install -p -m 0644 %{S:96} %{buildroot}%{_cross_libdir}/repart.d/80-local.conf
 
 install -d %{buildroot}%{_cross_sysctldir}
-install -p -m 0644 %{S:97} %{buildroot}%{_cross_sysctldir}/80-release.conf
+install -p -m 0644 %{S:80} %{buildroot}%{_cross_sysctldir}/80-release.conf
+install -p -m 0644 %{S:81} %{buildroot}%{_cross_sysctldir}/81-release-swap.conf
 
 install -d %{buildroot}%{_cross_unitdir}/service.d
 install -p -m 0644 %{S:1104} %{buildroot}%{_cross_unitdir}/service.d/00-aws-config.conf
@@ -196,6 +213,7 @@ install -p -m 0644 \
   %{S:1025} %{S:1026} %{S:1027} %{S:1028} %{S:1029} \
   %{S:1040} %{S:1041} %{S:1042} %{S:1043} %{S:1044} \
   %{S:1045} %{S:1046} %{S:1047} %{S:1048} %{S:1049} \
+  %{S:1050} \
   %{S:1060} %{S:1061} %{S:1062} %{S:1063} %{S:1064} \
   %{S:1065} %{S:1066} %{S:1067} \
   %{buildroot}%{_cross_unitdir}
@@ -354,5 +372,9 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/check-fips-modules.service
 %dir %{_cross_unitdir}/check-fips-modules.service.d
 %{_cross_unitdir}/fips-modprobe@.service
+
+%files swap
+%{_cross_sysctldir}/81-release-swap.conf
+%{_cross_unitdir}/prepare-swap.service
 
 %changelog


### PR DESCRIPTION
**Issue number:**
Related: bottlerocket-os/bottlerocket#4075

**Description of changes:**
In low memory, pre-OOM-kill conditions, an orchestrator agent like kubelet that is responsible for freeing up system resources may be unable to terminate a process that allocates too much memory, if its clean pages are dropped from the cache and must be read back from the filesystem's block device whenever it runs, only to have those pages dropped again when the scheduler selects another process to run.

For storage devices with metered I/O, such Amazon EBS gp2 volumes, this cycle of reading the same filesystem blocks over and over can exhaust the available credits, and leave the system livelocked for for hours or days.

Providing a swap device gives the kernel an alternative to evicting clean pages to free up memory prior to invoking the OOM killer: it can swap out anonymous memory instead.

If the swap device were also stored on a device with I/O limits, the same failure mode might arise when faulting in pages for anonymous memory.

Using zram for the swap device avoids this problem. Instead of being swapped to disk, the anonymous memory pages are compressed, and the savings relative to the uncompressed size are returned to the system. The zram device is not used until physical memory is exhausted; it has an overhead of around 1%, or 1 MiB for the 1 GiB reservation.

Enabling zram-backed swap may become the default for Bottlerocket in the future. For now, add the logic to a new subpackage so variants can opt in by specifying "release-swap" instead of "release" in their package list.


**Testing done:**
Verified that the service started up as expected:
```
systemctl status prepare-swap
● prepare-swap.service - Prepare Swap
     Loaded: loaded (/aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/prepare-swap.service; enabled; preset: enabled)
    Drop-In: /aarch64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (exited) since Thu 2025-07-17 21:30:17 UTC; 2min 27s ago
   Main PID: 1287 (code=exited, status=0/SUCCESS)
        CPU: 19ms

Jul 17 21:30:17 localhost prepare-swap[727]: Setting up swapspace version 1, size = 1024 MiB (1073737728 bytes)
Jul 17 21:30:17 localhost prepare-swap[727]: no label, UUID=00000000-0000-0000-0000-000000000000
Jul 17 21:30:17 localhost systemd[1]: Finished Prepare Swap.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
