### PR TITLE
enable JSON output for nftables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "libglib",
  "libinih",
  "libisal",
+ "libjansson",
  "libjson-c",
  "libmnl",
  "libncurses",
@@ -607,6 +608,13 @@ dependencies = [
 [[package]]
 name = "libisal"
 version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "libjansson"
+version = "2.14.1"
 dependencies = [
  "glibc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,7 @@ version = "0.1.0"
 dependencies = [
  "glibc",
  "iptables",
+ "libjansson",
  "libmnl",
  "libnftnl",
  "readline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
   "packages/libglib",
   "packages/libinih",
   "packages/libisal",
+  "packages/libjansson",
   "packages/libmnl",
   "packages/libncurses",
   "packages/libnetfilter_conntrack",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -76,6 +76,7 @@ libgcc = { path = "../../packages/libgcc" }
 libglib = { path = "../../packages/libglib" }
 libinih = { path = "../../packages/libinih" }
 libisal = { path = "../../packages/libisal" }
+libjansson = { path = "../../packages/libjansson" }
 libmnl = { path = "../../packages/libmnl" }
 libncurses = { path = "../../packages/libncurses" }
 libnetfilter_conntrack = { path = "../../packages/libnetfilter_conntrack" }

--- a/packages/libjansson/Cargo.toml
+++ b/packages/libjansson/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "libjansson"
+version = "2.14.1"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/akheron/jansson/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/akheron/jansson/archive/v2.14.1.tar.gz"
+sha512 = "7d3a01566cf42a2d8f1ddca12bfb04a93a11ad30bcccb7d5f862015d9a59f8376b2ed46026aa0f0828acc4b74f4537cae5a1874ab81b83b8638d75ad0c94e243"
+path = "jansson-2.14.1.tar.gz"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/libjansson/libjansson.spec
+++ b/packages/libjansson/libjansson.spec
@@ -1,0 +1,44 @@
+Name: %{_cross_os}libjansson
+Version: 2.14.1
+Release: 1%{?dist}
+Summary: Library for encoding, decoding and manipulating JSON data
+License: MIT
+URL: https://github.com/akheron/jansson
+Source0: https://github.com/akheron/jansson/archive/v%{version}.tar.gz#/jansson-%{version}.tar.gz
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the library for encoding, decoding and manipulating JSON data
+Requires: %{name}
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n jansson-%{version} -p1
+
+%build
+autoreconf -fiv
+
+%cross_configure \
+  --disable-static \
+  --disable-dtoa \
+  %{nil}
+
+%make_build
+
+%install
+%make_install
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_libdir}/*.so.*
+
+%files devel
+%{_cross_includedir}/*.h
+%{_cross_libdir}/*.so
+%{_cross_pkgconfigdir}/*.pc

--- a/packages/nftables/Cargo.toml
+++ b/packages/nftables/Cargo.toml
@@ -22,6 +22,7 @@ sha512 = "7aa972c146e0dfaacc8faaef9b9ebbe419f7cbc5814d1fb978b35a4972d384aabe2e6e
 [build-dependencies]
 glibc = { path = "../glibc" }
 iptables = { path = "../iptables" }
+libjansson = { path = "../libjansson" }
 libmnl = { path = "../libmnl" }
 libnftnl = { path = "../libnftnl" }
 readline = { path = "../readline" }

--- a/packages/nftables/nftables.spec
+++ b/packages/nftables/nftables.spec
@@ -11,10 +11,12 @@ Source10: nftables-tmpfiles.conf
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}iptables-devel
+BuildRequires: %{_cross_os}libjansson-devel
 BuildRequires: %{_cross_os}libmnl-devel
 BuildRequires: %{_cross_os}libnftnl-devel
 BuildRequires: %{_cross_os}readline-devel
 Requires: %{_cross_os}iptables
+Requires: %{_cross_os}libjansson
 Requires: %{_cross_os}libmnl
 Requires: %{_cross_os}libnftnl
 Requires: %{_cross_os}readline
@@ -39,8 +41,8 @@ Requires: %{name}
   --enable-debug \
   --with-cli=readline \
   --with-mini-gmp \
+  --with-json \
   --with-xtables \
-  --without-json \
   %{nil}
 
 %force_disable_rpath


### PR DESCRIPTION
**Issue number:**
Related: #549

**Description of changes:**
Package `libjansson` so we can enable the JSON feature in `nftables`.


**Testing done:**
Verified that `nft --json` outputs JSON.
```
# nft --json list ruleset
{"nftables": [{"metainfo": {"version": "1.1.3", "release_name": "Commodore Bullmoose #4" ...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
