### PR TITLE
add eusc-de-east-1 and us-isob-west-1 regions to account maps

### DIFF
--- a/sources/api/schnauzer/src/helpers/mod.rs
+++ b/sources/api/schnauzer/src/helpers/mod.rs
@@ -62,6 +62,7 @@ lazy_static! {
         m.insert("eu-west-1", "328549459982");
         m.insert("eu-west-2", "328549459982");
         m.insert("eu-west-3", "328549459982");
+        m.insert("eusc-de-east-1", "587143065468");
         m.insert("il-central-1", "288123944683");
         m.insert("me-central-1", "553577323255");
         m.insert("me-south-1", "509306038620");
@@ -117,6 +118,7 @@ lazy_static! {
         m.insert("us-isob-east-1", "bottlerocket-updates-us-isob-east-1.s3");
         m.insert("us-isof-east-1", "bottlerocket-updates-us-isof-east-1.s3");
         m.insert("us-isof-south-1", "bottlerocket-updates-us-isof-south-1.s3");
+        m.insert("eusc-de-east-1", "bottlerocket-updates-eusc-de-east-1.s3");
         m
     };
 }
@@ -130,6 +132,7 @@ lazy_static! {
         m.insert("cn-north-1", "aws-cn");
         m.insert("cn-northwest-1", "aws-cn");
         m.insert("eu-isoe-west-1", "aws-iso-e");
+        m.insert("eusc-de-east-1", "aws-eusc");
         m.insert("us-gov-east-1", "aws-us-gov");
         m.insert("us-gov-west-1", "aws-us-gov");
         m.insert("us-iso-west-1", "aws-iso");
@@ -1546,6 +1549,7 @@ fn ecr_registry<S: AsRef<str>>(region: S) -> String {
         "aws-iso-b" => format!("{registry_id}.dkr.ecr.{region}.sc2s.sgov.gov"),
         "aws-iso-e" => format!("{registry_id}.dkr.ecr.{region}.cloud.adc-e.uk"),
         "aws-iso-f" => format!("{registry_id}.dkr.ecr.{region}.csp.hci.ic.gov"),
+        "aws-eusc" => format!("{registry_id}.dkr.ecr.{region}.amazonaws.eu"),
         _ => {
             // Only inject the FIPS service endpoint if the variant is in FIPS mode and the
             // region supports FIPS.
@@ -1577,6 +1581,7 @@ fn tuf_repository<S: AsRef<str>>(region: S) -> String {
         "aws-iso-b" => format!("https://{endpoint}.{region}.sc2s.sgov.gov/latest"),
         "aws-iso-e" => format!("https://{endpoint}.{region}.cloud.adc-e.uk/latest"),
         "aws-iso-f" => format!("https://{endpoint}.{region}.csp.hci.ic.gov/latest"),
+        "aws-eusc" => format!("https://{endpoint}.{region}.amazonaws.eu/latest"),
         _ => format!("https://{endpoint}.{region}.amazonaws.com/latest"),
     }
 }
@@ -1769,6 +1774,10 @@ mod test_ecr_registry {
         (
             "us-isof-east-1",
             "891631471851.dkr.ecr.us-isof-east-1.csp.hci.ic.gov/bottlerocket-admin:v0.5.1",
+        ),
+        (
+            "eusc-de-east-1",
+            "587143065468.dkr.ecr.eusc-de-east-1.amazonaws.eu/bottlerocket-admin:v0.5.1",
         ),
     ];
 

--- a/sources/api/schnauzer/src/helpers/mod.rs
+++ b/sources/api/schnauzer/src/helpers/mod.rs
@@ -75,6 +75,7 @@ lazy_static! {
         m.insert("us-iso-east-1", "999945528765");
         m.insert("us-iso-west-1", "928668704122");
         m.insert("us-isob-east-1", "782457047625");
+        m.insert("us-isob-west-1", "125731337581");
         m.insert("us-isof-east-1", "891631471851");
         m.insert("us-isof-south-1", "482061074055");
         m.insert("us-northeast-1", "891377225511");
@@ -116,6 +117,7 @@ lazy_static! {
         m.insert("us-iso-east-1", "bottlerocket-updates-us-iso-east-1.s3");
         m.insert("us-iso-west-1", "bottlerocket-updates-us-iso-west-1.s3");
         m.insert("us-isob-east-1", "bottlerocket-updates-us-isob-east-1.s3");
+        m.insert("us-isob-west-1", "bottlerocket-updates-us-isob-west-1.s3");
         m.insert("us-isof-east-1", "bottlerocket-updates-us-isof-east-1.s3");
         m.insert("us-isof-south-1", "bottlerocket-updates-us-isof-south-1.s3");
         m.insert("eusc-de-east-1", "bottlerocket-updates-eusc-de-east-1.s3");
@@ -138,6 +140,7 @@ lazy_static! {
         m.insert("us-iso-west-1", "aws-iso");
         m.insert("us-iso-east-1", "aws-iso");
         m.insert("us-isob-east-1", "aws-iso-b");
+        m.insert("us-isob-west-1", "aws-iso-b");
         m.insert("us-isof-east-1", "aws-iso-f");
         m.insert("us-isof-south-1", "aws-iso-f");
         m

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -55,6 +55,7 @@ var ecrRefPrefixMapping = map[string]string{
 	"us-iso-east-1":   "ecr.aws/arn:aws-iso:ecr:us-iso-east-1:",
 	"us-iso-west-1":   "ecr.aws/arn:aws-iso:ecr:us-iso-west-1:",
 	"us-isob-east-1":  "ecr.aws/arn:aws-iso-b:ecr:us-isob-east-1:",
+	"us-isob-west-1":  "ecr.aws/arn:aws-iso-b:ecr:us-isob-west-1:",
 	"us-isof-south-1": "ecr.aws/arn:aws-iso-f:ecr:us-isof-south-1:",
 	"us-isof-east-1":  "ecr.aws/arn:aws-iso-f:ecr:us-isof-east-1:",
 }

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -42,7 +42,7 @@ import (
 
 // ECR hostname pattern also used in the ecr-credential-provider:
 // https://github.com/kubernetes/cloud-provider-aws/blob/212135d0d7b448cd34e2e11e5e81f59e3e6c2d7a/cmd/ecr-credential-provider/main.go#L45
-var ecrRegex = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov).*$`)
+var ecrRegex = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws(\.com(?:\.cn)?|\.eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov).*$`)
 
 // A set of currently supported ECR regions which are not yet present in the golang SDK
 var ecrRefPrefixMapping = map[string]string{
@@ -52,6 +52,7 @@ var ecrRefPrefixMapping = map[string]string{
 	"ap-southeast-6":  "ecr.aws/arn:aws:ecr:ap-southeast-6:",
 	"us-northeast-1":  "ecr.aws/arn:aws:ecr:us-northeast-1:",
 	"eu-isoe-west-1":  "ecr.aws/arn:aws-iso-e:ecr:eu-isoe-west-1:",
+	"eusc-de-east-1":  "ecr.aws/arn:aws-eusc:ecr:eusc-de-east-1:",
 	"us-iso-east-1":   "ecr.aws/arn:aws-iso:ecr:us-iso-east-1:",
 	"us-iso-west-1":   "ecr.aws/arn:aws-iso:ecr:us-iso-west-1:",
 	"us-isob-east-1":  "ecr.aws/arn:aws-iso-b:ecr:us-isob-east-1:",

--- a/sources/host-ctr/cmd/host-ctr/main_test.go
+++ b/sources/host-ctr/cmd/host-ctr/main_test.go
@@ -204,6 +204,17 @@ func TestParseImageURIAsECR(t *testing.T) {
 		},
 		{
 			"Parse special region",
+			"777777777777.dkr.ecr.eusc-de-east-1.amazonaws.eu/my_image:latest",
+			false,
+			&parsedECR{
+				Account:  "777777777777",
+				Region:   "eusc-de-east-1",
+				RepoPath: "my_image:latest",
+				Fips:     false,
+			},
+		},
+		{
+			"Parse special region",
 			"777777777777.dkr.ecr.us-iso-east-1.c2s.ic.gov/my_image:latest",
 			false,
 			&parsedECR{

--- a/sources/host-ctr/cmd/host-ctr/main_test.go
+++ b/sources/host-ctr/cmd/host-ctr/main_test.go
@@ -226,6 +226,17 @@ func TestParseImageURIAsECR(t *testing.T) {
 		},
 		{
 			"Parse special region",
+			"777777777777.dkr.ecr.us-isob-west-1.sc2s.sgov.gov/my_image:latest",
+			false,
+			&parsedECR{
+				Account:  "777777777777",
+				Region:   "us-isob-west-1",
+				RepoPath: "my_image:latest",
+				Fips:     false,
+			},
+		},
+		{
+			"Parse special region",
 			"777777777777.dkr.ecr.us-isof-east-1.csp.hci.ic.gov/my_image:latest",
 			false,
 			&parsedECR{


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

## Add support for eusc-de-east-1 and us-isob-west-1 regions in schnauzer and host-ctr

This PR adds regional account configuration for the new eusc-de-east-1 and us-isob-west-1 regions.

### Changes

- [x] Added regional account ID 587143065468 for eusc-de-east-1 region
- [x] Added regional account ID 125731337581 for us-isob-west-1 region
- [x] Mapped eusc-de-east-1 to the aws-eusc partition
- [x] Added us-isob-west-1 to host-ctr ecr arn mapping
- [x] Added eusc-de-east-1 to host-ctr ecr arn mapping with aws-eusc partition
- [x] Added amazonaws.eu handling to ecr regex
  
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
