### PR TITLE
feat: allow overriding `{host,bootstrap}-containers` entrypoint command

### DIFF
--- a/packages/os/bootstrap-containers-toml
+++ b/packages/os/bootstrap-containers-toml
@@ -1,6 +1,6 @@
 [required-extensions]
 bootstrap-containers = "v1"
-std = { version = "v1", helpers = ["if_not_null"] }
+std = { version = "v1", helpers = ["if_not_null", "toml_encode"]}
 +++
 {{#if_not_null settings.bootstrap-containers}}
 {{#each settings.bootstrap-containers}}
@@ -16,6 +16,9 @@ user-data = "{{{this.user-data}}}"
 {{/if_not_null}}
 {{#if_not_null this.essential}}
 essential = {{this.essential}}
+{{/if_not_null}}
+{{#if_not_null this.command}}
+command = {{ toml_encode this.command }}
 {{/if_not_null}}
 {{/each}}
 {{/if_not_null}}

--- a/packages/os/bootstrap-containers@.service
+++ b/packages/os/bootstrap-containers@.service
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/host-ctr run \
     --container-id='%i' \
     --source='${CTR_SOURCE}' \
     --container-type='bootstrap' \
+    --command='${CTR_COMMAND}' \
     --registry-config=/etc/host-containers/host-ctr.toml
 ExecStartPost=/usr/bin/bootstrap-containers mark-bootstrap \
     --container-id '%i' \

--- a/packages/os/host-containers-toml
+++ b/packages/os/host-containers-toml
@@ -1,6 +1,6 @@
 [required-extensions]
 host-containers = "v1"
-std = { version = "v1", helpers = ["if_not_null"]}
+std = { version = "v1", helpers = ["if_not_null", "toml_encode"]}
 +++
 {{#if_not_null settings.host-containers}}
 {{#each settings.host-containers}}
@@ -16,6 +16,9 @@ superpowered = {{this.superpowered}}
 {{/if_not_null}}
 {{#if_not_null this.user-data}}
 user-data = "{{{this.user-data}}}"
+{{/if_not_null}}
+{{#if_not_null this.command}}
+command = {{ toml_encode this.command }}
 {{/if_not_null}}
 {{/each}}
 {{/if_not_null}}

--- a/packages/os/host-containers@.service
+++ b/packages/os/host-containers@.service
@@ -12,6 +12,7 @@ ExecStart=/usr/bin/host-ctr run \
     --container-id='%i' \
     --source='${CTR_SOURCE}' \
     --superpowered='${CTR_SUPERPOWERED}' \
+    --command='${CTR_COMMAND}' \
     --registry-config=/etc/host-containers/host-ctr.toml
 Restart=always
 RestartSec=45

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2740,6 +2740,7 @@ dependencies = [
  "generate-readme",
  "log",
  "serde",
+ "serde_json",
  "simplelog",
  "snafu",
  "tempfile",

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -106,6 +106,8 @@ struct BootstrapContainer {
     user_data: Option<ValidBase64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     essential: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    command: Vec<String>,
 }
 
 /// Stores user-supplied global arguments
@@ -275,6 +277,11 @@ where
     let mode = container_details.mode.clone().unwrap_or_default();
 
     let essential = container_details.essential.unwrap_or(false);
+    let command = serde_json::to_string(&container_details.command).context(
+        error::SerializeContainerCommandSnafu {
+            command: container_details.command.clone(),
+        },
+    )?;
 
     // Create the directory regardless if user data was provided for the container
     let dir = Path::new(PERSISTENT_STORAGE_DIR).join(name);
@@ -299,7 +306,7 @@ where
 
     // Write the environment file needed for the systemd service to have details
     // this specific bootstrap container
-    write_config_files(name, source, &mode, essential)?;
+    write_config_files(name, source, &mode, essential, command)?;
 
     if mode == "off" {
         // If mode is 'off', disable the container, and clean up any left over tasks
@@ -311,7 +318,7 @@ where
 
         if host_containerd_unit.is_active()? {
             debug!("Cleaning up container '{}'", name);
-            command(
+            crate::command(
                 constants::HOST_CTR_BIN,
                 [
                     "clean-up",
@@ -325,7 +332,7 @@ where
 
         // Clean up any left over tasks, before the container is enabled
         if host_containerd_unit.is_active()? && !systemd_unit.is_enabled()? {
-            command(
+            crate::command(
                 constants::HOST_CTR_BIN,
                 [
                     "clean-up",
@@ -343,11 +350,18 @@ where
 }
 
 /// Write out the EnvironmentFile that systemd uses to fill in arguments to host-ctr
-fn write_config_files<S1, S2, S3>(name: S1, source: S2, mode: S3, essential: bool) -> Result<()>
+fn write_config_files<S1, S2, S3, S4>(
+    name: S1,
+    source: S2,
+    mode: S3,
+    essential: bool,
+    command: S4,
+) -> Result<()>
 where
     S1: AsRef<str>,
     S2: AsRef<str>,
     S3: AsRef<str>,
+    S4: AsRef<str>,
 {
     let name = name.as_ref();
 
@@ -362,6 +376,11 @@ where
         },
     )?;
     writeln!(output, "CTR_MODE={}", mode.as_ref()).context(
+        error::WriteConfigurationValueSnafu {
+            value: mode.as_ref(),
+        },
+    )?;
+    writeln!(output, "CTR_COMMAND={}", command.as_ref()).context(
         error::WriteConfigurationValueSnafu {
             value: mode.as_ref(),
         },
@@ -659,6 +678,16 @@ mod error {
 
         #[snafu(display("Failed write value '{}': {}", value, source))]
         WriteConfigurationValue { value: String, source: fmt::Error },
+
+        #[snafu(display(
+            "Failed to serialize container entrypoint command {:?}: {}",
+            command,
+            source
+        ))]
+        SerializeContainerCommand {
+            command: Vec<String>,
+            source: serde_json::Error,
+        },
     }
 }
 

--- a/sources/api/host-containers/Cargo.toml
+++ b/sources/api/host-containers/Cargo.toml
@@ -18,6 +18,7 @@ simplelog.workspace = true
 snafu.workspace = true
 toml.workspace = true
 bottlerocket-modeled-types.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/sources/api/host-containers/src/config.rs
+++ b/sources/api/host-containers/src/config.rs
@@ -15,4 +15,6 @@ pub(crate) struct HostContainer {
     pub(crate) enabled: Option<bool>,
     pub(crate) superpowered: Option<bool>,
     pub(crate) user_data: Option<ValidBase64>,
+    #[serde(default)]
+    pub(crate) command: Vec<String>,
 }

--- a/sources/api/host-containers/src/main.rs
+++ b/sources/api/host-containers/src/main.rs
@@ -113,6 +113,16 @@ mod error {
             name: String,
             source: std::io::Error,
         },
+
+        #[snafu(display(
+            "Failed to serialize container entrypoint command {:?}: {}",
+            command,
+            source
+        ))]
+        SerializeContainerCommand {
+            command: Vec<String>,
+            source: serde_json::Error,
+        },
     }
 }
 
@@ -233,10 +243,17 @@ where
 }
 
 /// Write out the EnvironmentFile that systemd uses to fill in arguments to host-ctr
-fn write_env_file<S1, S2>(name: S1, source: S2, enabled: bool, superpowered: bool) -> Result<()>
+fn write_env_file<S1, S2, S3>(
+    name: S1,
+    source: S2,
+    enabled: bool,
+    superpowered: bool,
+    command: S3,
+) -> Result<()>
 where
     S1: AsRef<str>,
     S2: AsRef<str>,
+    S3: AsRef<str>,
 {
     let name = name.as_ref();
     let filename = format!("{name}.env");
@@ -246,6 +263,8 @@ where
     writeln!(output, "CTR_SUPERPOWERED={superpowered}")
         .context(error::EnvFileBuildFailedSnafu { name })?;
     writeln!(output, "CTR_SOURCE={}", source.as_ref())
+        .context(error::EnvFileBuildFailedSnafu { name })?;
+    writeln!(output, "CTR_COMMAND={}", command.as_ref())
         .context(error::EnvFileBuildFailedSnafu { name })?;
 
     writeln!(
@@ -336,10 +355,15 @@ where
         })?;
     let enabled = image_details.enabled.unwrap_or(false);
     let superpowered = image_details.superpowered.unwrap_or(false);
+    let command = serde_json::to_string(&image_details.command).context(
+        error::SerializeContainerCommandSnafu {
+            command: image_details.command.clone(),
+        },
+    )?;
 
     info!(
-        "Host container '{}' is enabled: {}, superpowered: {}, with source: {}",
-        name, enabled, superpowered, source
+        "Host container '{}' is enabled: {}, superpowered: {}, with source: {}, entrypoint command: {}",
+        name, enabled, superpowered, source, command
     );
 
     // Create the directory regardless if user data was provided for the container
@@ -360,7 +384,7 @@ where
 
     // Write the environment file needed for the systemd service to have details about this
     // specific host container
-    write_env_file(name, source, enabled, superpowered)?;
+    write_env_file(name, source, enabled, superpowered, command)?;
 
     // Now start/stop the container according to the 'enabled' setting
     let unit_name = format!("host-containers@{name}.service");
@@ -376,13 +400,13 @@ where
     // We want to ensure the host container is running with its most recent configuration.
     if host_containerd_unit.is_active()? {
         debug!("Cleaning up host container: '{}'", unit_name);
-        command(
+        crate::command(
             constants::HOST_CTR_BIN,
             ["clean-up", "--container-id", name],
         )?;
     }
 
-    let systemd_target = command(constants::SYSTEMCTL_BIN, ["get-default"])?;
+    let systemd_target = crate::command(constants::SYSTEMCTL_BIN, ["get-default"])?;
 
     // What happens next depends on whether the system has finished booting, and whether the
     // host container is enabled.
@@ -501,6 +525,7 @@ mod test {
         enabled = true
         superpowered = true
         user-data = "Zm9vCg=="
+        command = ["sh", "-c", "echo hello"]
         "#;
 
         let temp_dir = tempfile::TempDir::new().unwrap();
@@ -517,6 +542,7 @@ mod test {
                 enabled: Some(true),
                 superpowered: Some(true),
                 user_data: Some(ValidBase64::try_from("Zm9vCg==").unwrap()),
+                command: ["sh", "-c", "echo hello"].map(String::from).into(),
             },
         );
 

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -106,6 +107,7 @@ func App() *cli.App {
 		registryConfig   string
 		cType            string
 		useCachedImage   bool
+		command          string
 	)
 
 	app := cli.NewApp()
@@ -171,9 +173,29 @@ func App() *cli.App {
 					Destination: &useCachedImage,
 					Value:       false,
 				},
+				&cli.StringFlag{
+					Name:        "command",
+					Usage:       "a JSON array of commands and arguments to run as the container's entrypoint",
+					Destination: &command,
+					Value:       "[]",
+				},
 			},
 			Action: func(_ *cli.Context) error {
-				return runCtr(containerdSocket, namespace, containerID, source, superpowered, registryConfig, containerType(cType), useCachedImage)
+				var commandParts []string
+				if err := json.Unmarshal([]byte(command), &commandParts); err != nil {
+					return fmt.Errorf("failed to parse entrypoint command: %w", err)
+				}
+				return runCtr(
+					containerdSocket,
+					namespace,
+					containerID,
+					source,
+					superpowered,
+					registryConfig,
+					containerType(cType),
+					useCachedImage,
+					commandParts,
+				)
 			},
 		},
 		{
@@ -284,7 +306,7 @@ func SliceContains(s []string, v string) bool {
 	return false
 }
 
-func runCtr(containerdSocket string, namespace string, containerID string, source string, superpowered bool, registryConfigPath string, cType containerType, useCachedImage bool) error {
+func runCtr(containerdSocket string, namespace string, containerID string, source string, superpowered bool, registryConfigPath string, cType containerType, useCachedImage bool, command []string) error {
 	// Check if the containerType provided is valid
 	if !cType.IsValid() {
 		return errors.New("Invalid container type")
@@ -378,6 +400,11 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 			specOpts = append(specOpts, withBootstrap())
 		default:
 			specOpts = append(specOpts, withDefault())
+		}
+
+		// Override the entrypoint command, regardless of container type or other options
+		if len(command) > 0 {
+			specOpts = append(specOpts, oci.WithProcessArgs(command...))
 		}
 
 		ctrOpts := containerd.WithNewSpec(specOpts...)
@@ -733,7 +760,6 @@ func fetchECRRef(ctx context.Context, input string, specialRegions specialRegion
 	// if a valid ECR ref has not yet been returned
 	log.G(ctx).WithError(err).WithField("source", input).Error("failed to parse special ECR reference")
 	return ecr.ECRSpec{}, errors.Wrap(err, "could not parse ECR reference for special regions")
-
 }
 
 // fetchECRImage does some additional conversions before resolving the image reference and fetches the image.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

implements #593 

**Description of changes:**

- adds a `--command` option to `host-ctr` that overrides a container's `ProcessArgs` during creation
- adds a `command` field to the `bootstrap-containers` and `host-containers` apis that populates systemd service envs
- updates systemd services to pass the `--command` option to `host-ctr` for both `host-containers` and `bootstrap-containers`

**Testing done:**

- created an AMI from a build of this `core-kit` and validated that
  - `host-ctr run --source  328549459982.dkr.ecr.us-east-1.amazonaws.com/bottlerocket-bootstrap:v0.2.4 --container-id hysm --command 'sh,-c,echo "hello world" && sleep infinity'` works as expected and that containers launched with this command are accessible with `apiclient exec`
  - the control and admin containers launch normally with no changes to their default config

**work in progress:**

in the current state, im getting a "Json deserialize error: unknown field `command`" whenever i try to create a host-container with a command through the apiclient as follows
```shell
apiclient set -j '{ "settings": { "host-containers": { "mycontainer": {
  "enabled": true,
  "source":"328549459982.dkr.ecr.us-east-1.amazonaws.com/bottlerocket-bootstrap:v0.2.4",
  "command": ["sleep","infinity"],
  "user-data": "ZWNobyBoZW5sb28K" } } } }'
```
despite making this pr <https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/94> and updating all references to `bottlerocket-os/bottlerocket-settings-sdk` in `sources/Cargo.toml` to point at it instead. im not sure what's missing to make the apiserver pick up on the new model schema.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
