### PR TITLE
chore: fix clippy lints in bloodhound

### DIFF
--- a/sources/bloodhound/src/bin/kubernetes-cis-checks/checks.rs
+++ b/sources/bloodhound/src/bin/kubernetes-cis-checks/checks.rs
@@ -753,7 +753,7 @@ impl Checker for K8S04021400Checker {
                 result.status = CheckStatus::FAIL;
             }
         } else {
-            result.error = format!("unable to read '{}'", KUBELET_CONF_FILE);
+            result.error = format!("unable to read '{KUBELET_CONF_FILE}'");
         }
 
         result
@@ -797,7 +797,7 @@ impl Checker for K8S04030100Checker {
                 result.status = CheckStatus::PASS;
             }
         } else {
-            result.error = format!("unable to read '{}'", KUBEPROXY_CONF_FILE);
+            result.error = format!("unable to read '{KUBEPROXY_CONF_FILE}'");
         }
         result
     }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #596

**Description of changes:**

Fix string format lints caught in bloodhound causing build errors.

**Testing done:**

`cd sources/ && cargo clippy -- -D warnings --no-deps`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
