### PR TITLE
Update k8s-1.34 related packages to v1.34.0

### DIFF
--- a/packages/ecr-credential-provider-1.34/Cargo.toml
+++ b/packages/ecr-credential-provider-1.34/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.34"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.34.0-rc.0.tar.gz"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.34.0.tar.gz"
 path = "cloud-provider-aws-1.34.0.tar.gz"
-sha512 = "de7fdbdc5bc26959334194178eb63a25013e552fdaf67947c29d3990aec18cb62dcc7d3b0f153e76754bf95f911894fa13ae1e24c2491fdc0d81ba24d127d734"
+sha512 = "2bdef11bc7180496b04d95f883961693a0e70cc4d8a284d6f5e5bc3c9b7cd5556a4383afee35dd4f70e982ec32406dc9d6adc838c9c1115086a5fa37d053650f"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.34/ecr-credential-provider-1.34.spec
+++ b/packages/ecr-credential-provider-1.34/ecr-credential-provider-1.34.spec
@@ -9,7 +9,7 @@
 
 Name: %{_cross_os}ecr-credential-provider-1.34
 Version: %{rpmver}
-Release: 0.rc0%{?dist}
+Release: 1%{?dist}
 Summary: Amazon ECR credential provider
 License: Apache-2.0
 URL: https://github.com/kubernetes/cloud-provider-aws
@@ -47,8 +47,8 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{summary}.
 
 %prep
-%setup -n %{gorepo}-%{gover}-rc.0 -q
-%setup -T -D -n %{gorepo}-%{gover}-rc.0 -b 1 -q
+%setup -n %{gorepo}-%{gover} -q
+%setup -T -D -n %{gorepo}-%{gover} -b 1 -q
 
 %build
 %set_cross_go_flags

--- a/packages/kubernetes-1.34/Cargo.toml
+++ b/packages/kubernetes-1.34/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.34"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/2/artifacts/kubernetes/v1.34.0-rc.0/kubernetes-src.tar.gz"
-sha512 = "1d40afcdbb682fcbc19f41e2aa91afe5727894c4351718fedb586e712f5519daf136852ddecd530b9f43839e9b3f7a402a23c8b39c5e26928a73dc2af116353e"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/3/artifacts/kubernetes/v1.34.0/kubernetes-src.tar.gz"
+sha512 = "7580e3acf4bffb5a8d44d4751e6af0826b210b768db3b76032d85fa13c26082157bcd127ee1689a2e52605a74e586a6f16c07ab1aa41a80c3a6929d554caa855"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.34/kubernetes-1.34.spec
+++ b/packages/kubernetes-1.34/kubernetes-1.34.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 0
+%global releasever 3
 %global gover 1.34.0
 %global rpmver %{gover}
 
@@ -33,12 +33,12 @@
 
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
-Release: 0.rc0%{?dist}
+Release: 1%{?dist}
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: https://distro.eks.amazonaws.com/kubernetes-1-34/releases/2/artifacts/kubernetes/v1.34.0-rc.0/kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-34/releases/%{releasever}/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Issue number:**
Related to: https://github.com/bottlerocket-os/bottlerocket/issues/4620

Closes #

**Description of changes:**
Update `kubernetes-1.34` and `ecr-credential-provider-1.34` pkgs to v1.34.0


