### PR TITLE
install driverdog for nvidia-fips variant

### DIFF
--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -78,6 +78,7 @@ Requires: %{_cross_os}bloodhound
 Requires: %{_cross_os}bootstrap-commands
 Requires: %{_cross_os}corndog
 Requires: %{_cross_os}certdog
+Requires: %{_cross_os}driverdog
 Requires: %{_cross_os}ghostdog
 Requires: %{_cross_os}logdog
 Requires: %{_cross_os}metricdog
@@ -103,8 +104,6 @@ Requires: (%{_cross_os}shibaken if %{_cross_os}variant-platform(aws))
 Requires: (%{_cross_os}cfsignal if %{_cross_os}variant-platform(aws))
 
 Requires: (%{_cross_os}warm-pool-wait if %{_cross_os}variant-family(aws-k8s))
-
-Requires: (%{_cross_os}driverdog if %{_cross_os}variant-flavor(nvidia))
 
 %description
 %{summary}.


### PR DESCRIPTION
This will handle new nvidia-fips variants as well as possible future uses of driverdog in other variants.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
