### PR TITLE
Network stack boot time optimization: decouple from DATA partition

### DIFF
--- a/packages/dbus-broker/dbus-broker.service
+++ b/packages/dbus-broker/dbus-broker.service
@@ -2,7 +2,9 @@
 Description=D-Bus System Message Bus
 Documentation=https://github.com/bus1/dbus-broker
 DefaultDependencies=false
-After=dbus.socket
+# Ensure the dbus user is created before starting dbus service
+After=dbus.socket systemd-sysusers.service
+Wants=dbus.socket systemd-sysusers.service
 Before=basic.target shutdown.target
 Requires=dbus.socket
 Conflicts=shutdown.target
@@ -13,7 +15,9 @@ Sockets=dbus.socket
 OOMScoreAdjust=-900
 LimitNOFILE=16384
 ProtectSystem=full
-PrivateTmp=true
+# Disable private /tmp to avoid dependency on systemd-tmpfiles and consequently
+# local-fs.target, allowing dbus to start earlier in the boot
+PrivateTmp=no
 PrivateDevices=true
 ExecStart=/usr/bin/dbus-broker-launch --scope system
 ExecReload=/usr/bin/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig

--- a/packages/dbus-broker/dbus.socket
+++ b/packages/dbus-broker/dbus.socket
@@ -1,5 +1,10 @@
 [Unit]
 Description=D-Bus System Message Bus Socket
+# Disable DefaultDependencies to allow D-Bus to be started earlier in the boot
+# so that it is available for other services
+DefaultDependencies=no
+Before=shutdown.target sockets.target
+Conflicts=shutdown.target
 
 [Socket]
 ListenStream=/run/dbus/system_bus_socket

--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -41,7 +41,7 @@ mkdir -p %{buildroot}%{_cross_infodir}
 mkdir -p %{buildroot}%{_cross_mandir}
 mkdir -p %{buildroot}%{_cross_localstatedir}
 mkdir -p %{buildroot}/{boot,dev,proc,run,sys,tmp}
-mkdir -p %{buildroot}/{home,local,media,mnt,opt,srv}
+mkdir -p %{buildroot}/{home,local,media,mnt,opt,srv,.bottlerocket}
 mkdir -p %{buildroot}/media/cdrom
 mkdir -p %{buildroot}/root/.aws
 
@@ -74,6 +74,7 @@ ln -s .%{_sbindir} %{buildroot}/sbin
 /sys
 /tmp
 
+/.bottlerocket
 /home
 /local
 /media

--- a/packages/netdog/generate-network-config.service
+++ b/packages/netdog/generate-network-config.service
@@ -1,9 +1,12 @@
 [Unit]
 Description=Generate network configuration
+DefaultDependencies=no
 # Block manual interactions with this service, since it could leave the system in an
 # unexpected state
 RefuseManualStart=true
 RefuseManualStop=true
+Before=network-pre.target
+RequiresMountsFor=/.bottlerocket
 
 [Service]
 Type=oneshot

--- a/packages/netdog/netdog-tmpfiles.conf
+++ b/packages/netdog/netdog-tmpfiles.conf
@@ -1,2 +1,0 @@
-d /var/lib/netdog 0700 root root -
-Z /var/lib/netdog 0700 root root -

--- a/packages/netdog/netdog.spec
+++ b/packages/netdog/netdog.spec
@@ -9,8 +9,6 @@ Summary: Bottlerocket network configuration helper
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket
 
-Source0: netdog-tmpfiles.conf
-
 Source10: run-netdog.mount
 Source11: write-network-status.service
 Source12: generate-network-config.service
@@ -64,9 +62,6 @@ install -p -m 0755 ${HOME}/.cache/dogtag/%{__cargo_target}/release/10-reverse-dn
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${HOME}/.cache/networkd/%{__cargo_target}/release/netdog %{buildroot}%{_cross_bindir}/netdog
 
