### PR TITLE
Update ghostdog to handle multiple neuron drivers

### DIFF
--- a/packages/release/drivers.target
+++ b/packages/release/drivers.target
@@ -1,0 +1,9 @@
+[Unit]
+Description=Driver units
+AllowIsolate=yes
+After=basic.target
+Before=preconfigured.target
+Requires=basic.target
+
+[Install]
+RequiredBy=preconfigured.target multi-user.target

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -50,6 +50,7 @@ Source1006: activate-configured.service
 Source1007: activate-multi-user.service
 Source1008: set-hostname.service
 Source1009: runtime.slice
+Source1010: drivers.target
 
 # Mount units.
 Source1020: var.mount
@@ -224,7 +225,7 @@ EOF
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:1001} %{S:1002} %{S:1003} %{S:1004} %{S:1005} \
-  %{S:1006} %{S:1007} %{S:1008} %{S:1009} \
+  %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} \
   %{S:1020} %{S:1021} %{S:1022} %{S:1023} %{S:1024} \
   %{S:1025} %{S:1026} %{S:1027} %{S:1028} %{S:1029} \
   %{S:1040} %{S:1041} %{S:1042} %{S:1043} %{S:1044} \
@@ -341,6 +342,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_libdir}/modules-load.d/nf_conntrack.conf
 %{_cross_libdir}/systemd/journald.conf.d/journald.conf
 %{_cross_unitdir}/configured.target
+%{_cross_unitdir}/drivers.target
 %{_cross_unitdir}/preconfigured.target
 %{_cross_unitdir}/multi-user.target
 %{_cross_unitdir}/default.target

--- a/sources/ghostdog/src/error.rs
+++ b/sources/ghostdog/src/error.rs
@@ -66,6 +66,18 @@ pub(super) enum Error {
         requested: String,
         preferred: String,
     },
+    #[snafu(display("{driver} is not a supported driver"))]
+    UnsupportedDriver { driver: String },
+    #[snafu(display("{flavor} is not a supported choice for {driver}"))]
+    UnsupportedDriverFlavor { driver: String, flavor: String },
+    #[snafu(display("Failed to check if this is an inf1 instance: {}", source))]
+    CheckInf1Failure { source: pciclient::PciClientError },
+    #[snafu(display("Failed to check if this is an inf2+ instance: {}", source))]
+    CheckInf2Failure { source: pciclient::PciClientError },
+    #[snafu(display("Did not detect inf1 hardware"))]
+    NoInf1Present,
+    #[snafu(display("Did not detect inf2+ hardware"))]
+    NoInf2Present,
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/sources/ghostdog/src/main.rs
+++ b/sources/ghostdog/src/main.rs
@@ -58,6 +58,7 @@ enum SubCommand {
     EbsDeviceName(EbsDeviceNameArgs),
     EfaPresent(EfaPresentArgs),
     NeuronPresent(NeuronPresentArgs),
+    MatchDriver(MatchDriverArgs),
     MatchNvidiaDriver(MatchNvidiaDriverArgs),
     WriteInfinibandGuid(WriteInfinibandGuidArgs),
 }
@@ -94,6 +95,16 @@ struct EbsDeviceNameArgs {
 struct MatchNvidiaDriverArgs {
     #[argh(positional)]
     driver_name: String,
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "match-driver")]
+/// Returns if devices on the PCI bus support the provided driver.
+struct MatchDriverArgs {
+    #[argh(positional)]
+    driver_name: String,
+    #[argh(positional)]
+    flavor_name: String,
 }
 
 #[derive(FromArgs, PartialEq, Debug)]
@@ -156,6 +167,19 @@ fn main() -> Result<()> {
             let driver_name = driver.driver_name;
             nvidia_driver_supported(&driver_name)?;
         }
+        SubCommand::MatchDriver(driver) => {
+            let driver_name = driver.driver_name;
+            let flavor_name = driver.flavor_name;
+            match driver_name.as_str() {
+                "nvidia" => nvidia_driver_supported(&flavor_name)?,
+                "neuron" => match_neuron_driver(&flavor_name)?,
+                _ => {
+                    return Err(error::Error::UnsupportedDriver {
+                        driver: driver_name.to_string(),
+                    })
+                }
+            }
+        }
         SubCommand::WriteInfinibandGuid(envfile) => {
             find_and_write_infiniband_guid(envfile.env_file)?;
         }
@@ -177,6 +201,24 @@ fn is_neuron_attached() -> Result<()> {
     } else {
         Err(error::Error::NoNeuronPresent)
     }
