### PR TITLE
apiclient: support `--` separator in `exec` subcommand

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "signal-hook",
  "simplelog",
  "snafu",
+ "test-case",
  "tokio",
  "tokio-tungstenite",
  "toml",

--- a/sources/api/apiclient/Cargo.toml
+++ b/sources/api/apiclient/Cargo.toml
@@ -45,5 +45,8 @@ toml.workspace = true
 unindent.workspace = true
 url.workspace = true
 
+[dev-dependencies]
+test-case.workspace = true
+
 [build-dependencies]
 generate-readme.workspace = true

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -300,7 +300,7 @@ fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
 // Arg parsing
 
 /// Parses user arguments into an Args structure.
-fn parse_args(args: env::Args) -> (Args, Subcommand) {
+fn parse_args(args: impl Iterator<Item = String>) -> (Args, Subcommand) {
     let mut global_args = Args::default();
     let mut subcommand = None;
     let mut subcommand_args = Vec::new();
@@ -308,6 +308,22 @@ fn parse_args(args: env::Args) -> (Args, Subcommand) {
     let mut iter = args.into_iter().skip(1);
     while let Some(arg) = iter.next() {
         match arg.as_ref() {
+            // Handle separator - only valid after exec subcommand is set
+            "--" => {
+                if subcommand.is_none() {
+                    usage_msg("'--' separator requires a subcommand to be specified first");
+                }
+                // Only do special handling for exec subcommand
+                if subcommand.as_deref() == Some("exec") {
+                    // For exec, collect all remaining args and stop processing
+                    subcommand_args.extend(iter);
+                    break;
+                } else {
+                    // For other subcommands, treat -- as a regular argument
+                    subcommand_args.push(arg);
+                }
+            }
+
             "-h" | "--help" => usage(),
 
             // Global args
@@ -1160,3 +1176,127 @@ mod error {
     }
 }
 type Result<T> = std::result::Result<T, error::Error>;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    // Helper macro for creating global Args with consistent formatting
+    macro_rules! global_args {
+        // Create Args with specified log_level and socket_path
+        ($log_level:expr, $socket_path:expr) => {
+            Args {
+                log_level: $log_level,
+                socket_path: $socket_path.to_string(),
+            }
+        };
+        // Create Args with just log_level (using default socket_path)
+        ($log_level:expr) => {
+            Args {
+                log_level: $log_level,
+                socket_path: constants::API_SOCKET.to_string(),
+            }
+        };
+    }
+
+    // Helper macro for creating exec subcommand
+    macro_rules! exec_cmd {
+        // For Exec subcommand with target, command args, and tty option
+        ($target:expr, [$($arg:expr),*], $tty:expr) => {
+            Subcommand::Exec(ExecArgs {
+                target: $target.to_string(),
+                command: vec![$($arg.into()),*],
+                tty: $tty,
+            })
+        };
+    }
+
+    fn parse_command_line(cmd_str: &str) -> (Args, Subcommand) {
+        let args: Vec<String> = cmd_str.split_whitespace().map(|s| s.to_string()).collect();
+        parse_args(args.into_iter())
+    }
+
+    #[test_case("apiclient exec admin -- sheltie df -h",
+        global_args!(LevelFilter::Info),
+        exec_cmd!("admin", ["sheltie", "df", "-h"], None);
+        "exec with separator")]
+    #[test_case("apiclient exec admin sheltie df",
+        global_args!(LevelFilter::Info),
+        exec_cmd!("admin", ["sheltie", "df"], None);
+        "exec without separator")]
+    #[test_case("apiclient exec -t admin -- sheltie df -h",
+        global_args!(LevelFilter::Info),
+        exec_cmd!("admin", ["sheltie", "df", "-h"], Some(true));
+        "exec with tty and separator")]
+    #[test_case("apiclient exec -T admin sheltie df",
+        global_args!(LevelFilter::Info),
+        exec_cmd!("admin", ["sheltie", "df"], Some(false));
+        "exec with no-tty")]
+    fn test_exec_parsing(cmd_str: &str, expected_args: Args, expected_subcommand: Subcommand) {
+        let (global_args, subcommand) = parse_command_line(cmd_str);
+
+        // Check the global arguments match what we expect
+        assert_eq!(global_args.log_level, expected_args.log_level);
+        assert_eq!(global_args.socket_path, expected_args.socket_path);
+
+        // Check the subcommand matches what we expect
+        match (&subcommand, &expected_subcommand) {
+            (Subcommand::Exec(actual), Subcommand::Exec(expected)) => {
+                assert_eq!(actual.target, expected.target);
+                assert_eq!(actual.tty, expected.tty);
+                assert_eq!(actual.command, expected.command);
+            }
+            _ => panic!(
+                "Expected Exec subcommand: {:?}, got: {:?}",
+                expected_subcommand, subcommand
+            ),
+        }
+    }
+
+    #[test_case("apiclient -v exec admin -- sheltie df -h",
+        global_args!(LevelFilter::Debug),
+        exec_cmd!("admin", ["sheltie", "df", "-h"], None);
+        "verbose flag with exec as global arg")]
+    #[test_case("apiclient --log-level error exec admin sheltie df",
+        global_args!(LevelFilter::Error),
+        exec_cmd!("admin", ["sheltie", "df"], None);
+        "log level with exec")]
+    #[test_case("apiclient exec admin -- sheltie -v df -h",
+        global_args!(LevelFilter::Info),
+        exec_cmd!("admin", ["sheltie", "-v", "df", "-h"], None);
+        "verbose flag after separator as command arg")]
+    #[test_case("apiclient -v exec admin -- sheltie -v df -h",
+        global_args!(LevelFilter::Debug),
+        exec_cmd!("admin", ["sheltie", "-v", "df", "-h"], None);
+        "verbose flag in both global and command positions")]
+    fn test_args_parsing_with_separator(
+        cmd_str: &str,
+        expected_args: Args,
+        expected_subcommand: Subcommand,
+    ) {
+        let (global_args, subcommand) = parse_command_line(cmd_str);
+
+        // Check the global arguments match what we expect
+        assert_eq!(
+            global_args.log_level, expected_args.log_level,
+            "Global log level should match"
+        );
+        assert_eq!(
+            global_args.socket_path, expected_args.socket_path,
+            "Socket path should match"
+        );
+
+        // Check the subcommand matches what we expect
+        match (&subcommand, &expected_subcommand) {
+            (Subcommand::Exec(actual), Subcommand::Exec(expected)) => {
+                assert_eq!(actual.target, expected.target, "Target should match");
+                assert_eq!(actual.tty, expected.tty, "TTY setting should match");
+                assert_eq!(actual.command, expected.command, "Command should match");
+            }
+            _ => panic!(
+                "Expected Exec subcommand: {:?}, got: {:?}",
+                expected_subcommand, subcommand
+            ),
+        }
+    }
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/633