-install -d %{buildroot}%{_cross_tmpfilesdir}
-install -p -m 0644 %{S:0} %{buildroot}%{_cross_tmpfilesdir}/netdog.conf
-
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:10} %{S:11} %{S:12} %{S:13} %{buildroot}%{_cross_unitdir}
 
@@ -75,7 +70,6 @@ install -d %{buildroot}%{_cross_libdir}/systemd/resolved.conf.d
 install -p -m 0644 %{S:20} %{buildroot}%{_cross_libdir}/systemd/resolved.conf.d
 
 %files
-%{_cross_tmpfilesdir}/netdog.conf
 %{_cross_unitdir}/generate-network-config.service
 %{_cross_unitdir}/disable-udp-offload.service
 %{_cross_unitdir}/run-netdog.mount

--- a/packages/netdog/write-network-status.service
+++ b/packages/netdog/write-network-status.service
@@ -1,17 +1,20 @@
 [Unit]
 Description=Write network status
+DefaultDependencies=no
 # Block manual interactions with this service, since it could leave the system in an
 # unexpected state
 RefuseManualStart=true
 RefuseManualStop=true
-Before=early-boot-config.service
+Before=early-boot-config.service network-online.target
 # This service creates a symlink to the resolv.conf systemd-resolved creates
 # and we would like it to exist first
+RequiresMountsFor=/.bottlerocket /run/netdog
 After=systemd-networkd-wait-online.service systemd-resolved.service
 Wants=systemd-networkd-wait-online.service systemd-resolved.service
 
 [Service]
 Type=oneshot
+ExecStart=mkdir -p /etc/sysctl.d
 ExecStart=/usr/bin/netdog write-primary-interface-status
 RemainAfterExit=true
 StandardError=journal+console

--- a/packages/os/migrator.service
+++ b/packages/os/migrator.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Bottlerocket data store migrator
+DefaultDependencies=no
 Before=apiserver.service mark-successful-boot.service storewolf.service
+RequiresMountsFor=/var/lib/bottlerocket
 
 RefuseManualStart=true
 RefuseManualStop=true

--- a/packages/os/whippet.service
+++ b/packages/os/whippet.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=D-Bus System Message Bus
 DefaultDependencies=false
-After=dbus.socket
+# Ensure the dbus user is created before starting dbus service
+After=dbus.socket systemd-sysusers.service
+Wants=dbus.socket systemd-sysusers.service
 Before=basic.target shutdown.target
 Requires=dbus.socket
 Conflicts=shutdown.target
@@ -12,7 +14,9 @@ Sockets=dbus.socket
 OOMScoreAdjust=-900
 LimitNOFILE=16384
 ProtectSystem=full
-PrivateTmp=true
+# Disable private /tmp to avoid dependency on systemd-tmpfiles and consequently
+# local-fs.target, allowing dbus to start earlier in the boot
+PrivateTmp=no
 PrivateDevices=true
 ExecStart=/usr/bin/whippet
 

--- a/packages/release/bottlerocket.mount.in
+++ b/packages/release/bottlerocket.mount.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Private Directory (/.bottlerocket)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dPRIVATE.device selinux-policy-files.service
+Requires=dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dPRIVATE.device
+Wants=selinux-policy-files.service
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Mount]
+What=/dev/disk/by-partlabel/BOTTLEROCKET-PRIVATE
+Where=/.bottlerocket
+Options=defaults,noexec,nosuid,nodev,noatime,private,context=system_u:object_r:private_t:s0
+StandardError=journal+console
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/release/network-pre-target-dbus-dep.conf
+++ b/packages/release/network-pre-target-dbus-dep.conf
@@ -1,0 +1,10 @@
+[Unit]
+# Ensure D-Bus is fully initialized before network services start.
+# This prevents a race condition where network services could attempt
+# to use D-Bus functionality (like networkctl commands) before the D-Bus
+# broker service is fully ready to handle requests.
+DefaultDependencies=no
+After=dbus.service
+Requires=dbus.service
+Before=shutdown.target
+Conflicts=shutdown.target

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -95,6 +95,7 @@ Source1082: usr-share-licenses.mount.in
 Source1083: lib-modules.mount.in
 Source1084: usr-bin.mount.in
 Source1085: usr-libexec.mount.in
