### PR TITLE
kubernetes-1.28: backport patch for config merge behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v10.0.1 (2025-07-31)
+
+## Orchestrator Changes
+### Kubernetes
+- Backport a patch to fix kubelet drop-in config merge behavior in kubernetes-1.28 ([#613])
+
+[#613]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/613
+
 # v10.0.0 (2025-07-25)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "10.0.0"
+release-version = "10.0.1"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/packages/kubernetes-1.28/1001-cmd-kubelet-fix-overriding-default-KubeletConfig-fie.patch
+++ b/packages/kubernetes-1.28/1001-cmd-kubelet-fix-overriding-default-KubeletConfig-fie.patch
@@ -1,0 +1,356 @@
+From ee5578be526815ab3ea63abda6cb95588c8265a3 Mon Sep 17 00:00:00 2001
+From: Sohan Kunkerkar <sohank2602@gmail.com>
+Date: Thu, 2 Nov 2023 09:24:27 -0400
+Subject: [PATCH] cmd/kubelet: fix overriding default KubeletConfig fields in
+ drop-in configs if not set
+
+This commit resolves an issue where certain KubeletConfig fields, specifically:
+- FileCheckFrequency
+- VolumeStatsAggPeriod
+- EvictionPressureTransitionPeriod
+- Authorization.Mode
+- EvictionHard
+were inadvertently overridden when not explicitly set in drop-in configs. To retain the
+original values if they were absent in the drop-in configs, mergeKubeletConfigurations
+uses a JSON patch merge strategy to selectively merge configurations. It prevents essential
+configuration settings from being overridden, ensuring a more predictable behavior for users.
+
+Signed-off-by: Sohan Kunkerkar <sohank2602@gmail.com>
+Co-authored-by: Peter Hunt <pehunt@redhat.com>
+Signed-off-by: Gavin Inglis <giinglis@amazon.com>
+---
+ cmd/kubelet/app/server.go                     | 41 +++++++---
+ cmd/kubelet/app/server_test.go                | 77 +++++++++++--------
+ go.mod                                        |  2 +-
+ .../kubeletconfig/configfiles/configfiles.go  | 17 ++++
+ pkg/kubelet/kubeletconfig/util/codec/codec.go | 15 ++++
+ 5 files changed, 108 insertions(+), 44 deletions(-)
+
+diff --git a/cmd/kubelet/app/server.go b/cmd/kubelet/app/server.go
+index bb81ec68738..76e8cdf7b99 100644
+--- a/cmd/kubelet/app/server.go
++++ b/cmd/kubelet/app/server.go
+@@ -20,6 +20,7 @@ package app
+ import (
+ 	"context"
+ 	"crypto/tls"
++	"encoding/json"
+ 	"errors"
+ 	"fmt"
+ 	"io"
+@@ -34,7 +35,7 @@ import (
+ 	"time"
+ 
+ 	"github.com/coreos/go-systemd/v22/daemon"
+-	"github.com/imdario/mergo"
++	jsonpatch "github.com/evanphx/json-patch"
+ 	"github.com/spf13/cobra"
+ 	"github.com/spf13/pflag"
+ 	"google.golang.org/grpc/codes"
+@@ -312,30 +313,34 @@ is checked every 20 seconds (also configurable with a flag).`,
+ // potentially overriding the previous values.
+ func mergeKubeletConfigurations(kubeletConfig *kubeletconfiginternal.KubeletConfiguration, kubeletDropInConfigDir string) error {
+ 	const dropinFileExtension = ".conf"
+-
++	baseKubeletConfigJSON, err := json.Marshal(kubeletConfig)
++	if err != nil {
++		return fmt.Errorf("failed to marshal base config: %w", err)
++	}
+ 	// Walk through the drop-in directory and update the configuration for each file
+-	err := filepath.WalkDir(kubeletDropInConfigDir, func(path string, info fs.DirEntry, err error) error {
++	if err := filepath.WalkDir(kubeletDropInConfigDir, func(path string, info fs.DirEntry, err error) error {
+ 		if err != nil {
+ 			return err
+ 		}
+ 		if !info.IsDir() && filepath.Ext(info.Name()) == dropinFileExtension {
+-			dropinConfig, err := loadConfigFile(path)
++			dropinConfigJSON, err := loadDropinConfigFileIntoJSON(path)
+ 			if err != nil {
+ 				return fmt.Errorf("failed to load kubelet dropin file, path: %s, error: %w", path, err)
+ 			}
+-
+-			// Merge dropinConfig with kubeletConfig
+-			if err := mergo.Merge(kubeletConfig, dropinConfig, mergo.WithOverride); err != nil {
+-				return fmt.Errorf("failed to merge kubelet drop-in config, path: %s, error: %w", path, err)
++			mergedConfigJSON, err := jsonpatch.MergePatch(baseKubeletConfigJSON, dropinConfigJSON)
++			if err != nil {
++				return fmt.Errorf("failed to merge drop-in and current config: %w", err)
+ 			}
++			baseKubeletConfigJSON = mergedConfigJSON
+ 		}
+ 		return nil
+-	})
+-
+-	if err != nil {
++	}); err != nil {
+ 		return fmt.Errorf("failed to walk through kubelet dropin directory %q: %w", kubeletDropInConfigDir, err)
+ 	}
+ 
++	if err := json.Unmarshal(baseKubeletConfigJSON, kubeletConfig); err != nil {
++		return fmt.Errorf("failed to unmarshal merged JSON into kubelet configuration: %w", err)
++	}
+ 	return nil
+ }
+ 
+@@ -415,6 +420,20 @@ func loadConfigFile(name string) (*kubeletconfiginternal.KubeletConfiguration, e
+ 	return kc, err
+ }
+ 
++func loadDropinConfigFileIntoJSON(name string) ([]byte, error) {
++	const errFmt = "failed to load drop-in kubelet config file %s, error %v"
++	// compute absolute path based on current working dir
++	kubeletConfigFile, err := filepath.Abs(name)
++	if err != nil {
++		return nil, fmt.Errorf(errFmt, name, err)
++	}
++	loader, err := configfiles.NewFsLoader(&utilfs.DefaultFs{}, kubeletConfigFile)
++	if err != nil {
++		return nil, fmt.Errorf(errFmt, name, err)
++	}
++	return loader.LoadIntoJSON()
++}
++
+ // UnsecuredDependencies returns a Dependencies suitable for being run, or an error if the server setup
+ // is not valid.  It will not start any background processes, and does not include authentication/authorization
+ func UnsecuredDependencies(s *options.KubeletServer, featureGate featuregate.FeatureGate) (*kubelet.Dependencies, error) {
+diff --git a/cmd/kubelet/app/server_test.go b/cmd/kubelet/app/server_test.go
+index 0a4fda291a2..3513c5fc7ed 100644
+--- a/cmd/kubelet/app/server_test.go
++++ b/cmd/kubelet/app/server_test.go
+@@ -21,8 +21,11 @@ import (
+ 	"path/filepath"
+ 	"reflect"
+ 	"testing"
++	"time"
+ 
+ 	"github.com/stretchr/testify/require"
++	"gopkg.in/yaml.v2"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/kubernetes/cmd/kubelet/app/options"
+ 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
+ )
+@@ -71,7 +74,7 @@ func TestValueOfAllocatableResources(t *testing.T) {
+ 
+ func TestMergeKubeletConfigurations(t *testing.T) {
+ 	testCases := []struct {
+-		kubeletConfig           string
++		kubeletConfig           *kubeletconfiginternal.KubeletConfiguration
+ 		dropin1                 string
+ 		dropin2                 string
+ 		overwrittenConfigFields map[string]interface{}
+@@ -79,12 +82,14 @@ func TestMergeKubeletConfigurations(t *testing.T) {
+ 		name                    string
+ 	}{
+ 		{
+-			kubeletConfig: `
+-apiVersion: kubelet.config.k8s.io/v1beta1
+-kind: KubeletConfiguration
+-port: 9080
+-readOnlyPort: 10257
+-`,
++			kubeletConfig: &kubeletconfiginternal.KubeletConfiguration{
++				TypeMeta: metav1.TypeMeta{
++					Kind:       "KubeletConfiguration",
++					APIVersion: "kubelet.config.k8s.io/v1beta1",
++				},
++				Port:         int32(9090),
++				ReadOnlyPort: int32(10257),
++			},
+ 			dropin1: `
+ apiVersion: kubelet.config.k8s.io/v1beta1
+ kind: KubeletConfiguration
+@@ -103,13 +108,15 @@ readOnlyPort: 10255
+ 			name: "kubelet.conf.d overrides kubelet.conf",
+ 		},
+ 		{
+-			kubeletConfig: `
+-apiVersion: kubelet.config.k8s.io/v1beta1
+-kind: KubeletConfiguration
+-readOnlyPort: 10256
+-kubeReserved:
+-	memory: 70Mi
+-`,
++			kubeletConfig: &kubeletconfiginternal.KubeletConfiguration{
++				TypeMeta: metav1.TypeMeta{
++					Kind:       "KubeletConfiguration",
++					APIVersion: "kubelet.config.k8s.io/v1beta1",
++				},
++				ReadOnlyPort:  int32(10256),
++				KubeReserved:  map[string]string{"memory": "100Mi"},
++				SyncFrequency: metav1.Duration{Duration: 5 * time.Minute},
++			},
+ 			dropin1: `
+ apiVersion: kubelet.config.k8s.io/v1beta1
+ kind: KubeletConfiguration
+@@ -131,18 +138,19 @@ kubeReserved:
+ 					"cpu":    "200m",
+ 					"memory": "100Mi",
+ 				},
++				"SyncFrequency": metav1.Duration{Duration: 5 * time.Minute},
+ 			},
+ 			name: "kubelet.conf.d overrides kubelet.conf with subfield override",
+ 		},
+ 		{
+-			kubeletConfig: `
+-apiVersion: kubelet.config.k8s.io/v1beta1
+-kind: KubeletConfiguration
+-port: 9090
+-clusterDNS:
+-	- 192.168.1.3
+-	- 192.168.1.4
+-`,
++			kubeletConfig: &kubeletconfiginternal.KubeletConfiguration{
++				TypeMeta: metav1.TypeMeta{
++					Kind:       "KubeletConfiguration",
++					APIVersion: "kubelet.config.k8s.io/v1beta1",
++				},
++				Port:       int32(9090),
++				ClusterDNS: []string{"192.168.1.3", "192.168.1.4"},
++			},
+ 			dropin1: `
+ apiVersion: kubelet.config.k8s.io/v1beta1
+ kind: KubeletConfiguration
+@@ -173,6 +181,7 @@ clusterDNS:
+ 			name: "kubelet.conf.d overrides kubelet.conf with slices/lists",
+ 		},
+ 		{
++			kubeletConfig: nil,
+ 			dropin1: `
+ apiVersion: kubelet.config.k8s.io/v1beta1
+ kind: KubeletConfiguration
+@@ -195,13 +204,14 @@ readOnlyPort: 10255
+ 			name: "cli args override kubelet.conf.d",
+ 		},
+ 		{
+-			kubeletConfig: `
+-apiVersion: kubelet.config.k8s.io/v1beta1
+-kind: KubeletConfiguration
+-port: 9090
+-clusterDNS:
+-	- 192.168.1.3
+-`,
++			kubeletConfig: &kubeletconfiginternal.KubeletConfiguration{
++				TypeMeta: metav1.TypeMeta{
++					Kind:       "KubeletConfiguration",
++					APIVersion: "kubelet.config.k8s.io/v1beta1",
++				},
++				Port:       int32(9090),
++				ClusterDNS: []string{"192.168.1.3"},
++			},
+ 			overwrittenConfigFields: map[string]interface{}{
+ 				"Port":       int32(9090),
+ 				"ClusterDNS": []string{"192.168.1.2"},
+@@ -222,12 +232,15 @@ clusterDNS:
+ 			kubeletConfig := &kubeletconfiginternal.KubeletConfiguration{}
+ 			kubeletFlags := &options.KubeletFlags{}
+ 
+-			if len(test.kubeletConfig) > 0 {
++			if test.kubeletConfig != nil {
+ 				// Create the Kubeletconfig
+ 				kubeletConfFile := filepath.Join(tempDir, "kubelet.conf")
+-				err := os.WriteFile(kubeletConfFile, []byte(test.kubeletConfig), 0644)
+-				require.NoError(t, err, "failed to create config from a yaml file")
++				yamlData, err := yaml.Marshal(test.kubeletConfig) // Convert struct to YAML
++				require.NoError(t, err, "failed to convert kubelet config to YAML")
++				err = os.WriteFile(kubeletConfFile, yamlData, 0644)
++				require.NoError(t, err, "failed to create config from YAML data")
+ 				kubeletFlags.KubeletConfigFile = kubeletConfFile
++				kubeletConfig = test.kubeletConfig
+ 			}
+ 			if len(test.dropin1) > 0 || len(test.dropin2) > 0 {
+ 				// Create kubelet.conf.d directory and drop-in configuration files
+diff --git a/go.mod b/go.mod
+index f5dae6d2475..e3cac99d9be 100644
+--- a/go.mod
++++ b/go.mod
+@@ -45,7 +45,6 @@ require (
+ 	github.com/google/go-cmp v0.6.0
+ 	github.com/google/gofuzz v1.2.0
+ 	github.com/google/uuid v1.3.1
+-	github.com/imdario/mergo v0.3.6
+ 	github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5
+ 	github.com/libopenstorage/openstorage v1.0.0
+ 	github.com/lithammer/dedent v1.1.0
+@@ -185,6 +184,7 @@ require (
+ 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+ 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+ 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
++	github.com/imdario/mergo v0.3.6 // indirect
+ 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+ 	github.com/jonboulle/clockwork v0.2.2 // indirect
+ 	github.com/josharian/intern v1.0.0 // indirect
+diff --git a/pkg/kubelet/kubeletconfig/configfiles/configfiles.go b/pkg/kubelet/kubeletconfig/configfiles/configfiles.go
+index 63aef74f126..46423cb241d 100644
+--- a/pkg/kubelet/kubeletconfig/configfiles/configfiles.go
++++ b/pkg/kubelet/kubeletconfig/configfiles/configfiles.go
+@@ -31,6 +31,9 @@ import (
+ type Loader interface {
+ 	// Load loads and returns the KubeletConfiguration from the storage layer, or an error if a configuration could not be loaded
+ 	Load() (*kubeletconfig.KubeletConfiguration, error)
++	// LoadIntoJSON loads and returns the KubeletConfiguration from the storage layer, or an error if a configuration could not be
++	// loaded. It returns the configuration as a JSON byte slice
++	LoadIntoJSON() ([]byte, error)
+ }
+ 
+ // fsLoader loads configuration from `configDir`
+@@ -78,6 +81,20 @@ func (loader *fsLoader) Load() (*kubeletconfig.KubeletConfiguration, error) {
+ 	return kc, nil
+ }
+ 
++func (loader *fsLoader) LoadIntoJSON() ([]byte, error) {
++	data, err := loader.fs.ReadFile(loader.kubeletFile)
++	if err != nil {
++		return nil, fmt.Errorf("failed to read drop-in kubelet config file %q, error: %v", loader.kubeletFile, err)
++	}
++
++	// no configuration is an error, some parameters are required
++	if len(data) == 0 {
++		return nil, fmt.Errorf("kubelet config file %q was empty", loader.kubeletFile)
++	}
++
++	return utilcodec.DecodeKubeletConfigurationIntoJSON(loader.kubeletCodecs, data)
++}
++
+ // resolveRelativePaths makes relative paths absolute by resolving them against `root`
+ func resolveRelativePaths(paths []*string, root string) {
+ 	for _, path := range paths {
+diff --git a/pkg/kubelet/kubeletconfig/util/codec/codec.go b/pkg/kubelet/kubeletconfig/util/codec/codec.go
+index 8598c0ca2d9..ba4b41cfd85 100644
+--- a/pkg/kubelet/kubeletconfig/util/codec/codec.go
++++ b/pkg/kubelet/kubeletconfig/util/codec/codec.go
+@@ -17,6 +17,7 @@ limitations under the License.
+ package codec
+ 
+ import (
++	"encoding/json"
+ 	"fmt"
+ 
+ 	"k8s.io/klog/v2"
+@@ -24,6 +25,7 @@ import (
+ 	// ensure the core apis are installed
+ 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+ 
++	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+ 	"k8s.io/apimachinery/pkg/runtime"
+ 	"k8s.io/apimachinery/pkg/runtime/schema"
+ 	"k8s.io/apimachinery/pkg/runtime/serializer"
+@@ -105,3 +107,16 @@ func DecodeKubeletConfiguration(kubeletCodecs *serializer.CodecFactory, data []b
+ 
+ 	return internalKC, nil
+ }
++
++// DecodeKubeletConfigurationIntoJSON decodes a serialized KubeletConfiguration to the internal type.
++func DecodeKubeletConfigurationIntoJSON(kubeletCodecs *serializer.CodecFactory, data []byte) ([]byte, error) {
++	// The UniversalDecoder runs defaulting and returns the internal type by default.
++	obj, _, err := kubeletCodecs.UniversalDecoder().Decode(data, nil, &unstructured.Unstructured{})
++	if err != nil {
++		return nil, err
++	}
++
++	objT := obj.(*unstructured.Unstructured)
++
++	return json.Marshal(objT.Object)
++}
+-- 
+2.47.1
+

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -68,6 +68,9 @@ Source102: pod-infra-container-image
 
 Source1000: clarify.toml
 
+# Backport patch for config drop-in merge behavior parity with k8s-1.29+
+Patch1001: 1001-cmd-kubelet-fix-overriding-default-KubeletConfig-fie.patch
+
 BuildRequires: git
 BuildRequires: rsync
 BuildRequires: %{_cross_os}glibc-devel


### PR DESCRIPTION
**Issue number:**

Closes #612

**Description of changes:**

The kubelet configuration merge process was incorrectly overriding default KubeletConfig fields when they were not explicitly set in drop-in configuration files.

The previous merge strategy using mergo.Merge with override would replace unset fields with zero values, breaking expected default behavior and potentially causing runtime issues.

This change backports a patch from upstream Kubernetes that replaces the merge strategy with JSON patch merge. The new approach selectively merges only the fields that are explicitly configured in drop-in files, preserving the original default values for unset fields.

The patch modifies the mergeKubeletConfigurations function to:
* Marshal the base configuration to JSON
* Use JSON patch merge strategy for each drop-in file
* Unmarshal the final merged result back to the configuration struct


This is a backport of https://github.com/kubernetes/kubernetes/commit/ee5578be526815ab3ea63abda6cb95588c8265a3


**Testing done:**

Quick tests:

```
 NAME                                                  TYPE                         STATE                                           PASSED                     FAILED                     SKIPPED   BUILD ID                           LAST UPDATE
 x86-64-aws-k8s-128-quick                              Test                         passed                                               5                          0                        7391   00afa14f-dirty                     2025-07-31T01:06:03Z
 x86-64-aws-k8s-128                                    Resource                     completed                                                                                                       00afa14f-dirty                     2025-07-31T01:03:47Z
 x86-64-aws-k8s-128-instances-xtwt                     Resource                     completed                                                                                                       00afa14f-dirty                     2025-07-31T01:03:55Z
```

Confirmed that the kubelet configuration matches that of Bottlerocket v1.43.0:

<details>

The fix:

```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "00afa14f-dirty",
    "pretty_name": "Bottlerocket OS 1.44.0 (aws-k8s-1.28)",
    "variant_id": "aws-k8s-1.28",
    "version_id": "1.44.0"
  }
}

curl -X GET http://127.0.0.1:8001/api/v1/nodes/ip-192-168-75-70.us-west-2.compute.internal/proxy/configz | jq .  > fixed-kubeconfig.json

    {
      "kubeletconfig": {
        "enableServer": true,
        "staticPodPath": "/etc/kubernetes/static-pods/",
        "syncFrequency": "1m0s",
        "fileCheckFrequency": "20s",
        "httpCheckFrequency": "20s",
        "address": "0.0.0.0",
        "port": 10250,
        "tlsCipherSuites": [
          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
          "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
          "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
          "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
          "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
          "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
        ],
        "serverTLSBootstrap": true,
        "authentication": {
          "x509": {
            "clientCAFile": "/etc/kubernetes/pki/ca.crt"
          },
          "webhook": {
            "enabled": true,
            "cacheTTL": "2m0s"
          },
          "anonymous": {
            "enabled": false
          }
        },
        "authorization": {
          "mode": "Webhook",
          "webhook": {
            "cacheAuthorizedTTL": "5m0s",
            "cacheUnauthorizedTTL": "30s"
          }
        },
        "registryPullQPS": 5,
        "registryBurst": 10,
        "eventRecordQPS": 50,
        "eventBurst": 100,
        "enableDebuggingHandlers": true,
        "healthzPort": 10248,
        "healthzBindAddress": "127.0.0.1",
        "oomScoreAdj": -999,
        "clusterDomain": "cluster.local",
        "clusterDNS": [
          "10.100.0.10"
        ],
        "streamingConnectionIdleTimeout": "4h0m0s",
        "nodeStatusUpdateFrequency": "10s",
        "nodeStatusReportFrequency": "5m0s",
        "nodeLeaseDurationSeconds": 40,
        "imageMinimumGCAge": "2m0s",
        "imageGCHighThresholdPercent": 85,
        "imageGCLowThresholdPercent": 80,
        "volumeStatsAggPeriod": "1m0s",
        "cgroupRoot": "/",
        "cgroupsPerQOS": true,
        "cgroupDriver": "systemd",
        "cpuManagerPolicy": "none",
        "cpuManagerReconcilePeriod": "10s",
        "memoryManagerPolicy": "None",
        "topologyManagerPolicy": "none",
        "topologyManagerScope": "container",
        "runtimeRequestTimeout": "15m0s",
        "hairpinMode": "hairpin-veth",
        "maxPods": 737,
        "podPidsLimit": 1048576,
        "resolvConf": "/run/netdog/resolv.conf",
        "cpuCFSQuota": true,
        "cpuCFSQuotaPeriod": "100ms",
        "nodeStatusMaxImages": 50,
        "maxOpenFiles": 1000000,
        "contentType": "application/vnd.kubernetes.protobuf",
        "kubeAPIQPS": 50,
        "kubeAPIBurst": 100,
        "serializeImagePulls": false,
        "evictionHard": {
          "imagefs.available": "15%",
          "memory.available": "100Mi",
          "nodefs.available": "10%",
          "nodefs.inodesFree": "5%"
        },
        "evictionPressureTransitionPeriod": "5m0s",
        "enableControllerAttachDetach": true,
        "protectKernelDefaults": true,
        "makeIPTablesUtilChains": true,
        "iptablesMasqueradeBit": 14,
        "iptablesDropBit": 15,
        "failSwapOn": false,
        "memorySwap": {},
        "containerLogMaxSize": "10Mi",
        "containerLogMaxFiles": 5,
        "configMapAndSecretChangeDetectionStrategy": "Watch",
        "kubeReserved": {
          "cpu": "310m",
          "ephemeral-storage": "1Gi",
          "memory": "8362Mi"
        },
        "kubeReservedCgroup": "/runtime",
        "enforceNodeAllocatable": [
          "pods"
        ],
        "volumePluginDir": "/var/lib/kubelet/plugins/volume/exec",
        "providerID": "aws:///us-west-2c/i-0bb6e3d3e01eb858e",
        "logging": {
          "format": "text",
          "flushFrequency": "5s",
          "verbosity": 0,
          "options": {
            "json": {
              "infoBufferSize": "0"
            }
          }
        },
        "enableSystemLogHandler": true,
        "enableSystemLogQuery": false,
        "shutdownGracePeriod": "0s",
        "shutdownGracePeriodCriticalPods": "0s",
        "enableProfilingHandler": true,
        "enableDebugFlagsHandler": true,
        "seccompDefault": false,
        "memoryThrottlingFactor": 0.9,
        "registerNode": true,
        "localStorageCapacityIsolation": true,
        "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock"
      }
    }
```

A k8s-1.28 Bottlerocket v1.43.0 node: 

```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "c71bcbe9",
    "pretty_name": "Bottlerocket OS 1.43.0 (aws-k8s-1.28)",
    "variant_id": "aws-k8s-1.28",
    "version_id": "1.43.0"
  }
}
{
  "kubeletconfig": {
    "enableServer": true,
    "staticPodPath": "/etc/kubernetes/static-pods/",
    "syncFrequency": "1m0s",
    "fileCheckFrequency": "20s",
    "httpCheckFrequency": "20s",
    "address": "0.0.0.0",
    "port": 10250,
    "tlsCipherSuites": [
      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
    ],
    "serverTLSBootstrap": true,
    "authentication": {
      "x509": {
        "clientCAFile": "/etc/kubernetes/pki/ca.crt"
      },
      "webhook": {
        "enabled": true,
        "cacheTTL": "2m0s"
      },
      "anonymous": {
        "enabled": false
      }
    },
    "authorization": {
      "mode": "Webhook",
      "webhook": {
        "cacheAuthorizedTTL": "5m0s",
        "cacheUnauthorizedTTL": "30s"
      }
    },
    "registryPullQPS": 5,
    "registryBurst": 10,
    "eventRecordQPS": 50,
    "eventBurst": 100,
    "enableDebuggingHandlers": true,
    "healthzPort": 10248,
    "healthzBindAddress": "127.0.0.1",
    "oomScoreAdj": -999,
    "clusterDomain": "cluster.local",
    "clusterDNS": [
      "10.100.0.10"
    ],
    "streamingConnectionIdleTimeout": "4h0m0s",
    "nodeStatusUpdateFrequency": "10s",
    "nodeStatusReportFrequency": "5m0s",
    "nodeLeaseDurationSeconds": 40,
    "imageMinimumGCAge": "2m0s",
    "imageGCHighThresholdPercent": 85,
    "imageGCLowThresholdPercent": 80,
    "volumeStatsAggPeriod": "1m0s",
    "cgroupRoot": "/",
    "cgroupsPerQOS": true,
    "cgroupDriver": "systemd",
    "cpuManagerPolicy": "none",
    "cpuManagerReconcilePeriod": "10s",
    "memoryManagerPolicy": "None",
    "topologyManagerPolicy": "none",
    "topologyManagerScope": "container",
    "runtimeRequestTimeout": "15m0s",
    "hairpinMode": "hairpin-veth",
    "maxPods": 737,
    "podPidsLimit": 1048576,
    "resolvConf": "/run/netdog/resolv.conf",
    "cpuCFSQuota": true,
    "cpuCFSQuotaPeriod": "100ms",
    "nodeStatusMaxImages": 50,
    "maxOpenFiles": 1000000,
    "contentType": "application/vnd.kubernetes.protobuf",
    "kubeAPIQPS": 50,
    "kubeAPIBurst": 100,
    "serializeImagePulls": false,
    "evictionHard": {
      "imagefs.available": "15%",
      "memory.available": "100Mi",
      "nodefs.available": "10%",
      "nodefs.inodesFree": "5%"
    },
    "evictionPressureTransitionPeriod": "5m0s",
    "enableControllerAttachDetach": true,
    "protectKernelDefaults": true,
    "makeIPTablesUtilChains": true,
    "iptablesMasqueradeBit": 14,
    "iptablesDropBit": 15,
    "failSwapOn": false,
    "memorySwap": {},
    "containerLogMaxSize": "10Mi",
    "containerLogMaxFiles": 5,
    "configMapAndSecretChangeDetectionStrategy": "Watch",
    "kubeReserved": {
      "cpu": "310m",
      "ephemeral-storage": "1Gi",
      "memory": "8362Mi"
    },
    "kubeReservedCgroup": "/runtime",
    "enforceNodeAllocatable": [
      "pods"
    ],
    "volumePluginDir": "/var/lib/kubelet/plugins/volume/exec",
    "providerID": "aws:///us-west-2c/i-0bb6e3d3e01eb858e",
    "logging": {
      "format": "text",
      "flushFrequency": "5s",
      "verbosity": 0,
      "options": {
        "json": {
          "infoBufferSize": "0"
        }
      }
    },
    "enableSystemLogHandler": true,
    "enableSystemLogQuery": false,
    "shutdownGracePeriod": "0s",
    "shutdownGracePeriodCriticalPods": "0s",
    "enableProfilingHandler": true,
    "enableDebugFlagsHandler": true,
    "seccompDefault": false,
    "memoryThrottlingFactor": 0.9,
    "registerNode": true,
    "localStorageCapacityIsolation": true,
    "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
  }
}
```


Diff the two:

```
diff <(jq . fixed-kubeconfig.json) <(jq . fixed-kubeconfig-1.43.0.json)
106c106
<     "providerID": "aws:///us-west-2c/i-0bb6e3d3e01eb858e",
---
>     "providerID": "aws:///us-west-2c/i-0906ca693454a620e",
```

Quick soci test:

```
"imageServiceEndpoint": "unix:///run/soci-snapshotter/soci-snapshotter.sock"
```
```
bash-5.1# containerd config dump | grep soci
      snapshotter = "soci"
  [proxy_plugins.soci]
    address = "/run/soci-snapshotter/soci-snapshotter.sock"
    [proxy_plugins.soci.exports]
      address = "/run/soci-snapshotter/soci-snapshotter.sock"
      root = "/var/lib/soci-snapshotter
```



```
NAME                              READY   STATUS    RESTARTS   AGE
djl-deployment-5d75f8ff5b-twwzd   1/1     Running   0          7m44s
rmq-deployment-9c7d5b6cd-2wk78    1/1     Running   0          7m44s
```




</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
