### PR TITLE
Prep: 10.4.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v10.4.1 (2025-09-11)
+
+## Build Changes
+* Update `bottlerocket-settings-models` to 0.15.0 ([#658])
+
+[#658]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/658
+
 # v10.4.0 (2025-09-08)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "10.4.0"
+release-version = "10.4.1"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "darling 0.20.10",
  "quote",
@@ -1309,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-modeled-types"
 version = "0.11.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -1345,7 +1345,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.10",
@@ -1378,8 +1378,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.14.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+version = "0.15.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1443,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "serde",
 ]
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -4770,7 +4770,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4783,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4796,7 +4796,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4810,7 +4810,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4823,7 +4823,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4836,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4848,8 +4848,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-container-runtime"
-version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+version = "0.4.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4862,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4878,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4891,7 +4891,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4904,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4917,7 +4917,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4943,7 +4943,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4957,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4970,7 +4970,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -4983,7 +4983,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -4996,7 +4996,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5009,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5022,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5036,7 +5036,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5049,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.14.0#40dc88ab3f9495f0401b96802a2f74a1d9a9ee26"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.15.0#113a9d5ea28602f98bbfb49866012fe7798dcd45"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -211,13 +211,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.14.0"
+tag = "bottlerocket-settings-models-v0.15.0"
 version = "0.11.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.14.0"
-version = "0.14.0"
+tag = "bottlerocket-settings-models-v0.15.0"
+version = "0.15.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -226,7 +226,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.14.0"
+tag = "bottlerocket-settings-models-v0.15.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
Bump settings sdk to 0.15.0 to fix deserialization bug. 


**Testing done:**

```
[ssm-user@control]$ apiclient apply <<EOF
> [settings.container-runtime]
> snapshotter = "soci"
> [settings.container-runtime-plugins.soci-snapshotter]
> pull-mode = "parallel-pull-unpack"
> [settings.container-runtime-plugins.soci-snapshotter.parallel-pull-unpack]
> concurrent-download-chunk-size = "8mb"
> discard-unpacked-layers = true
> max-concurrent-downloads = 12
> max-concurrent-downloads-per-image = 5
> max-concurrent-unpacks = 8
> max-concurrent-unpacks-per-image = 4
> EOF
[ssm-user@control]$
[ssm-user@control]$ apiclient get settings.container-runtime
{
  "settings": {
    "container-runtime": {
      "snapshotter": "soci"
    },
    "container-runtime-plugins": {
      "soci-snapshotter": {
        "parallel-pull-unpack": {
          "concurrent-download-chunk-size": 8000000,
          "discard-unpacked-layers": true,
          "max-concurrent-downloads": 12,
          "max-concurrent-downloads-per-image": 5,
          "max-concurrent-unpacks": 8,
          "max-concurrent-unpacks-per-image": 4
        },
        "pull-mode": "parallel-pull-unpack"
      }
    }
  }
}
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
