### PR TITLE
Update several lib packages and cni plugins

### DIFF
--- a/packages/cni-plugins/Cargo.toml
+++ b/packages/cni-plugins/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containernetworking/plugins/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/plugins/archive/v1.6.2/plugins-1.6.2.tar.gz"
-sha512 = "ee577e3fe39558d6a6296754c97de6608f95152805c01b8053e2958d16634ab57d147eea7c950fcc4d1a98d6733a85717adf7078ee2dffff007ec3b063386c24"
+url = "https://github.com/containernetworking/plugins/archive/v1.7.1/plugins-1.7.1.tar.gz"
+sha512 = "5b1a8c1a63f6f7a7ca4df570bf5c4b2003cdfe1b861ac86f145b5b523c9371275f68b01a115566a4f3455e56709a5a280b485005ea3fa121c1f381fbf6bd500e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -2,7 +2,7 @@
 %global gorepo plugins
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.6.2
+%global gover 1.7.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/cni/Cargo.toml
+++ b/packages/cni/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/containernetworking/cni/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containernetworking/cni/archive/v1.2.3/cni-1.2.3.tar.gz"
-sha512 = "7df2a2d01b85ace4e73ea577017e7c98a5d3b86373da5cf9e4ec7f50a1439753ed447c8f7fc871876c624336d91848fd42f309481bffbccc388377dbfad2e133"
+url = "https://github.com/containernetworking/cni/archive/v1.3.0/cni-1.3.0.tar.gz"
+sha512 = "b723187db7f08bce9ad71fa1fef805aa72752aa5916edb5b9402f23b85f97c01a8a1e19a633550d7b547c582cba43452b1da92ba4ae8435d95d01a2399874694"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/cni/cni.spec
+++ b/packages/cni/cni.spec
@@ -2,7 +2,7 @@
 %global gorepo cni
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.2.3
+%global gover 1.3.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/libaudit/Cargo.toml
+++ b/packages/libaudit/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-audit/audit-userspace/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-audit/audit-userspace/archive/v4.0.3/audit-userspace-4.0.3.tar.gz"
-sha512 = "a20d2f832632fa844764086aac98c80f7fcb120ceeaae7472248e04eec0493981e31fd59f22c3f0dbff81ccbcd132b8297812f2b4cdb87b866c59aedf3611342"
+url = "https://github.com/linux-audit/audit-userspace/archive/v4.1.0/audit-userspace-4.1.0.tar.gz"
+sha512 = "fe17a4a7ea44160b439ac39c311cce10341149e780136d95911db304b244d35b745e93c3834b9eb5c6123093ca96852dd72dc4fde2d6339443514bc9a96e46ca"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libaudit
-Version: 4.0.3
+Version: 4.1.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for the audit subsystem

--- a/packages/libbpf/Cargo.toml
+++ b/packages/libbpf/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/libbpf/libbpf/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/libbpf/libbpf/archive/refs/tags/v1.5.0.tar.gz"
-sha512 = "0cc25addcf5fcee0537d598037feab4bc73a513e6025d8f559bed58fe8850a10fcfeefd1a9dafc5e0bac6202d445944b12811cb7254b9b3be4dd3d2cc1e9419b"
+url = "https://github.com/libbpf/libbpf/archive/refs/tags/v1.6.1.tar.gz"
+sha512 = "8089f6aad10507eacaccf08b1521b571490a1b0d72f9ea6da141c5e530a6d62d71b30c561774428c6d6dcfb5df7d8470d3107930eb03389c3c4f35a87f530db8"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libbpf/libbpf.spec
+++ b/packages/libbpf/libbpf.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libbpf
-Version: 1.5.0
+Version: 1.6.1
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for BPF

--- a/packages/libdevmapper/Cargo.toml
+++ b/packages/libdevmapper/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://sourceware.org/lvm2"
 
 [[package.metadata.build-package.external-files]]
-url = "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.31.tgz"
-sha512 = "254131e28b22d55531d211886afbfdc219e77a4df802e3ec9b66d889ff22bf6d0a6c2df9c5ff017592d92e1dce0f658a6628fb321c1e90152ff7257492218242"
+url = "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.33.tgz"
+sha512 = "e023b99bffdf0bdfbb06148fc8f305533db609df0448a645f85cd047ab464f66450351f57e4b3a178e20001db6d632caf1d9f9cb1786f47722cbd29f5cc10348"
 
 [[package.metadata.build-package.external-files]]
