### PR TITLE
test: inject a trait into check execution to allow unit testing

### DIFF
--- a/sources/bloodhound/Cargo.toml
+++ b/sources/bloodhound/Cargo.toml
@@ -16,8 +16,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
 walkdir.workspace = true
-
-[dev-dependencies]
 tempfile.workspace = true
 
 [build-dependencies]

--- a/sources/bloodhound/src/bin/bottlerocket-cis-checks/checks.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-cis-checks/checks.rs
@@ -1,7 +1,7 @@
 use bloodhound::results::{CheckStatus, Checker, CheckerMetadata, CheckerResult, Mode};
 use bloodhound::*;
 use std::os::unix::fs::PermissionsExt;
-use std::process::Command;
+use system_access::SystemAccess;
 use walkdir::WalkDir;
 
 const PROC_MODULES_FILE: &str = "/proc/modules";
@@ -21,11 +21,11 @@ const IP6TABLES_CMD: &str = "/usr/sbin/ip6tables";
 pub struct BR01010101Checker {}
 
 impl Checker for BR01010101Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let mut module_result = CheckerResult::default();
 
         // Make sure UDF isn't already loaded
-        if let Ok(found) = look_for_word_in_file(PROC_MODULES_FILE, "udf") {
+        if let Ok(found) = look_for_word_in_file(sac, PROC_MODULES_FILE, "udf") {
             if found {
                 module_result.error = "udf is currently loaded".to_string();
                 module_result.status = CheckStatus::FAIL;
@@ -39,8 +39,9 @@ impl Checker for BR01010101Checker {
 
         // Make sure the ability to load UDF is disabled
         check_output_contains!(
+            sac,
             MODPROBE_CMD,
-            ["-n", "-v", "udf"],
+            &["-n", "-v", "udf"],
             &["install /bin/true"],
             "unable to parse modprobe output to check if udf is enabled",
             "modprobe for udf is not disabled"
@@ -63,8 +64,9 @@ impl Checker for BR01010101Checker {
 pub struct BR01030100Checker {}
 
 impl Checker for BR01030100Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_file_contains!(
+            sac,
             PROC_CMDLINE_FILE,
             &[
                 "dm-mod.create=root,,,ro,0",
@@ -92,10 +94,11 @@ impl Checker for BR01030100Checker {
 pub struct BR01040100Checker {}
 
 impl Checker for BR01040100Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            ["fs.suid_dumpable"],
+            &["fs.suid_dumpable"],
             &["fs.suid_dumpable = 0"],
             "unable to verify fs.suid_dumpable setting",
             "setuid core dumps are not disabled"
@@ -118,10 +121,11 @@ impl Checker for BR01040100Checker {
 pub struct BR01040200Checker {}
 
 impl Checker for BR01040200Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            ["kernel.randomize_va_space"],
+            &["kernel.randomize_va_space"],
             &["kernel.randomize_va_space = 2"],
             "unable to verify kernel.randomize_va_space setting",
             "Address space layout randomization is not enabled"
@@ -144,10 +148,11 @@ impl Checker for BR01040200Checker {
 pub struct BR01040300Checker {}
 
 impl Checker for BR01040300Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            ["kernel.unprivileged_bpf_disabled"],
+            &["kernel.unprivileged_bpf_disabled"],
             &["kernel.unprivileged_bpf_disabled = 1"],
             "unable to verify kernel.unprivileged_bpf_disabled setting",
             "unprivileged eBPF is not disabled"
@@ -170,10 +175,11 @@ impl Checker for BR01040300Checker {
 pub struct BR01040400Checker {}
 
 impl Checker for BR01040400Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            ["user.max_user_namespaces"],
+            &["user.max_user_namespaces"],
             &["user.max_user_namespaces = 0"],
             "unable to verify user.max_user_namespaces setting",
             "user namespaces are not disabled"
@@ -196,7 +202,7 @@ impl Checker for BR01040400Checker {
 pub struct BR01050100Checker {}
 
 impl Checker for BR01050100Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let mut result = CheckerResult::default();
 
         // Trying to avoid bringing in regex for now
@@ -210,7 +216,7 @@ impl Checker for BR01050100Checker {
             ("Memory protection checking: ", " actual (secure)"),
         ];
 
-        if let Ok(output) = Command::new(SESTATUS_CMD).output() {
+        if let Ok(output) = sac.command_output(SESTATUS_CMD, &[]) {
             let mut matched = 0;
 
             if output.status.success() {
@@ -254,8 +260,9 @@ impl Checker for BR01050100Checker {
 pub struct BR01050200Checker {}
 
 impl Checker for BR01050200Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_file_contains!(
+            sac,
             LOCKDOWN_FILE,
             &["[integrity]"],
             "unable to verify lockdown mode",
@@ -279,8 +286,9 @@ impl Checker for BR01050200Checker {
 pub struct BR02010101Checker {}
 
 impl Checker for BR02010101Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let result = check_file_contains!(
+            sac,
             CHRONY_CONF_FILE,
             &["pool"],
             "unable to verify time-servers setting",
@@ -293,8 +301,9 @@ impl Checker for BR02010101Checker {
         }
 
         check_output_contains!(
+            sac,
             SYSTEMCTL_CMD,
-            ["show", "--property", "ActiveState", "chronyd"],
+            &["show", "--property", "ActiveState", "chronyd"],
             &["ActiveState=active"],
             "unable to verify chronyd service enabled",
             "chronyd NTP service is not enabled"
@@ -317,7 +326,7 @@ impl Checker for BR02010101Checker {
 pub struct BR03010100Checker {}
 
 impl Checker for BR03010100Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let settings = [
             "net.ipv4.conf.all.send_redirects",
             "net.ipv4.conf.default.send_redirects",
@@ -329,8 +338,9 @@ impl Checker for BR03010100Checker {
         ];
 
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            settings,
+            &settings,
             &output,
             "unable to verify redirect settings",
             "redirects not disabled"
@@ -353,7 +363,7 @@ impl Checker for BR03010100Checker {
 pub struct BR03020100Checker {}
 
 impl Checker for BR03020100Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let settings = [
             "net.ipv4.conf.all.accept_source_route",
             "net.ipv4.conf.default.accept_source_route",
@@ -369,8 +379,9 @@ impl Checker for BR03020100Checker {
         ];
 
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            settings,
+            &settings,
             &output,
             "unable to verify source route settings",
             "accept source route not disabled"
@@ -393,7 +404,7 @@ impl Checker for BR03020100Checker {
 pub struct BR03020200Checker {}
 
 impl Checker for BR03020200Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let settings = [
             "net.ipv4.conf.all.accept_redirects",
             "net.ipv4.conf.default.accept_redirects",
@@ -409,8 +420,9 @@ impl Checker for BR03020200Checker {
         ];
 
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            settings,
+            &settings,
             &output,
             "unable to verify redirect settings",
             "accept redirects not disabled"
@@ -433,7 +445,7 @@ impl Checker for BR03020200Checker {
 pub struct BR03020300Checker {}
 
 impl Checker for BR03020300Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let settings = [
             "net.ipv4.conf.all.secure_redirects",
             "net.ipv4.conf.default.secure_redirects",
@@ -445,8 +457,9 @@ impl Checker for BR03020300Checker {
         ];
 
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            settings,
+            &settings,
             &output,
             "unable to verify secure redirect settings",
             "secure redirects not disabled"
@@ -469,7 +482,7 @@ impl Checker for BR03020300Checker {
 pub struct BR03020400Checker {}
 
 impl Checker for BR03020400Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let settings = [
             "net.ipv4.conf.all.log_martians",
             "net.ipv4.conf.default.log_martians",
@@ -481,8 +494,9 @@ impl Checker for BR03020400Checker {
         ];
 
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            settings,
+            &settings,
             &output,
             "unable to verify martian packet logging settings",
             "martian packet logging not enabled"
@@ -505,10 +519,11 @@ impl Checker for BR03020400Checker {
 pub struct BR03020500Checker {}
 
 impl Checker for BR03020500Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            ["net.ipv4.icmp_echo_ignore_broadcasts"],
+            &["net.ipv4.icmp_echo_ignore_broadcasts"],
             &["net.ipv4.icmp_echo_ignore_broadcasts = 1"],
             "unable to verify broadcast ICMP requests setting",
             "broadcast ICMP requests not ignored"
@@ -531,10 +546,11 @@ impl Checker for BR03020500Checker {
 pub struct BR03020600Checker {}
 
 impl Checker for BR03020600Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            ["net.ipv4.icmp_ignore_bogus_error_responses"],
+            &["net.ipv4.icmp_ignore_bogus_error_responses"],
             &["net.ipv4.icmp_ignore_bogus_error_responses = 1"],
             "unable to verify bogus ICMP bogus requests setting",
             "ignore bogus ICMP requests not ignored"
@@ -557,10 +573,11 @@ impl Checker for BR03020600Checker {
 pub struct BR03020700Checker {}
 
 impl Checker for BR03020700Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_output_contains!(
+            sac,
             SYSCTL_CMD,
-            ["net.ipv4.tcp_syncookies"],
+            &["net.ipv4.tcp_syncookies"],
             &["net.ipv4.tcp_syncookies = 1"],
             "unable to verify SYN flood cookie protection setting",
             "SYN flood cookie protection not enabled"
@@ -583,11 +600,11 @@ impl Checker for BR03020700Checker {
 pub struct BR03030100Checker {}
 
 impl Checker for BR03030100Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let mut result = CheckerResult::default();
 
         // Make sure sctp isn't already loaded
-        if let Ok(found) = look_for_word_in_file(PROC_MODULES_FILE, "sctp") {
+        if let Ok(found) = look_for_word_in_file(sac, PROC_MODULES_FILE, "sctp") {
             if found {
                 result.error = "sctp is currently loaded".to_string();
                 result.status = CheckStatus::FAIL;
@@ -599,8 +616,9 @@ impl Checker for BR03030100Checker {
         }
 
         check_output_contains!(
+            sac,
             MODPROBE_CMD,
-            ["-n", "-v", "sctp"],
+            &["-n", "-v", "sctp"],
             &["install /bin/true"],
             "unable to parse modprobe output to check if sctp is enabled",
             "modprobe for sctp is not disabled"
@@ -623,7 +641,7 @@ impl Checker for BR03030100Checker {
 pub struct BR03040101Checker {}
 
 impl Checker for BR03040101Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let output = &[
             "Chain INPUT (policy DROP)",
             "Chain FORWARD (policy DROP)",
@@ -631,8 +649,9 @@ impl Checker for BR03040101Checker {
         ];
 
         check_output_contains!(
+            sac,
             IPTABLES_CMD,
-            ["-L"],
+            &["-L"],
             output,
             "unable to verify iptables settings",
             "unable to find expected iptables values"
@@ -655,7 +674,7 @@ impl Checker for BR03040101Checker {
 pub struct BR03040102Checker {}
 
 impl Checker for BR03040102Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let mut result = CheckerResult::default();
 
         // Order matters here, so need to find the first one, then look for the second one
@@ -665,10 +684,7 @@ impl Checker for BR03040102Checker {
         );
         let second = ("DROP", "--  *      *       127.0.0.0/8          0.0.0.0/0");
 
-        if let Ok(output) = Command::new(IPTABLES_CMD)
-            .args(["-L", "INPUT", "-v", "-n"])
-            .output()
-        {
+        if let Ok(output) = sac.command_output(IPTABLES_CMD, &["-L", "INPUT", "-v", "-n"]) {
             let mut first_found = false;
             let mut second_found = false;
 
@@ -699,8 +715,9 @@ impl Checker for BR03040102Checker {
         }
 
         if let Some(found) = look_for_string_in_output(
+            sac,
             IPTABLES_CMD,
-            ["-L", "OUTPUT", "-v", "-n"],
+            &["-L", "OUTPUT", "-v", "-n"],
             "ACCEPT     all  --  *      lo      0.0.0.0/0            0.0.0.0/0",
         ) {
             if !found {
@@ -733,7 +750,7 @@ impl Checker for BR03040102Checker {
 pub struct BR03040201Checker {}
 
 impl Checker for BR03040201Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let output = &[
             "Chain INPUT (policy DROP)",
             "Chain FORWARD (policy DROP)",
@@ -741,8 +758,9 @@ impl Checker for BR03040201Checker {
         ];
 
         check_output_contains!(
+            sac,
             IP6TABLES_CMD,
-            ["-L"],
+            &["-L"],
             output,
             "unable to verify ip6tables settings",
             "unable to find expected ip6tables values"
@@ -765,17 +783,14 @@ impl Checker for BR03040201Checker {
 pub struct BR03040202Checker {}
 
 impl Checker for BR03040202Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let mut result = CheckerResult::default();
 
         // Order matters here, so need to find the first one, then look for the second one
         let first = ("ACCEPT", "--  lo     *       ::/0                 ::/0");
         let second = ("DROP", "--  *      *       ::1                  ::/0");
 
-        if let Ok(output) = Command::new(IP6TABLES_CMD)
-            .args(["-L", "INPUT", "-v", "-n"])
-            .output()
-        {
+        if let Ok(output) = sac.command_output(IP6TABLES_CMD, &["-L", "INPUT", "-v", "-n"]) {
             let mut first_found = false;
             let mut second_found = false;
 
@@ -806,8 +821,9 @@ impl Checker for BR03040202Checker {
         }
 
         if let Some(found) = look_for_string_in_output(
+            sac,
             IP6TABLES_CMD,
-            ["-L", "OUTPUT", "-v", "-n"],
+            &["-L", "OUTPUT", "-v", "-n"],
             "ACCEPT     all  --  *      lo      ::/0                 ::/0",
         ) {
             if !found {
@@ -840,8 +856,9 @@ impl Checker for BR03040202Checker {
 pub struct BR04010101Checker {}
 
 impl Checker for BR04010101Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_file_contains!(
+            sac,
             JOURNALD_CONF_FILE,
             &["Storage=persistent"],
             "unable to verify journald settings",
@@ -865,7 +882,7 @@ impl Checker for BR04010101Checker {
 pub struct BR04010200Checker {}
 
 impl Checker for BR04010200Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, _: &dyn SystemAccess) -> CheckerResult {
         // Default the result to report success
         let mut result = {
             CheckerResult {
@@ -903,5 +920,1103 @@ impl Checker for BR04010200Checker {
             name: "br04010200".to_string(),
             mode: Mode::Automatic,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::checks::*;
+    use bloodhound::results::{CheckStatus, Checker};
+    use bloodhound::system_access::UnitTestSystemAccess;
+    use std::process::{ExitStatus, Output};
+
+    // BR01010101Checker tests
+    #[test]
+    pub fn test_br01010101checker_proc_modules_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = BR01010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    #[test]
+    pub fn test_br01010101checker_udf_loaded() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(PROC_MODULES_FILE, "udf\n");
+        let checker = BR01010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br01010101checker_udf_not_loaded_loading_not_blocked() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(PROC_MODULES_FILE, "other\nmodules\n");
+        sac.register_command(
+            MODPROBE_CMD,
+            &["-n", "-v", "udf"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "insmod /lib/modules/kernel/fs/udf/udf.ko".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br01010101checker_udf_not_loaded_loading_blocked() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(PROC_MODULES_FILE, "other\nmodules\n");
+        sac.register_command(
+            MODPROBE_CMD,
+            &["-n", "-v", "udf"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "install /bin/true".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    // BR01030100Checker tests
+    #[test]
+    pub fn test_br01030100checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(
+            PROC_CMDLINE_FILE,
+            "dm-mod.create=root,,,ro,0 root=/dev/dm-0 restart_on_corruption other_param=value",
+        );
+        let checker = BR01030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br01030100checker_missing_params() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(PROC_CMDLINE_FILE, "root=/dev/sda1 other_param=value");
+        let checker = BR01030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br01030100checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = BR01030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // BR01040100Checker tests
+    #[test]
+    pub fn test_br01040100checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["fs.suid_dumpable"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "fs.suid_dumpable = 0".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01040100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br01040100checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["fs.suid_dumpable"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "fs.suid_dumpable = 1".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01040100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR01040200Checker tests
+    #[test]
+    pub fn test_br01040200checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["kernel.randomize_va_space"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "kernel.randomize_va_space = 2".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01040200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br01040200checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["kernel.randomize_va_space"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "kernel.randomize_va_space = 0".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01040200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR01040300Checker tests
+    #[test]
+    pub fn test_br01040300checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["kernel.unprivileged_bpf_disabled"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "kernel.unprivileged_bpf_disabled = 1".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01040300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br01040300checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["kernel.unprivileged_bpf_disabled"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "kernel.unprivileged_bpf_disabled = 0".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01040300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR01040400Checker tests
+    #[test]
+    pub fn test_br01040400checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["user.max_user_namespaces"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "user.max_user_namespaces = 0".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01040400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br01040400checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["user.max_user_namespaces"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "user.max_user_namespaces = 1000".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01040400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+    // BR01050100Checker tests
+    #[test]
+    pub fn test_br01050100checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SESTATUS_CMD,
+            &[],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "SELinux status: enabled\n",
+                    "Loaded policy name: fortified\n",
+                    "Current mode: enforcing\n",
+                    "Mode from config file: enforcing\n",
+                    "Policy MLS status: enabled\n",
+                    "Policy deny_unknown status: denied\n",
+                    "Memory protection checking: actual (secure)\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01050100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br01050100checker_fail_missing_values() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SESTATUS_CMD,
+            &[],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "SELinux status: disabled\n",
+                    "Loaded policy name: fortified\n",
+                    "Current mode: permissive\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR01050100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br01050100checker_command_fail() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = BR01050100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // BR01050200Checker tests
+    #[test]
+    pub fn test_br01050200checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(LOCKDOWN_FILE, "[integrity] confidentiality");
+        let checker = BR01050200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br01050200checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(LOCKDOWN_FILE, "none [confidentiality]");
+        let checker = BR01050200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br01050200checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = BR01050200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // BR02010101Checker tests
+    #[test]
+    pub fn test_br02010101checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(
+            CHRONY_CONF_FILE,
+            "pool 2.amazon.pool.ntp.org iburst\nserver time.nist.gov",
+        );
+        sac.register_command(
+            SYSTEMCTL_CMD,
+            &["show", "--property", "ActiveState", "chronyd"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "ActiveState=active".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR02010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br02010101checker_fail_no_pool() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(
+            CHRONY_CONF_FILE,
+            "server time.nist.gov\ndriftfile /var/lib/chrony/drift",
+        );
+        let checker = BR02010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br02010101checker_fail_service_inactive() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(CHRONY_CONF_FILE, "pool 2.amazon.pool.ntp.org iburst");
+        sac.register_command(
+            SYSTEMCTL_CMD,
+            &["show", "--property", "ActiveState", "chronyd"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "ActiveState=inactive".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR02010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br02010101checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = BR02010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+    // BR03010100Checker tests
+    #[test]
+    pub fn test_br03010100checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &[
+                "net.ipv4.conf.all.send_redirects",
+                "net.ipv4.conf.default.send_redirects",
+            ],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "net.ipv4.conf.all.send_redirects = 0\n",
+                    "net.ipv4.conf.default.send_redirects = 0\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03010100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03010100checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &[
+                "net.ipv4.conf.all.send_redirects",
+                "net.ipv4.conf.default.send_redirects",
+            ],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "net.ipv4.conf.all.send_redirects = 1\n",
+                    "net.ipv4.conf.default.send_redirects = 0\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03010100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR03020100Checker tests
+    #[test]
+    pub fn test_br03020100checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &[
+                "net.ipv4.conf.all.accept_source_route",
+                "net.ipv4.conf.default.accept_source_route",
+                "net.ipv6.conf.all.accept_source_route",
+                "net.ipv6.conf.default.accept_source_route",
+            ],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "net.ipv4.conf.all.accept_source_route = 0\n",
+                    "net.ipv4.conf.default.accept_source_route = 0\n",
+                    "net.ipv6.conf.all.accept_source_route = 0\n",
+                    "net.ipv6.conf.default.accept_source_route = 0\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03020100checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &[
+                "net.ipv4.conf.all.accept_source_route",
+                "net.ipv4.conf.default.accept_source_route",
+                "net.ipv6.conf.all.accept_source_route",
+                "net.ipv6.conf.default.accept_source_route",
+            ],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "net.ipv4.conf.all.accept_source_route = 1\n",
+                    "net.ipv4.conf.default.accept_source_route = 0\n",
+                    "net.ipv6.conf.all.accept_source_route = 0\n",
+                    "net.ipv6.conf.default.accept_source_route = 0\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR03020200Checker tests
+    #[test]
+    pub fn test_br03020200checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &[
+                "net.ipv4.conf.all.accept_redirects",
+                "net.ipv4.conf.default.accept_redirects",
+                "net.ipv6.conf.all.accept_redirects",
+                "net.ipv6.conf.default.accept_redirects",
+            ],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "net.ipv4.conf.all.accept_redirects = 0\n",
+                    "net.ipv4.conf.default.accept_redirects = 0\n",
+                    "net.ipv6.conf.all.accept_redirects = 0\n",
+                    "net.ipv6.conf.default.accept_redirects = 0\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03020200checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &[
+                "net.ipv4.conf.all.accept_redirects",
+                "net.ipv4.conf.default.accept_redirects",
+                "net.ipv6.conf.all.accept_redirects",
+                "net.ipv6.conf.default.accept_redirects",
+            ],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "net.ipv4.conf.all.accept_redirects = 0\n",
+                    "net.ipv4.conf.default.accept_redirects = 1\n",
+                    "net.ipv6.conf.all.accept_redirects = 0\n",
+                    "net.ipv6.conf.default.accept_redirects = 0\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR03020300Checker tests
+    #[test]
+    pub fn test_br03020300checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &[
+                "net.ipv4.conf.all.secure_redirects",
+                "net.ipv4.conf.default.secure_redirects",
+            ],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "net.ipv4.conf.all.secure_redirects = 0\n",
+                    "net.ipv4.conf.default.secure_redirects = 0\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03020300checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &[
+                "net.ipv4.conf.all.secure_redirects",
+                "net.ipv4.conf.default.secure_redirects",
+            ],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "net.ipv4.conf.all.secure_redirects = 1\n",
+                    "net.ipv4.conf.default.secure_redirects = 0\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR03020400Checker tests
+    #[test]
+    pub fn test_br03020400checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &[
+                "net.ipv4.conf.all.log_martians",
+                "net.ipv4.conf.default.log_martians",
+            ],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "net.ipv4.conf.all.log_martians = 1\n",
+                    "net.ipv4.conf.default.log_martians = 1\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03020400checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &[
+                "net.ipv4.conf.all.log_martians",
+                "net.ipv4.conf.default.log_martians",
+            ],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "net.ipv4.conf.all.log_martians = 0\n",
+                    "net.ipv4.conf.default.log_martians = 1\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+    // BR03020500Checker tests
+    #[test]
+    pub fn test_br03020500checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["net.ipv4.icmp_echo_ignore_broadcasts"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "net.ipv4.icmp_echo_ignore_broadcasts = 1".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020500Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03020500checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["net.ipv4.icmp_echo_ignore_broadcasts"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "net.ipv4.icmp_echo_ignore_broadcasts = 0".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020500Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR03020600Checker tests
+    #[test]
+    pub fn test_br03020600checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["net.ipv4.icmp_ignore_bogus_error_responses"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "net.ipv4.icmp_ignore_bogus_error_responses = 1".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020600Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03020600checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["net.ipv4.icmp_ignore_bogus_error_responses"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "net.ipv4.icmp_ignore_bogus_error_responses = 0".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020600Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR03020700Checker tests
+    #[test]
+    pub fn test_br03020700checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["net.ipv4.tcp_syncookies"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "net.ipv4.tcp_syncookies = 1".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020700Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03020700checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            SYSCTL_CMD,
+            &["net.ipv4.tcp_syncookies"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "net.ipv4.tcp_syncookies = 0".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03020700Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR03030100Checker tests
+    #[test]
+    pub fn test_br03030100checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(PROC_MODULES_FILE, "other\nmodules\n");
+        sac.register_command(
+            MODPROBE_CMD,
+            &["-n", "-v", "sctp"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "install /bin/true".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03030100checker_fail_sctp_loaded() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(
+            PROC_MODULES_FILE,
+            "sctp 139264 0 - Live 0xffffffffc05e1000\n",
+        );
+        let checker = BR03030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br03030100checker_fail_sctp_not_blocked() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(PROC_MODULES_FILE, "other\nmodules\n");
+        sac.register_command(
+            MODPROBE_CMD,
+            &["-n", "-v", "sctp"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: "insmod /lib/modules/kernel/net/sctp/sctp.ko".into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br03030100checker_proc_modules_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = BR03030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+    // BR03040101Checker tests
+    #[test]
+    pub fn test_br03040101checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            IPTABLES_CMD,
+            &["-L"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain INPUT (policy DROP)\n",
+                    "Chain FORWARD (policy DROP)\n",
+                    "Chain OUTPUT (policy DROP)\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03040101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03040101checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            IPTABLES_CMD,
+            &["-L"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain INPUT (policy ACCEPT)\n",
+                    "Chain FORWARD (policy DROP)\n",
+                    "Chain OUTPUT (policy DROP)\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03040101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR03040102Checker tests
+    #[test]
+    pub fn test_br03040102checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            IPTABLES_CMD,
+            &["-L", "INPUT", "-v", "-n"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain INPUT (policy DROP 0 packets, 0 bytes)\n",
+                    " pkts bytes target     prot opt in     out     source               destination\n",
+                    "    0     0 ACCEPT     all  --  lo     *       0.0.0.0/0            0.0.0.0/0\n",
+                    "    0     0 DROP       all  --  *      *       127.0.0.0/8          0.0.0.0/0\n"
+                ).into(),
+                stderr: vec![],
+            },
+        );
+        sac.register_command(
+            IPTABLES_CMD,
+            &["-L", "OUTPUT", "-v", "-n"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain OUTPUT (policy DROP 0 packets, 0 bytes)\n",
+                    " pkts bytes target     prot opt in     out     source               destination\n",
+                    "    0     0 ACCEPT     all  --  *      lo      0.0.0.0/0            0.0.0.0/0\n"
+                ).into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03040102Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03040102checker_fail_missing_input_rules() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            IPTABLES_CMD,
+            &["-L", "INPUT", "-v", "-n"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain INPUT (policy DROP 0 packets, 0 bytes)\n",
+                    " pkts bytes target     prot opt in     out     source               destination\n"
+                ).into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03040102Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br03040102checker_fail_missing_output_rule() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            IPTABLES_CMD,
+            &["-L", "INPUT", "-v", "-n"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain INPUT (policy DROP 0 packets, 0 bytes)\n",
+                    " pkts bytes target     prot opt in     out     source               destination\n",
+                    "    0     0 ACCEPT     all  --  lo     *       0.0.0.0/0            0.0.0.0/0\n",
+                    "    0     0 DROP       all  --  *      *       127.0.0.0/8          0.0.0.0/0\n"
+                ).into(),
+                stderr: vec![],
+            },
+        );
+        sac.register_command(
+            IPTABLES_CMD,
+            &["-L", "OUTPUT", "-v", "-n"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain OUTPUT (policy DROP 0 packets, 0 bytes)\n",
+                    " pkts bytes target     prot opt in     out     source               destination\n"
+                ).into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03040102Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR03040201Checker tests
+    #[test]
+    pub fn test_br03040201checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            IP6TABLES_CMD,
+            &["-L"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain INPUT (policy DROP)\n",
+                    "Chain FORWARD (policy DROP)\n",
+                    "Chain OUTPUT (policy DROP)\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03040201Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03040201checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            IP6TABLES_CMD,
+            &["-L"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain INPUT (policy ACCEPT)\n",
+                    "Chain FORWARD (policy DROP)\n",
+                    "Chain OUTPUT (policy DROP)\n"
+                )
+                .into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03040201Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    // BR03040202Checker tests
+    #[test]
+    pub fn test_br03040202checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            IP6TABLES_CMD,
+            &["-L", "INPUT", "-v", "-n"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain INPUT (policy DROP 0 packets, 0 bytes)\n",
+                    " pkts bytes target     prot opt in     out     source               destination\n",
+                    "    0     0 ACCEPT     all  --  lo     *       ::/0                 ::/0\n",
+                    "    0     0 DROP       all  --  *      *       ::1                  ::/0\n"
+                ).into(),
+                stderr: vec![],
+            },
+        );
+        sac.register_command(
+            IP6TABLES_CMD,
+            &["-L", "OUTPUT", "-v", "-n"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain OUTPUT (policy DROP 0 packets, 0 bytes)\n",
+                    " pkts bytes target     prot opt in     out     source               destination\n",
+                    "    0     0 ACCEPT     all  --  *      lo      ::/0                 ::/0\n"
+                ).into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03040202Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br03040202checker_fail_missing_input_rules() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            IP6TABLES_CMD,
+            &["-L", "INPUT", "-v", "-n"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain INPUT (policy DROP 0 packets, 0 bytes)\n",
+                    " pkts bytes target     prot opt in     out     source               destination\n"
+                ).into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03040202Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br03040202checker_fail_missing_output_rule() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_command(
+            IP6TABLES_CMD,
+            &["-L", "INPUT", "-v", "-n"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain INPUT (policy DROP 0 packets, 0 bytes)\n",
+                    " pkts bytes target     prot opt in     out     source               destination\n",
+                    "    0     0 ACCEPT     all  --  lo     *       ::/0                 ::/0\n",
+                    "    0     0 DROP       all  --  *      *       ::1                  ::/0\n"
+                ).into(),
+                stderr: vec![],
+            },
+        );
+        sac.register_command(
+            IP6TABLES_CMD,
+            &["-L", "OUTPUT", "-v", "-n"],
+            Output {
+                status: ExitStatus::default(),
+                stdout: concat!(
+                    "Chain OUTPUT (policy DROP 0 packets, 0 bytes)\n",
+                    " pkts bytes target     prot opt in     out     source               destination\n"
+                ).into(),
+                stderr: vec![],
+            },
+        );
+        let checker = BR03040202Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+    // BR04010101Checker tests
+    #[test]
+    pub fn test_br04010101checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(
+            JOURNALD_CONF_FILE,
+            "Storage=persistent\nCompress=yes\nSeal=yes",
+        );
+        let checker = BR04010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_br04010101checker_fail() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(
+            JOURNALD_CONF_FILE,
+            "Storage=volatile\nCompress=yes\nSeal=yes",
+        );
+        let checker = BR04010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_br04010101checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = BR04010101Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
     }
 }

--- a/sources/bloodhound/src/bin/bottlerocket-cis-checks/main.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-cis-checks/main.rs
@@ -1,6 +1,7 @@
 mod checks;
 
 use bloodhound::results::*;
+use bloodhound::system_access::NativeSystemAccess;
 use checks::*;
 use std::env;
 use std::path::Path;
@@ -71,12 +72,12 @@ fn main() {
 
     // Check if the metadata subcommand is being called
     let get_metadata = env::args().nth(1).unwrap_or_default() == "metadata";
-
+    let sac = NativeSystemAccess {};
     if get_metadata {
         let metadata = checker.metadata();
         println!("{metadata}");
     } else {
-        let result = checker.execute();
+        let result = checker.execute(&sac);
         println!("{result}");
     }
 }

--- a/sources/bloodhound/src/bin/bottlerocket-fips-checks/checks.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-fips-checks/checks.rs
@@ -1,4 +1,5 @@
 use bloodhound::results::{CheckStatus, Checker, CheckerMetadata, CheckerResult, Mode};
+use bloodhound::system_access::SystemAccess;
 use bloodhound::*;
 
 const CRYPTO_FIPS_ENABLED: &str = "/proc/sys/crypto/fips_enabled";
@@ -15,8 +16,9 @@ const FIPS_MODULE_CHECK_MARKER: &str = "/etc/.fips-module-check-passed";
 pub struct FIPS01000000Checker {}
 
 impl Checker for FIPS01000000Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_file_contains!(
+            sac,
             CRYPTO_FIPS_ENABLED,
             &[EXPECTED_FIPS_ENABLED],
             format!("{CRYPTO_FIPS_ENABLED} != {EXPECTED_FIPS_ENABLED}"),
@@ -40,8 +42,9 @@ impl Checker for FIPS01000000Checker {
 pub struct FIPS01010000Checker {}
 
 impl Checker for FIPS01010000Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         check_file_contains!(
+            sac,
             CRYPTO_FIPS_NAME,
             &[EXPECTED_FIPS_NAME],
             format!("{CRYPTO_FIPS_NAME} != '{EXPECTED_FIPS_NAME}'"),
@@ -65,8 +68,9 @@ impl Checker for FIPS01010000Checker {
 pub struct FIPS01020000Checker {}
 
 impl Checker for FIPS01020000Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let result = check_file_exists!(
+            sac,
             FIPS_KERNEL_CHECK_MARKER,
             format!("{FIPS_KERNEL_CHECK_MARKER} not found")
         );
@@ -77,6 +81,7 @@ impl Checker for FIPS01020000Checker {
         }
 
         check_file_exists!(
+            sac,
             FIPS_MODULE_CHECK_MARKER,
             format!("{FIPS_MODULE_CHECK_MARKER} not found")
         )
@@ -90,5 +95,89 @@ impl Checker for FIPS01020000Checker {
             name: "fips01020000".to_string(),
             mode: Mode::Automatic,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::checks::*;
+    use bloodhound::results::{CheckStatus, Checker};
+    use bloodhound::system_access::UnitTestSystemAccess;
+
+    #[test]
+    pub fn test_fips01000000checker_missing_file() {
+        let usac = UnitTestSystemAccess::default();
+        let checker = FIPS01000000Checker {};
+        let result = checker.execute(&usac);
+        // skip the test if /proc/sys/crypto/fips_enabled is missing
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+    #[test]
+    pub fn test_fips01000000checker_fips_disabled() {
+        let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_ENABLED, "0");
+        let checker = FIPS01000000Checker {};
+        let result = checker.execute(&usac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+    #[test]
+    pub fn test_fips01000000checker_fips_enabled() {
+        let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_ENABLED, EXPECTED_FIPS_ENABLED);
+        let checker = FIPS01000000Checker {};
+        let result = checker.execute(&usac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_fips01010000checker_missing_fips_name() {
+        let usac = UnitTestSystemAccess::default();
+        let checker = FIPS01010000Checker {};
+        let result = checker.execute(&usac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    #[test]
+    pub fn test_fips01010000checker_wrong_fips_name() {
+        let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_NAME, "some wrong name");
+        let checker = FIPS01010000Checker {};
+        let result = checker.execute(&usac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_fips01010000checker_passing() {
+        let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_NAME, EXPECTED_FIPS_NAME);
+        let checker = FIPS01010000Checker {};
+        let result = checker.execute(&usac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_fips01020000checker_missing_module_check_marker() {
+        let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(FIPS_KERNEL_CHECK_MARKER, "1");
+        let checker = FIPS01020000Checker {};
+        let result = checker.execute(&usac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+    #[test]
+    pub fn test_fips01020000checker_missing_kernel_check_marker() {
+        let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(FIPS_MODULE_CHECK_MARKER, "1");
+        let checker = FIPS01020000Checker {};
+        let result = checker.execute(&usac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+    #[test]
+    pub fn test_fips01020000checker_passing() {
+        let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(FIPS_KERNEL_CHECK_MARKER, "1");
+        usac.register_file(FIPS_MODULE_CHECK_MARKER, "1");
+        let checker = FIPS01020000Checker {};
+        let result = checker.execute(&usac);
+        assert_eq!(result.status, CheckStatus::PASS);
     }
 }

--- a/sources/bloodhound/src/bin/bottlerocket-fips-checks/main.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-fips-checks/main.rs
@@ -1,6 +1,7 @@
 mod checks;
 
 use bloodhound::results::*;
+use bloodhound::system_access::NativeSystemAccess;
 use checks::*;
 use std::env;
 use std::path::Path;
@@ -25,12 +26,12 @@ fn main() {
 
     // Check if the metadata subcommand is being called
     let get_metadata = env::args().nth(1).unwrap_or_default() == "metadata";
-
+    let sac = NativeSystemAccess {};
     if get_metadata {
         let metadata = checker.metadata();
         println!("{metadata}");
     } else {
-        let result = checker.execute();
+        let result = checker.execute(&sac);
         println!("{result}");
     }
 }

--- a/sources/bloodhound/src/bin/kubernetes-cis-checks/checks.rs
+++ b/sources/bloodhound/src/bin/kubernetes-cis-checks/checks.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashSet, fs::File, path::Path};
+use std::collections::HashSet;
 
+use bloodhound::system_access::SystemAccess;
 use bloodhound::{
     check_file_not_mode, ensure_file_owner_and_group_root,
     results::{CheckStatus, Checker, CheckerMetadata, CheckerResult, Mode},
@@ -19,9 +20,9 @@ pub const KUBEPROXY_CONF_FILE: &str = "/etc/kubernetes/kube-proxy/kube-proxy.con
 pub struct K8S04010100Checker {}
 
 impl Checker for K8S04010100Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let no_x_xwr_xwr = S_IXUSR | S_IRWXG | S_IRWXO;
-        check_file_not_mode(KUBELET_SERVICE_FILE, no_x_xwr_xwr)
+        check_file_not_mode(sac, KUBELET_SERVICE_FILE, no_x_xwr_xwr)
     }
 
     fn metadata(&self) -> CheckerMetadata {
@@ -40,8 +41,8 @@ impl Checker for K8S04010100Checker {
 pub struct K8S04010200Checker {}
 
 impl Checker for K8S04010200Checker {
-    fn execute(&self) -> CheckerResult {
-        ensure_file_owner_and_group_root(KUBELET_SERVICE_FILE)
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
+        ensure_file_owner_and_group_root(sac, KUBELET_SERVICE_FILE)
     }
 
     fn metadata(&self) -> CheckerMetadata {
@@ -60,9 +61,9 @@ impl Checker for K8S04010200Checker {
 pub struct K8S04010500Checker {}
 
 impl Checker for K8S04010500Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let no_x_xwr_xwr = S_IXUSR | S_IRWXG | S_IRWXO;
-        check_file_not_mode(KUBELET_KUBECONFIG_FILE, no_x_xwr_xwr)
+        check_file_not_mode(sac, KUBELET_KUBECONFIG_FILE, no_x_xwr_xwr)
     }
 
     fn metadata(&self) -> CheckerMetadata {
@@ -81,8 +82,8 @@ impl Checker for K8S04010500Checker {
 pub struct K8S04010600Checker {}
 
 impl Checker for K8S04010600Checker {
-    fn execute(&self) -> CheckerResult {
-        ensure_file_owner_and_group_root(KUBELET_KUBECONFIG_FILE)
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
+        ensure_file_owner_and_group_root(sac, KUBELET_KUBECONFIG_FILE)
     }
 
     fn metadata(&self) -> CheckerMetadata {
@@ -102,9 +103,9 @@ impl Checker for K8S04010600Checker {
 pub struct K8S04010700Checker {}
 
 impl Checker for K8S04010700Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let no_x_xw_xw = S_IXUSR | S_IXGRP | S_IWGRP | S_IXOTH | S_IWOTH;
-        check_file_not_mode(KUBELET_CLIENT_CA_FILE, no_x_xw_xw)
+        check_file_not_mode(sac, KUBELET_CLIENT_CA_FILE, no_x_xw_xw)
     }
 
     fn metadata(&self) -> CheckerMetadata {
@@ -123,8 +124,8 @@ impl Checker for K8S04010700Checker {
 pub struct K8S04010800Checker {}
 
 impl Checker for K8S04010800Checker {
-    fn execute(&self) -> CheckerResult {
-        ensure_file_owner_and_group_root(KUBELET_CLIENT_CA_FILE)
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
+        ensure_file_owner_and_group_root(sac, KUBELET_CLIENT_CA_FILE)
     }
 
     fn metadata(&self) -> CheckerMetadata {
@@ -145,9 +146,9 @@ impl Checker for K8S04010800Checker {
 pub struct K8S04010900Checker {}
 
 impl Checker for K8S04010900Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let no_x_xwr_xwr = S_IXUSR | S_IRWXG | S_IRWXO;
-        check_file_not_mode(KUBELET_CONF_FILE, no_x_xwr_xwr)
+        check_file_not_mode(sac, KUBELET_CONF_FILE, no_x_xwr_xwr)
     }
 
     fn metadata(&self) -> CheckerMetadata {
@@ -166,8 +167,8 @@ impl Checker for K8S04010900Checker {
 pub struct K8S04011000Checker {}
 
 impl Checker for K8S04011000Checker {
-    fn execute(&self) -> CheckerResult {
-        ensure_file_owner_and_group_root(KUBELET_CONF_FILE)
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
+        ensure_file_owner_and_group_root(sac, KUBELET_CONF_FILE)
     }
 
     fn metadata(&self) -> CheckerMetadata {
@@ -187,7 +188,7 @@ impl Checker for K8S04011000Checker {
 pub struct K8S04020100Checker {}
 
 impl Checker for K8S04020100Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct Anonymous {
             enabled: bool,
@@ -205,7 +206,7 @@ impl Checker for K8S04020100Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 if config.authentication.anonymous.enabled {
                     result.error = "anonymous authentication is configured".to_string();
@@ -239,7 +240,7 @@ impl Checker for K8S04020100Checker {
 pub struct K8S04020200Checker {}
 
 impl Checker for K8S04020200Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct Authorization {
             mode: String,
@@ -252,7 +253,7 @@ impl Checker for K8S04020200Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 if config.authorization.mode == "AlwaysAllow" {
                     result.error = "AlwaysAllow authorization is configured".to_string();
@@ -287,7 +288,7 @@ impl Checker for K8S04020200Checker {
 pub struct K8S04020300Checker {}
 
 impl Checker for K8S04020300Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct X509 {
             #[serde(rename = "clientCAFile")]
@@ -306,10 +307,10 @@ impl Checker for K8S04020300Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 if !config.authentication.x509.client_ca_file.is_empty()
-                    && Path::new(&config.authentication.x509.client_ca_file).exists()
+                    && sac.exists(&config.authentication.x509.client_ca_file)
                 {
                     result.status = CheckStatus::PASS;
                 } else {
@@ -342,7 +343,7 @@ impl Checker for K8S04020300Checker {
 pub struct K8S04020400Checker {}
 
 impl Checker for K8S04020400Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct KubeletConfig {
             #[serde(rename = "readOnlyPort")]
@@ -351,7 +352,7 @@ impl Checker for K8S04020400Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 if config.read_only_port != 0 {
                     result.error = "Kubelet readOnlyPort not set to 0".to_string();
@@ -385,7 +386,7 @@ impl Checker for K8S04020400Checker {
 pub struct K8S04020500Checker {}
 
 impl Checker for K8S04020500Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct KubeletConfig {
             #[serde(rename = "streamingConnectionIdleTimeout")]
@@ -394,7 +395,7 @@ impl Checker for K8S04020500Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 if config.streaming_connection_idle_timeout == 0 {
                     result.error = "Kubelet streamingConnectionIdleTimeout is set to 0".to_string();
@@ -430,7 +431,7 @@ impl Checker for K8S04020500Checker {
 pub struct K8S04020600Checker {}
 
 impl Checker for K8S04020600Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct KubeletConfig {
             #[serde(rename = "makeIPTablesUtilChains")]
@@ -439,7 +440,7 @@ impl Checker for K8S04020600Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 if !config.make_iptables_util_chains {
                     result.error = "Kubelet makeIPTablesUtilChains is disabled".to_string();
@@ -475,7 +476,7 @@ impl Checker for K8S04020600Checker {
 pub struct K8S04020900Checker {}
 
 impl Checker for K8S04020900Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct KubeletConfig {
             #[serde(rename = "tlsCertFile")]
@@ -486,11 +487,11 @@ impl Checker for K8S04020900Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
-                if (!config.tls_cert_file.is_empty() && Path::new(&config.tls_cert_file).exists())
+                if (!config.tls_cert_file.is_empty() && sac.exists(&config.tls_cert_file))
                     && (!config.tls_private_key_file.is_empty()
-                        && Path::new(&config.tls_private_key_file).exists())
+                        && sac.exists(&config.tls_private_key_file))
                 {
                     result.status = CheckStatus::PASS;
                 } else {
@@ -526,7 +527,7 @@ pub struct K8S04021000Checker {}
 // Not actually applicable for Bottlerocket, but leaving logic here in case we
 // make any changes in the future.
 impl Checker for K8S04021000Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct KubeletConfig {
             #[serde(rename = "rotateCertificates")]
@@ -535,7 +536,7 @@ impl Checker for K8S04021000Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 if !config.rotate_certificates {
                     result.error = "Kubelet rotateCertificates is disabled".to_string();
@@ -571,7 +572,7 @@ impl Checker for K8S04021000Checker {
 pub struct K8S04021100Checker {}
 
 impl Checker for K8S04021100Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct FeatureGates {
             #[serde(rename = "RotateKubeletServerCertificate")]
@@ -586,7 +587,7 @@ impl Checker for K8S04021100Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 if !config.feature_gates.rotate_kubelet_server_certificate {
                     result.error = "Kubelet RotateKubeletServerCertificate is disabled".to_string();
@@ -622,7 +623,7 @@ impl Checker for K8S04021100Checker {
 pub struct K8S04021200Checker {}
 
 impl Checker for K8S04021200Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let allowed_suites: HashSet<&str> = vec![
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -644,7 +645,7 @@ impl Checker for K8S04021200Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 let configured_suites: HashSet<&str> = config
                     .tls_cipher_suites
@@ -684,7 +685,7 @@ impl Checker for K8S04021200Checker {
 pub struct K8S04021300Checker {}
 
 impl Checker for K8S04021300Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct KubeletConfig {
             #[serde(rename = "podPidsLimit")]
@@ -693,7 +694,7 @@ impl Checker for K8S04021300Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 if config.pod_pids_limit <= 0 {
                     result.error = "podPidsLimit is unrestricted".to_string();
@@ -729,7 +730,7 @@ impl Checker for K8S04021300Checker {
 pub struct K8S04021400Checker {}
 
 impl Checker for K8S04021400Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct KubeletConfig {
             #[serde(rename = "seccompDefault")]
@@ -738,7 +739,7 @@ impl Checker for K8S04021400Checker {
 
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBELET_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBELET_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeletConfig>(kubelet_file) {
                 if !config.seccomp_default {
                     result.error = "Kubelet seccompDefault is not set to true".to_string();
@@ -773,7 +774,7 @@ impl Checker for K8S04021400Checker {
 
 pub struct K8S04030100Checker {}
 impl Checker for K8S04030100Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         #[derive(Deserialize)]
         struct KubeProxyConfig {
             #[serde(rename = "metricsBindAddress")]
@@ -781,7 +782,7 @@ impl Checker for K8S04030100Checker {
         }
         let mut result = CheckerResult::default();
 
-        if let Ok(kubelet_file) = File::open(KUBEPROXY_CONF_FILE) {
+        if let Ok(kubelet_file) = sac.open(KUBEPROXY_CONF_FILE) {
             if let Ok(config) = serde_yaml::from_reader::<_, KubeProxyConfig>(kubelet_file) {
                 if config.metrics_bind_address.contains("0.0.0.0")
                     || config.metrics_bind_address.contains("[::]")
@@ -816,9 +817,9 @@ impl Checker for K8S04030100Checker {
 
 pub struct K8S04010300Checker {}
 impl Checker for K8S04010300Checker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
         let no_x_xwr_xwr = S_IXUSR | S_IRWXG | S_IRWXO;
-        check_file_not_mode(KUBEPROXY_CONF_FILE, no_x_xwr_xwr)
+        check_file_not_mode(sac, KUBEPROXY_CONF_FILE, no_x_xwr_xwr)
     }
     fn metadata(&self) -> CheckerMetadata {
         CheckerMetadata {
@@ -835,8 +836,8 @@ impl Checker for K8S04010300Checker {
 
 pub struct K8S04010400Checker {}
 impl Checker for K8S04010400Checker {
-    fn execute(&self) -> CheckerResult {
-        ensure_file_owner_and_group_root(KUBEPROXY_CONF_FILE)
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
+        ensure_file_owner_and_group_root(sac, KUBEPROXY_CONF_FILE)
     }
     fn metadata(&self) -> CheckerMetadata {
         CheckerMetadata {
@@ -847,5 +848,927 @@ impl Checker for K8S04010400Checker {
             name: "k8s04010400".to_string(),
             mode: Mode::Automatic,
         }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bloodhound::results::{CheckStatus, Checker};
+    use bloodhound::system_access::UnitTestSystemAccess;
+
+    // K8S04010100Checker tests - kubelet service file permissions
+    #[test]
+    pub fn test_k8s04010100checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_SERVICE_FILE, "", 0o600, 0, 0);
+        let checker = K8S04010100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04010100checker_fail_too_permissive() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_SERVICE_FILE, "", 0o755, 0, 0);
+        let checker = K8S04010100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04010100checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04010100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04010200Checker tests - kubelet service file ownership
+    #[test]
+    pub fn test_k8s04010200checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_SERVICE_FILE, "", 0o600, 0, 0);
+        let checker = K8S04010200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04010200checker_fail_wrong_owner() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_SERVICE_FILE, "", 0o600, 1000, 1000);
+        let checker = K8S04010200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04010200checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04010200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04010300Checker tests - proxy kubeconfig file permissions
+    #[test]
+    pub fn test_k8s04010300checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBEPROXY_CONF_FILE, "", 0o600, 0, 0);
+        let checker = K8S04010300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04010300checker_fail_too_permissive() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBEPROXY_CONF_FILE, "", 0o644, 0, 0);
+        let checker = K8S04010300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04010300checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04010300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04010400Checker tests - proxy kubeconfig file ownership
+    #[test]
+    pub fn test_k8s04010400checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBEPROXY_CONF_FILE, "", 0o600, 0, 0);
+        let checker = K8S04010400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04010400checker_fail_wrong_owner() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBEPROXY_CONF_FILE, "", 0o600, 500, 500);
+        let checker = K8S04010400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04010400checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04010400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04010500Checker tests - kubelet kubeconfig file permissions
+    #[test]
+    pub fn test_k8s04010500checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_KUBECONFIG_FILE, "", 0o600, 0, 0);
+        let checker = K8S04010500Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04010500checker_fail_too_permissive() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_KUBECONFIG_FILE, "", 0o777, 0, 0);
+        let checker = K8S04010500Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04010500checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04010500Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04010600Checker tests - kubelet kubeconfig file ownership
+    #[test]
+    pub fn test_k8s04010600checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_KUBECONFIG_FILE, "", 0o600, 0, 0);
+        let checker = K8S04010600Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04010600checker_fail_wrong_owner() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_KUBECONFIG_FILE, "", 0o600, 1001, 0);
+        let checker = K8S04010600Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04010600checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04010600Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04010700Checker tests - certificate authorities file permissions
+    #[test]
+    pub fn test_k8s04010700checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_CLIENT_CA_FILE, "", 0o644, 0, 0);
+        let checker = K8S04010700Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04010700checker_fail_too_permissive() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_CLIENT_CA_FILE, "", 0o666, 0, 0);
+        let checker = K8S04010700Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04010700checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04010700Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04010800Checker tests - certificate authorities file ownership
+    #[test]
+    pub fn test_k8s04010800checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_CLIENT_CA_FILE, "", 0o644, 0, 0);
+        let checker = K8S04010800Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04010800checker_fail_wrong_owner() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_CLIENT_CA_FILE, "", 0o644, 0, 100);
+        let checker = K8S04010800Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04010800checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04010800Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04010900Checker tests - kubelet config file permissions
+    #[test]
+    pub fn test_k8s04010900checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_CONF_FILE, "", 0o600, 0, 0);
+        let checker = K8S04010900Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04010900checker_fail_too_permissive() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_CONF_FILE, "", 0o666, 0, 0);
+        let checker = K8S04010900Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04010900checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04010900Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04011000Checker tests - kubelet config file ownership
+    #[test]
+    pub fn test_k8s04011000checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_CONF_FILE, "", 0o600, 0, 0);
+        let checker = K8S04011000Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04011000checker_fail_wrong_owner() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file_with_metadata(KUBELET_CONF_FILE, "", 0o600, 1000, 1000);
+        let checker = K8S04011000Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04011000checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04011000Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+    // K8S04020100Checker tests - anonymous authentication
+    #[test]
+    pub fn test_k8s04020100checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+authentication:
+  anonymous:
+    enabled: false
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04020100checker_fail_anonymous_enabled() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+authentication:
+  anonymous:
+    enabled: true
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04020100checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04020100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    #[test]
+    pub fn test_k8s04020100checker_invalid_config() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(KUBELET_CONF_FILE, "invalid yaml content");
+        let checker = K8S04020100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04020200Checker tests - authorization mode
+    #[test]
+    pub fn test_k8s04020200checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+authorization:
+  mode: Webhook
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04020200checker_fail_always_allow() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+authorization:
+  mode: AlwaysAllow
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04020200checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04020200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    #[test]
+    pub fn test_k8s04020200checker_invalid_config() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(KUBELET_CONF_FILE, "invalid: yaml: content:");
+        let checker = K8S04020200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04020300Checker tests - client CA file
+    #[test]
+    pub fn test_k8s04020300checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+authentication:
+  x509:
+    clientCAFile: /etc/kubernetes/pki/ca.crt
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        // Register the CA file to simulate it exists
+        sac.register_file("/etc/kubernetes/pki/ca.crt", "dummy ca content");
+        let checker = K8S04020300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04020300checker_fail_ca_file_missing() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+authentication:
+  x509:
+    clientCAFile: /nonexistent/ca.crt
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04020300checker_fail_empty_ca_file() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+authentication:
+  x509:
+    clientCAFile: ""
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04020300checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04020300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04020400Checker tests - read only port
+    #[test]
+    pub fn test_k8s04020400checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+readOnlyPort: 0
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04020400checker_fail_port_not_zero() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+readOnlyPort: 10255
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04020400checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04020400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    #[test]
+    pub fn test_k8s04020400checker_invalid_config() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(KUBELET_CONF_FILE, "invalid yaml");
+        let checker = K8S04020400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04020500Checker tests - streaming connection idle timeout
+    #[test]
+    pub fn test_k8s04020500checker_pass_timeout_set() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+streamingConnectionIdleTimeout: 300
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020500Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04020500checker_pass_timeout_not_present() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+someOtherSetting: value
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020500Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04020500checker_fail_timeout_zero() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+streamingConnectionIdleTimeout: 0
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020500Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04020500checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04020500Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04020600Checker tests - make iptables util chains
+    #[test]
+    pub fn test_k8s04020600checker_pass_enabled() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+makeIPTablesUtilChains: true
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020600Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04020600checker_pass_not_present() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+someOtherSetting: value
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020600Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04020600checker_fail_disabled() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+makeIPTablesUtilChains: false
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020600Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04020600checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04020600Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+    // K8S04020900Checker tests - TLS cert and key files
+    #[test]
+    pub fn test_k8s04020900checker_pass_with_files() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+tlsCertFile: /etc/kubernetes/pki/kubelet.crt
+tlsPrivateKeyFile: /etc/kubernetes/pki/kubelet.key
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        sac.register_file("/etc/kubernetes/pki/kubelet.crt", "dummy cert");
+        sac.register_file("/etc/kubernetes/pki/kubelet.key", "dummy key");
+        let checker = K8S04020900Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04020900checker_pass_without_files() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+someOtherSetting: value
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020900Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04020900checker_fail_cert_missing() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+tlsCertFile: /nonexistent/kubelet.crt
+tlsPrivateKeyFile: /etc/kubernetes/pki/kubelet.key
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        sac.register_file("/etc/kubernetes/pki/kubelet.key", "dummy key");
+        let checker = K8S04020900Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04020900checker_fail_key_missing() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+tlsCertFile: /etc/kubernetes/pki/kubelet.crt
+tlsPrivateKeyFile: /nonexistent/kubelet.key
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        sac.register_file("/etc/kubernetes/pki/kubelet.crt", "dummy cert");
+        let checker = K8S04020900Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04020900checker_fail_empty_paths() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+tlsCertFile: ""
+tlsPrivateKeyFile: ""
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04020900Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04020900checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04020900Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04021000Checker tests - rotate certificates
+    #[test]
+    pub fn test_k8s04021000checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+rotateCertificates: true
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021000Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04021000checker_fail_disabled() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+rotateCertificates: false
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021000Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04021000checker_fail_not_present() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+someOtherSetting: value
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021000Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04021000checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04021000Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04021100Checker tests - rotate kubelet server certificate
+    #[test]
+    pub fn test_k8s04021100checker_pass_enabled() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+featureGates:
+  RotateKubeletServerCertificate: true
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04021100checker_pass_not_present() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+someOtherSetting: value
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04021100checker_fail_disabled() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+featureGates:
+  RotateKubeletServerCertificate: false
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04021100checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04021100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04021200Checker tests - TLS cipher suites
+    #[test]
+    pub fn test_k8s04021200checker_pass_allowed_suites() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+tlsCipherSuites:
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04021200checker_fail_disallowed_suites() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+tlsCipherSuites:
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_RSA_WITH_RC4_128_SHA
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04021200checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04021200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    #[test]
+    pub fn test_k8s04021200checker_invalid_config() {
+        let mut sac = UnitTestSystemAccess::default();
+        sac.register_file(KUBELET_CONF_FILE, "invalid yaml");
+        let checker = K8S04021200Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04021300Checker tests - pod PIDs limit
+    #[test]
+    pub fn test_k8s04021300checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+podPidsLimit: 1024
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04021300checker_fail_zero_limit() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+podPidsLimit: 0
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04021300checker_fail_negative_limit() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+podPidsLimit: -1
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04021300checker_fail_not_configured() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+someOtherSetting: value
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04021300checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04021300Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+
+    // K8S04021400Checker tests - seccomp default
+    #[test]
+    pub fn test_k8s04021400checker_pass() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+seccompDefault: true
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04021400checker_fail_disabled() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+seccompDefault: false
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04021400checker_fail_not_configured() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+someOtherSetting: value
+"#;
+        sac.register_file(KUBELET_CONF_FILE, config);
+        let checker = K8S04021400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04021400checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04021400Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
+    }
+    // K8S04030100Checker tests - kube-proxy metrics bind address
+    #[test]
+    pub fn test_k8s04030100checker_pass_localhost() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+metricsBindAddress: 127.0.0.1:10249
+"#;
+        sac.register_file(KUBEPROXY_CONF_FILE, config);
+        let checker = K8S04030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04030100checker_pass_not_configured() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+someOtherSetting: value
+"#;
+        sac.register_file(KUBEPROXY_CONF_FILE, config);
+        let checker = K8S04030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_k8s04030100checker_fail_all_interfaces_ipv4() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+metricsBindAddress: 0.0.0.0:10249
+"#;
+        sac.register_file(KUBEPROXY_CONF_FILE, config);
+        let checker = K8S04030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04030100checker_fail_all_interfaces_ipv6() {
+        let mut sac = UnitTestSystemAccess::default();
+        let config = r#"
+metricsBindAddress: "[::]:10249"
+"#;
+        sac.register_file(KUBEPROXY_CONF_FILE, config);
+        let checker = K8S04030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
+    pub fn test_k8s04030100checker_file_missing() {
+        let sac = UnitTestSystemAccess::default();
+        let checker = K8S04030100Checker {};
+        let result = checker.execute(&sac);
+        assert_eq!(result.status, CheckStatus::SKIP);
     }
 }

--- a/sources/bloodhound/src/bin/kubernetes-cis-checks/main.rs
+++ b/sources/bloodhound/src/bin/kubernetes-cis-checks/main.rs
@@ -1,6 +1,7 @@
 mod checks;
 
 use bloodhound::results::*;
+use bloodhound::system_access::NativeSystemAccess;
 use checks::*;
 use std::env;
 use std::path::Path;
@@ -95,11 +96,12 @@ fn main() {
     // Check if the metadata subcommand is being called
     let get_metadata = env::args().nth(1).unwrap_or_default() == "metadata";
 
+    let sac = NativeSystemAccess {};
     if get_metadata {
         let metadata = checker.metadata();
         println!("{metadata}");
     } else {
-        let result = checker.execute();
+        let result = checker.execute(&sac);
         println!("{result}");
     }
 }

--- a/sources/bloodhound/src/lib.rs
+++ b/sources/bloodhound/src/lib.rs
@@ -1,17 +1,19 @@
 use results::{CheckStatus, CheckerResult};
-use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader};
-use std::os::linux::fs::MetadataExt;
-use std::os::unix::fs::PermissionsExt;
-use std::{ffi::OsStr, process::Command};
+use system_access::SystemAccess;
 
 pub mod args;
 pub mod output;
 pub mod results;
+pub mod system_access;
 
 /// Reads a file and checks if the given `search_word` is present in its contents.
-pub fn look_for_word_in_file(path: &str, search_word: &str) -> Result<bool, io::Error> {
-    let reader = BufReader::new(File::open(path)?);
+pub fn look_for_word_in_file(
+    sac: &dyn SystemAccess,
+    path: &str,
+    search_word: &str,
+) -> Result<bool, io::Error> {
+    let reader = BufReader::new(sac.open(path)?);
     Ok(reader.lines().any(|line| {
         line.unwrap_or_default()
             .split_ascii_whitespace()
@@ -20,18 +22,26 @@ pub fn look_for_word_in_file(path: &str, search_word: &str) -> Result<bool, io::
 }
 
 /// Reads a file and checks if the given `search_str` is present in its contents.
-pub fn look_for_string_in_file(path: &str, search_str: &str) -> Result<bool, io::Error> {
-    let reader = BufReader::new(File::open(path)?);
+pub fn look_for_string_in_file(
+    sac: &dyn SystemAccess,
+    path: &str,
+    search_str: &str,
+) -> Result<bool, io::Error> {
+    let reader = BufReader::new(sac.open(path)?);
     Ok(reader
         .lines()
         .any(|line| line.unwrap_or_default().contains(search_str)))
 }
 
 /// Reads a file and checks if the given `search_strs` are present in its contents.
-pub fn look_for_strings_in_file(path: &str, search_strs: &[&str]) -> Result<bool, io::Error> {
+pub fn look_for_strings_in_file(
+    sac: &dyn SystemAccess,
+    path: &str,
+    search_strs: &[&str],
+) -> Result<bool, io::Error> {
     let mut matched = 0;
 
-    let reader = BufReader::new(File::open(path)?);
+    let reader = BufReader::new(sac.open(path)?);
     for line in reader.lines() {
         let content = line.unwrap_or_default();
         for search_str in search_strs {
@@ -51,10 +61,10 @@ pub fn look_for_strings_in_file(path: &str, search_strs: &[&str]) -> Result<bool
 /// Otherwise, the `CheckerResult` returned will have a `CheckStatus::FAIL`.
 #[macro_export]
 macro_rules! check_file_exists {
-    ($path:expr, $unable_to_find_error:expr) => {{
+    ($sac:expr, $path:expr, $unable_to_find_error:expr) => {{
         let mut result = CheckerResult::default();
 
-        if let Ok(file) = std::fs::File::open($path) {
+        if let Ok(file) = $sac.open($path) {
             result.status = CheckStatus::PASS;
         } else {
             result.error = $unable_to_find_error.to_string();
@@ -77,10 +87,10 @@ macro_rules! check_file_exists {
 /// `unable_to_check_error` value.
 #[macro_export]
 macro_rules! check_file_contains {
-    ($path:expr, $strings_to_match:expr, $unable_to_check_error:expr, $unable_to_find_error:expr) => {{
+    ($sac:expr, $path:expr, $strings_to_match:expr, $unable_to_check_error:expr, $unable_to_find_error:expr) => {{
         let mut result = CheckerResult::default();
 
-        if let Ok(found) = look_for_strings_in_file($path, $strings_to_match) {
+        if let Ok(found) = look_for_strings_in_file($sac, $path, $strings_to_match) {
             if found {
                 result.status = CheckStatus::PASS;
             } else {
@@ -96,22 +106,24 @@ macro_rules! check_file_contains {
 }
 
 /// Executes a command and checks if the given `search_str` is in the output.
-pub fn look_for_string_in_output<I, S>(cmd: &str, args: I, search_str: &str) -> Option<bool>
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
+pub fn look_for_string_in_output(
+    sac: &dyn SystemAccess,
+    cmd: &str,
+    args: &[&str],
+    search_str: &str,
+) -> Option<bool> {
     let search_strs = [search_str];
-    look_for_strings_in_output(cmd, args, &search_strs)
+    look_for_strings_in_output(sac, cmd, args, &search_strs)
 }
 
 /// Executes a command and checks if the given `search_strs` are in the output.
-pub fn look_for_strings_in_output<I, S>(cmd: &str, args: I, search_strs: &[&str]) -> Option<bool>
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
-    if let Ok(output) = Command::new(cmd).args(args).output() {
+pub fn look_for_strings_in_output(
+    sac: &dyn SystemAccess,
+    cmd: &str,
+    args: &[&str],
+    search_strs: &[&str],
+) -> Option<bool> {
+    if let Ok(output) = sac.command_output(cmd, args) {
         if output.status.success() {
             let mut matched = 0;
 
@@ -144,10 +156,10 @@ where
 /// check will need to be performed and the `error` field will contain the `unable_to_check_error` value.
 #[macro_export]
 macro_rules! check_output_contains {
-    ($cmd:expr, $args:expr, $strings_to_match:expr, $unable_to_check_error:expr, $unable_to_find_error:expr) => {{
+    ($sac:expr, $cmd:expr, $args:expr, $strings_to_match:expr, $unable_to_check_error:expr, $unable_to_find_error:expr) => {{
         let mut result = CheckerResult::default();
 
-        if let Some(found) = look_for_strings_in_output($cmd, $args, $strings_to_match) {
+        if let Some(found) = look_for_strings_in_output($sac, $cmd, $args, $strings_to_match) {
             if found {
                 result.status = CheckStatus::PASS;
             } else {
@@ -163,36 +175,31 @@ macro_rules! check_output_contains {
 }
 
 /// Tests whether a file has the given permission mode bits set, returning a `Result` based on the results.
-pub fn check_file_not_mode(file_path: &str, mode: u32) -> CheckerResult {
+pub fn check_file_not_mode(sac: &dyn SystemAccess, file_path: &str, mode: u32) -> CheckerResult {
     let mut result = CheckerResult::default();
 
-    if let Ok(file) = File::open(file_path) {
-        if let Ok(metadata) = file.metadata() {
-            // Extract just the permission bits
-            let file_mode = metadata.permissions().mode() & 0o777;
-
-            if (file_mode & mode) > 0 {
-                result.error = format!("file {file_path} has extra permissions: 0x{file_mode:o}");
-                result.status = CheckStatus::FAIL;
-            } else {
-                result.status = CheckStatus::PASS;
-            }
+    if let Ok(metadata) = sac.metadata(file_path) {
+        // Extract just the permission bits
+        let file_mode = metadata.mode & 0o777;
+        if (file_mode & mode) > 0 {
+            result.error = format!("file {file_path} has extra permissions: 0x{file_mode:o}");
+            result.status = CheckStatus::FAIL;
         } else {
-            result.error = "unable to get file metadata information".to_string();
+            result.status = CheckStatus::PASS;
         }
     } else {
-        result.error = format!("unable to inspect '{file_path}'");
+        result.error = "unable to get file metadata information".to_string();
     }
 
     result
 }
 
 /// Verifies the file at the given path is owned by root:root, returning a `Results` based on the results.
-pub fn ensure_file_owner_and_group_root(file_path: &str) -> CheckerResult {
+pub fn ensure_file_owner_and_group_root(sac: &dyn SystemAccess, file_path: &str) -> CheckerResult {
     let mut result = CheckerResult::default();
 
-    if let Ok(metadata) = fs::metadata(file_path) {
-        if metadata.st_uid() != 0 || metadata.st_gid() != 0 {
+    if let Ok(metadata) = sac.metadata(file_path) {
+        if metadata.uid != 0 || metadata.gid != 0 {
             result.error = "File owner is not root:root".to_string();
             result.status = CheckStatus::FAIL;
         } else {
@@ -207,12 +214,12 @@ pub fn ensure_file_owner_and_group_root(file_path: &str) -> CheckerResult {
 
 #[cfg(test)]
 mod test_utils {
+    use super::*;
     use std::fs::{self, OpenOptions};
     use std::io::Write;
     use std::os::unix::fs::OpenOptionsExt;
+    use system_access::NativeSystemAccess;
     use tempfile::NamedTempFile;
-
-    use super::*;
 
     macro_rules! temp_file_path {
         ($path:expr) => {{
@@ -238,7 +245,9 @@ mod test_utils {
         )
         .unwrap();
 
-        let found = look_for_word_in_file(temp_file_path!(test_file), "udf").unwrap();
+        let found =
+            look_for_word_in_file(&NativeSystemAccess {}, temp_file_path!(test_file), "udf")
+                .unwrap();
         assert!(found);
     }
 
@@ -255,7 +264,9 @@ mod test_utils {
         )
         .unwrap();
 
-        let found = look_for_word_in_file(temp_file_path!(test_file), "udf").unwrap();
+        let found =
+            look_for_word_in_file(&NativeSystemAccess {}, temp_file_path!(test_file), "udf")
+                .unwrap();
         assert!(!found);
     }
 
@@ -272,13 +283,16 @@ mod test_utils {
         )
         .unwrap();
 
-        let found = look_for_word_in_file(temp_file_path!(test_file), "udf").unwrap();
+        let found =
+            look_for_word_in_file(&NativeSystemAccess {}, temp_file_path!(test_file), "udf")
+                .unwrap();
         assert!(!found);
     }
 
     #[test]
     fn test_look_for_word_in_file_bad_path() {
-        let result = look_for_word_in_file("/not/a/real/path", "search_str");
+        let result =
+            look_for_word_in_file(&NativeSystemAccess {}, "/not/a/real/path", "search_str");
         assert!(result.is_err());
     }
 
@@ -295,7 +309,9 @@ mod test_utils {
         )
         .unwrap();
 
-        let found = look_for_string_in_file(temp_file_path!(test_file), " udf,").unwrap();
+        let found =
+            look_for_string_in_file(&NativeSystemAccess {}, temp_file_path!(test_file), " udf,")
+                .unwrap();
         assert!(found);
     }
 
@@ -312,13 +328,16 @@ mod test_utils {
         )
         .unwrap();
 
-        let found = look_for_string_in_file(temp_file_path!(test_file), " udf,").unwrap();
+        let found =
+            look_for_string_in_file(&NativeSystemAccess {}, temp_file_path!(test_file), " udf,")
+                .unwrap();
         assert!(!found);
     }
 
     #[test]
     fn test_string_in_file_bad_path() {
-        let result = look_for_string_in_file("/not/a/real/path", "search_str");
+        let result =
+            look_for_string_in_file(&NativeSystemAccess {}, "/not/a/real/path", "search_str");
         assert!(result.is_err());
     }
 
@@ -335,8 +354,12 @@ mod test_utils {
         )
         .unwrap();
 
-        let found =
-            look_for_strings_in_file(temp_file_path!(test_file), &[" udf,", "57344 1"]).unwrap();
+        let found = look_for_strings_in_file(
+            &NativeSystemAccess {},
+            temp_file_path!(test_file),
+            &[" udf,", "57344 1"],
+        )
+        .unwrap();
         assert!(found);
     }
 
@@ -345,8 +368,12 @@ mod test_utils {
         let mut test_file = NamedTempFile::new().unwrap();
         writeln!(test_file, "udf 139264 0 - Live 0xffffffffc05e1000, crc_itu_t 16384 1 udf, Live 0xffffffffc05dc000, configfs 57344 1 - Live 0xffffffffc0320000").unwrap();
 
-        let found =
-            look_for_strings_in_file(temp_file_path!(test_file), &[" udf,", "57344 1"]).unwrap();
+        let found = look_for_strings_in_file(
+            &NativeSystemAccess {},
+            temp_file_path!(test_file),
+            &[" udf,", "57344 1"],
+        )
+        .unwrap();
         assert!(found);
     }
 
@@ -363,14 +390,22 @@ mod test_utils {
         )
         .unwrap();
 
-        let found =
-            look_for_strings_in_file(temp_file_path!(test_file), &[" udf,", "57344 1"]).unwrap();
+        let found = look_for_strings_in_file(
+            &NativeSystemAccess {},
+            temp_file_path!(test_file),
+            &[" udf,", "57344 1"],
+        )
+        .unwrap();
         assert!(!found);
     }
 
     #[test]
     fn test_strings_in_file_bad_path() {
-        let result = look_for_strings_in_file("/not/a/real/path", &["foo", "search_str"]);
+        let result = look_for_strings_in_file(
+            &NativeSystemAccess {},
+            "/not/a/real/path",
+            &["foo", "search_str"],
+        );
         assert!(result.is_err());
     }
 
@@ -380,7 +415,13 @@ mod test_utils {
         insmod /lib/modules/5.15.90/kernel/lib/crc-itu-t.ko.xz
         install /bin/true'";
 
-        let found = look_for_string_in_output("echo", [cmd_output], "install /bin/true").unwrap();
+        let found = look_for_string_in_output(
+            &NativeSystemAccess {},
+            "echo",
+            &[cmd_output],
+            "install /bin/true",
+        )
+        .unwrap();
         assert!(found);
     }
 
@@ -388,13 +429,19 @@ mod test_utils {
     fn test_string_in_output_not_found() {
         let cmd_output = "'insmod /lib/modules/5.15.90/kernel/fs/udf/udf.ko.xz'";
 
-        let found = look_for_string_in_output("echo", [cmd_output], "install /bin/true").unwrap();
+        let found = look_for_string_in_output(
+            &NativeSystemAccess {},
+            "echo",
+            &[cmd_output],
+            "install /bin/true",
+        )
+        .unwrap();
         assert!(!found);
     }
 
     #[test]
     fn test_string_in_output_bad_cmd() {
-        let result = look_for_string_in_output("ekko", [""], "blah");
+        let result = look_for_string_in_output(&NativeSystemAccess {}, "ekko", &[""], "blah");
         assert!(result.is_none());
     }
 
@@ -404,9 +451,13 @@ mod test_utils {
         insmod /lib/modules/5.15.90/kernel/lib/crc-itu-t.ko.xz
         install /bin/true'";
 
-        let found =
-            look_for_strings_in_output("echo", [cmd_output], &["5.15.90", "install /bin/true"])
-                .unwrap();
+        let found = look_for_strings_in_output(
+            &NativeSystemAccess {},
+            "echo",
+            &[cmd_output],
+            &["5.15.90", "install /bin/true"],
+        )
+        .unwrap();
         assert!(found);
     }
 
@@ -414,15 +465,19 @@ mod test_utils {
     fn test_strings_in_output_not_found() {
         let cmd_output = "'insmod /lib/modules/5.15.90/kernel/fs/udf/udf.ko.xz'";
 
-        let found =
-            look_for_strings_in_output("echo", [cmd_output], &["5.15.90", "install /bin/true"])
-                .unwrap();
+        let found = look_for_strings_in_output(
+            &NativeSystemAccess {},
+            "echo",
+            &[cmd_output],
+            &["5.15.90", "install /bin/true"],
+        )
+        .unwrap();
         assert!(!found);
     }
 
     #[test]
     fn test_strings_in_output_bad_cmd() {
-        let result = look_for_strings_in_output("ekko", [""], &["blah"]);
+        let result = look_for_strings_in_output(&NativeSystemAccess {}, "ekko", &[""], &["blah"]);
         assert!(result.is_none());
     }
 
@@ -446,7 +501,7 @@ mod test_utils {
             .open(&test_file_path)
             .unwrap();
 
-        let result = check_file_not_mode(test_file_path.as_str(), 0b111111);
+        let result = check_file_not_mode(&NativeSystemAccess {}, test_file_path.as_str(), 0b111111);
         assert_eq!(result.status, CheckStatus::PASS);
 
         // Clean up, fine to ignore errors
@@ -473,7 +528,7 @@ mod test_utils {
             .open(&test_file_path)
             .unwrap();
 
-        let result = check_file_not_mode(test_file_path.as_str(), 0b111111);
+        let result = check_file_not_mode(&NativeSystemAccess {}, test_file_path.as_str(), 0b111111);
         assert_eq!(result.status, CheckStatus::FAIL);
 
         // Clean up, fine to ignore errors
@@ -484,7 +539,7 @@ mod test_utils {
     fn test_check_file_not_mode_file_not_found() {
         let test_file_path = "/tmp/whatdoyouwant";
 
-        let result = check_file_not_mode(test_file_path, 0b111111);
+        let result = check_file_not_mode(&NativeSystemAccess {}, test_file_path, 0b111111);
         assert_eq!(result.status, CheckStatus::SKIP);
 
         // Clean up, fine to ignore errors

--- a/sources/bloodhound/src/results.rs
+++ b/sources/bloodhound/src/results.rs
@@ -1,3 +1,4 @@
+use crate::system_access::SystemAccess;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt};
@@ -85,7 +86,7 @@ impl fmt::Display for CheckerResult {
 /// - Check could not be performed, return error text to stderr and exit 1
 pub trait Checker {
     fn metadata(&self) -> CheckerMetadata;
-    fn execute(&self) -> CheckerResult;
+    fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult;
 }
 
 /// Common checker type for reporting manual check results.
@@ -97,7 +98,7 @@ pub struct ManualChecker {
 }
 
 impl Checker for ManualChecker {
-    fn execute(&self) -> CheckerResult {
+    fn execute(&self, _: &dyn SystemAccess) -> CheckerResult {
         CheckerResult {
             error: "Manual check, see benchmark for audit details.".to_string(),
             status: CheckStatus::SKIP,

--- a/sources/bloodhound/src/system_access.rs
+++ b/sources/bloodhound/src/system_access.rs
@@ -1,0 +1,137 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{ErrorKind, Seek, SeekFrom, Write};
+use std::os::linux::fs::MetadataExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::{fs, io};
+use tempfile::tempfile;
+
+/// The SystemAccess trait allows for plumbing in host system access during execution of checks. It
+/// exists solely to make is possible to unit tests checks.
+pub trait SystemAccess {
+    /// open opens the specified file
+    fn open(&self, path: &str) -> io::Result<File>;
+    /// metadata returns the file metadata (owner, group, mode)
+    fn metadata(&self, path: &str) -> io::Result<FileMetadata>;
+    /// exists returns true if the given path exists
+    fn exists(&self, path: &str) -> bool;
+    /// command_output returns the output of running the specified command with the suppplied arguments
+    fn command_output(&self, cmd: &str, args: &[&str]) -> io::Result<Output>;
+}
+
+/// FileMetadata is the subset of file metadata used in checks. The standard fs::Metadata type can't
+/// be mocked, so this type replaces it to allow for tests that relay on file metadata.
+#[derive(Clone, Debug)]
+pub struct FileMetadata {
+    pub uid: u32,
+    pub gid: u32,
+    pub mode: u32,
+}
+
+/// NativeSystemAccess provides access to the host system.
+pub struct NativeSystemAccess;
+impl SystemAccess for NativeSystemAccess {
+    fn open(&self, path: &str) -> io::Result<File> {
+        File::open(path)
+    }
+    fn metadata(&self, path: &str) -> io::Result<FileMetadata> {
+        let metadata = fs::metadata(path)?;
+        Ok(FileMetadata {
+            uid: metadata.st_uid(),
+            gid: metadata.st_gid(),
+            mode: metadata.permissions().mode(),
+        })
+    }
+    fn exists(&self, path: &str) -> bool {
+        Path::new(path).exists()
+    }
+    fn command_output(&self, cmd: &str, args: &[&str]) -> io::Result<Output> {
+        Command::new(cmd).args(args).output()
+    }
+}
+
+/// UnitTestSystemAccess is only used for unit tests
+#[doc(hidden)]
+pub struct UnitTestSystemAccess {
+    files: HashMap<String, String>,
+    metadata: HashMap<String, FileMetadata>,
+    commands: HashMap<(String, Vec<String>), Output>,
+}
+
+impl UnitTestSystemAccess {
+    pub fn new() -> Self {
+        UnitTestSystemAccess {
+            files: HashMap::new(),
+            metadata: HashMap::new(),
+            commands: HashMap::new(),
+        }
+    }
+    pub fn register_file(&mut self, path: &str, contents: &str) {
+        self.files.insert(path.to_string(), contents.to_string());
+    }
+
+    pub fn register_file_with_metadata(
+        &mut self,
+        path: &str,
+        contents: &str,
+        mode: u32,
+        uid: u32,
+        gid: u32,
+    ) {
+        self.register_file(path, contents);
+        self.metadata
+            .insert(path.to_string(), FileMetadata { uid, gid, mode });
+    }
+    pub fn register_command(&mut self, command: &str, args: &[&str], output: Output) {
+        let key = (
+            command.to_string(),
+            args.iter().map(|s| s.to_string()).collect(),
+        );
+        self.commands.insert(key, output);
+    }
+}
+impl Default for UnitTestSystemAccess {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl SystemAccess for UnitTestSystemAccess {
+    fn open(&self, path: &str) -> io::Result<File> {
+        let contents = self.files.get(path).ok_or(io::Error::new(
+            ErrorKind::NotFound,
+            "No such file or directory",
+        ))?;
+        let mut file = tempfile()?;
+        file.write_all(contents.as_bytes())?;
+        file.seek(SeekFrom::Start(0))?;
+        Ok(file)
+    }
+
+    fn metadata(&self, path: &str) -> io::Result<FileMetadata> {
+        let metadata = self.metadata.get(path).ok_or(io::Error::new(
+            ErrorKind::NotFound,
+            "No such file or directory",
+        ))?;
+        Ok(metadata.clone())
+    }
+
+    fn exists(&self, path: &str) -> bool {
+        self.files.contains_key(path)
+    }
+
+    fn command_output(&self, cmd: &str, args: &[&str]) -> io::Result<Output> {
+        let output = self
+            .commands
+            .get(&(
+                cmd.to_string(),
+                args.iter().map(|s| s.to_string()).collect(),
+            ))
+            .ok_or(io::Error::new(
+                ErrorKind::NotFound,
+                "No such file or directory",
+            ))?;
+        Ok(output.clone())
+    }
+}


### PR DESCRIPTION

**Issue number:**

Closes #

**Description of changes:**

File access and command execution is now through the trait to allow mocking input for testing. Also adds tests for the existing checks.

**Testing done:**

`cargo test`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