+}
+
+// Returns true if this is an inf1 instance
+fn is_inf1_instance() -> Result<()> {
+    if pciclient::is_inf1_instance().context(error::CheckInf1FailureSnafu)? {
+        return Ok(());
+    }
+    Err(error::Error::NoInf1Present)
+}
+
+// Returns true if is a Neuron-based instance but not inf1. Inf2 is a stand in name for all hardware after
+// inf1 but leaves this open for more hardware types that may need specific decisions from ghostdog in the
+// future.
+fn is_inf2_instance() -> Result<()> {
+    if pciclient::is_inf2_instance().context(error::CheckInf2FailureSnafu)? {
+        return Ok(());
+    }
+    Err(error::Error::NoInf2Present)
 }
 
 /// Detects if infiniband is present. If not, return early. If it does find Infiniband devices,
@@ -357,6 +399,17 @@ fn nvidia_driver_supported(driver_name: &str) -> Result<()> {
         }
     );
     Ok(())
+}
+
+fn match_neuron_driver(driver_flavor: &str) -> Result<()> {
+    match driver_flavor {
+        "inf1" => is_inf1_instance(),
+        "latest" => is_inf2_instance(),
+        _ => Err(error::Error::UnsupportedDriverFlavor {
+            driver: "neuron".to_string(),
+            flavor: driver_flavor.to_string(),
+        }),
+    }
 }
 
 // Known system partition types for Bottlerocket.

--- a/sources/pciclient/src/lib.rs
+++ b/sources/pciclient/src/lib.rs
@@ -7,7 +7,10 @@ pciclient provides util functions that can:
 */
 mod private;
 
-use private::{call_list_devices, check_efa_attachment, check_neuron_attachment, PciClient};
+use private::{
+    call_list_devices, check_efa_attachment, check_inf1_attachment, check_inf2_attachment,
+    check_neuron_attachment, PciClient,
+};
 
 use bon::Builder;
 use derive_getters::Getters;
@@ -120,6 +123,16 @@ pub fn is_neuron_attached() -> Result<bool> {
     check_neuron_attachment(PciClient {})
 }
 
