### PR TITLE
containerd-2.1: add configurable concurrent-download-chunk-size setting

### DIFF
--- a/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
@@ -26,7 +26,7 @@ address = "/run/containerd/containerd.sock"
 {{#if settings.container-runtime.max-concurrent-downloads}}
 max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
-concurrent_layer_fetch_buffer = 8388608
+concurrent_layer_fetch_buffer = {{default 8388608 settings.container-runtime.concurrent-download-chunk-size}}
 use_local_image_pull = false
 
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
@@ -50,7 +50,7 @@ enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp
 {{#if settings.container-runtime.max-concurrent-downloads}}
 max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
-concurrent_layer_fetch_buffer = 8388608
+concurrent_layer_fetch_buffer = {{default 8388608 settings.container-runtime.concurrent-download-chunk-size}}
 
 [[plugins."io.containerd.transfer.v1.local".unpack_config]]
 snapshotter = "overlayfs"

--- a/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -26,7 +26,7 @@ address = "/run/containerd/containerd.sock"
 {{#if settings.container-runtime.max-concurrent-downloads}}
 max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
-concurrent_layer_fetch_buffer = 8388608
+concurrent_layer_fetch_buffer = {{default 8388608 settings.container-runtime.concurrent-download-chunk-size}}
 use_local_image_pull = false
 
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
@@ -50,7 +50,7 @@ enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp
 {{#if settings.container-runtime.max-concurrent-downloads}}
 max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
-concurrent_layer_fetch_buffer = 8388608
+concurrent_layer_fetch_buffer = {{default 8388608 settings.container-runtime.concurrent-download-chunk-size}}
 
 [[plugins."io.containerd.transfer.v1.local".unpack_config]]
 snapshotter = "overlayfs"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1308,8 +1308,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.10.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.11.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -1317,6 +1317,7 @@ dependencies = [
  "bottlerocket-scalar-derive",
  "bottlerocket-string-impls-for",
  "bounded-integer",
+ "byte-unit",
  "indexmap",
  "lazy_static",
  "regex",
@@ -1344,7 +1345,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1353,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1377,8 +1378,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.13.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.14.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1429,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1442,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "serde",
 ]
@@ -1450,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -4768,7 +4769,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4781,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4794,7 +4795,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4807,8 +4808,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-bootstrap-containers"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4821,7 +4822,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4834,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4846,8 +4847,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-container-runtime"
-version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.3.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4859,13 +4860,12 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-container-runtime-plugins"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
  "bottlerocket-settings-sdk",
- "byte-unit",
  "env_logger",
  "lazy_static",
  "regex",
@@ -4877,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4890,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4902,8 +4902,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-host-containers"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4916,7 +4916,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4929,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4942,7 +4942,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4956,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4969,7 +4969,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -4982,7 +4982,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4995,7 +4995,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5008,7 +5008,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5021,7 +5021,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5035,7 +5035,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5048,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5061,7 +5061,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.13.0#faf59ef8d38cdca41fa0e25ad073471d78b5552f"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -211,13 +211,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.13.0"
-version = "0.10.0"
+tag = "bottlerocket-settings-models-v0.14.0"
+version = "0.11.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.13.0"
-version = "0.13.0"
+tag = "bottlerocket-settings-models-v0.14.0"
+version = "0.14.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -226,7 +226,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.13.0"
+tag = "bottlerocket-settings-models-v0.14.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Add `concurrent-download-chunk-size` setting in the containerd-2.1 config.toml, allowing for transfer service default to be updated. 

Related: 
* https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/99

**Testing done:**

Set several chunk_sizes and verfied they updated the config properly. 



```
[root@admin]#  apiclient set settings.container-runtime.concurrent-download-chunk-size="32mib"
[root@admin]# apiclient get settings.container-runtime.concurrent-download-chunk-size
{
  "settings": {
    "container-runtime": {
      "concurrent-download-chunk-size": 33554432
    }
  }
}
```


Also verified via debug, containerd logs during image fetch:

<details>

```
Aug 28 01:11:38 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:38.657403163Z" level=debug msg="fetching layer" chunk_size=33554432 digest="sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5" initial_parallelism=3 mediatype=application/vnd.oci.image.index.v1+json offset=0 parallelism=3 size=8933
    Aug 28 01:11:38 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:38.657479360Z" level=debug msg="do request" digest="sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5" mediatype=application/vnd.oci.image.index.v1+json request.header.accept="application/vnd.oci.image.index.v1+json, */*" request.header.accept-encoding="zstd;q=1.0, gzip;q=0.8, deflate;q=0.5" request.header.range="bytes=0-" request.header.user-agent=containerd/2.1.4+bottlerocket request.method=GET size=8933 url="https://registry-1.docker.io/v2/library/debian/manifests/sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5"
    Aug 28 01:11:38 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:38.853513039Z" level=debug msg="fetch response received" digest="sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5" mediatype=application/vnd.oci.image.index.v1+json response.header.connection=keep-alive response.header.content-length=157 response.header.content-type=application/json response.header.date="Thu, 28 Aug 2025 01:11:38 GMT" response.header.docker-distribution-api-version=registry/2.0 response.header.docker-ratelimit-source=44.234.62.213 response.header.strict-transport-security="max-age=31536000" response.header.www-authenticate="Bearer realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\",scope=\"repository:library/debian:pull\"" response.status="401 Unauthorized" size=8933 url="https://registry-1.docker.io/v2/library/debian/manifests/sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5"
    Aug 28 01:11:38 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:38.853577633Z" level=debug msg=Unauthorized digest="sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5" header="Bearer realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\",scope=\"repository:library/debian:pull\"" mediatype=application/vnd.oci.image.index.v1+json size=8933
    Aug 28 01:11:38 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:38.853685865Z" level=debug msg="do request" digest="sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5" mediatype=application/vnd.oci.image.index.v1+json request.header.accept="application/vnd.oci.image.index.v1+json, */*" request.header.accept-encoding="zstd;q=1.0, gzip;q=0.8, deflate;q=0.5" request.header.range="bytes=0-" request.header.user-agent=containerd/2.1.4+bottlerocket request.method=GET size=8933 url="https://registry-1.docker.io/v2/library/debian/manifests/sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5"
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.293481878Z" level=debug msg="fetch response received" digest="sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5" mediatype=application/vnd.oci.image.index.v1+json response.header.connection=keep-alive response.header.content-length=8933 response.header.content-type=application/vnd.oci.image.index.v1+json response.header.date="Thu, 28 Aug 2025 01:11:39 GMT" response.header.docker-content-digest="sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5" response.header.docker-distribution-api-version=registry/2.0 response.header.docker-ratelimit-source=44.234.62.213 response.header.etag="\"sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5\"" response.header.ratelimit-limit="100;w=21600" response.header.ratelimit-remaining="97;w=21600" response.header.strict-transport-security="max-age=31536000" response.status="200 OK" size=8933 url="https://registry-1.docker.io/v2/library/debian/manifests/sha256:6d87375016340817ac2391e670971725a9981cfc24e221c47734681ed0f6c0f5"
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.302582477Z" level=debug msg=fetch digest="sha256:a9114963cf3cd27fdae799d3c987758a26709515db3673ce85e2c4befd88199e" mediatype=application/vnd.oci.image.manifest.v1+json size=1021
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.308717245Z" level=debug msg="fetching layer" chunk_size=33554432 digest="sha256:a9114963cf3cd27fdae799d3c987758a26709515db3673ce85e2c4befd88199e" initial_parallelism=3 mediatype=application/vnd.oci.image.manifest.v1+json offset=0 parallelism=3 size=1021
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.308763513Z" level=debug msg="do request" digest="sha256:a9114963cf3cd27fdae799d3c987758a26709515db3673ce85e2c4befd88199e" mediatype=application/vnd.oci.image.manifest.v1+json request.header.accept="application/vnd.oci.image.manifest.v1+json, */*" request.header.accept-encoding="zstd;q=1.0, gzip;q=0.8, deflate;q=0.5" request.header.range="bytes=0-" request.header.user-agent=containerd/2.1.4+bottlerocket request.method=GET size=1021 url="https://registry-1.docker.io/v2/library/debian/manifests/sha256:a9114963cf3cd27fdae799d3c987758a26709515db3673ce85e2c4befd88199e"
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.417055008Z" level=debug msg="fetch response received" digest="sha256:a9114963cf3cd27fdae799d3c987758a26709515db3673ce85e2c4befd88199e" mediatype=application/vnd.oci.image.manifest.v1+json response.header.connection=keep-alive response.header.content-length=1021 response.header.content-type=application/vnd.oci.image.manifest.v1+json response.header.date="Thu, 28 Aug 2025 01:11:39 GMT" response.header.docker-content-digest="sha256:a9114963cf3cd27fdae799d3c987758a26709515db3673ce85e2c4befd88199e" response.header.docker-distribution-api-version=registry/2.0 response.header.docker-ratelimit-source=44.234.62.213 response.header.etag="\"sha256:a9114963cf3cd27fdae799d3c987758a26709515db3673ce85e2c4befd88199e\"" response.header.ratelimit-limit="100;w=21600" response.header.ratelimit-remaining="96;w=21600" response.header.strict-transport-security="max-age=31536000" response.status="200 OK" size=1021 url="https://registry-1.docker.io/v2/library/debian/manifests/sha256:a9114963cf3cd27fdae799d3c987758a26709515db3673ce85e2c4befd88199e"
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.425644190Z" level=debug msg=fetch digest="sha256:047bd8d819400f5dab52d40aa2c424109b6627b9e4ec27c113a308e72aac0e7b" mediatype=application/vnd.oci.image.config.v1+json size=451
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.444000024Z" level=debug msg=fetch digest="sha256:80b7316254b3093eb3c7ac44bb6c34bde013f27947c1ed8d8afe456b957ebfdb" mediatype=application/vnd.oci.image.layer.v1.tar+gzip size=49278280
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.450092500Z" level=debug msg="fetching layer" chunk_size=33554432 digest="sha256:80b7316254b3093eb3c7ac44bb6c34bde013f27947c1ed8d8afe456b957ebfdb" initial_parallelism=3 mediatype=application/vnd.oci.image.layer.v1.tar+gzip offset=0 parallelism=3 size=49278280
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.450142467Z" level=debug msg="do request" digest="sha256:80b7316254b3093eb3c7ac44bb6c34bde013f27947c1ed8d8afe456b957ebfdb" mediatype=application/vnd.oci.image.layer.v1.tar+gzip request.header.accept="application/vnd.oci.image.layer.v1.tar+gzip, */*" request.header.accept-encoding="zstd;q=1.0, gzip;q=0.8, deflate;q=0.5" request.header.range="bytes=0-" request.header.user-agent=containerd/2.1.4+bottlerocket request.method=GET size=49278280 url="https://registry-1.docker.io/v2/library/debian/blobs/sha256:80b7316254b3093eb3c7ac44bb6c34bde013f27947c1ed8d8afe456b957ebfdb"
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.745760228Z" level=debug msg="fetch response received" digest="sha256:80b7316254b3093eb3c7ac44bb6c34bde013f27947c1ed8d8afe456b957ebfdb" mediatype=application/vnd.oci.image.layer.v1.tar+gzip response.header.accept-ranges=bytes response.header.cf-ray=975fef982c9cff09-PDX response.header.connection=keep-alive response.header.content-length=49278280 response.header.content-range="bytes 0-49278279/49278280" response.header.content-type=application/octet-stream response.header.date="Thu, 28 Aug 2025 01:11:39 GMT" response.header.etag="\"5f656b1c0a883408edb64c4f18262db8\"" response.header.last-modified="Tue, 12 Aug 2025 20:45:14 GMT" response.header.server=cloudflare response.header.vary=Accept-Encoding response.status="206 Partial Content" size=49278280 url="https://registry-1.docker.io/v2/library/debian/blobs/sha256:80b7316254b3093eb3c7ac44bb6c34bde013f27947c1ed8d8afe456b957ebfdb"
    Aug 28 01:11:39 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:39.747370761Z" level=debug msg="do request" digest="sha256:80b7316254b3093eb3c7ac44bb6c34bde013f27947c1ed8d8afe456b957ebfdb" mediatype=application/vnd.oci.image.layer.v1.tar+gzip request.header.accept="application/vnd.oci.image.layer.v1.tar+gzip, */*" request.header.accept-encoding="zstd;q=1.0, gzip;q=0.8, deflate;q=0.5" request.header.range="bytes=33554432-" request.header.user-agent=containerd/2.1.4+bottlerocket request.method=GET size=49278280 url="https://registry-1.docker.io/v2/library/debian/blobs/sha256:80b7316254b3093eb3c7ac44bb6c34bde013f27947c1ed8d8afe456b957ebfdb"
    Aug 28 01:11:40 ip-192-168-47-119.us-west-2.compute.internal containerd[16099]: time="2025-08-28T01:11:40.005249637Z" level=debug msg="fetch response received" digest="sha256:80b7316254b3093eb3c7ac44bb6c34bde013f27947c1ed8d8afe456b957ebfdb" mediatype=application/vnd.oci.image.layer.v1.tar+gzip response.header.accept-ranges=bytes response.header.cf-ray=975fef99fce22d7c-PDX response.header.connection=keep-alive response.header.content-length=15723848 response.header.content-range="bytes 33554432-49278279/49278280" response.header.content-type=application/octet-stream response.header.date="Thu, 28 Aug 2025 01:11:40 GMT" response.header.etag="\"5f656b1c0a883408edb64c4f18262db8\"" response.header.last-modified="Tue, 12 Aug 2025 20:45:14 GMT" response.header.server=cloudflare response.header.vary=Accept-Encoding response.status="206 Partial Content" size=49278280 url="https://registry-1.docker.io/v2/library/debian/blobs/sha256:80b7316254b3093eb3c7ac44bb6c34bde013f27947c1ed8d8afe456b957ebfdb"
```

</details>

* 64mb using the alias `concurrent-layer-fetch-buffer`
```
[root@admin]# apiclient set settings.container-runtime.concurrent-layer-fetch-buffer="64mb"
[root@admin]# apiclient get settings.container-runtime
{
  "settings": {
    "container-runtime": {
      "concurrent-download-chunk-size": 64000000
    }
  }
}
```

config.toml:

```
[plugins."io.containerd.cri.v1.images"]
concurrent_layer_fetch_buffer = 64000000
use_local_image_pull = false

[plugins."io.containerd.transfer.v1.local"]
concurrent_layer_fetch_buffer = 64000000

[[plugins."io.containerd.transfer.v1.local".unpack_config]]
snapshotter = "overlayfs"
differ = "walking"
platform = "linux/amd64"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
