### PR TITLE
always lowercase the hostnames provided by the hostname helpers

### DIFF
--- a/sources/dogtag/bin/imds.rs
+++ b/sources/dogtag/bin/imds.rs
@@ -20,7 +20,10 @@ async fn main() -> Result<()> {
         .fetch_hostname()
         .await
         .context(error::ImdsSnafu)?
-        .context(error::NoHostnameSnafu)?;
+        .context(error::NoHostnameSnafu)?
+        // the IMDS client returns a lowercase hostname anyway, but there's some
+        // symmetry in having both helpers lowercase the result always
+        .to_ascii_lowercase();
     println!("{hostname}");
     Ok(())
 }

--- a/sources/dogtag/bin/reverse.rs
+++ b/sources/dogtag/bin/reverse.rs
@@ -25,7 +25,8 @@ async fn main() -> Result<()> {
         .await
         .map_err(|e| error::Error::Lookup {
             source: Box::new(e),
-        })?;
+        })?
+        .to_ascii_lowercase();
     println!("{hostname}");
     Ok(())
 }

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -242,8 +242,8 @@ impl ImdsClient {
         Ok(self.fetch_string(&hostname_target).await?.and_then(|h| {
             h.split_whitespace()
                 .next()
-                .map(|h| h.trim_end_matches('.'))
-                .map(String::from)
+                // trim any trailing dots and lowercase the result
+                .map(|h| h.trim_end_matches('.').to_ascii_lowercase())
         }))
     }
 
@@ -842,8 +842,9 @@ mod test {
         let base_uri = format!("http://{}", server.addr());
         let token = "some+token";
         let response_code = 200;
+        // should always lowercase the response
         let response_body =
-            r#"ip-10-0-13-37.example.com. ip-10-0-13-37.eu-central-1.compute.internal"#;
+            r#"ip-10-0-13-37.EXAMPLE.com. ip-10-0-13-37.eu-central-1.compute.internal"#;
         server.expect(
             Expectation::matching(request::method_path("PUT", "/latest/api/token"))
                 .times(1)


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

The DHCP RFC doesn't require that the domain name option 15 be lowercase, which can result in hostname that has uppercase letters. This isn't a valid hostname and causes setting deserialization to fail.


**Testing done:**

- Unit testing
- Built an AMI with this core-kit and a VPC configured with DHCP Options using a capital letter domain name. Nodes went ready and Pods scheduled and went running.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
