### PR TITLE
apiserver: fix file descriptor leak in exec

### DIFF
--- a/sources/api/apiserver/src/server/exec/child.rs
+++ b/sources/api/apiserver/src/server/exec/child.rs
@@ -241,6 +241,13 @@ impl ChildHandles {
     }
 }
 
+impl Drop for ChildHandles {
+    /// Ensures the RawFd is properly closed when ChildHandles is dropped.
+    fn drop(&mut self) {
+        let _ = close(self.pty_fd);
+    }
+}
+
 /// ChildFds sets up read and write file descriptors for a Command (before it's spawned) based on
 /// whether the user requested a TTY.
 struct ChildFds {


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #572

**Description of changes:**
The [ChildHandles](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/0551078bb322ab7d30c5cf2c707a0b87452a3eae/sources/api/apiserver/src/server/exec/child.rs#L53C19-L53C31) struct was not implementing the Drop trait to properly close the
raw file descriptor (pty_fd) when the struct was dropped. 

Unlike `write_fd` which is wrapped in a File object with automatic cleanup, this raw `pty_fd` requires explicit closure to
prevent leaks. 


**Testing done:**
* Enabled debug logs on api server and performed several  apiclient exec commands
* Confirmed this happens with and without TTY

Reaches Max Limit of fds before change / works after
```
for i in {1..1500}; do
  echo "Iteration $i"
  apiclient exec admin ls -la > /dev/null &
  echo "FD count: $(ls -l /proc/$(pgrep apiserver)/fd | wc -l)"
done
```

Before the change:

```
bash-4.2#  ls -la /proc/1535/fd | wc -l
25
bash-4.2# apiclient exec admin echo hello
hello
bash-4.2# ls -la /proc/1535/fd | wc -l
26
```

After the change:
```
bash-5.1# ls -la /proc/$(pgrep apiserver)/fd/ | wc -l
22
bash-5.1# apiclient exec -T control echo test
test
bash-5.1# ls -la /proc/$(pgrep apiserver)/fd/ | wc -l
22
```






**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