**Testing done:**
```
[root@admin]# sheltie
bash-5.1# ctr version
Client:
  Version:  2.1.4+bottlerocket
  Revision: 75cb2b7193e4e490e9fbdc236c0e811ccaba3376
  Go version: go1.23.12

Server:
  Version:  2.1.4+bottlerocket
  Revision: 75cb2b7193e4e490e9fbdc236c0e811ccaba3376
  UUID: bdb5bf3c-9a91-4959-9909-5c5b7ab35f85
bash-5.1# uname -r
6.12.40
bash-5.1# nvidia-smi
Mon Sep  8 06:35:58 2025
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.65.06              Driver Version: 580.65.06      CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA T4G                     On  |   00000000:00:1F.0 Off |                    0 |
| N/A   40C    P8              9W /   70W |       0MiB /  15360MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
bash-5.1#
```
- [x] Verified `containerd` version is 2.1
- [x] Verified kernel version is 6.12
- [x] Verified new 580 drivers are used on nvidia variants
- [x] Conformance tests
- - [x] x86-64-aws-k8s-134
- - [x] x86-64-aws-k8s-134-fips
- - [x] x86-64-aws-k8s-134-fips-ipv6
- - [x] x86-64-aws-k8s-134-ipv6
- - [x] x86-64-aws-k8s-134-nvidia
- - [x] aarch64-aws-k8s-134
- - [x] aarch64-aws-k8s-134-fips
- - [x] aarch64-aws-k8s-134-fips-ipv6
- - [x] aarch64-aws-k8s-134-ipv6
- - [x] aarch64-aws-k8s-134-nvidia

