### PR TITLE
[ecs-agent] Fix ECS_DISABLE_PRIVILEGED environment variable

### DIFF
--- a/packages/ecs-agent/ecs-base-conf
+++ b/packages/ecs-agent/ecs-base-conf
@@ -24,7 +24,7 @@ Environment=ECS_TASK_METADATA_RPS_LIMIT="{{ecs_metadata_service_limits settings.
 Environment=ECS_WARM_POOLS_CHECK="{{default "false" settings.autoscaling.should-wait}}"
 
 # Boolean configurations whose values are inverted in the API
-Environment=ECS_PRIVILEGED_DISABLED="{{negate_or_else true settings.ecs.allow-privileged-containers}}"
+Environment=ECS_DISABLE_PRIVILEGED="{{negate_or_else true settings.ecs.allow-privileged-containers}}"
 Environment=ECS_DISABLE_IMAGE_CLEANUP="{{negate_or_else false settings.ecs.image-cleanup-enabled}}"
 
 Environment=ECS_INSTANCE_ATTRIBUTES='{ "bottlerocket.variant": "{{os.variant_id}}"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
Fixes privileged mode in ECS agent. Currently, incorrect environment variable is being used.
Ref - https://github.com/aws/amazon-ecs-agent?tab=readme-ov-file#environment-variables


**Testing done:** Yes



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
