### PR TITLE
containerd-2.0: fix max-concurrent-downloads config placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v10.1.1 (2025-08-13)
+
+## OS Changes
+* Fix `containerd-2.0` settings for `max_concurrent_downloads` ([#623])
+
+[#623]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/623
+
 # v10.1.0 (2025-08-11)
 
 ## OS Changes
@@ -50,11 +57,11 @@
 
 ## Orchestrator Changes
 ### Kubernetes
-- Add soci-snapshotter support 
+- Add soci-snapshotter support
   - Configure soci-snapshotter for parallel pull unpack feature ([#569])
   - Optionally configure containerd and kubelet with soci-snapshotter via drop-in configuration files ([#576])
   - Extend selinux-policy to cover soci-snapshotter ([#579])
-  - Add `configure-snapshotter.service` to reset state directories of snapshotters on boot when selected snapshotter changes ([#582]) 
+  - Add `configure-snapshotter.service` to reset state directories of snapshotters on boot when selected snapshotter changes ([#582])
   - Apply upstream patches to soci-snapshotter ([#599])
   - Drop CLI from `soci-snapshotter` ([#569])
 - Support extending kubelet configuration via drop-in files ([#576])

--- a/packages/containerd-2.0/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.0/containerd-config-toml_k8s_containerd_sock
@@ -19,8 +19,12 @@ imports = ["/etc/containerd/config.d/*.toml"]
 [grpc]
 address = "/run/containerd/containerd.sock"
 
-# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
 [plugins."io.containerd.cri.v1.images"]
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+
+# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
 [plugins."io.containerd.cri.v1.images".pinned_images]
 sandbox = "localhost/kubernetes/pause:0.1.0"
 
@@ -29,9 +33,6 @@ device_ownership_from_security_context = {{default false settings.kubernetes.dev
 enable_selinux = true
 {{#if settings.container-runtime.max-container-log-line-size}}
 max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
-{{/if}}
-{{#if settings.container-runtime.max-concurrent-downloads}}
-max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
 {{#if settings.container-runtime.enable-unprivileged-ports}}
 enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}

--- a/packages/containerd-2.0/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.0/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -19,8 +19,12 @@ imports = ["/etc/containerd/config.d/*.toml"]
 [grpc]
 address = "/run/containerd/containerd.sock"
 
-# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
 [plugins."io.containerd.cri.v1.images"]
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+
+# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
 [plugins."io.containerd.cri.v1.images".pinned_images]
 sandbox = "localhost/kubernetes/pause:0.1.0"
 
@@ -29,9 +33,6 @@ device_ownership_from_security_context = {{default false settings.kubernetes.dev
 enable_selinux = true
 {{#if settings.container-runtime.max-container-log-line-size}}
 max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
-{{/if}}
-{{#if settings.container-runtime.max-concurrent-downloads}}
-max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
 {{#if settings.container-runtime.enable-unprivileged-ports}}
 enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Fixes: https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/622

**Description of changes:**

Moves the placement of:  `max_concurrent_downloads` from: `[plugins."io.containerd.cri.v1.runtime"]` to: `[plugins."io.containerd.cri.v1.images"]`



**Testing done:**
* Build containerd 2.0 set the setting and verified no warning. 

```
bash-5.1# containerd config dump | grep -C 5 max_concurrent
[plugins]
  [plugins.'io.containerd.cri.v1.images']
    snapshotter = 'overlayfs'
    disable_snapshot_annotations = true
    discard_unpacked_layers = false
    max_concurrent_downloads = 3
    image_pull_progress_timeout = '5m0s'
    image_pull_with_sync_fs = false
    stats_collect_period = 10

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