- [x] Nvidia smoke tests
```
(25-08-30 23:32:10) <0> [~/eks-test]  
dev-dsk-jepiyush-2b-19036c7e % kubectl --kubeconfig=x86-64-aws-k8s-134-nvidia.kubeconfig get pods -A
NAMESPACE     NAME                       READY   STATUS      RESTARTS   AGE
default       nvidia-smoke-test-kv4vs    0/1     Completed   0          19m
kube-system   aws-node-n4p7g             2/2     Running     0          46h
kube-system   aws-node-n56jf             2/2     Running     0          46h
kube-system   coredns-7bf648ff5d-gw5dh   1/1     Running     0          44h
kube-system   coredns-7bf648ff5d-m2r4w   1/1     Running     0          45h
kube-system   kube-proxy-fxv2l           1/1     Running     0          46h
kube-system   kube-proxy-jwl42           1/1     Running     0          46h
sonobuoy      sonobuoy                   1/1     Running     0          45h
 
(25-08-30 23:32:32) <0> [~/eks-test]  
dev-dsk-jepiyush-2b-19036c7e % kubectl --kubeconfig=aarch64-aws-k8s-134-nvidia.kubeconfig get pods -A
NAMESPACE     NAME                       READY   STATUS      RESTARTS   AGE
default       nvidia-smoke-test-k2dhx    0/1     Completed   0          20m
kube-system   aws-node-9mh9k             2/2     Running     0          44h
kube-system   aws-node-fxmpj             2/2     Running     0          44h
kube-system   coredns-7bf648ff5d-h6fp9   1/1     Running     0          44h
kube-system   coredns-7bf648ff5d-m4hzb   1/1     Running     0          44h
kube-system   kube-proxy-7cm2v           1/1     Running     0          44h
kube-system   kube-proxy-trvdr           1/1     Running     0          44h
sonobuoy      sonobuoy                   1/1     Running     0          44h
```
- [x] EBS driver testing
```
(25-09-02 6:33:14) <0> [~/eks-test/aws-ebs-csi-driver/examples/kubernetes/block-volume]  
dev-dsk-jepiyush-2b-19036c7e % helm upgrade --install aws-ebs-csi-driver \                                                                                 
    --namespace kube-system \
    aws-ebs-csi-driver/aws-ebs-csi-driver \
--kubeconfig=/home/jepiyush/eks-test/x86-64-aws-k8s-134-fips-ipv6.kubeconfig
Release "aws-ebs-csi-driver" does not exist. Installing it now.
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Tue Sep  2 06:34:29 2025
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
NOTES:
To verify that aws-ebs-csi-driver has started, run:
 
    kubectl get pod -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver"
 
[Deprecation announcement] AWS Snow Family device support for the EBS CSI Driver
 
Support for the EBS CSI Driver on [AWS Snow Family devices](https://aws.amazon.com/snowball/) is deprecated, effective immediately. No further Snow-specific bugfixes or feature requests will be merged. The existing functionality for Snow devices has been removed on the 1.44 release of the EBS CSI Driver. Support of the EBS CSI Driver on other platforms, such as [Amazon EC2](https://aws.amazon.com/ec2/) or EC2 on [AWS Outposts](https://aws.amazon.com/outposts/) is not affected.
 
(25-09-02 6:35:01) <1> [~/eks-test/aws-ebs-csi-driver/examples/kubernetes/block-volume]  
dev-dsk-jepiyush-2b-19036c7e % kubectl apply -f manifests --kubeconfig=/home/jepiyush/eks-test/x86-64-aws-k8s-134-fips-ipv6.kubeconfig                               
persistentvolumeclaim/block-claim created
pod/app created
storageclass.storage.k8s.io/ebs-sc created
 
(25-09-02 6:35:26) <0> [~/eks-test/aws-ebs-csi-driver/examples/kubernetes/block-volume]  
dev-dsk-jepiyush-2b-19036c7e % kubectl get pvc block-claim --kubeconfig=/home/jepiyush/eks-test/x86-64-aws-k8s-134-fips-ipv6.kubeconfig
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
block-claim   Bound    pvc-feb9e8f6-2661-49f4-b410-c602fd16f94e   4Gi        RWO            ebs-sc         <unset>                 17s
```
- [x] cloud-provider-credential test
```
(25-09-02 7:17:17) <0> [~/eks-test]  
dev-dsk-jepiyush-2b-19036c7e % kubectl get pods -A --kubeconfig=/home/jepiyush/eks-test/x86-64-aws-k8s-134-fips-ipv6.kubeconfig
NAMESPACE     NAME                                  READY   STATUS             RESTARTS   AGE
default       app                                   1/1     Running            0          42m
default       hello-nodejs-test                     0/1     ImagePullBackOff   0          18s
kube-system   aws-node-2v4ks                        2/2     Running            0          67m
kube-system   aws-node-kclrq                        2/2     Running            0          5h28m
kube-system   aws-node-r27tn                        2/2     Running            0          5h28m
kube-system   aws-node-tqgbd                        2/2     Running            0          67m
kube-system   coredns-7bf648ff5d-dwgfm              1/1     Running            0          5h53m
kube-system   coredns-7bf648ff5d-z5vkw              1/1     Running            0          5h53m
kube-system   ebs-csi-controller-54754d78dd-hmxvt   5/5     Running            0          43m
kube-system   ebs-csi-controller-54754d78dd-tjc9v   5/5     Running            0          43m
kube-system   ebs-csi-node-6ptgm                    3/3     Running            0          43m
kube-system   ebs-csi-node-8wtrj                    3/3     Running            0          43m
kube-system   ebs-csi-node-snzch                    3/3     Running            0          43m
kube-system   ebs-csi-node-z4msz                    3/3     Running            0          43m
kube-system   kube-proxy-57f2h                      1/1     Running            0          67m
kube-system   kube-proxy-9mb6g                      1/1     Running            0          5h28m
kube-system   kube-proxy-l5gq9                      1/1     Running            0          67m
kube-system   kube-proxy-wcvq4                      1/1     Running            0          5h28m
```
After putting the following settings in the instances
```
[ssm-user@control]$ apiclient apply <<EOF
> [settings.kubernetes.credential-providers.ecr-credential-provider]
> enabled = true
> cache-duration = "30m"
> image-patterns = [
>   "*.dkr.ecr.us-east-2.amazonaws.com",
>   "*.dkr.ecr.us-west-2.amazonaws.com"
> ]
>
> [settings.aws]
> profile = "ecr"
> config = "xxxxxxxxxxxxx"
> EOF
```
```
(25-09-02 7:24:03) <0> [~/eks-test]  
dev-dsk-jepiyush-2b-19036c7e % kubectl get pods -A --kubeconfig=/home/jepiyush/eks-test/x86-64-aws-k8s-134-fips-ipv6.kubeconfig
NAMESPACE     NAME                                  READY   STATUS      RESTARTS   AGE
default       app                                   1/1     Running     0          48m
default       hello-nodejs-test                     0/1     Completed   0          6m51s
kube-system   aws-node-2v4ks                        2/2     Running     0          74m
kube-system   aws-node-kclrq                        2/2     Running     0          5h34m
kube-system   aws-node-r27tn                        2/2     Running     0          5h34m
kube-system   aws-node-tqgbd                        2/2     Running     0          74m
kube-system   coredns-7bf648ff5d-dwgfm              1/1     Running     0          5h59m
kube-system   coredns-7bf648ff5d-z5vkw              1/1     Running     0          5h59m
kube-system   ebs-csi-controller-54754d78dd-hmxvt   5/5     Running     0          49m
kube-system   ebs-csi-controller-54754d78dd-tjc9v   5/5     Running     0          49m
kube-system   ebs-csi-node-6ptgm                    3/3     Running     0          49m
kube-system   ebs-csi-node-8wtrj                    3/3     Running     0          49m
kube-system   ebs-csi-node-snzch                    3/3     Running     0          49m
kube-system   ebs-csi-node-z4msz                    3/3     Running     0          49m
kube-system   kube-proxy-57f2h                      1/1     Running     0          74m
kube-system   kube-proxy-9mb6g                      1/1     Running     0          5h34m
kube-system   kube-proxy-l5gq9                      1/1     Running     0          74m
kube-system   kube-proxy-wcvq4                      1/1     Running     0          5h34m
```
- [x] cdi works out of the box in nvidia variants

