### PR TITLE
Enable MutableCSINodeAllocatableCount in kubernetes-1.34

### DIFF
--- a/packages/kubernetes-1.34/kubelet-config
+++ b/packages/kubernetes-1.34/kubelet-config
@@ -209,3 +209,4 @@ singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
 {{/if}}
 featureGates:
   DynamicResourceAllocation: true
+  MutableCSINodeAllocatableCount: true


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes # NA

**Description of changes:**

This PR enables MutableCSINodeAllocatableCount in v1.34.0+ by default.

See https://github.com/awslabs/amazon-eks-ami/pull/2389

**Testing done:**

CI

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
