### PR TITLE
kubernetes: add pid resource to kubeReserved setting

### DIFF
--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -91,6 +91,9 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+  {{#if settings.kubernetes.kube-reserved.pid}}
+  pid: "{{settings.kubernetes.kube-reserved.pid}}"
+  {{/if}}
 {{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
 {{/unless}}

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -91,6 +91,9 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+  {{#if settings.kubernetes.kube-reserved.pid}}
+  pid: "{{settings.kubernetes.kube-reserved.pid}}"
+  {{/if}}
 {{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
 {{/unless}}

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -91,6 +91,9 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+  {{#if settings.kubernetes.kube-reserved.pid}}
+  pid: "{{settings.kubernetes.kube-reserved.pid}}"
+  {{/if}}
 {{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
 {{/unless}}

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -91,6 +91,9 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+  {{#if settings.kubernetes.kube-reserved.pid}}
+  pid: "{{settings.kubernetes.kube-reserved.pid}}"
+  {{/if}}
 {{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
 {{/unless}}

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -91,6 +91,9 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+  {{#if settings.kubernetes.kube-reserved.pid}}
+  pid: "{{settings.kubernetes.kube-reserved.pid}}"
+  {{/if}}
 {{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
 {{/unless}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -91,6 +91,9 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+  {{#if settings.kubernetes.kube-reserved.pid}}
+  pid: "{{settings.kubernetes.kube-reserved.pid}}"
+  {{/if}}
 {{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
 {{/unless}}

--- a/packages/kubernetes-1.34/kubelet-config
+++ b/packages/kubernetes-1.34/kubelet-config
@@ -91,6 +91,9 @@ kubeReserved:
   {{/if}}
   {{/if}}
   ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+  {{#if settings.kubernetes.kube-reserved.pid}}
+  pid: "{{settings.kubernetes.kube-reserved.pid}}"
+  {{/if}}
 {{#unless settings.kubernetes.reserved-cpus}}
 kubeReservedCgroup: "/runtime"
 {{/unless}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1309,8 +1309,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.11.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+version = "0.12.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -1346,7 +1346,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1379,8 +1379,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.15.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+version = "0.16.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1431,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1444,7 +1444,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "serde",
 ]
@@ -1452,7 +1452,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -4771,7 +4771,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4797,7 +4797,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4811,7 +4811,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4824,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4837,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4879,7 +4879,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4892,7 +4892,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4918,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4931,7 +4931,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4944,7 +4944,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4971,7 +4971,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -4984,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4997,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5010,7 +5010,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5023,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5037,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5050,7 +5050,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -211,13 +211,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.15.0"
-version = "0.11.0"
+tag = "bottlerocket-settings-models-v0.16.0"
+version = "0.12.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.15.0"
-version = "0.15.0"
+tag = "bottlerocket-settings-models-v0.16.0"
+version = "0.16.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -226,7 +226,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.15.0"
+tag = "bottlerocket-settings-models-v0.16.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/3788

**Description of changes:**

Adds a `pid` field to the `kubeReserved` setting for all existing kubelet configs (1.28 - 1.34). As mentioned in the `bottlerocket-settings-sdk` PR, this feature was marked stable in k8s-1.20.

The `systemReserved` setting doesn't need to be updated since it simply loops through the keys.

Related to:
* https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/98

The new setting in the PR above was released in `bottlerocket-settings-models-v0.16.0`, so bumping the respective sources in the core-kit to take that change.

**Testing done:**

See Testing Description section here: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/98

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