-url = "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.31.tgz.asc"
-sha512 = "5f69cc9e04028964fdbb61fbcb07ca86e62d8dfbf9d789ac3567c9f607c1045e03410ba92a5987227c3002e97101a855f091dc87d2c17c5d9bf45401c0ad1f29"
+url = "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.33.tgz.asc"
+sha512 = "25c5b4ad2bba3a606d09e7e7a47a933671200fc9cd6eccd6cc9cadddb43270446227383738a24a97065af2742031e103edbb159e35d5c85220f43ea03a381925"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libdevmapper/libdevmapper.spec
+++ b/packages/libdevmapper/libdevmapper.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libdevmapper
-Version: 2.03.31
+Version: 2.03.33
 Release: 1%{?dist}
 Summary: Library for device mapper
 License: LGPL-2.1-only

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -13,8 +13,8 @@ releases-url = "https://download.gnome.org/sources/glib"
 
 # glib uses the "stable releases use even minor numbers" versioning scheme
 [[package.metadata.build-package.external-files]]
-url = "https://download.gnome.org/sources/glib/2.84/glib-2.84.1.tar.xz"
-sha512 = "ee7f38a4726fd72e41ddb75c4933c7b1bb30935bb2fddc84902d0627a836af512534195132cc02e3d15f168fefc816576181a8d6e436472b582191437b79a456"
+url = "https://download.gnome.org/sources/glib/2.84/glib-2.84.3.tar.xz"
+sha512 = "73f2d67d2ef5b4dc8cd2f6df9ce7903853ec619924e2927adbc73d706974a7d660afea55be18e12ccb0dee1145cf4149b743278d2b128fd466e3df2bbf90ef57"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libglib
-Version: 2.84.1
+Version: 2.84.3
 Release: 1%{?dist}
 Epoch: 1
 Summary: The GLib libraries

--- a/packages/libncurses/Cargo.toml
+++ b/packages/libncurses/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://invisible-mirror.net/archives/ncurses/current/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20241207.tgz"
-sha512 = "45a0a96f88c3d67e9ed2e1d38186516f10223715a5127cfd933fcb6825a1d2da15c9facf92fd38a78715b150b2a9079a86ccb8128cb27f1d0fc97223fba13f0a"
+url = "https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20250720.tgz"
+sha512 = "4650f2c1b59c02442ad61bcedfec5d4cd5af214d7577cfdffdf2875022faec40dffe1215355c4d42c415beb43d591516a2f45cfdcd96c60b02eb290a3091464e"
 
 [[package.metadata.build-package.external-files]]
-url = "https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20241207.tgz.asc"
-sha512 = "6f65aea9c326e76b9e73a3bf2025bb1c58233637c28b54bb2dd36814b36d35360c7b2d75f855c98aa76eb3ad6e49195bf5aa73d4d060c67142e1b280ce526faf"
+url = "https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20250720.tgz.asc"
+sha512 = "d48f990aa72070e8554c641db6f53e9c9215fb95b7292a3253a68030b6d6bd0eb9ec4c394cc10cc0d44d45cdcb8fd2b09b11a8d45e8a511ccb15885b172a6200"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libncurses/libncurses.spec
+++ b/packages/libncurses/libncurses.spec
@@ -1,5 +1,5 @@
 %global ncurses_ver 6.5
-%global ncurses_rev 20241207
+%global ncurses_rev 20250720
 
 Name: %{_cross_os}libncurses
 Version: %{ncurses_ver}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

Updated packages:
* `cni` to 1.3.0
* `cni-plugins` to 1.7.1
* `libaudit` to 4.1.0
* `libbpf` to 1.6.1
* `libdevmapper` to 2.03.33
* `libglib` to 2.84.3
* `libncurses` to 6.5.20250720


**Testing done:**
* Launched Vmware dev variant; verified Power commands

```
# cryptsetup luksFormat --pbkdf argon2id --batch-mode --key-file /tmp/passphrase /tmp/volume
# cryptsetup open --key-file /tmp/passphrase /tmp/volume crypt
# ls -latr /dev/mapper/crypt 
brw-rw----. 1 root root 252, 1 Jul 22 01:28 /dev/mapper/crypt
```

* Ran Quick tests
```
aarch64-aws-k8s-133-quick                  Test                     passed                                       5                      0                    6730   0daf4c2b                2025-07-21T20:25:34Z
x86-64-aws-k8s-133-quick                   Test                     passed                                       5                      0                    6730   0daf4c2b                2025-07-21T20:25:45Z
 ```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
