### PR TITLE
kubernetes: update kubelet config to use new static pods setting

### DIFF
--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
 kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["any_enabled", "default"] }
+std = { version = "v1", helpers = ["any_enabled", "if_not_null", "default"] }
 +++
 ---
 kind: KubeletConfiguration
@@ -154,7 +154,13 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+{{#if_not_null settings.kubernetes.static-pods-enabled}}
+{{#if settings.kubernetes.static-pods-enabled}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if}}
+{{else}}
+staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if_not_null}}
 {{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{/if}}

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
 kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["any_enabled", "default"] }
+std = { version = "v1", helpers = ["any_enabled", "if_not_null", "default"] }
 +++
 ---
 kind: KubeletConfiguration
@@ -154,7 +154,13 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+{{#if_not_null settings.kubernetes.static-pods-enabled}}
+{{#if settings.kubernetes.static-pods-enabled}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if}}
+{{else}}
+staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if_not_null}}
 {{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{/if}}

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
 kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["any_enabled", "default"] }
+std = { version = "v1", helpers = ["any_enabled", "if_not_null", "default"] }
 +++
 ---
 kind: KubeletConfiguration
@@ -154,7 +154,13 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+{{#if_not_null settings.kubernetes.static-pods-enabled}}
+{{#if settings.kubernetes.static-pods-enabled}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if}}
+{{else}}
+staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if_not_null}}
 {{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{/if}}

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
 kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["any_enabled", "default"] }
+std = { version = "v1", helpers = ["any_enabled", "if_not_null", "default"] }
 +++
 ---
 kind: KubeletConfiguration
@@ -154,7 +154,13 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+{{#if_not_null settings.kubernetes.static-pods-enabled}}
+{{#if settings.kubernetes.static-pods-enabled}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if}}
+{{else}}
+staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if_not_null}}
 {{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{/if}}

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
 kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["any_enabled", "default"] }
+std = { version = "v1", helpers = ["any_enabled", "if_not_null", "default"] }
 +++
 ---
 kind: KubeletConfiguration
@@ -154,7 +154,13 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+{{#if_not_null settings.kubernetes.static-pods-enabled}}
+{{#if settings.kubernetes.static-pods-enabled}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if}}
+{{else}}
+staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if_not_null}}
 {{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{/if}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
 kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["any_enabled", "default"] }
+std = { version = "v1", helpers = ["any_enabled", "if_not_null", "default"] }
 +++
 ---
 kind: KubeletConfiguration
@@ -154,7 +154,13 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+{{#if_not_null settings.kubernetes.static-pods-enabled}}
+{{#if settings.kubernetes.static-pods-enabled}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if}}
+{{else}}
+staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if_not_null}}
 {{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{/if}}

--- a/packages/kubernetes-1.34/kubelet-config
+++ b/packages/kubernetes-1.34/kubelet-config
@@ -1,6 +1,6 @@
 [required-extensions]
 kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
-std = { version = "v1", helpers = ["any_enabled", "default"] }
+std = { version = "v1", helpers = ["any_enabled", "if_not_null", "default"] }
 +++
 ---
 kind: KubeletConfiguration
@@ -154,7 +154,13 @@ tlsCipherSuites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
 maxPods: {{default 110 settings.kubernetes.max-pods}}
+{{#if_not_null settings.kubernetes.static-pods-enabled}}
+{{#if settings.kubernetes.static-pods-enabled}}
 staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if}}
+{{else}}
+staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if_not_null}}
 {{#if settings.kubernetes.container-log-max-size includeZero=true}}
 containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
 {{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1309,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-modeled-types"
 version = "0.10.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1353,7 +1353,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1377,8 +1377,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.12.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+version = "0.13.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1442,7 +1442,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "serde",
 ]
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4834,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4860,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4890,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4903,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4916,7 +4916,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4929,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4941,8 +4941,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubernetes"
-version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+version = "0.5.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4956,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4969,19 +4969,20 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
  "env_logger",
  "serde",
  "serde_json",
+ "snafu",
 ]
 
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4994,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5007,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5020,7 +5021,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5034,7 +5035,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5047,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5060,7 +5061,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.12.0#5a84632ff96298615baeb96c0f20ce6a2267354e"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -211,13 +211,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.12.0"
+tag = "bottlerocket-settings-models-v0.13.0"
 version = "0.10.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.12.0"
-version = "0.12.0"
+tag = "bottlerocket-settings-models-v0.13.0"
+version = "0.13.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -226,7 +226,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.12.0"
+tag = "bottlerocket-settings-models-v0.13.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Makes use of the new enable-static-pods setting to allow static pods to be disabled with an explicit false setting. If unset, defaults to true.


**Testing done:**

1. Launched without setting and confirmed Kubelet set static pod path
2. Launched with setting explicitly enabled and confirmed Kubelet set static pod path
3. Launched with setting explicitly disabled and confirmed Kubelet did not set static pod path

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
