### PR TITLE
apiclient: add implicit default behavior for ephemeral-storage bind

### DIFF
--- a/sources/api/apiclient/README.md
+++ b/sources/api/apiclient/README.md
@@ -193,6 +193,45 @@ If you want to group sets of changes yourself, pick a transaction name and appen
 For example, if you want the name "FOO", you can `PATCH` to `/settings?tx=FOO` and `POST` to `/tx/commit_and_apply?tx=FOO`.
 (Transactions are created automatically when used, and are cleaned up on reboot.)
 
+### Ephemeral storage
+
+This lets you manage ephemeral storage on instances that have local instance storage (like NVMe SSDs).
+
+#### Initialize ephemeral storage
+
+Before binding directories, you need to initialize the ephemeral storage:
+
+```shell
+apiclient ephemeral-storage init
+```
+
+This sets up the storage devices as a RAID array and formats them.
+
+#### Bind directories to ephemeral storage
+
+You can bind directories to the ephemeral storage so they persist across container restarts:
+
+```shell
+apiclient ephemeral-storage bind
+```
+
+This automatically binds the appropriate directories for your platform (Kubernetes vs ECS). For Kubernetes variants, this includes directories like `/var/lib/kubelet`, `/var/lib/containerd`, `/var/log/pods`, and `/var/lib/soci-snapshotter`. For ECS variants, it includes `/var/lib/docker`, `/var/lib/containerd`, and `/var/log/ecs`.
+
+You can also specify custom directories:
+
+```shell
+apiclient ephemeral-storage bind --dirs /var/lib/containerd /custom/path
+```
+
+#### List ephemeral storage information
+
+You can list available disks and currently bound directories:
+
+```shell
+apiclient ephemeral-storage list-disks
+apiclient ephemeral-storage list-dirs
+```
+
 ### Report mode
 
 This allows you to generate certain reports based on the current state of the system.

--- a/sources/api/apiclient/README.tpl
+++ b/sources/api/apiclient/README.tpl
@@ -193,6 +193,45 @@ If you want to group sets of changes yourself, pick a transaction name and appen
 For example, if you want the name "FOO", you can `PATCH` to `/settings?tx=FOO` and `POST` to `/tx/commit_and_apply?tx=FOO`.
 (Transactions are created automatically when used, and are cleaned up on reboot.)
 
+### Ephemeral storage
+
+This lets you manage ephemeral storage on instances that have local instance storage (like NVMe SSDs).
+
+#### Initialize ephemeral storage
+
+Before binding directories, you need to initialize the ephemeral storage:
+
+```shell
+apiclient ephemeral-storage init
+```
+
+This sets up the storage devices as a RAID array and formats them.
+
+#### Bind directories to ephemeral storage
+
+You can bind directories to the ephemeral storage so they persist across container restarts:
+
+```shell
+apiclient ephemeral-storage bind
+```
+
+This automatically binds the appropriate directories for your platform (Kubernetes vs ECS). For Kubernetes variants, this includes directories like `/var/lib/kubelet`, `/var/lib/containerd`, `/var/log/pods`, and `/var/lib/soci-snapshotter`. For ECS variants, it includes `/var/lib/docker`, `/var/lib/containerd`, and `/var/log/ecs`.
+
+You can also specify custom directories:
+
+```shell
+apiclient ephemeral-storage bind --dirs /var/lib/containerd /custom/path
+```
+
+#### List ephemeral storage information
+
+You can list available disks and currently bound directories:
+
+```shell
+apiclient ephemeral-storage list-disks
+apiclient ephemeral-storage list-dirs
+```
+
 ### Report mode
 
 This allows you to generate certain reports based on the current state of the system.

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -272,8 +272,9 @@ fn usage() -> ! {
 
         ephemeral-storage bind options:
             --dirs DIR [DIR ...]       Directories to bind to configured ephemeral storage
-                                       (e.g. /var/lib/containerd). If no ephemeral disks are found
-                                       this operation does nothing.
+                                       (e.g. /var/lib/containerd). If not specified, uses platform (k8s vs. ECS)
+                                       defaults. If no ephemeral disks are found this operation does nothing.
+
 
         ephemeral-storage list-disks options:
             -f, --format               Format of the disk listing (text or json). Default format is text.
@@ -794,9 +795,13 @@ fn parse_ephemeral_storage_init_args(args: Vec<String>) -> EphemeralStorageSubco
 
 /// Parses arguments for the 'bind' ephemeral-storage subcommand.
 fn parse_ephemeral_storage_bind_args(args: Vec<String>) -> EphemeralStorageSubcommand {
+    // If no arguments, use default directories
     if args.is_empty() {
-        usage_msg("Did not give arguments to bind")
+        return EphemeralStorageSubcommand::Bind(EphemeralStorageBindArgs {
+            targets: Vec::new(),
+        });
     }
+
     let mut targets = Vec::new();
     let mut iter = args.into_iter().peekable();
     while let Some(arg) = iter.next() {
@@ -810,6 +815,7 @@ fn parse_ephemeral_storage_bind_args(args: Vec<String>) -> EphemeralStorageSubco
             x => usage_msg(format!("Unknown argument '{x}'")),
         }
     }
+
     EphemeralStorageSubcommand::Bind(EphemeralStorageBindArgs { targets })
 }
 

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -118,6 +118,17 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         _ => format!("{RAID_DEVICE_DIR}{RAID_DEVICE_NAME}"),
     };
 