+Source1086: bottlerocket.mount.in
 
 # Drop-in units to override defaults
 Source1100: systemd-tmpfiles-setup-service-debug.conf
@@ -302,6 +303,10 @@ LIBEXECDIRPATH=$(systemd-escape --path %{_cross_libexecdir})
 sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:1085} > ${LIBEXECDIRPATH}.mount
 install -p -m 0644 ${LIBEXECDIRPATH}.mount %{buildroot}%{_cross_unitdir}
 
+# Process bottlerocket mount template files with proper systemd naming
+BOTTLEROCKET_PATH=$(systemd-escape --path /.bottlerocket)
+install -p -m 0644 %{S:1086} %{buildroot}%{_cross_unitdir}/${BOTTLEROCKET_PATH}.mount
+
 install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
@@ -355,6 +360,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/prepare-opt.service
 %{_cross_unitdir}/prepare-var.service
 %{_cross_unitdir}/repart-local.service
+%{_cross_unitdir}/\x2ebottlerocket.mount
 %{_cross_unitdir}/var.mount
 %{_cross_unitdir}/opt.mount
 %{_cross_unitdir}/mnt.mount

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -109,6 +109,7 @@ Source1107: systemd-journald-compat.conf
 Source1108: systemd-sysusers-selinux.conf
 Source1109: modprobe-no-exit.conf
 Source1110: tmp-mount-noexec.conf
+Source1111: network-pre-target-dbus-dep.conf
 
 # network link rules
 Source1200: 80-release.link
@@ -270,6 +271,10 @@ install -d %{buildroot}%{_cross_unitdir}/tmp.mount.d
 install -p -m 0644 %{S:1110} \
   %{buildroot}%{_cross_unitdir}/tmp.mount.d/10-no-exec.conf
 
+install -d %{buildroot}%{_cross_unitdir}/network-pre.target.d
+install -p -m 0644 %{S:1111} \
+  %{buildroot}%{_cross_unitdir}/network-pre.target.d/00-dbus-dep.conf
+
 # Empty (but packaged) directory. The FIPS packages for kernels will add drop-ins to
 # this directory to arrange for the right modules to be loaded before the check runs.
 install -d %{buildroot}%{_cross_unitdir}/check-fips-modules.service.d
@@ -379,6 +384,8 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/mask-local-mnt.service
 %{_cross_unitdir}/mask-local-opt.service
 %{_cross_unitdir}/mask-local-var.service
+%dir %{_cross_unitdir}/network-pre.target.d
+%{_cross_unitdir}/network-pre.target.d/00-dbus-dep.conf
 %{_cross_unitdir}/root-.aws.mount
 %{_cross_unitdir}/repart-data-preferred.service
 %{_cross_unitdir}/repart-data-fallback.service

--- a/packages/release/var-lib-bottlerocket.mount
+++ b/packages/release/var-lib-bottlerocket.mount
@@ -2,14 +2,14 @@
 Description=Private Directory (/var/lib/bottlerocket)
 DefaultDependencies=no
 Conflicts=umount.target
-RequiresMountsFor=/var
+RequiresMountsFor=/var /.bottlerocket
 Before=local-fs.target umount.target
 
 [Mount]
-What=/dev/disk/by-partlabel/BOTTLEROCKET-PRIVATE
+What=/.bottlerocket
 Where=/var/lib/bottlerocket
-Type=ext4
-Options=defaults,nosuid,nodev,noexec,noatime,private,context=system_u:object_r:private_t:s0
+Type=none
+Options=rbind,rshared
 
 [Install]
 WantedBy=preconfigured.target

