### PR TITLE
Add package: containerd-2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "conntrack-tools",
  "containerd-1_7",
  "containerd-2_0",
+ "containerd-2_1",
  "coreutils",
  "dbus-broker",
  "docker-cli",
@@ -233,6 +234,13 @@ dependencies = [
 
 [[package]]
 name = "containerd-2_0"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "containerd-2_1"
 version = "0.1.0"
 dependencies = [
  "glibc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "packages/conntrack-tools",
   "packages/containerd-1.7",
   "packages/containerd-2.0",
+  "packages/containerd-2.1",
   "packages/coreutils",
   "packages/libcryptsetup",
   "packages/dbus-broker",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -26,6 +26,7 @@ cni-plugins = { path = "../../packages/cni-plugins" }
 conntrack-tools = { path = "../../packages/conntrack-tools" }
 containerd-1_7 = { path = "../../packages/containerd-1.7" }
 containerd-2_0 = { path = "../../packages/containerd-2.0" }
+containerd-2_1 = { path = "../../packages/containerd-2.1" }
 coreutils = { path = "../../packages/coreutils" }
 dbus-broker = { path = "../../packages/dbus-broker" }
 docker-cli = { path = "../../packages/docker-cli" }

--- a/packages/containerd-1.7/containerd-1.7.spec
+++ b/packages/containerd-1.7/containerd-1.7.spec
@@ -6,7 +6,7 @@
 %global rpmver %{gover}
 %global gitrev 05044ec0a9a75232cad458027ca83437aae3f4da
 
-%global package_priority_epoch 1
+%global package_priority_epoch 2
 %global _dwz_low_mem_die_limit 0
 
 Name: %{_cross_os}%{gorepo}-1.7

--- a/packages/containerd-2.0/containerd-2.0.spec
+++ b/packages/containerd-2.0/containerd-2.0.spec
@@ -6,7 +6,7 @@
 %global rpmver %{gover}
 %global gitrev fb4c30d4ede3531652d86197bf3fc9515e5276d9
 
-%global package_priority_epoch 0
+%global package_priority_epoch 1
 %global _dwz_low_mem_die_limit 0
 
 Name: %{_cross_os}%{gorepo}-2.0

--- a/packages/containerd-2.1/1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
+++ b/packages/containerd-2.1/1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
@@ -1,0 +1,72 @@
+From f6f4f959862cad73cc44d07b088f449ae6c69066 Mon Sep 17 00:00:00 2001
+From: Henry Wang <henwang@amazon.com>
+Date: Thu, 10 Apr 2025 20:50:50 +0000
+Subject: [PATCH] Revert "Don't allow io_uring related syscalls in the
+ RuntimeDefault seccomp profile."
+
+This reverts commit a48ddf4a208b24eadea82f0eac62e236f2acf004.
+---
+ contrib/seccomp/seccomp_default.go      |  3 +++
+ contrib/seccomp/seccomp_default_test.go | 36 -------------------------
+ 2 files changed, 3 insertions(+), 36 deletions(-)
+ delete mode 100644 contrib/seccomp/seccomp_default_test.go
+
+diff --git a/contrib/seccomp/seccomp_default.go b/contrib/seccomp/seccomp_default.go
+index 55d673fcb..1135f2391 100644
+--- a/contrib/seccomp/seccomp_default.go
++++ b/contrib/seccomp/seccomp_default.go
+@@ -188,6 +188,9 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
+ 				"ioprio_set",
+ 				"io_setup",
+ 				"io_submit",
++				"io_uring_enter",
++				"io_uring_register",
++				"io_uring_setup",
+ 				"ipc",
+ 				"kill",
+ 				"landlock_add_rule",
+diff --git a/contrib/seccomp/seccomp_default_test.go b/contrib/seccomp/seccomp_default_test.go
+deleted file mode 100644
+index 53e386809..000000000
+--- a/contrib/seccomp/seccomp_default_test.go
++++ /dev/null
+@@ -1,36 +0,0 @@
+-package seccomp
+-
+-import (
+-	"testing"
+-
+-	"github.com/opencontainers/runtime-spec/specs-go"
+-)
+-
+-func TestIOUringIsNotAllowed(t *testing.T) {
+-
+-	disallowed := map[string]bool{
+-		"io_uring_enter":    true,
+-		"io_uring_register": true,
+-		"io_uring_setup":    true,
+-	}
+-
+-	got := DefaultProfile(&specs.Spec{
+-		Process: &specs.Process{
+-			Capabilities: &specs.LinuxCapabilities{
+-				Bounding: []string{},
+-			},
+-		},
+-	})
+-
+-	for _, config := range got.Syscalls {
+-		if config.Action != specs.ActAllow {
+-			continue
+-		}
+-
+-		for _, name := range config.Names {
+-			if disallowed[name] {
+-				t.Errorf("found disallowed io_uring related syscalls")
+-			}
+-		}
+-	}
+-}
+-- 
+2.45.0
+

--- a/packages/containerd-2.1/Cargo.toml
+++ b/packages/containerd-2.1/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "containerd-2_1"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+package-name = "containerd-2.1"
+releases-url = "https://github.com/containerd/containerd/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/containerd/containerd/archive/v2.1.4/containerd-2.1.4.tar.gz"
+sha512 = "a9f84784e917621ee5ea38ad20b8106e642fbf463a00d319b73a1a8e4d1fdd5be2fba0789b6a5d31107ef239d3713eced99ce979d4b2764714271a63c0936c15"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/containerd-2.1/clarify.toml
+++ b/packages/containerd-2.1/clarify.toml
@@ -1,0 +1,16 @@
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT AND BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0x617d80bc },
+    { path = "goyaml.v2/LICENSE", hash = 0xe569d630 },
+    { path = "goyaml.v2/LICENSE.libyaml", hash = 0xa2e4ce3 },
+    { path = "goyaml.v2/NOTICE", hash = 0x49bceeb9 }
+
+]
+
+[clarify."github.com/grpc-ecosystem/go-grpc-middleware/v2"]
+expression = "Apache-2.0"
+license-files = [
+    { path = "COPYRIGHT", hash = 0x4bba7b1 },
+    { path = "LICENSE", hash = 0x6a39c900 }
+]