Find container-id
```
(25-09-08 9:47:44) <130> dev-dsk-jepiyush-2b-19036c7e %  kubectl get pod nvidia-cdi -o=json --kubeconfig=/home/jepiyush/bottlerocket-workspace/src/Bottlerocket-release-scripts/testsys/eks-manifest-targetted/x86-64-aws-k8s-134-nvidia.kubeconfig \
    | jq -r '.status.containerStatuses[] | select(.name=="oci-hook-validation").containerID' \
    | sed 's+containerd://++g'
2c67bba2d5165475186fe2768dd05d1cd3b0323ddb50c2fe14489c1f24cef4ed
```
Get hooks
```
[root@admin]# cat /.bottlerocket/rootfs/run/containerd/io.containerd.runtime.v2.task/k8s.io/2c67bba2d5165475186fe2768dd05d1cd3b0323ddb50c2fe14489c1f24cef4ed/config.json | jq '.hooks'
{
  "createContainer": [
    {
      "path": "/usr/bin/nvidia-ctk",
      "args": [
        "nvidia-ctk",
        "hook",
        "create-symlinks",
        "--link",
        "../libnvidia-allocator.so.1::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/gbm/nvidia-drm_gbm.so"
      ],
      "env": [
        "NVIDIA_CTK_DEBUG=false"
      ]
    },
    {
      "path": "/usr/bin/nvidia-ctk",
      "args": [
        "nvidia-ctk",
        "hook",
        "create-symlinks",
        "--link",
        "libGLX_nvidia.so.580.65.06::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLX_indirect.so.0",
        "--link",
        "libcuda.so.1::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libcuda.so",
        "--link",
        "libnvidia-opticalflow.so.1::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-opticalflow.so"
      ],
      "env": [
        "NVIDIA_CTK_DEBUG=false"
      ]
    },
    {
      "path": "/usr/bin/nvidia-ctk",
      "args": [
        "nvidia-ctk",
        "hook",
        "update-ldcache",
        "--folder",
        "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla"
      ],
      "env": [
        "NVIDIA_CTK_DEBUG=false"
      ]
    }
  ]
}
[root@admin]#
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
