### PR TITLE
Revert "ecs-agent: update from 1.91.2 to 1.97.0"

### DIFF
--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.97.0/amazon-ecs-agent-1.97.0.tar.gz"
-sha512 = "86d625fe9700c26fb79d6432658b9c7beb695b91838c6c04246d9e02962d41f82bb1ebbbec14f036c0597993f321148aac39afeb813d36747b727b4005731fc1"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.91.2/amazon-ecs-agent-1.91.2.tar.gz"
+sha512 = "c079dc22ee60ff0701d9a66f59add26fcab02baae36c72f98e8397ea6747a1858c4df2cada9ed3e2af3657d65920d2495b0b94c88dfbd573a6485ce2a4d6a816"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,7 +2,7 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.97.0
+%global agent_gover 1.91.2
 
 # git rev-parse --short=8
 %global agent_gitrev b7e96508


### PR DESCRIPTION
This reverts commit 3f65f4e74603f7b8bd1f5c6160a6331cc1aede4d.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Related to https://github.com/aws/amazon-ecs-agent/issues/4538

**Description of changes:**
We found incompatibility during our testing with the recent bump of ECS Agent. Reverting the version bump.


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