--- a/sources/netdog/README.md
+++ b/sources/netdog/README.md
@@ -15,7 +15,7 @@ It contains two subcommands meant for use as settings generators:
 The subcommand `set-hostname` sets the hostname for the system.
 
 The subcommand `generate-net-config` generates the network interface configuration for the host. If
-a `net.toml` file exists in `/var/lib/bottlerocket`, it is used to generate the configuration. If
+a `net.toml` file exists in `/.bottlerocket`, it is used to generate the configuration. If
 `net.toml` doesn't exist, the kernel command line `/proc/cmdline` is checked for the prefix
 `netdog.default-interface`.  If an interface is defined with that prefix, it is used to generate an
 interface configuration.  A single default interface may be defined on the kernel command line with

--- a/sources/netdog/src/cli/mod.rs
+++ b/sources/netdog/src/cli/mod.rs
@@ -7,9 +7,8 @@ pub(crate) mod write_resolv_conf;
 
 use crate::net_config::{self, Interfaces};
 use crate::{
-    DEFAULT_NET_CONFIG_FILE, KERNEL_CMDLINE, OVERRIDE_NET_CONFIG_FILE, PRIMARY_INTERFACE,
-    PRIMARY_MAC_ADDRESS, PRIMARY_SYSCTL_CONF, SYSCTL_MARKER_FILE, SYSTEMD_SYSCTL, SYS_CLASS_NET,
-    USR_NET_CONFIG_FILE,
+    DEFAULT_NET_CONFIG_FILE, KERNEL_CMDLINE, PRIMARY_INTERFACE, PRIMARY_MAC_ADDRESS,
+    PRIMARY_SYSCTL_CONF, SYSCTL_MARKER_FILE, SYSTEMD_SYSCTL, SYS_CLASS_NET, USR_NET_CONFIG_FILE,
 };
 pub(crate) use generate_hostname::GenerateHostnameArgs;
 pub(crate) use generate_net_config::GenerateNetConfigArgs;
