### PR TITLE
Bump ecs-agent, amazon-ssm-agent, docker-engine

### DIFF
--- a/packages/amazon-ssm-agent/0001-agent-Add-config-to-make-shell-optional.patch
+++ b/packages/amazon-ssm-agent/0001-agent-Add-config-to-make-shell-optional.patch
@@ -1,9 +1,10 @@
-From af0299d3f9ffb36b1f10b3c608b68301af664b1e Mon Sep 17 00:00:00 2001
+From 096dad878552ea342ddad9f3132453fd7cc4e08b Mon Sep 17 00:00:00 2001
 From: Kush Upadhyay <kushupad@amazon.com>
 Date: Mon, 7 Oct 2024 09:13:38 +0000
 Subject: [PATCH] agent: Add config to make shell optional
 
 Signed-off-by: Kush Upadhyay <kushupad@amazon.com>
+Signed-off-by: Yutong Sun <yutongsu@amazon.com>
 ---
  agent/appconfig/appconfig.go         |  1 +
  agent/appconfig/contracts.go         |  2 ++
@@ -11,22 +12,22 @@ Signed-off-by: Kush Upadhyay <kushupad@amazon.com>
  3 files changed, 28 insertions(+), 11 deletions(-)
 
 diff --git a/agent/appconfig/appconfig.go b/agent/appconfig/appconfig.go
-index 021d9f2..867f9e0 100644
+index 6b278f50..2013cf92 100644
 --- a/agent/appconfig/appconfig.go
 +++ b/agent/appconfig/appconfig.go
-@@ -119,6 +119,7 @@ func DefaultConfig() SsmagentConfig {
- 		SessionLogsDestination:                SessionLogsDestinationNone,
+@@ -120,6 +120,7 @@ func DefaultConfig() SsmagentConfig {
  		PluginLocalOutputCleanup:              DefaultPluginOutputRetention,
  		OrchestrationDirectoryCleanup:         DefaultOrchestrationDirCleanup,
+ 		SessionHandshakeTimeoutSeconds:        DefaultSessionHandshakeTimeoutSeconds,
 +		UseShell:                              false,
  	}
- 	var agent = AgentInfo{
+ 	agent := AgentInfo{
  		Name:                                    "amazon-ssm-agent",
 diff --git a/agent/appconfig/contracts.go b/agent/appconfig/contracts.go
-index 687aed2..dcb8412 100644
+index 69501310..bf42380f 100644
 --- a/agent/appconfig/contracts.go
 +++ b/agent/appconfig/contracts.go
-@@ -50,6 +50,8 @@ type SsmCfg struct {
+@@ -55,6 +55,8 @@ type SsmCfg struct {
  	PluginLocalOutputCleanup string
  	// Configure only when it is safe to delete orchestration folder after document execution. This config overrides PluginLocalOutputCleanup when set.
  	OrchestrationDirectoryCleanup string
@@ -36,10 +37,10 @@ index 687aed2..dcb8412 100644
  
  // AgentInfo represents metadata for amazon-ssm-agent
 diff --git a/agent/plugins/runscript/runscript.go b/agent/plugins/runscript/runscript.go
-index 48be5e7..d8cbcf1 100644
+index c89bf92a..b56e973a 100644
 --- a/agent/plugins/runscript/runscript.go
 +++ b/agent/plugins/runscript/runscript.go
-@@ -174,23 +174,37 @@ func (p *Plugin) runCommands(pluginID string, pluginInput RunScriptPluginInput,
+@@ -177,23 +177,37 @@ func (p *Plugin) runCommands(pluginID string, pluginInput RunScriptPluginInput,
  		return
  	}
  
@@ -89,5 +90,5 @@ index 48be5e7..d8cbcf1 100644
  	exitCode, err := p.CommandExecuter.NewExecute(p.Context, workingDir, output.GetStdoutWriter(), output.GetStderrWriter(), cancelFlag, executionTimeout, commandName, commandArguments, pluginInput.Environment)
  
 -- 
-2.40.1
+2.47.0
 

--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ssm-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.1957.0/amazon-ssm-agent-3.3.1957.0.tar.gz"
-sha512 = "ee3ef0c05c308e81c35e1e63f33522684fe3ae4016a2769643a59e97f581383fb9abff16b12bbfdf1e097522ffb9872daf35e2b37157c278542e00f8270f0c8a"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.2746.0/amazon-ssm-agent-3.3.2746.0.tar.gz"
+sha512 = "a0f2af7cf5cb9a8466f6ec8ed79fa3f4f00633c43d772624bdf1f71dc75967e760a997a7e37138bbc2197945848a9278fec0c2f21146945849bda64b8803b6dc"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.3.1957.0
+Version: 3.3.2746.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0

--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v25.0.8/moby-25.0.8.tar.gz"
-sha512 = "573f738df9fa1655c56ba5836fcfd0691521b81c4807e09156dd2813b172219b283b7ff1639f19379b46a7c3e1b0da4c8ae4f11f96e50e7efb0587d6bcc682fa"
+url = "https://github.com/moby/moby/archive/v25.0.12/moby-25.0.12.tar.gz"
+sha512 = "8954a86e87be392988cb56c9f99ee3004033b0b82b2ed5c6c6064d3409fb1357db115aa9b6e5a9f49084e5fc2a596d52c8b958482eb1a21b91c6e6791d81d637"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,7 +3,7 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 25.0.8
+%global gover 25.0.12
 %global rpmver %{gover}
 %global gitrev b08a51fe16eed67de3861c03b363ba403643b12e
 

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.91.2/amazon-ecs-agent-1.91.2.tar.gz"
-sha512 = "c079dc22ee60ff0701d9a66f59add26fcab02baae36c72f98e8397ea6747a1858c4df2cada9ed3e2af3657d65920d2495b0b94c88dfbd573a6485ce2a4d6a816"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.97.0/amazon-ecs-agent-1.97.0.tar.gz"
+sha512 = "86d625fe9700c26fb79d6432658b9c7beb695b91838c6c04246d9e02962d41f82bb1ebbbec14f036c0597993f321148aac39afeb813d36747b727b4005731fc1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,7 +2,7 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.91.2
+%global agent_gover 1.97.0
 
 # git rev-parse --short=8
 %global agent_gitrev b7e96508


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Update third party packages:
- ecs-agent from 1.91.2 to 1.97.0
- amazon-ssm-agent from 3.3.1957.0 to 3.3.2746.0
- docker-engine from from 25.0.8 to 25.0.12


**Testing done:**
Run internal ECS conformance tests on `aws-ecs-2` variant.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
