### PR TITLE
release: prepend logind configuration with number

### DIFF
--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -202,7 +202,7 @@ install -d %{buildroot}%{_cross_libdir}/systemd/network
 install -p -m 0644 %{S:1200} %{buildroot}%{_cross_libdir}/systemd/network/80-release.link
 
 install -d %{buildroot}%{_cross_libdir}/systemd/logind.conf.d
-install -p -m 0644 %{S:1103} %{buildroot}%{_cross_libdir}/systemd/logind.conf.d/systemd-logind.conf
+install -p -m 0644 %{S:1103} %{buildroot}%{_cross_libdir}/systemd/logind.conf.d/80-inhibit-maxdelay.conf
 
 cat >%{buildroot}%{_cross_libdir}/os-release <<EOF
 NAME=Bottlerocket
@@ -302,7 +302,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_libdir}/os-release
 %dir %{_cross_libdir}/repart.d
 %{_cross_libdir}/repart.d/80-local.conf
-%{_cross_libdir}/systemd/logind.conf.d/systemd-logind.conf
+%{_cross_libdir}/systemd/logind.conf.d/80-inhibit-maxdelay.conf
 %{_cross_libdir}/systemd/network/80-release.link
 %{_cross_libdir}/systemd/networkd.conf.d/80-release.conf
 %{_cross_libdir}/systemd/system.conf.d/80-release.conf


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #608

**Description of changes:**

Kubelet is hardcoded to create a 99-kubelet.conf[1] file when the current InhibitDelayMaxSec is lower than the requested shutdownGracePeriod[2]. Kubelet then reloads systemd-logind and checks that its requested InhibitDelayMaxSec has been applied.

Logind will gather all drop-in files and merge lexicographically[3], with later files taking precedence on settings over earlier ones; the current filename of `systemd-logind.conf` will _always_ have its InhibitDelayMaxSec set over `99-kubelet.conf`. This results in kubelet failing to set up an inhibition lock when setting
settings.kubernetes.shutdown-grace-period>=300.

Following this change, the InhibitDelayMaxSec set in the image still applies but can be overridden when by kubelet as `99-kubelet.conf` will take precedence.

[1] https://github.com/kubernetes/kubernetes/blob/release-1.33/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go#L173-L176
[2] https://github.com/kubernetes/kubernetes/blob/release-1.33/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go#L185
[3] https://www.freedesktop.org/software/systemd/man/latest/logind.conf.html

**Testing done:**

Ran on local qemu image:

```shell
bash-5.2# cat x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/logind.conf.d/80-inhibit-maxdelay.conf 
[Login]
# Maximum time a system shutdown or sleep request is delayed due to to an inhibitor lock.
# We set it to 5 minutes to let configurations in bootstrap commands to finish before a restart.
InhibitDelayMaxSec=300

bash-5.2# systemd-analyze cat-config systemd/logind.conf
# Main configuration file systemd/logind.conf not found
# /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/logind.conf.d/80-inhibit-maxdelay.conf
[Login]
# Maximum time a system shutdown or sleep request is delayed due to to an inhibitor lock.
# We set it to 5 minutes to let configurations in bootstrap commands to finish before a restart.
InhibitDelayMaxSec=300
```

the previous InhibitDelayMaxSec is still the same, at 300.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