+    let dirs = if dirs.is_empty() {
+        let allowed_dirs = allowed_bind_dirs(variant);
+        allowed_dirs
+            .allowed_exact
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect()
+    } else {
+        dirs
+    };
+
     // Normalize input by trimming trailing "/"
     let dirs: Vec<String> = dirs
         .into_iter()
@@ -431,3 +442,33 @@ pub mod error {
 }
 
 pub type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bind_with_default_dirs_k8s() {
+        let variant = "aws-k8s-1.33";
+        let allowed_dirs = allowed_bind_dirs(variant);
+
+        for dir in [
+            "/var/lib/kubelet",
+            "/var/lib/containerd",
+            "/var/lib/soci-snapshotter",
+            "/var/log/pods",
+        ] {
+            assert!(allowed_dirs.allowed_exact.contains(dir));
+        }
+    }
+
+    #[test]
+    fn test_bind_with_default_dirs_ecs() {
+        let variant = "aws-ecs-2";
+        let allowed_dirs = allowed_bind_dirs(variant);
+
+        for dir in ["/var/lib/docker", "/var/lib/containerd", "/var/log/ecs"] {
+            assert!(allowed_dirs.allowed_exact.contains(dir));
+        }
+    }
+}


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #630

**Description of changes:**

Add implicit default behavior where running `apiclient ephemeral-storage bind` without `--dirs` automatically uses platform-specific default directories.

Update help documentation to reflect the implicit default behavior where running `ephemeral-storage bind` without `--dirs` uses platform defaults.

**Testing done:**

Unit tests; Manual testing:

User data:

```
[settings.bootstrap-commands.ephemeral-storage]
commands = [
    ["apiclient", "ephemeral-storage", "init"],
    ["apiclient", "ephemeral-storage" ,"bind"]
]
essential = true
mode = "always"
```

k8s-1.33 variant `lsblk` output:

```
...
nvme3n1      259:16   0  6.8T  0 disk
`-md127        9:127  0 54.6T  0 raid0 /var/lib/kubelet
                                       /var/lib/soci-snapshotter
                                       /var/log/pods
                                       /var/lib/containerd
                                       /var/lib/host-containerd
                                       /mnt/.ephemeral

...
```


ecs-2 variant `lsblk` output:

```
...
nvme4n1      259:23   0  6.8T  0 disk
`-md127        9:127  0 54.6T  0 raid0 /var/lib/docker
                                       /var/log/ecs
                                       /var/lib/host-containerd
                                       /var/lib/containerd
                                       /mnt/.ephemeral
...
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
