### PR TITLE
Backport systemd patch to downgrade log from error to debug

### DIFF
--- a/packages/systemd-257/1001-exec-util-make-missing-agents-a-gracefull-handled-issues.patch
+++ b/packages/systemd-257/1001-exec-util-make-missing-agents-a-gracefull-handled-issues.patch
@@ -1,0 +1,34 @@
+From 0d5ee894c4839b8432b530879a7cda070b29e393 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Wed, 7 May 2025 17:47:01 +0200
+Subject: [PATCH] exec-util: make missing agents a gracefull handled issues
+
+Just downgrade the log message in case of ENOENT of agent binaries to
+LOG_DEBUG. Do this in order to support distros which split off some
+agent bianries into separate optional binaries.
+
+Fixes: #37369
+
+[vighmah:
+Reworked to work with the changes between origin/main and v257-stable branches 
+]
+---
+ src/shared/exec-util.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git i/src/shared/exec-util.c w/src/shared/exec-util.c
+index 599b925a99..27a25ccb17 100644
+--- i/src/shared/exec-util.c
++++ w/src/shared/exec-util.c
+@@ -623,6 +623,9 @@ int _fork_agent(const char *name, const int except[], size_t n_except, pid_t *re
+         va_end(ap);
+
+         execv(path, l);
+-        log_error_errno(errno, "Failed to execute %s: %m", path);
++        /* Let's treat missing agent binary as a graceful issue (in order to support splitting out the Polkit
++         * or password agents into separate, optional distro packages), and not complain loudly. */
++        log_full_errno(errno == ENOENT ? LOG_DEBUG : LOG_ERR, errno,
++                       "Failed to execute %s: %m", path);
+         _exit(EXIT_FAILURE);
+ }
+

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -14,6 +14,10 @@ Source0: https://github.com/systemd/systemd/archive/v%{version}/systemd-%{versio
 Source1: systemd-mount-rate-bootconfig.conf
 Source2: systemd-cgroup-legacy-force-bootconfig.conf
 
+# Backport of upstream patch to change `Failed to execute <filepath> No such file 
+# or directory` error logs to debug 
+Patch1001: 1001-exec-util-make-missing-agents-a-gracefull-handled-issues.patch
+
 # Local patch to add the acquire the id for VMware
 Patch9001: 9001-machine-id-setup-generate-stable-ID-under-VM.patch
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
When restarting or starting services with systemd-257, the following is observed:
```
bash-5.1# systemctl start containerd
Failed to execute /x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/systemd-tty-ask-password-agent: No such file or directory
```
The process completes successfully but the log is still present on the console. This is because, `systemd-tty-ask-password-agent` is only shipped inside the `systemd-console` subpackage and is not present in any standard variant.


The added patch is backported from systemd upstream where this log is downgraded to a Debug when the error is due to `ENOENT` (error no entity). 

**Testing done:**
- Built and tested an AMI with the patch and the error was not seen on restarting services

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