@@ -147,12 +146,11 @@ where
 
 // Gather net config from possible sources, returning both the config and the source
 fn fetch_net_config() -> Result<(Option<Box<dyn Interfaces>>, PathBuf)> {
-    let override_path = PathBuf::from(OVERRIDE_NET_CONFIG_FILE);
     let default_path = PathBuf::from(DEFAULT_NET_CONFIG_FILE);
     let usr_path = PathBuf::from(USR_NET_CONFIG_FILE);
     let cmdline = PathBuf::from(KERNEL_CMDLINE);
 
-    for path in [override_path, default_path, usr_path] {
+    for path in [default_path, usr_path] {
         if Path::exists(&path) {
             return Ok((
                 net_config::from_path(&path).context(error::NetConfigParseSnafu { path: &path })?,

--- a/sources/netdog/src/main.rs
+++ b/sources/netdog/src/main.rs
@@ -12,7 +12,7 @@ It contains two subcommands meant for use as settings generators:
 The subcommand `set-hostname` sets the hostname for the system.
 
 The subcommand `generate-net-config` generates the network interface configuration for the host. If
-a `net.toml` file exists in `/var/lib/bottlerocket`, it is used to generate the configuration. If
+a `net.toml` file exists in `/.bottlerocket`, it is used to generate the configuration. If
 `net.toml` doesn't exist, the kernel command line `/proc/cmdline` is checked for the prefix
 `netdog.default-interface`.  If an interface is defined with that prefix, it is used to generate an
 interface configuration.  A single default interface may be defined on the kernel command line with
@@ -42,12 +42,11 @@ use argh::FromArgs;
 use std::process;
 
 static KERNEL_HOSTNAME: &str = "/proc/sys/kernel/hostname";
-static CURRENT_IP: &str = "/var/lib/netdog/current_ip";
+static CURRENT_IP: &str = "/run/netdog/current_ip";
 static KERNEL_CMDLINE: &str = "/proc/cmdline";
-static PRIMARY_INTERFACE: &str = "/var/lib/netdog/primary_interface";
-static PRIMARY_MAC_ADDRESS: &str = "/var/lib/netdog/primary_mac_address";
-static DEFAULT_NET_CONFIG_FILE: &str = "/var/lib/bottlerocket/net.toml";
-static OVERRIDE_NET_CONFIG_FILE: &str = "/var/lib/netdog/net.toml";
+static PRIMARY_INTERFACE: &str = "/run/netdog/primary_interface";
+static PRIMARY_MAC_ADDRESS: &str = "/run/netdog/primary_mac_address";
+static DEFAULT_NET_CONFIG_FILE: &str = "/.bottlerocket/net.toml";
 static USR_NET_CONFIG_FILE: &str = "/usr/share/bottlerocket/net.toml";
 static PRIMARY_SYSCTL_CONF: &str = "/etc/sysctl.d/90-primary_interface.conf";
 static SYSCTL_MARKER_FILE: &str = "/run/netdog/primary_sysctls_set";


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

  Closes #637

**Description of changes:**

This PR optimizes boot time by decoupling the network stack initialization from the DATA partition, allowing network services to start in parallel with local filesystem operations.

### Boot sequence change overview
| Before | After |
|--------|-------|
| <img width="600" alt="image(1)" src="https://github.com/user-attachments/assets/f0d77349-df69-4f82-ba5f-a6506fe8be8e" /> | <img width="600" alt="After" src="https://github.com/user-attachments/assets/2fd04ce9-2244-46f6-b22e-f97284debfc6" /> |



### Direct PRIVATE Partition Mount
- Added direct mount point `/.bottlerocket` for the PRIVATE partition that bypasses dependency on DATA partition
- Created a bind mount from `/.bottlerocket` to `/var/lib/bottlerocket` for backward compatibility
- Network services now use `/.bottlerocket/netdog` directly instead of `/var/lib/netdog`

### Netdog Updates
- Updated path constants to use `/.bottlerocket/netdog` instead of `/var/lib/netdog`
- Drop default dependencies and update `generate-network-config.service` with /.bottlerocket dependencies.
- Create `/etc/sysctl.d` with `ExecStart` entry for `write-network-status.service`.
- Drop default dependencies for `write-network-status.service` and explicitly add `Before=network-online.target` for `write-network-status.service`.
- Removed dependency on `systemd-tmpfiles` for directory creation

### D-Bus and Network Service Improvements
- Added `DefaultDependencies=no` to `dbus.socket` to allow early D-Bus initialization
- Made `network-pre.target` require `dbus-broker.service` to ensure D-Bus is ready before network services start
- Disabled `PrivateTmp` for `dbus-broker.service` to remove dependency on `systemd-tmpfiles` and `local-fs.target`


**Testing done:**

<details>
  <summary>Click to expand testing details</summary>

  ### Functional Testing
  - Tested using `metal-dev` instance to confirm that `net.toml` injected to PRIVATE partition can still be read and that
  `write-network-status.service` can write to the `/.bottlerocket/netdog` path with no issue
  - Verified the node booted properly with all network functionality intact
  - Used systemd-analyze plot to generate the boot plot and confirmed the decoupling of the network stack and DATA
  partition
  - Verified that network initialization and local-fs (DATA) now occur in parallel
  - Confirmed network configuration and state files are properly persisted across reboots
  - Validated that all existing network functionality is maintained with the new directory structure

  ### Boot-time Testing
  - Initial tests on m5.xlarge instances show ~987ms improvement in network-online.target timing and ~817ms improvement in configured.target timing
  - Ran over 10k sample boots to measure the improvement and we are seeing about 700ms improvement statistically.


  </details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