+/// Call `lspci` and check if there are inf1 devices attached
+pub fn is_inf1_instance() -> Result<bool> {
+    check_inf1_attachment(PciClient {})
+}
+
+/// Call `lspci` and check if there are inf2 or later devices attached
+pub fn is_inf2_instance() -> Result<bool> {
+    check_inf2_attachment(PciClient {})
+}
+
 mod error {
     use snafu::Snafu;
 
@@ -147,4 +160,5 @@ mod error {
 }
 
 pub use error::PciClientError;
+
 pub type Result<T> = std::result::Result<T, PciClientError>;

--- a/sources/pciclient/src/private.rs
+++ b/sources/pciclient/src/private.rs
@@ -15,12 +15,19 @@ use crate::{
 const AMAZON_VENDOR_CODE: &str = "1d0f";
 const EFA_KEYWORD: &str = "efa";
 
+// Neuron devices specific to inf1 instance types
 lazy_static! {
-    static ref NEURON_DEVICES: HashSet<&'static str> = hashset! {
+    static ref INF1_DEVICES: HashSet<&'static str> = hashset! {
         "7064", // inf1 device id 0
         "7065", // inf1 device id 1
         "7066", // inf1 device id 2
         "7067", // inf1 device id 3
+    };
+}
+
+// Neuron device ids outside of inf1-specific devices
+lazy_static! {
+    static ref NEURON_DEVICES: HashSet<&'static str> = hashset! {
         "7164", // trn1 device id 0
         "7264", // inf2 device id 0
         "7364", // trn2 device id 0
@@ -170,6 +177,33 @@ pub(crate) fn check_neuron_attachment<T: CommandExecutor>(command_executor: T) -
         .vendor(AMAZON_VENDOR_CODE.to_string())
         .build();
     let list_device_results = call_list_devices(command_executor, list_devices_param)?;
+    Ok(list_device_results.iter().any(|device_info| {
+        NEURON_DEVICES.contains(&device_info.device.as_str())
+            || INF1_DEVICES.contains(&device_info.device.as_str())
+    }))
+}
+
+/// Call `lspci` and check if there is any inf1-specific Neuron device attached.
+/// Internal usage, adding command_executor as parameter allows us to better unit test.
+/// For external usage, check [`crate::is_inf1_instance`].
+pub(crate) fn check_inf1_attachment<T: CommandExecutor>(command_executor: T) -> Result<bool> {
+    let list_devices_param = ListDevicesParam::builder()
+        .vendor(AMAZON_VENDOR_CODE.to_string())
+        .build();
+    let list_device_results = call_list_devices(command_executor, list_devices_param)?;
+    Ok(list_device_results
+        .iter()
+        .any(|device_info| INF1_DEVICES.contains(&device_info.device.as_str())))
+}
+
+/// Call `lspci` and check if there is any inf2 or later Neuron device attached.
+/// Internal usage, adding command_executor as parameter allows us to better unit test.
+/// For external usage, check [`crate::is_inf2_instance`].
+pub(crate) fn check_inf2_attachment<T: CommandExecutor>(command_executor: T) -> Result<bool> {
+    let list_devices_param = ListDevicesParam::builder()
+        .vendor(AMAZON_VENDOR_CODE.to_string())
+        .build();
+    let list_device_results = call_list_devices(command_executor, list_devices_param)?;
     Ok(list_device_results
         .iter()
         .any(|device_info| NEURON_DEVICES.contains(&device_info.device.as_str())))
@@ -194,7 +228,7 @@ mod test {
     use crate::{ListDevicesOutput, ListDevicesParam, Result};
 
     use super::{
-        call_list_devices, check_efa_attachment, check_neuron_attachment,
+        call_list_devices, check_efa_attachment, check_inf1_attachment, check_neuron_attachment,
         parse_list_devices_output, CommandExecutor,
     };
 
@@ -385,5 +419,31 @@ mod test {
         let check_neuron_attachment_result = check_neuron_attachment(mock_pci_client);
         assert!(check_neuron_attachment_result.is_ok());
         assert!(!check_neuron_attachment_result.unwrap());
+    }
+
+    #[test]
+    fn test_is_inf1_attached() {
+        let mock_pci_client = MockPciClient {
+            // inf1 device has class code: 0880 for system peripheral, vendor 1d0f for amazon, device code 7064.
+            // Below is a mock output from lspci for inf1 device.
+            output: vec![
+                r#"00:1e.0 "0880" "1d0f" "7064" -p00 "" """#.to_string(),
+                r#"00:1e.0 "0302" "10de" "1eb8" -ra1 -p00 "10de" "12a2""#.to_string(),
+            ],
+        };
+        let check_inf1_attachment_result = check_inf1_attachment(mock_pci_client);
+        assert!(check_inf1_attachment_result.is_ok());
+        assert!(check_inf1_attachment_result.unwrap());
+    }
+
+    #[test]
+    fn test_is_inf1_attached_negative_case() {
+        let mock_pci_client = MockPciClient {
+            // Below is an actual output from lspci for trn1 device (not inf1).
+            output: vec![r#"00:1e.0 "0880" "1d0f" "7164" -p00 "" """#.to_string()],
+        };
+        let check_inf1_attachment_result = check_inf1_attachment(mock_pci_client);
+        assert!(check_inf1_attachment_result.is_ok());
+        assert!(!check_inf1_attachment_result.unwrap());
     }
 }


### PR DESCRIPTION
**Issue number:**

Related to https://github.com/bottlerocket-os/bottlerocket-kernel-kit/issues/238

**Description of changes:**
This adds a `match-driver` command to ghostdog which will eventually replace `match-nvidia-driver` as a generic command for multiple drivers. This allows neuron devices to be chosen in the same way that NVIDIA drivers are based upon the devices found on the PCI bus.

This is useful for inf1 instances where they will need to remain on 2.21.* but newer instances would benefit from a newer driver. This will allow Bottlerocket to choose the best driver for the particular instance it is launched on. This change relies upon a change in the kernel kit to vend this additional driver and call `driverdog` to actually do the loading.

See https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/277 for the other side of this change. 


**Testing done:**
Booted an image with this and https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/277 and booted on both inf1 and trn1 instances. The correct driver is loaded on each.

### on `trn1.2xlarge'
```
[ssm-user@control]$ apiclient exec admin modinfo neuron
filename:       /lib/modules/6.12.40/neuron_latest/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.23.9.0
license:        GPL
description:    Neuron Driver, built from SHA: b8ad53947481bbe9d8e76b117c06b2484b8a949f
import_ns:      DMA_BUF
srcversion:     68886FE4A17A11B0934DAFE
depends:
name:           neuron
retpoline:      Y
vermagic:       6.12.40 SMP preempt mod_unload modversions
```

### on `inf1.xlarge`
```
[ssm-user@control]$ apiclient exec admin modinfo neuron
filename:       /lib/modules/6.12.40/neuron_2_21/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.21.37.0
license:        GPL
description:    Neuron Driver, built from SHA: fd7535995e4b3ae73c543f829b152c3351ef21f6
import_ns:      DMA_BUF
srcversion:     4DE159506B58B4692C035AA
depends:
name:           neuron
retpoline:      Y
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