**Description of changes:**
For subcommand like `exec` in `apiclient`, it would further execute nested commands. From the GH issue #633, example command was reported not working as expected:
```sh
apiclient exec admin sheltie df -h
```
This was because when in the parsing of the argument, `-h` would always be treated as global arguments and `apiclient` would exit early upon parsing this flag (See https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/sources/api/apiclient/src/main.rs#L311). Note that `usage()` is a helper function that would print the help information of `apiclient` and call process::exit(2). But in the example command, `-h` was intended to be used as an argument to the nested command `df`.

As per discusssion in https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/633#issuecomment-3215790291, this PR extends `apiclient` to support `--` for subcommand `exec`, but only for the `exec` subcommand. This special handling is limited to the `exec` subcommand because it's the only command where passing arbitrary flags to a nested command makes sense.

With this change, arguments passed after `--` for the `exec` subcommand will be treated as arguments to the nested command being executed. This makes it possible to invoke the above command via:
```sh
apiclient exec admin -- sheltie df -h
``` 
 

**Testing done:**
Manually tested with multiple variations of the command to ensure the special handling for `--` works correctly:

<ins>_All of these commands correctly pass -h to df_</ins>
```sh
apiclient exec -- admin sheltie df -h
apiclient exec admin -- sheltie df -h
apiclient exec admin sheltie -- df -h
apiclient exec admin sheltie df -- -h
```

All test cases display the same output, confirming that the special handling of `--` for the `exec` subcommand works as expected.
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       306M  306M     0 100% /
devtmpfs        3.9G     0  3.9G   0% /dev
tmpfs           3.9G     0  3.9G   0% /dev/shm
tmpfs           1.6G  380K  1.6G   1% /run
tmpfs           3.9G  476K  3.9G   1% /etc
tmpfs           3.9G     0  3.9G   0% /etc/cni
tmpfs           3.9G     0  3.9G   0% /tmp
tmpfs           3.9G   16K  3.9G   1% /etc/containerd
tmpfs           3.9G  4.0K  3.9G   1% /etc/soci-snapshotter
tmpfs           3.9G   16K  3.9G   1% /etc/host-containers
tmpfs           3.9G     0  3.9G   0% /etc/kubernetes/pki/private
tmpfs           3.9G  4.0K  3.9G   1% /root/.aws
tmpfs           3.9G     0  3.9G   0% /run/netdog
/dev/xvda3       23M   14M  7.6M  64% /boot
/dev/xvdb1       20G  1.5G   19G   8% /local
/dev/xvda12      35M  1.5M   31M   5% /var/lib/bottlerocket
overlay          20G  1.5G   19G   8% /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/modules
overlay          20G  1.5G   19G   8% /opt/cni
overlay          20G  1.5G   19G   8% /opt/csi
overlay          20G  1.5G   19G   8% /x86_64-bottlerocket-linux-gnu/sys-root/usr/src/kernels
overlay          20G  1.5G   19G   8% /run/host-containerd/io.containerd.runtime.v2.task/default/control/rootfs
overlay          20G  1.5G   19G   8% /run/host-containerd/io.containerd.runtime.v2.task/default/admin/rootfs
```

For non-exec subcommands, the behavior remains unchanged. For example, attempting to use `--` with the `get` subcommand still results in:
```
[ssm-user@control]$ apiclient get -- settings
Unknown argument '--'

Usage: apiclient [SUBCOMMAND] [OPTION]...

Global options:
      -s, --socket-path PATH     Override the server socket path.  Default: /run/api.sock
      --log-level                Desired amount of output; trace|debug|info|warn|error
      -v, --verbose              Sets log level to 'debug'.  This prints extra info,
                                 like HTTP status code to stderr in 'raw' mode.
  ...
```

Also, ran the unit tests which cover these test cases:
```
  test tests::test_exec_parsing::exec_with_separator - Tests "apiclient exec admin -- sheltie df -h"
  test tests::test_exec_parsing::exec_without_separator - Tests "apiclient exec admin sheltie df"
  test tests::test_exec_parsing::exec_with_tty_and_separator - Tests "apiclient exec -t admin -- sheltie df -h"
  test tests::test_issue_case_df_with_h_flag - Tests specific handling of "-h" flag in "apiclient exec admin -- sheltie df -h"
```
All tests pass successfully:
```
  cargo test --no-default-features
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