--- a/packages/containerd-2.1/containerd-2.1.spec
+++ b/packages/containerd-2.1/containerd-2.1.spec
@@ -1,0 +1,179 @@
+%global goproject github.com/containerd
+%global gorepo containerd
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 2.1.4
+%global rpmver %{gover}
+%global gitrev 75cb2b7193e4e490e9fbdc236c0e811ccaba3376
+
+%global package_priority_epoch 0
+%global _dwz_low_mem_die_limit 0
+
+Name: %{_cross_os}%{gorepo}-2.1
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: An industry-standard container runtime
+License: Apache-2.0
+URL: https://%{goimport}
+Source0: https://%{goimport}/archive/v%{gover}/%{gorepo}-%{gover}.tar.gz
+Source1: containerd.service
+Source2: containerd-config-toml_k8s_containerd_sock
+Source3: containerd-config-toml_basic
+Source4: containerd-config-toml_k8s_nvidia_containerd_sock
+Source5: containerd-tmpfiles.conf
+Source6: containerd-cri-base-json
+Source7: snapshotter-toml
+
+# Mount for writing containerd configuration
+Source100: etc-containerd.mount
+
+# Create container storage mount point.
+Source110: prepare-var-lib-containerd.service
+
+# Drop-ins to disable igzip or pigz if the other implementation is preferred.
+Source200: containerd-disable-igzip.conf
+Source201: containerd-disable-pigz.conf
+
+Source1000: clarify.toml
+
+# Patch to support moving from containerd-1.7 to 2.x
+Patch1001: 1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
+
+BuildRequires: git
+BuildRequires: %{_cross_os}glibc-devel
+Requires: %{_cross_os}runc
+Requires: %{name}(optimized-gunzip)
+Requires: %{name}(binaries)
+
+Provides: %{_cross_os}%{gorepo} = %{package_priority_epoch}:
+Conflicts: %{_cross_os}%{gorepo}
+
+%description
+%{summary}.
+
+%package bin
+Summary: An industry-standard container runtime's binaries
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
+
+%description bin
+%{summary}.
+
+%package fips-bin
+Summary: An industry-standard container runtime's binaries, FIPS edition
+Provides: %{name}(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{name})
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
+
+%description fips-bin
+%{summary}.
+
+%package pigz
+Summary: Prefer pigz for gzip decompression
+Requires: %{_cross_os}pigz
+Requires: %{name}
+Provides: %{_cross_os}%{gorepo}-pigz = %{package_priority_epoch}:
+Conflicts: %{name}-igzip
+Provides: %{name}(optimized-gunzip) = 1:
+
+%description pigz
+%{summary}.
+
+%package igzip
+Summary: Prefer igzip for gzip decompression
+Requires: %{_cross_os}igzip
+Requires: %{name}
+Provides: %{_cross_os}%{gorepo}-igzip = %{package_priority_epoch}:
+Conflicts: %{name}-pigz
+%if "%{_cross_arch}" == "x86_64"
+Provides: %{name}(optimized-gunzip) = 2:
+%else
+Provides: %{name}(optimized-gunzip) = 0:
+%endif
+
+%description igzip
+%{summary}.
+
+%prep
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
+
+%build
+%set_cross_go_flags
+
+export BUILDTAGS="no_btrfs selinux"
+export LD_VERSION="-X github.com/containerd/containerd/v2/version.Version=%{gover}+bottlerocket"
+export LD_REVISION="-X github.com/containerd/containerd/v2/version.Revision=%{gitrev}"
+
+declare -a BUILD_ARGS
+BUILD_ARGS=(
+  -tags="${BUILDTAGS}"
+  -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}"
+)
+
+for bin in \
+  containerd \
+  containerd-shim-runc-v2 \
+  ctr ;
+do
+  go build "${BUILD_ARGS[@]}" -o ${bin} ./cmd/${bin}
+  gofips build "${BUILD_ARGS[@]}" -o fips/${bin} ./cmd/${bin}
+done
+
+%install
+install -d %{buildroot}{%{_cross_bindir},%{_cross_fips_bindir}}
+for bin in \
+  containerd \
+  containerd-shim-runc-v2 \
+  ctr ;
+do
+  install -p -m 0755 ${bin} %{buildroot}%{_cross_bindir}
+  install -p -m 0755 fips/${bin} %{buildroot}%{_cross_fips_bindir}
+done
+
+install -d %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:1} %{S:100} %{S:110} %{buildroot}%{_cross_unitdir}
+
+install -d %{buildroot}%{_cross_templatedir}
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/containerd
+install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{S:7} %{buildroot}%{_cross_templatedir}
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
+
+install -d %{buildroot}%{_cross_unitdir}/containerd.service.d
+install -p -m 0644 %{S:200} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
+install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-pigz.conf
+
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
+
+%files
+%license LICENSE NOTICE
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+%{_cross_unitdir}/containerd.service
+%{_cross_unitdir}/etc-containerd.mount
+%{_cross_unitdir}/prepare-var-lib-containerd.service
+%dir %{_cross_factorydir}%{_cross_sysconfdir}/containerd
+%{_cross_templatedir}/containerd-config-toml*
+%{_cross_templatedir}/containerd-cri-base-json
+%{_cross_templatedir}/snapshotter-toml
+%{_cross_tmpfilesdir}/containerd.conf
+
+%files bin
+%{_cross_bindir}/containerd
+%{_cross_bindir}/containerd-shim-runc-v2
+%{_cross_bindir}/ctr
+
+%files fips-bin
+%{_cross_fips_bindir}/containerd
+%{_cross_fips_bindir}/containerd-shim-runc-v2
+%{_cross_fips_bindir}/ctr
+
+%files pigz
+%{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
+
+%files igzip
+%{_cross_unitdir}/containerd.service.d/005-disable-pigz.conf
+
+%changelog

--- a/packages/containerd-2.1/containerd-config-toml_basic
+++ b/packages/containerd-2.1/containerd-config-toml_basic
@@ -1,0 +1,17 @@
++++
+version = 3
+root = "/var/lib/containerd"
+state = "/run/containerd"
+disabled_plugins = [
+    "io.containerd.internal.v1.opt",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.snapshotter.v1.blockfile",
+    "io.containerd.snapshotter.v1.devmapper",
+    "io.containerd.snapshotter.v1.native",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.grpc.v1.cri",
+    "io.containerd.tracing.processor.v1.otlp",
+]
+
+[grpc]
+address = "/run/containerd/containerd.sock"

--- a/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
@@ -1,0 +1,105 @@
+[required-extensions]
+container-registry = "v1"
+container-runtime = "v1"
+kubernetes = "v1"
+std = { version = "v1", helpers = ["join_array", "default"]}
++++
+version = 3
+root = "/var/lib/containerd"
+state = "/run/containerd"
+disabled_plugins = [
+    "io.containerd.internal.v1.opt",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.snapshotter.v1.blockfile",
+    "io.containerd.snapshotter.v1.devmapper",
+    "io.containerd.snapshotter.v1.native",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.tracing.processor.v1.otlp",
+]
+
+imports = ["/etc/containerd/config.d/*.toml"]
+
+[grpc]
+address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.cri.v1.images"]
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+concurrent_layer_fetch_buffer = 8388608
+use_local_image_pull = false
+
+# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
+[plugins."io.containerd.cri.v1.images".pinned_images]
+sandbox = "localhost/kubernetes/pause:0.1.0"
+
+[plugins."io.containerd.cri.v1.runtime"]
+device_ownership_from_security_context = {{default false settings.kubernetes.device-ownership-from-security-context}}
+enable_selinux = true
+{{#if settings.container-runtime.max-container-log-line-size}}
+max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-ports}}
+enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-icmp}}
+enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp}}
+{{/if}}
+
+[plugins."io.containerd.transfer.v1.local"]
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+concurrent_layer_fetch_buffer = 8388608
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+snapshotter = "overlayfs"
+differ = "walking"
+{{#if (eq os.arch "aarch64")}}
+platform = "linux/arm64"
+{{else}}
+{{#if (eq os.arch "x86_64")}}
+platform = "linux/amd64"
+{{/if}}
+{{/if}}
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
+SystemdCgroup = true
+
+[plugins."io.containerd.cri.v1.runtime".cni]
+bin_dirs = [ "/opt/cni/bin" ]
+conf_dir = "/etc/cni/net.d"
+
+[plugins."io.containerd.cri.v1.images".registry]
+{{#if settings.container-registry.mirrors}}
+{{#each settings.container-registry.mirrors}}
+[plugins."io.containerd.cri.v1.images".registry.mirrors."{{registry}}"]
+endpoint = [{{join_array ", " endpoint }}]
+{{/each}}
+{{/if}}
+
+{{#if settings.container-registry.credentials}}
+{{#each settings.container-registry.credentials}}
+{{#if (eq registry "docker.io") }}
+[plugins."io.containerd.cri.v1.images".registry.configs."registry-1.docker.io".auth]
+{{else}}
+[plugins."io.containerd.cri.v1.images".registry.configs."{{registry}}".auth]
+{{/if}}
+{{#if username}}
+username = "{{{username}}}"
+{{/if}}
+{{#if password}}
+password = "{{{password}}}"
+{{/if}}
+{{#if auth}}
+auth = "{{{auth}}}"
+{{/if}}
+{{#if identitytoken}}
+identitytoken = "{{{identitytoken}}}"
+{{/if}}
+{{/each}}
+{{/if}}

--- a/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -1,0 +1,127 @@
+[required-extensions]
+container-registry = "v1"
+container-runtime = "v1"
+kubernetes = "v1"
+std = { version = "v1", helpers = ["join_array", "default"]}
++++
+version = 3
+root = "/var/lib/containerd"
+state = "/run/containerd"
+disabled_plugins = [
+    "io.containerd.internal.v1.opt",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.snapshotter.v1.blockfile",
+    "io.containerd.snapshotter.v1.devmapper",
+    "io.containerd.snapshotter.v1.native",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.tracing.processor.v1.otlp",
+]
+
+imports = ["/etc/containerd/config.d/*.toml"]
+
+[grpc]
+address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.cri.v1.images"]
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+concurrent_layer_fetch_buffer = 8388608
+use_local_image_pull = false
+
+# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
+[plugins."io.containerd.cri.v1.images".pinned_images]
+sandbox = "localhost/kubernetes/pause:0.1.0"
+
+[plugins."io.containerd.cri.v1.runtime"]
+device_ownership_from_security_context = {{default false settings.kubernetes.device-ownership-from-security-context}}
+enable_selinux = true
+{{#if settings.container-runtime.max-container-log-line-size}}
+max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-ports}}
+enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-icmp}}
+enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp}}
+{{/if}}
+
+[plugins."io.containerd.transfer.v1.local"]
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+concurrent_layer_fetch_buffer = 8388608
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+snapshotter = "overlayfs"
+differ = "walking"
+{{#if (eq os.arch "aarch64")}}
+platform = "linux/arm64"
+{{else}}
+{{#if (eq os.arch "x86_64")}}
+platform = "linux/amd64"
+{{/if}}
+{{/if}}
+
+[plugins."io.containerd.cri.v1.runtime".containerd]
+default_runtime_name = "nvidia"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+# CDI only nvidia container runtime
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-cdi]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+# legacy only nvidia container runtime
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-legacy]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-cdi.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime.cdi"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-legacy.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime.legacy"
+
+[plugins."io.containerd.cri.v1.runtime".cni]
+bin_dirs = [ "/opt/cni/bin" ]
+conf_dir = "/etc/cni/net.d"
+
+[plugins."io.containerd.cri.v1.images".registry]
+{{#if settings.container-registry.mirrors}}
+{{#each settings.container-registry.mirrors}}
+[plugins."io.containerd.cri.v1.images".registry.mirrors."{{registry}}"]
+endpoint = [{{join_array ", " endpoint }}]
+{{/each}}
+{{/if}}
+
+{{#if settings.container-registry.credentials}}
+{{#each settings.container-registry.credentials}}
+{{#if (eq registry "docker.io") }}
+[plugins."io.containerd.cri.v1.images".registry.configs."registry-1.docker.io".auth]
+{{else}}
+[plugins."io.containerd.cri.v1.images".registry.configs."{{registry}}".auth]
+{{/if}}
+{{#if username}}
+username = "{{{username}}}"
+{{/if}}
+{{#if password}}
+password = "{{{password}}}"
+{{/if}}
+{{#if auth}}
+auth = "{{{auth}}}"
+{{/if}}
+{{#if identitytoken}}
+identitytoken = "{{{identitytoken}}}"
+{{/if}}
+{{/each}}
+{{/if}}

--- a/packages/containerd-2.1/containerd-cri-base-json
+++ b/packages/containerd-2.1/containerd-cri-base-json
@@ -1,0 +1,164 @@
+[required-extensions]
+oci-defaults = { version = "v1", helpers = ["oci_defaults"] }
++++
+{
+    "ociVersion": "1.2.0",
+    "process": {
+        "user": {
+            "uid": 0,
+            "gid": 0
+        },
+        "cwd": "/",
+        {{~#if settings.oci-defaults.capabilities~}}
+        "capabilities": {
+            {{~oci_defaults "containerd" settings.oci-defaults.capabilities~}}
+        },
+        {{~/if~}}
+        {{~#if settings.oci-defaults.resource-limits~}}
+        "rlimits": [
+            {{~oci_defaults "containerd" settings.oci-defaults.resource-limits~}}
+        ],
+        {{~/if~}}
+        "noNewPrivileges": true
+    },
+    "root": {
+        "path": "rootfs"
+    },
+    "mounts": [
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/dev",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/pts",
+            "type": "devpts",
+            "source": "devpts",
+            "options": [
+                "nosuid",
+                "noexec",
+                "newinstance",
+                "ptmxmode=0666",
+                "mode=0620",
+                "gid=5"
+            ]
+        },
+        {
+            "destination": "/dev/shm",
+            "type": "tmpfs",
+            "source": "shm",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "mode=1777",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/mqueue",
+            "type": "mqueue",
+            "source": "mqueue",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/sys",
+            "type": "sysfs",
+            "source": "sysfs",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "ro"
+            ]
+        },
+        {
+            "destination": "/run",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/usr/local/sbin/modprobe",
+            "source": "/usr/bin/kmod",
+            "options": [
+                "exec",
+                "bind",
+                "ro"
+            ]
+        }
+    ],
+    "linux": {
+        "resources": {
+            "devices": [
+                {
+                    "allow": false,
+                    "access": "rwm"
+                }
+            ]
+        },
+        "cgroupsPath": "/default",
+        "namespaces": [
+            {
+                "type": "pid"
+            },
+            {
+                "type": "ipc"
+            },
+            {
+                "type": "uts"
+            },
+            {
+                "type": "mount"
+            },
+            {
+                "type": "network"
+            }
+        ],
+        "maskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap",
+            "/proc/scsi"
+        ],
+        "readonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+        ]
+    }
+}

--- a/packages/containerd-2.1/containerd-disable-igzip.conf
+++ b/packages/containerd-2.1/containerd-disable-igzip.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=CONTAINERD_DISABLE_IGZIP=1

--- a/packages/containerd-2.1/containerd-disable-pigz.conf
+++ b/packages/containerd-2.1/containerd-disable-pigz.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=CONTAINERD_DISABLE_PIGZ=1

--- a/packages/containerd-2.1/containerd-tmpfiles.conf
+++ b/packages/containerd-2.1/containerd-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /etc/cni/net.d - - - -
+d /etc/containerd/config.d - - - -

--- a/packages/containerd-2.1/containerd.service
+++ b/packages/containerd-2.1/containerd.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network-online.target configured.target
+Wants=network-online.target configured.target
+Requires=configure-snapshotter.service
+
+[Service]
+Slice=runtime.slice
+EnvironmentFile=/etc/network/proxy.env
+ExecStart=/usr/bin/containerd
+Type=notify
+Delegate=yes
+KillMode=process
+TimeoutSec=0
+RestartSec=2
+Restart=always
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/containerd-2.1/etc-containerd.mount
+++ b/packages/containerd-2.1/etc-containerd.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Containerd Configuration Directory (/etc/containerd)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/etc/containerd
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,mode=0750,context=system_u:object_r:etc_secret_t:s0
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/containerd-2.1/prepare-var-lib-containerd.service
+++ b/packages/containerd-2.1/prepare-var-lib-containerd.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Prepare Containerd Directory (/var/lib/containerd)
+DefaultDependencies=no
+RequiresMountsFor=/var
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+
+# Remove an existing symlink, if present. Intentionally not recursive!
+ExecStartPre=-/usr/bin/rm -f /var/lib/containerd
+
+# Create /var/lib/containerd so it is available for bind mounts.
+ExecStart=/usr/bin/mkdir -p /var/lib/containerd
+
+# Suppress warning if directory exists.
+StandardError=null
+
+RemainAfterExit=true
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/containerd-2.1/snapshotter-toml
+++ b/packages/containerd-2.1/snapshotter-toml
@@ -1,0 +1,20 @@
+[required-extensions]
+container-runtime = "v1"
+std = { version = "v1" }
++++
+{{#if settings.container-runtime.snapshotter}}
+{{#if (eq settings.container-runtime.snapshotter "soci" )}}
+[plugins."io.containerd.cri.v1.images"]
+snapshotter = "soci"
+disable_snapshot_annotations = false
+# Plug soci snapshotter into containerd
+[proxy_plugins.soci]
+type = "snapshot"
+address = "/run/soci-snapshotter/soci-snapshotter.sock"
+[proxy_plugins.soci.exports]
+root = "/var/lib/soci-snapshotter"
+{{else}}
+[plugins."io.containerd.cri.v1.images"]
+snapshotter = "overlayfs"
+{{/if}}
+{{/if}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related #495

**Description of changes:**
 Add containerd 2.1 as a package.

###  ContainerD 2.1 Testing

```
bash-5.1# ctr --version
ctr github.com/containerd/containerd/v2 2.1.4+bottlerocket
bash-5.1# containerd --version
containerd github.com/containerd/containerd/v2 2.1.4+bottlerocket 75cb2b7193e4e490e9fbdc236c0e811ccaba3376
```
#### Conformance across kernels and variants

<details>

| Variant Name | Test Status | Passed | Failed | Skipped |
|-------------|------------|--------|--------|---------|
| aarch64-aws-k8s-133-conformance | passed | 423 | 0 | 6312 |
| aarch64-aws-k8s-133-fips-conformance | passed | 423 | 0 | 6312 |
| aarch64-aws-k8s-133-fips-quick | passed | 5 | 0 | 6730 |
| aarch64-aws-k8s-133-nvidia-conformance | passed | 423 | 0 | 6312 |
| aarch64-aws-k8s-133-nvidia-quick | passed | 5 | 0 | 6730 |
| aarch64-aws-k8s-133-quick | passed | 5 | 0 | 6730 |
| x86-64-aws-k8s-133-fips-conformance | passed | 423 | 0 | 6312 |
| x86-64-aws-k8s-133-fips-quick | passed | 5 | 0 | 6730 |
| x86-64-aws-k8s-133-nvidia-conformance | passed | 423 | 0 | 6312 |
| x86-64-aws-k8s-133-nvidia-quick | passed | 5 | 0 | 6730 |
| x86-64-aws-k8s-133-quick | passed | 5 | 0 | 6730 |
| aarch64-aws-k8s-133-conformance | passed | 423 | 0 | 6312 |
| aarch64-aws-k8s-133-fips-conformance | passed | 423 | 0 | 6312 |
| aarch64-aws-k8s-133-fips-quick | passed | 5 | 0 | 6730 |
| aarch64-aws-k8s-133-nvidia-conformance | passed | 423 | 0 | 6312 |
| aarch64-aws-k8s-133-nvidia-quick | passed | 5 | 0 | 6730 |
| aarch64-aws-k8s-133-quick | passed | 5 | 0 | 6730 |
| x86-64-aws-k8s-133-fips-conformance | passed | 423 | 0 | 6312 |
| x86-64-aws-k8s-133-fips-quick | passed | 5 | 0 | 6730 |
| x86-64-aws-k8s-133-nvidia-conformance | passed | 423 | 0 | 6312 |
| x86-64-aws-k8s-133-nvidia-quick | passed | 5 | 0 | 6730 |
| x86-64-aws-k8s-133-quick | passed | 5 | 0 | 6730 |
| aarch64-aws-k8s-128-conformance | passed | 384 | 0 | 7012 |
| aarch64-aws-k8s-128-fips-conformance | passed | 384 | 0 | 7012 |
| aarch64-aws-k8s-128-nvidia-conformance | passed | 384 | 0 | 7012 |
| aarch64-aws-k8s-132-conformance | passed | 415 | 0 | 6214 |
| aarch64-aws-k8s-132-fips-conformance | passed | 415 | 0 | 6214 |
| aarch64-aws-k8s-132-nvidia-conformance | passed | 415 | 0 | 6214 |
| x86-64-aws-k8s-128-conformance | passed | 384 | 0 | 7012 |
| x86-64-aws-k8s-128-fips-conformance | passed | 384 | 0 | 7012 |
| x86-64-aws-k8s-132-conformance | passed | 415 | 0 | 6214 |
| x86-64-aws-k8s-132-fips-conformance | passed | 415 | 0 | 6214 |
| x86-64-aws-k8s-132-nvidia-conformance | passed | 415 | 0 | 6214 |
| x86-64-aws-k8s-133-conformance | passed | 423 | 0 | 6312 |



</details>
#### Variant builds:

<details>
- Variant included packages test:  `containerd-2.1(optimized-gunzip)` on x86

```
bash-5.1# ctr --version
ctr github.com/containerd/containerd/v2 2.1.4+bottlerocket
bash-5.1# ls /usr/lib/systemd/system/containerd.service.d/
005-disable-pigz.conf
```
- Variant included packages test:  `containerd-2.1(optimized-gunzip)` on aarch64
```
bash-5.1# ctr --version
ctr github.com/containerd/containerd/v2 2.1.4+bottlerocket
bash-5.1# ls /usr/lib/systemd/system/containerd.service.d/
005-disable-igzip.conf
```
- Variant included packages test: `containerd-2.0` on x86

```
bash-5.1# ctr --version
ctr github.com/containerd/containerd/v2 2.0.5+bottlerocket
bash-5.1# ls /usr/lib/systemd/system/containerd.service.d/
005-disable-pigz.conf
```

- Variant included packages test: `containerd-pigz`
```
bash-5.1# ls /usr/lib/systemd/system/containerd.service.d/
005-disable-igzip.conf
bash-5.1# ctr --version
ctr github.com/containerd/containerd 1.7.27+bottlerocket
```

- Variant included packages test: `containerd-2.1` and  `containerd-pigz` on aarch64
```
bash-5.1# ctr --version
ctr github.com/containerd/containerd/v2 2.1.4+bottlerocket
bash-5.1# ls /usr/lib/systemd/system/containerd.service.d/
005-disable-igzip.conf
```

- Variant included packages test:`containerd-2.1` and  `containerd-pigz` on x86
```
bash-5.1# ctr --version
ctr github.com/containerd/containerd/v2 2.1.4+bottlerocket
bash-5.1# ls /usr/lib/systemd/system/containerd.service.d/
005-disable-igzip.conf
```

</details>


## Containerd 2.1 for Bottlerocket
* Full summary of containerd 2.1 changes: https://github.com/containerd/containerd/releases/tag/v2.1.0


### Highlights
* Transfer service for image pull is now made the default
* Multipart layer fetch support added and has a default of 8MiB in Bottlerocket.

### Compatibility Breaks
* Remove the support for Schema 1 images 
    * https://github.com/containerd/containerd/pull/11681
    
### New features to explore
* Add support for container restore (https://github.com/containerd/containerd/pull/10365). With containerd-2.1 being added we can consider adding [criu](https://github.com/checkpoint-restore/criu) to bottlerocket
* Enable Writable cgroups for unprivileged containers (https://github.com/containerd/containerd/pull/11131) - would likely needed to be added as a setting if we were interested. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
