### PR TITLE
fix: Remove LimitNOFILE=infinity from containerd.service

### DIFF
--- a/packages/containerd-2.0/containerd.service
+++ b/packages/containerd-2.0/containerd.service
@@ -18,7 +18,6 @@ RestartSec=2
 Restart=always
 LimitNPROC=infinity
 LimitCORE=infinity
-LimitNOFILE=infinity
 TasksMax=infinity
 OOMScoreAdjust=-999
 


### PR DESCRIPTION
**Issue number:**
Closes #617

**Description of changes:**

This PR removes the problematic `LimitNOFILE=infinity` configuration from the containerd.service file, aligning with the upstream containerd project's changes in PR #8924.

### Problem:
The `LimitNOFILE=infinity` setting can cause:
- Significantly increased resource usage
- Performance regression or runtime failures
- Memory issues and resource exhaustion
- Difficult-to-troubleshoot problems

### Solution:
Remove the `LimitNOFILE=infinity` line to rely on systemd's implicit defaults:
- Systemd v240+ provides adequate defaults of `1024:524288`
- The hard limit of 524288 is sufficient for most processes
- This aligns with containerd upstream changes in v1.8.0 and v2.0+

### Changes made:
- Removed `LimitNOFILE=infinity` from `packages/containerd-2.0/containerd.service`
- No other changes required

### References:
- https://github.com/containerd/containerd/pull/8924
- https://github.com/containerd/containerd/releases/tag/v2.0.0

**Testing done:**

- Verified the containerd.service file no longer contains the problematic configuration
- Confirmed the service file structure remains valid
- Checked that this change aligns with upstream containerd practices