### PR TITLE
Add whippet

### DIFF
--- a/packages/os/Cargo.toml
+++ b/packages/os/Cargo.toml
@@ -26,6 +26,7 @@ source-groups = [
     "bloodhound",
     "xfscli",
     "brush",
+    "whippet",
 ]
 
 [lib]

--- a/packages/os/dbus-1-system.toml
+++ b/packages/os/dbus-1-system.toml
@@ -1,0 +1,22 @@
+[user.root]
+rules = [
+    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.systemd1.Activator", allow = true },
+    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus.Monitoring", allow = true },
+    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus.Debug.Stats", allow = true }
+]
+
+[default]
+rules = [
+    { user = "*", allow = true },
+    { own = "*", allow = false },
+    { send_type = "method-call", allow = false },
+    { send_type = "signal", allow = true },
+    { receive_type = "method-call", allow = true },
+    { receive_type = "signal", allow = true },
+    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus", allow = true },
+    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus.Introspectable", allow = true },
+    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus.Properties", allow = true },
+    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus", send_member = "UpdateActivationEnvironment", allow = false },
+    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus.Debug.Stats", allow = false },
+    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.systemd1.Activator", allow = false }
+]

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -33,6 +33,7 @@ Source18: bootstrap-containers-toml
 Source19: host-containers-toml
 Source20: bottlerocket-fips-checks-metadata-json
 Source21: bootstrap-commands-toml
+Source22: dbus-1-system.toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -52,6 +53,7 @@ Source121: warm-pool-wait.service
 Source122: has-boot-ever-succeeded.service
 Source123: pluto.service
 Source124: bootstrap-commands.service
+Source125: whippet.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -423,6 +425,13 @@ Conflicts: %{_cross_os}bash
 %description -n %{_cross_os}brush
 %{summary}.
 
+%package -n %{_cross_os}whippet
+Summary: Custom launcher for the D-Bus message broker
+Provides: %{_cross_os}dbus-broker(launcher) = 0:
+Conflicts: %{_cross_os}dbus-broker(launcher)
+%description -n %{_cross_os}whippet
+%{summary}.
+
 %prep
 %setup -T -c
 %cargo_prep
@@ -543,6 +552,7 @@ echo "** Output from non-static builds:"
     -p shibaken \
     -p driverdog \
     -p brush \
+    -p whippet \
     %{nil}
 
 # Wait for fips builds from the background, if they're not already done.
@@ -604,7 +614,7 @@ for p in \
   bottlerocket-cis-checks \
   bottlerocket-fips-checks \
   kubernetes-cis-checks \
-  shibaken driverdog brush \
+  shibaken driverdog brush whippet \
 ; do
   install -p -m 0755 %{__cargo_outdir}/${p} %{buildroot}%{_cross_bindir}
 done
@@ -710,6 +720,7 @@ install -p -m 0644 \
   %{S:100} %{S:102} %{S:103} %{S:105} \
   %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
   %{S:113} %{S:114} %{S:120} %{S:122} %{S:123} %{S:124} \
+  %{S:125} \
   %{buildroot}%{_cross_unitdir}
 
 install -p -m 0644 %{S:10} %{buildroot}%{_cross_templatedir}
@@ -730,6 +741,9 @@ install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-storage.rules
 install -p -m 0644 %{S:301} %{buildroot}%{_cross_udevrulesdir}/81-ebs-volumes.rules
 install -p -m 0644 %{S:302} %{buildroot}%{_cross_udevrulesdir}/82-supplemental-storage.rules
+
+install -d %{buildroot}%{_cross_datadir}/whippet/
+install -p -m 0644 %{S:22} %{buildroot}%{_cross_datadir}/whippet/system.toml
 
 %cross_scan_attribution --clarify %{_builddir}/sources/clarify.toml \
     cargo --offline --locked %{_builddir}/sources/Cargo.toml
@@ -931,5 +945,10 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %{_cross_bindir}/brush
 %{_cross_bindir}/sh
 %dir %{_cross_libexecdir}/brush/allowed-programs
+
+%files -n %{_cross_os}whippet
+%{_cross_bindir}/whippet
+%{_cross_datadir}/whippet/system.toml
+%{_cross_unitdir}/whippet.service
 
 %changelog

--- a/packages/os/whippet.service
+++ b/packages/os/whippet.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=D-Bus System Message Bus
+DefaultDependencies=false
+After=dbus.socket
+Before=basic.target shutdown.target
+Requires=dbus.socket
+Conflicts=shutdown.target
+
+[Service]
+Type=notify
+Sockets=dbus.socket
+OOMScoreAdjust=-900
+LimitNOFILE=16384
+ProtectSystem=full
+PrivateTmp=true
+PrivateDevices=true
+ExecStart=/usr/bin/whippet
+
+[Install]
+Alias=dbus.service
+WantedBy=preconfigured.target

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -50,6 +50,7 @@
 (filecon "/.*/usr(/fips)?/bin/cfsignal" file api_exec)
 (filecon "/.*/usr/bin/thar-be-settings" file api_exec)
 (filecon "/.*/usr/bin/dbus-broker.*" file bus_exec)
+(filecon "/.*/usr/bin/whippet" file bus_exec)
 (filecon "/.*/usr/sbin/chronyd" file clock_exec)
 (filecon "/.*/usr/lib/systemd/systemd-networkd.*" file network_exec)
 (filecon "/.*/usr(/fips)?/bin/containerd.*" file runtime_exec)

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
  "libc",
  "log",
  "models",
- "nix",
+ "nix 0.26.4",
  "rand 0.8.5",
  "reqwest",
  "retry-read",
@@ -439,7 +439,7 @@ dependencies = [
  "log",
  "maplit",
  "models",
- "nix",
+ "nix 0.26.4",
  "num",
  "rand 0.8.5",
  "serde",
@@ -550,6 +550,18 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1879,6 +1891,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const_panic"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,6 +2351,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2423,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2501,6 +2570,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -3526,6 +3608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metricdog"
 version = "0.1.0"
 dependencies = [
@@ -3562,7 +3653,7 @@ dependencies = [
  "lz4",
  "maplit",
  "models",
- "nix",
+ "nix 0.26.4",
  "pentacle",
  "percent-encoding",
  "rand 0.8.5",
@@ -3662,8 +3753,21 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -3842,10 +3946,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4085,7 +4205,7 @@ dependencies = [
  "generate-readme",
  "log",
  "maplit",
- "nix",
+ "nix 0.26.4",
  "schnauzer",
  "serde",
  "serde_json",
@@ -4867,6 +4987,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5423,6 +5554,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "storewolf"
 version = "0.1.0"
 dependencies = [
@@ -5615,7 +5752,7 @@ dependencies = [
  "log",
  "maplit",
  "models",
- "nix",
+ "nix 0.26.4",
  "schnauzer",
  "serde_json",
  "simplelog",
@@ -5634,7 +5771,7 @@ dependencies = [
  "fs2",
  "generate-readme",
  "log",
- "nix",
+ "nix 0.26.4",
  "num-derive",
  "num-traits",
  "semver",
@@ -5771,6 +5908,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.10",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -6175,6 +6313,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6538,6 +6687,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "whippet"
+version = "0.1.0"
+dependencies = [
+ "argh",
+ "generate-readme",
+ "indexmap",
+ "log",
+ "nix 0.26.4",
+ "serde",
+ "serde_repr",
+ "simplelog",
+ "snafu",
+ "tokio",
+ "toml",
+ "zbus",
+ "zvariant",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6891,6 +7059,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d07e46d035fb8e375b2ce63ba4e4ff90a7f73cf2ffb0138b29e1158d2eaadf7"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "nix 0.30.1",
+ "ordered-stream",
+ "rand 0.9.2",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.60.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e797a9c847ed3ccc5b6254e8bcce056494b375b511b3d6edcec0aeb4defaca"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6968,4 +7192,44 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999dd3be73c52b1fccd109a4a81e4fcd20fab1d3599c8121b38d04e1419498db"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6643fd0b26a46d226bd90d3f07c1b5321fe9bb7f04673cb37ac6d6883885b68e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.106",
+ "winnow",
 ]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -77,6 +77,8 @@ members = [
     "constants",
 
     "xfscli",
+
+    "whippet",
 ]
 
 [workspace.dependencies]
@@ -183,6 +185,7 @@ serde-xml-rs = "0.6"
 serde_json = "1"
 serde_plain = "1"
 serde_yaml = "0.9"
+serde_repr = "0.1"
 shell-words = "1"
 shlex = "1"
 signal-hook = "0.3"
@@ -205,6 +208,8 @@ unindent = "0.2"
 url = "2"
 walkdir = "2.5"
 which = "4"
+zbus = { version = "5.11", default-features = false }
+zvariant = "5.7"
 x509-parser = "0.16"
 base64 = "0.22"
 

--- a/sources/deny.toml
+++ b/sources/deny.toml
@@ -65,6 +65,9 @@ skip-tree = [
     # breaking changes which will need to be explored for our first party code
     # https://rust-random.github.io/book/update-0.9.html
     { name = "rand", version = "=0.8" },
+    # zbus introduces newer versions of crates that are either
+    # incompatible or way ahead from the versions used in other crates
+    { name = "zbus", version = "=5.11" }
 ]
 
 [bans.workspace-dependencies]

--- a/sources/whippet/Cargo.toml
+++ b/sources/whippet/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "whippet"
+version = "0.1.0"
+license = "(Apache-2.0 OR MIT) AND Apache-2.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+argh = { workspace = true }
+indexmap = { workspace = true, features = ["serde"]}
+log = { workspace = true }
+nix = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_repr = { workspace = true }
+simplelog = { workspace = true }
+snafu = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "process", "signal"] }
+toml = { workspace = true }
+zbus = { workspace = true, features = ["p2p", "tokio"] }
+zvariant = { workspace = true }
+
+[build-dependencies]
+generate-readme.workspace = true

--- a/sources/whippet/README.md
+++ b/sources/whippet/README.md
@@ -1,0 +1,67 @@
+# whippet
+
+Current version: 0.1.0
+
+## Introduction
+
+*whippet* is Bottlerocket's implementation of a launcher for `dbus-broker`. It
+implements the minimal set of features to configure and start the `dbus-broker`
+which include:
+
+- Policy configuration
+- Systemd socket activation
+
+### Writing D-Bus policies for whippet
+*whippet* uses TOML to define Dbus policies. This is an example of how to
+define rules for the default context:
+
+```toml
+[policy.default]
+rules = [
+    { allow = true, user = "*" },             # This is a connect user rule
+    { allow = true, own = "*" },              # This is an own rule
+    { allow = true, send_destination = "*" }, # This is a send rule
+    { allow = true, receive_sender = "*"},    # This is a receive rule
+]
+```
+
+The rules in the default context will be included in the list of rules that
+apply to all the users in the policy.
+
+*whippet* supports user-specific rules as maps where the keys are either the
+user names or user ids of the target users and the values are the list of
+rules. This is an example to define rules for the users "pixie" and `1001`:
+
+```toml
+# A rule for user Pixie
+[policy.user.pixie]
+rules = [
+    { allow = false, own = "*" }
+]
+
+# A rule for UID 1001
+[policy.user."1001"]
+rules = [
+    { allow = false, own = "*" }
+]
+```
+
+*whippet* supports all the fields supported in the original dbus-daemon policy
+format, except:
+
+- `mandatory`, `at_console`, and `group` contexts
+- The `eavesdrop` field in rules
+- The `own_prefix` field in own rules
+- The `send_error`, `send_destination_prefix`, and `send_requested_reply`
+  fields in send rules
+- The `receive_error` and `receive_requested_reply` fields in receive rules
+
+### Policy drop-in files
+
+*whippet* supports reading additional policy files from `/usr/share/whippet`
+which will be loaded in lexicographic order. Rules loaded last can be used to
+override rules defined by a previously loaded policy.
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/whippet/README.tpl
+++ b/sources/whippet/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/whippet/build.rs
+++ b/sources/whippet/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    generate_readme::from_main().unwrap();
+}

--- a/sources/whippet/src/broker.rs
+++ b/sources/whippet/src/broker.rs
@@ -1,0 +1,155 @@
+//! D-Bus broker management and lifecycle control.
+//!
+//! This module provides the [`BrokerManager`] which handles spawning and communicating
+//! with the dbus-broker process, including policy transfer and systemd integration.
+
+use crate::child::BrokerChildInitial;
+use crate::dbus_policy::DbusPolicy;
+use crate::error::{self, Result};
+use crate::socket;
+use snafu::ResultExt;
+use std::mem;
+use std::os::unix::io::BorrowedFd;
+use tokio::net::UnixStream;
+use zbus::conn::Builder;
+use zbus::zvariant::{Fd, ObjectPath, Value as ZVariantValue};
+use zbus::{proxy, Connection};
+
+/// A proxy client used to interact with the spawned dbus broker once it establishes a connection
+/// back to whippet
+#[proxy(
+    interface = "org.bus1.DBus.Broker",
+    default_path = "/org/bus1/DBus/Broker"
+)]
+trait DBusBroker {
+    /// Client call of the AddListener method to transfer the systemd socket and dbus policy to the
+    /// broker
+    fn add_listener(
+        &self,
+        path: ObjectPath<'_>,
+        fd: Fd<'_>,
+        policy: ZVariantValue<'_>,
+    ) -> zbus::Result<()>;
+}
+
+/// Manages the lifecycle of the spawned broker
+pub(crate) struct BrokerManager {
+    policy: DbusPolicy,
+    launcher_socket: UnixStream,
+    broker_socket: UnixStream,
+    child: BrokerChildInitial,
+}
+
+impl BrokerManager {
+    pub(crate) fn new(broker_path: &str, policy: DbusPolicy) -> Result<Self> {
+        debug!("Creating BrokerManager with broker path: {broker_path}");
+
+        let (launcher_socket, broker_socket) = socket::controller_pair()?;
+        let child = BrokerChildInitial::new(broker_path)?;
+
+        Ok(Self {
+            policy,
+            child,
+            broker_socket,
+            launcher_socket,
+        })
+    }
+
+    /// Spawn the broker and transfer the systemd socket and policy
+    pub(crate) async fn run(self) -> Result<()> {
+        let journal_socket = socket::journal_socket()?;
+        // The broker has to be started on the background before the connection is created
+        // otherwise the creation of the connection hangs since there isn't anything connected on
+        // the other side of the pair.
+        let running = self.child.run(journal_socket, self.broker_socket)?;
+
+        // Configure the broker in the background to prevent connections from hanging
+        // if the child dies before it gets to use the inherited socket (e.g. bad flag used)
+        let configure_task = tokio::spawn(configure_broker(self.policy, self.launcher_socket));
+
+        // Wait for the two tasks to complete, otherwise we can't extract the error from either
+        // thread. If any error occurs in the configure task, the connection socket will be dropped
+        // and the broker task will exit
+        let (configure_result, broker_result) = tokio::join! {
+            configure_task,
+            running.wait()
+        };
+
+        let configure_result = configure_result.context(error::DbusBrokerConfigureSnafu)?;
+        configure_result?;
+        broker_result?;
+
+        Ok(())
+    }
+}
+
+/// Configure the broker with the provided policy notifying systemd when ready
+async fn configure_broker(policy: DbusPolicy, launcher_socket: UnixStream) -> Result<()> {
+    debug!("Creating D-Bus connection to broker controller");
+    let connection_builder: Builder<'_> = Builder::unix_stream(launcher_socket).p2p();
+    let connection = connection_builder
+        .build()
+        .await
+        .context(error::DbusBrokerConnectionBuildSnafu)?;
+
+    debug!("Adding listener with parsed policy");
+    set_listener_policy(policy, &connection).await?;
+    info!("Policy applied successfully");
+    notify_systemd_ready()?;
+    info!("Notified systemd that service is ready");
+    // The connection has to live for as long as whippet runs, otherwise the broker exits. Forget
+    // the connection to prevent dropping it
+    mem::forget(connection);
+
+    Ok(())
+}
+
+/// Call AddListener method with policy
+async fn set_listener_policy(policy: DbusPolicy, connection: &Connection) -> Result<()> {
+    debug!("Starting AddListener call");
+
+    debug!("Getting systemd listener socket");
+    let listener_fd = socket::listener_socket()?;
+    info!("Using listener socket FD: {listener_fd}");
+
+    let object_path =
+        ObjectPath::try_from("/org/bus1/DBus/Listener/0").context(error::ParseObjectPathSnafu)?;
+    // The listener file descriptor technically isn't owned by whippet and it is managed by systemd.
+    // Wrap the file descriptor around a BorrowedFd to prevent the file descriptor from being
+    // closed once the broker goes out of scope and let systemd handle the lifecycle of the socket.
+    let fd_handle = Fd::from(unsafe { BorrowedFd::borrow_raw(listener_fd as i32) });
+
+    info!("Setting broker listener socket and policy");
+
+    let policy = ZVariantValue::from(policy);
+    debug!("Creating D-Bus broker proxy");
+    let proxy = DBusBrokerProxy::builder(connection)
+        .destination("org.bus1.DBus.Broker")
+        .context(error::DbusBrokerProxyBuildSnafu)?
+        .build()
+        .await
+        .context(error::DbusBrokerProxyBuildSnafu)?;
+
+    // This is the call that transfers the policy to the broker. The broker uses the Dbus format to
+    // communicate with the launcher. This call will wait until the broker loads, parses and applies
+    // the policy, returning an error if the policy was invalid.
+    proxy
+        .add_listener(object_path, fd_handle, policy)
+        .await
+        .context(error::DbusBrokerAddListenerSnafu)?;
+
+    info!("Done setting broker listener socket and policy");
+    Ok(())
+}
+
+/// Notify systemd that the service is ready
+fn notify_systemd_ready() -> Result<()> {
+    let socket = socket::notify_socket()?;
+
+    socket
+        .send(b"READY=1")
+        .context(error::SystemdNotificationSnafu)?;
+
+    debug!("Sent READY=1 notification to systemd");
+    Ok(())
+}

--- a/sources/whippet/src/child.rs
+++ b/sources/whippet/src/child.rs
@@ -1,0 +1,128 @@
+//! Child process management for dbus-broker.
+//!
+//! This module provides the [`BrokerChild`] which manages the lifecycle of the spawned
+//! dbus-broker process, including signal handling and resource cleanup.
+
+use crate::error::{self, Result};
+use snafu::ResultExt;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::net::UnixDatagram;
+use std::process::Stdio;
+use tokio::net::UnixStream;
+use tokio::process::{Child, Command};
+use tokio::signal;
+
+/// Hardcoded path to machine-id file in Bottlerocket
+const MACHINE_ID_PATH: &str = "/etc/machine-id";
+
+/// Default limits from dbus-launcher
+/// See: https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/launcher.c#L35
+const DEFAULT_MAX_OUTGOING_BYTES: u64 = 8 * 1024 * 1024;
+const DEFAULT_MAX_OUTGOING_UNIX_FDS: u64 = 64;
+const DEFAULT_MAX_CONNECTIONS_PER_USER: u64 = 64;
+const DEFAULT_MAX_MATCH_RULES_PER_CONNECTION: u64 = 256;
+
+/// Calculated limits (per-user = per-connection × max-connections)
+/// See: https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/launcher.c#L1102-L1105
+const MAX_BYTES: u64 = DEFAULT_MAX_CONNECTIONS_PER_USER * DEFAULT_MAX_OUTGOING_BYTES;
+const MAX_FDS: u64 = DEFAULT_MAX_CONNECTIONS_PER_USER * DEFAULT_MAX_OUTGOING_UNIX_FDS;
+const MAX_MATCHES: u64 = DEFAULT_MAX_CONNECTIONS_PER_USER * DEFAULT_MAX_MATCH_RULES_PER_CONNECTION;
+
+#[derive(Debug)]
+pub(crate) struct BrokerChildInitial {
+    broker_path: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct BrokerChildRunning {
+    child: Child,
+    _journal_socket: UnixDatagram,
+    _broker_socket: UnixStream,
+}
+
+impl BrokerChildInitial {
+    /// Returns a new instance of the `BrokerChild`
+    pub(crate) fn new(broker_path: &str) -> Result<Self> {
+        Ok(Self {
+            broker_path: broker_path.to_string(),
+        })
+    }
+
+    /// Forks the dbus-broker with the parameters configured for the child
+    pub(crate) fn run(
+        self,
+        journal_socket: UnixDatagram,
+        broker_socket: UnixStream,
+    ) -> Result<BrokerChildRunning> {
+        debug!("Reading machine ID from {MACHINE_ID_PATH}");
+        let machine_id = std::fs::read_to_string(MACHINE_ID_PATH)
+            .context(error::MachineIdSnafu {
+                path: MACHINE_ID_PATH,
+            })?
+            .trim()
+            .to_string();
+        debug!("Machine ID: {machine_id}");
+
+        let mut cmd = Command::new(&self.broker_path);
+        cmd.arg("--log")
+            .arg(format!("{}", journal_socket.as_raw_fd()))
+            .arg("--controller")
+            .arg(format!("{}", broker_socket.as_raw_fd()))
+            .arg("--machine-id")
+            .arg(machine_id)
+            .arg("--max-bytes")
+            .arg(format!("{MAX_BYTES}"))
+            .arg("--max-fds")
+            .arg(format!("{MAX_FDS}"))
+            .arg("--max-matches")
+            .arg(format!("{MAX_MATCHES}"))
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+
+        debug!(
+            "Spawning dbus-broker with limits: max-bytes={MAX_BYTES}, max-fds={MAX_FDS}, max-matches={MAX_MATCHES}",
+        );
+
+        // Hold the reference to the spawned process, so that it can be killed if needed
+        let child = cmd.spawn().context(error::BrokerSpawnSnafu)?;
+        info!("dbus-broker spawned with PID: {:?}", child.id());
+
+        // Pass down the sockets to the active running child, to prevent them from going out of
+        // scope before the child exits
+        Ok(BrokerChildRunning {
+            child,
+            _journal_socket: journal_socket,
+            _broker_socket: broker_socket,
+        })
+    }
+}
+
+impl BrokerChildRunning {
+    /// Wait for either the spawned process to complete, or for the SIGTERM signal to be sent
+    pub(crate) async fn wait(mut self) -> Result<()> {
+        debug!("Setting up signal handlers");
+        let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
+            .context(error::CreateSigTermSignalSnafu)?;
+        // Wait for either the child process to stop, or for the kill signal
+        tokio::select! {
+            // Child process died naturally
+            status = self.child.wait() => {
+                let status = status.context(error::BrokerWaitSnafu)?;
+                if status.success() {
+                    info!("dbus-broker exited successfully: {status}");
+                } else {
+                    warn!("dbus-broker exited with status: {status}");
+                }
+                Ok(())
+            }
+            _ = sigterm.recv() => {
+                info!("Received SIGTERM, shutting down");
+                debug!("Killing dbus-broker process");
+                let _ = self.child.kill().await;
+                info!("Shutdown complete");
+                Ok(())
+            }
+        }
+    }
+}

--- a/sources/whippet/src/dbus_policy.rs
+++ b/sources/whippet/src/dbus_policy.rs
@@ -1,0 +1,441 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  Copyright (C) 2016-2023 Red Hat, Inc.
+ *  Copyright (C) 2023 David Rheinsberg <david@readahead.eu>
+ *  Copyright (C) 2023 Tom Gundersen <teg@jklm.no>
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Originally derived from:
+ *  https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c
+ *
+ *  Changes for Bottlerocket:
+ *    - Use Zvariant types to serialize in the Dbus format
+ *    - Default console_entries and selinux_contexts to empty lists (they aren't used)
+ *    - Default apparmor_enabled to false (not supported in Bottlerocket)
+ *    - Default bus_type to system
+ */
+
+//! D-Bus policy serialization and conversion.
+//!
+//! This module converts whippet's TOML-based policy format into the binary format
+//! expected by dbus-broker, ensuring compatibility with the broker's policy engine.
+
+use crate::error::{self, Result};
+use crate::policy::{Context, MessageType, Policy, Rule};
+use serde::Serialize;
+use snafu::ResultExt;
+use zvariant::{Type, Value as ZVariantValue};
+
+/// Top-level policy structure that matches launcher's Dbus format. It is crucial that
+/// the order of the fields remains like it is, otherwise the broker rejects the policy.
+///
+/// Use zvariant's Type and Value to generate both the Dbus signature (available at
+/// DbusPolicy::SIGNATURE), and to simplify the serialization into the Dbus format
+/// See:
+/// https://github.com/bus1/dbus-broker/blob/a7960f21977059dbb2356072bcd6f583b667593c/src/launch/policy.h#L21
+/// https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c#L936
+#[derive(Debug, Type, Serialize, Clone, ZVariantValue, Default)]
+pub(crate) struct DbusPolicy {
+    pub(crate) uid_entries: Vec<(u32, PolicyBatch)>,
+    pub(crate) console_entries: Vec<(bool, u32, u32, PolicyBatch)>,
+    pub(crate) selinux_contexts: Vec<(String, String)>,
+    pub(crate) apparmor_enabled: bool,
+    pub(crate) bus_type: String,
+}
+
+/// Represents the actual policy in the dbus-launcher, as with the DbusPolicy, the order of the
+/// fields is crucial
+/// See:
+/// https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c#L930
+#[derive(Debug, Type, Serialize, Clone, ZVariantValue, Default)]
+pub struct PolicyBatch {
+    pub(crate) connect_verdict: bool,
+    pub(crate) connect_priority: u64,
+    pub(crate) own_rules: Vec<OwnRecord>,
+    pub(crate) send_rules: Vec<SendReceiveRecord>,
+    pub(crate) recv_rules: Vec<SendReceiveRecord>,
+}
+
+/// Represents an Own Record in the actual dbus policy
+/// See:
+/// https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c#L836
+#[derive(Debug, Type, Serialize, Clone, ZVariantValue, Default)]
+pub struct OwnRecord {
+    pub verdict: bool,
+    pub priority: u64,
+    pub prefix: bool,
+    pub name: String,
+}
+
+/// Represents a Send Record in the actual dbus policy
+/// See:
+/// https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c#L877
+#[derive(Debug, Type, Serialize, Clone, ZVariantValue, Default)]
+pub struct SendReceiveRecord {
+    pub verdict: bool,
+    pub priority: u64,
+    pub name: String,
+    pub path: String,
+    pub interface: String,
+    pub member: String,
+    pub record_type: MessageType,
+    pub broadcast: u32,
+    pub min_fds: u64,
+    pub max_fds: u64,
+}
+
+impl DbusPolicy {
+    /// Builds a new DbusPolicy object using "system" as the only supported bus_type
+    fn new() -> Self {
+        Self {
+            uid_entries: Vec::new(),
+            console_entries: Vec::new(),
+            selinux_contexts: Vec::new(),
+            apparmor_enabled: false,
+            bus_type: String::from("system"),
+        }
+    }
+}
+
+impl TryFrom<Policy> for DbusPolicy {
+    type Error = crate::error::Error;
+
+    /// Convert TOML config to DbusPolicy format, inserting the default policy batch as the policy
+    /// for the default user, and appending the same batch to all the policy batches
+    /// See:
+    /// https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c#L1056
+    fn try_from(policy: Policy) -> Result<Self> {
+        debug!("Converting TOML config to D-Bus policy format");
+
+        let mut dbus_policy = Self::new();
+
+        let default_batch = if let Some(default_policy) = &policy.default {
+            default_policy.try_into()?
+        } else {
+            // If there isn't a default policy batch, create one with verdict false and priority 1
+            // as the dbus-launcher does
+            PolicyBatch {
+                connect_priority: 1,
+                ..Default::default()
+            }
+        };
+        // Insert the default batch at the beginning, this mimics what the launcher does and it is
+        // easier for debugging
+        dbus_policy
+            .uid_entries
+            .insert(0, (u32::MAX, default_batch.clone()));
+
+        for (uid, user_policy) in policy.user.iter().flatten() {
+            let mut batch: PolicyBatch = user_policy.try_into()?;
+            // If this policy batch didn't include a connect rule, use the default connect
+            // verdict and priority, matching the fallback behavior in the dbus-launcher
+            if !user_policy.has_connect_rule() {
+                batch.connect_verdict = default_batch.connect_verdict;
+                batch.connect_priority = default_batch.connect_priority;
+            }
+            // Also, append all the default rules, as the launcher does
+            batch.copy_rules_from(&default_batch);
+
+            dbus_policy.uid_entries.push((
+                uid.parse::<u32>().context(error::ParseUidSnafu { uid })?,
+                batch,
+            ));
+        }
+
+        Ok(dbus_policy)
+    }
+}
+
+impl PolicyBatch {
+    /// Copies rules from the provided policy batch
+    fn copy_rules_from(&mut self, source: &PolicyBatch) {
+        let mut copy = source.clone();
+        self.own_rules.append(&mut copy.own_rules);
+        self.send_rules.append(&mut copy.send_rules);
+        self.recv_rules.append(&mut copy.recv_rules);
+    }
+}
+
+impl TryFrom<&Context> for PolicyBatch {
+    type Error = crate::error::Error;
+
+    fn try_from(value: &Context) -> Result<Self> {
+        let mut batch = Self::default();
+        for rule in &value.rules {
+            match rule {
+                // The connect rule determines what's the verdict and priority for the entire batch
+                Rule::ConnectUser {
+                    allow, priority, ..
+                } => {
+                    batch.connect_verdict = *allow;
+                    batch.connect_priority = *priority;
+                }
+                Rule::Own { .. } => {
+                    batch.own_rules.push(rule.try_into()?);
+                }
+                Rule::Send { .. } => {
+                    batch.send_rules.push(rule.try_into()?);
+                }
+                Rule::Receive { .. } => {
+                    batch.recv_rules.push(rule.try_into()?);
+                }
+            }
+        }
+
+        Ok(batch)
+    }
+}
+
+impl TryFrom<&Rule> for OwnRecord {
+    type Error = crate::error::Error;
+
+    fn try_from(rule: &Rule) -> Result<Self> {
+        match rule {
+            Rule::Own {
+                own,
+                allow,
+                priority,
+                ..
+            } => {
+                // Follows what the launcher does for own rules
+                // See:
+                // https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c#L373
+                let (name, prefix) = if own == "*" {
+                    ("", true)
+                } else {
+                    (own.as_ref(), false)
+                };
+                Ok(OwnRecord {
+                    verdict: *allow,
+                    name: name.to_owned(),
+                    priority: *priority,
+                    prefix,
+                })
+            }
+            _ => error::RuleToRecordSnafu {
+                rule_type: format!("{rule:?}"),
+                record_type: "OwnRecord".to_string(),
+            }
+            .fail(),
+        }
+    }
+}
+
+impl TryFrom<&Rule> for SendReceiveRecord {
+    type Error = crate::error::Error;
+
+    fn try_from(rule: &Rule) -> Result<Self> {
+        match rule {
+            Rule::Send {
+                allow,
+                send_destination,
+                send_path,
+                send_interface,
+                send_member,
+                send_type,
+                send_broadcast,
+                priority,
+                ..
+            } => Ok(SendReceiveRecord {
+                verdict: *allow,
+                name: send_destination.clone(),
+                path: send_path.clone(),
+                interface: send_interface.clone(),
+                member: send_member.clone(),
+                record_type: *send_type,
+                broadcast: *send_broadcast,
+                priority: *priority,
+                ..SendReceiveRecord::default()
+            }),
+
+            Rule::Receive {
+                receive_sender,
+                receive_path,
+                receive_interface,
+                receive_member,
+                receive_type,
+                receive_broadcast,
+                allow,
+                priority,
+                ..
+            } => Ok(SendReceiveRecord {
+                verdict: *allow,
+                name: receive_sender.clone(),
+                path: receive_path.clone(),
+                interface: receive_interface.clone(),
+                member: receive_member.clone(),
+                record_type: *receive_type,
+                broadcast: *receive_broadcast,
+                priority: *priority,
+                ..SendReceiveRecord::default()
+            }),
+            _ => error::RuleToRecordSnafu {
+                rule_type: format!("{rule:?}"),
+                record_type: "SendRecord".to_string(),
+            }
+            .fail(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dbus_policy_signature_compatibility() {
+        // Expected signature that matches dbus-broker launcher. Any changes to the DbusPolicy
+        // ordering results in changes to this signature
+        let expected_signature = "(a(u(bta(btbs)a(btssssuutt)a(btssssuutt)))a(buu(bta(btbs)a(btssssuutt)a(btssssuutt)))a(ss)bs)";
+        let actual_signature = DbusPolicy::SIGNATURE.to_string();
+
+        assert_eq!(
+            actual_signature, expected_signature,
+            "DbusPolicy signature must match dbus-broker launcher expectations exactly"
+        );
+    }
+
+    #[test]
+    fn test_dbus_policy_fallback_connect() {
+        // With this policy, user "1" should get the default connect rule from the default context
+        let config_str = format!(
+            r#"
+            [default]
+            rules = [
+                {{ allow = true, user = "{}" }}
+            ]
+
+            [user."1"]
+            rules = [
+                {{ allow = true, send_interface = "org.example.Dummy" }}
+            ]
+        "#,
+            u32::MAX
+        );
+
+        let mut policy: Policy = toml::from_str(&config_str).unwrap();
+        let mut current_priority: u64 = 0;
+        policy.set_rule_priorities(&mut current_priority);
+        policy.prepare().unwrap();
+        policy.optimize();
+
+        let dbus_policy: DbusPolicy = policy.try_into().unwrap();
+        // Test user "1" gets connect_verdict == true due to the default policy
+        assert!(dbus_policy
+            .uid_entries
+            .iter()
+            .any(|(id, batch)| *id == 1 && batch.connect_verdict));
+    }
+
+    #[test]
+    fn test_dbus_policy_fallback_connect_missing_default() {
+        // With this policy, the default connect rule is missing so the user "1" gets
+        // verdict = false for its policy batch
+        let config_str = r#"
+            [user."1"]
+            rules = [
+                { allow = true, send_interface = "org.example.Dummy" }
+            ]
+        "#;
+
+        let mut policy: Policy = toml::from_str(config_str).unwrap();
+        let mut current_priority: u64 = 0;
+        policy.set_rule_priorities(&mut current_priority);
+        policy.prepare().unwrap();
+        policy.optimize();
+
+        let dbus_policy: DbusPolicy = policy.try_into().unwrap();
+        // There is always a default batch, even if it is missing in the policy
+        assert_eq!(dbus_policy.uid_entries.len(), 2);
+        // Since there wasn't an allow connect rule, the user's verdict is false
+        assert!(dbus_policy
+            .uid_entries
+            .iter()
+            .any(|(id, batch)| *id == 1 && !batch.connect_verdict));
+    }
+
+    #[test]
+    fn test_dbus_policy_user_with_connect_rule_default_deny() {
+        // With this policy, user 2 gets a default deny due to Rule 1
+        let config_str = format!(
+            r#"
+            [default]
+            rules = [
+                {{ allow = false, user = "{}" }},                           # Rule 1
+                {{ allow = true, user = "1" }}                              # Rule 2
+            ]
+
+            [user."1"]
+            rules = [
+                {{ allow = true, send_interface = "org.example.Dummy" }}    # Rule 3
+            ]
+            [user."2"]
+            rules = [
+                {{ allow = true, send_interface = "org.example.Dummy" }}    # Rule 4
+            ]
+        "#,
+            u32::MAX
+        );
+
+        let mut policy: Policy = toml::from_str(&config_str).unwrap();
+        policy.set_rule_priorities(&mut 0u64);
+        policy.prepare().unwrap();
+        policy.optimize();
+
+        let dbus_policy: DbusPolicy = policy.try_into().unwrap();
+        // User 1 gets verdict = true, as RULE 2 allows connections
+        assert!(dbus_policy
+            .uid_entries
+            .iter()
+            .any(|(id, batch)| *id == 1 && batch.connect_verdict));
+        // User 2 gets verdict = false, as RULE 1 forbids connections
+        assert!(dbus_policy
+            .uid_entries
+            .iter()
+            .any(|(id, batch)| *id == 2 && !batch.connect_verdict));
+    }
+
+    #[test]
+    fn test_default_user_is_first() {
+        let config_str = r#"
+            [default]
+            rules = [
+                { allow = true, send_interface = "*" }
+            ]
+
+            [user."1"]
+            rules = [
+                { allow = true, send_interface = "org.example.Dummy" }
+            ]
+        "#;
+        let mut policy: Policy = toml::from_str(config_str).unwrap();
+        policy.set_rule_priorities(&mut 0u64);
+        policy.prepare().unwrap();
+        policy.optimize();
+
+        let dbus_policy: DbusPolicy = policy.try_into().unwrap();
+        assert_eq!(dbus_policy.uid_entries[0].0, u32::MAX);
+    }
+
+    #[test]
+    fn test_users_get_default_policy() {
+        let config_str = r#"
+            [default]
+            rules = [
+                { allow = true, send_interface = "*" }
+            ]
+
+            [user."1"]
+            rules = [
+                { allow = true, send_interface = "org.example.Dummy" }
+            ]
+        "#;
+        let mut policy: Policy = toml::from_str(config_str).unwrap();
+        policy.set_rule_priorities(&mut 0u64);
+        policy.prepare().unwrap();
+        policy.optimize();
+
+        let dbus_policy: DbusPolicy = policy.try_into().unwrap();
+        assert_eq!(dbus_policy.uid_entries[1].1.send_rules.len(), 2);
+    }
+}

--- a/sources/whippet/src/error.rs
+++ b/sources/whippet/src/error.rs
@@ -1,0 +1,136 @@
+//! Error types and handling for whippet.
+//!
+//! This module defines all error types used throughout the application,
+//! providing structured error handling with context information.
+
+use snafu::Snafu;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum Error {
+    // Configuration errors
+    #[snafu(display("Failed to initialize logger"))]
+    Logger { source: log::SetLoggerError },
+
+    // Policy parsing errors
+    #[snafu(display("Failed to parse policy content"))]
+    PolicyParse { source: toml::de::Error },
+
+    #[snafu(display("Failed to collect paths from '{what}'"))]
+    CollectPaths {
+        what: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to read path '{what}'"))]
+    ReadPath {
+        what: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("User context for user '{username}' includes connect rule"))]
+    UserContextWithConnectRule { username: String },
+
+    #[snafu(display("User '{username}' not found"))]
+    UserNotFound { username: String },
+
+    #[snafu(display("Failed to lookup user '{username}'"))]
+    UserLookupFailed {
+        username: String,
+        source: nix::errno::Errno,
+    },
+
+    // Broker errors
+    #[snafu(display("Failed to build D-Bus broker proxy"))]
+    DbusBrokerProxyBuild { source: zbus::Error },
+
+    #[snafu(display("Failed to build connection to D-Bus broker"))]
+    DbusBrokerConnectionBuild { source: zbus::Error },
+
+    #[snafu(display("Failed to send policy and socket to the broker"))]
+    DbusBrokerAddListener { source: zbus::Error },
+
+    #[snafu(display("Failed to configure D-Bus broker"))]
+    DbusBrokerConfigure { source: tokio::task::JoinError },
+
+    #[snafu(display("Failed to parse object path for add listener call"))]
+    ParseObjectPath { source: zvariant::Error },
+
+    #[snafu(display("Failed to notify systemd"))]
+    SystemdNotification { source: std::io::Error },
+
+    #[snafu(display("Failed to clone controller socket handle"))]
+    ControllerClone { source: std::io::Error },
+
+    // Socket errors
+    #[snafu(display("Failed to retrieve '{what}' environment variable"))]
+    MissingEnvVar {
+        what: String,
+        source: std::env::VarError,
+    },
+
+    #[snafu(display("LISTEN_PID mismatch, '{expected}', found '{found}'"))]
+    UnexpectedPid { expected: String, found: String },
+
+    #[snafu(display("Expected at most 1 file descriptor, found '{found}'"))]
+    UnexpectedFileDescriptorCount { found: u32 },
+
+    #[snafu(display("Invalid file descriptor count: {count}"))]
+    InvalidFileDescriptorCount {
+        count: String,
+        source: std::num::ParseIntError,
+    },
+
+    #[snafu(display("Failed to get flags for file descriptor '{fd}'"))]
+    GetFdFlags { fd: i32, source: nix::errno::Errno },
+
+    #[snafu(display("Failed to set '{what}' flag for file descriptor '{fd}'"))]
+    SetFlag {
+        what: String,
+        fd: i32,
+        source: nix::errno::Errno,
+    },
+
+    #[snafu(display("Socket pair creation failed"))]
+    SocketPair { source: std::io::Error },
+
+    #[snafu(display("Error while creating socket for journal"))]
+    JournalSocket { source: std::io::Error },
+
+    #[snafu(display("Error while creating socket for systemd notification"))]
+    SystemdNotifySocket { source: std::io::Error },
+
+    // Child errors
+    #[snafu(display("Failed to read machine ID from '{path}'"))]
+    MachineId {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Called wait in a child that hasn't started"))]
+    ChildNotRunning,
+
+    #[snafu(display("Failed to create SIGTERM signal"))]
+    CreateSigTermSignal { source: std::io::Error },
+
+    #[snafu(display("Failed to spawn dbus-broker process"))]
+    BrokerSpawn { source: std::io::Error },
+
+    #[snafu(display("Failed to wait for dbus-broker process"))]
+    BrokerWait { source: std::io::Error },
+
+    // Dbus Policy
+    #[snafu(display("Cannot convert rule '{rule_type}' to '{record_type}'"))]
+    RuleToRecord {
+        rule_type: String,
+        record_type: String,
+    },
+
+    #[snafu(display("Cannot convert UID '{uid}' to integer"))]
+    ParseUid {
+        uid: String,
+        source: std::num::ParseIntError,
+    },
+}

--- a/sources/whippet/src/main.rs
+++ b/sources/whippet/src/main.rs
@@ -1,0 +1,137 @@
+/*!
+# Introduction
+
+*whippet* is Bottlerocket's implementation of a launcher for `dbus-broker`. It
+implements the minimal set of features to configure and start the `dbus-broker`
+which include:
+
+- Policy configuration
+- Systemd socket activation
+
+## Writing D-Bus policies for whippet
+*whippet* uses TOML to define Dbus policies. This is an example of how to
+define rules for the default context:
+
+```toml
+[policy.default]
+rules = [
+    { allow = true, user = "*" },             # This is a connect user rule
+    { allow = true, own = "*" },              # This is an own rule
+    { allow = true, send_destination = "*" }, # This is a send rule
+    { allow = true, receive_sender = "*"},    # This is a receive rule
+]
+```
+
+The rules in the default context will be included in the list of rules that
+apply to all the users in the policy.
+
+*whippet* supports user-specific rules as maps where the keys are either the
+user names or user ids of the target users and the values are the list of
+rules. This is an example to define rules for the users "pixie" and `1001`:
+
+```toml
+# A rule for user Pixie
+[policy.user.pixie]
+rules = [
+    { allow = false, own = "*" }
+]
+
+# A rule for UID 1001
+[policy.user."1001"]
+rules = [
+    { allow = false, own = "*" }
+]
+```
+
+*whippet* supports all the fields supported in the original dbus-daemon policy
+format, except:
+
+- `mandatory`, `at_console`, and `group` contexts
+- The `eavesdrop` field in rules
+- The `own_prefix` field in own rules
+- The `send_error`, `send_destination_prefix`, and `send_requested_reply`
+  fields in send rules
+- The `receive_error` and `receive_requested_reply` fields in receive rules
+
+## Policy drop-in files
+
+*whippet* supports reading additional policy files from `/usr/share/whippet`
+which will be loaded in lexicographic order. Rules loaded last can be used to
+override rules defined by a previously loaded policy.
+*/
+
+#[macro_use]
+extern crate log;
+
+mod broker;
+mod child;
+mod dbus_policy;
+mod error;
+mod policy;
+mod socket;
+
+use crate::dbus_policy::DbusPolicy;
+use crate::error::Result;
+use crate::policy::{PasswdUsernameResolver, Policy};
+use argh::FromArgs;
+use broker::BrokerManager;
+use log::LevelFilter;
+use simplelog::{Config as LogConfig, SimpleLogger};
+use snafu::ResultExt;
+
+/// D-Bus launcher replacement for Bottlerocket
+#[derive(FromArgs)]
+struct Args {
+    /// path to TOML configuration file
+    #[argh(
+        option,
+        long = "config-file",
+        default = "String::from(\"/usr/share/whippet/system.toml\")"
+    )]
+    config_file: String,
+
+    /// path to dbus-broker binary
+    #[argh(
+        option,
+        long = "broker-path",
+        default = "String::from(\"/usr/bin/dbus-broker\")"
+    )]
+    broker_path: String,
+
+    /// path to policy directory
+    #[argh(
+        option,
+        long = "policy-dir",
+        default = "policy::DBUS_POLICY_DROPINS_PATH.to_string()"
+    )]
+    policy_dir: String,
+
+    /// log level (error, warn, info, debug, trace)
+    #[argh(option, long = "log-level", default = "LevelFilter::Info")]
+    log_level: LevelFilter,
+}
+
+#[tokio::main]
+#[snafu::report]
+async fn main() -> Result<()> {
+    let args: Args = argh::from_env();
+
+    SimpleLogger::init(args.log_level, LogConfig::default()).context(error::LoggerSnafu)?;
+
+    info!("Starting whippet D-Bus launcher");
+    debug!("Config file: {}", args.config_file);
+    debug!("Broker path: {}", args.broker_path);
+
+    let username_resolver = PasswdUsernameResolver::default();
+    let mut policy = Policy::new(&args.config_file, &args.policy_dir, username_resolver)?;
+    policy.prepare()?;
+    policy.optimize();
+
+    let dbus_policy: DbusPolicy = policy.try_into()?;
+
+    info!("Starting dbus-broker: {}", args.broker_path);
+    let broker = BrokerManager::new(&args.broker_path, dbus_policy)?;
+    broker.run().await?;
+
+    Ok(())
+}

--- a/sources/whippet/src/policy.rs
+++ b/sources/whippet/src/policy.rs
@@ -1,0 +1,923 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  Copyright (C) 2016-2023 Red Hat, Inc.
+ *  Copyright (C) 2023 David Rheinsberg <david@readahead.eu>
+ *  Copyright (C) 2023 Tom Gundersen <teg@jklm.no>
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Originally derived from:
+ *  https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c
+ *
+ *  Changes for Bottlerocket:
+ *    - Hard-coded path to drop-in overrides
+ *    - Skip default connect rule for the launcher user
+ *    - Drop ignored or deprecated fields
+ *    - Parse the default contexts and user contexts in fixed order, rather than parsing the
+ *    first one found
+ */
+
+use crate::error::{self, Result};
+use indexmap::IndexMap;
+use serde::Deserialize;
+use serde_repr::Serialize_repr;
+use snafu::{ensure, ResultExt};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use zvariant::{Type as ZVariantType, Value as ZVariantValue};
+
+/// Default directory path additional policies are read from
+pub(crate) const DBUS_POLICY_DROPINS_PATH: &str = "/usr/share/whippet/policies.d";
+/// Multiplier used to calculate the priority of a rule
+const DEFAULT_POLICY_CONTEXT_MULTIPLIER: u64 = 1;
+const DEFAULT_POLICY_CONTEXT_USER: u64 = 3;
+const PRIORITY_BASE: u64 = u64::MAX / 7;
+
+const DEFAULT_USER_ID: u32 = u32::MAX;
+
+/// Represents a minimal policy configuration for the dbus-broker. Each section on the policy is
+/// known as a Context.
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Policy {
+    /// The default rules that apply to all contexts
+    pub(crate) default: Option<Context>,
+    /// User-specific rules
+    pub(crate) user: Option<IndexMap<String, Context>>,
+}
+
+/// A context contains the rules that actually make a policy
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Context {
+    pub(crate) rules: Vec<Rule>,
+}
+
+/// Represents a rule to configure permissions in the Dbus
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(untagged, deny_unknown_fields)]
+pub(crate) enum Rule {
+    /// Connect users dictates whether a user is allowed to connect to the bus
+    ConnectUser {
+        allow: bool,
+        user: String,
+        #[serde(skip)]
+        priority: u64,
+    },
+    /// Own rules allow services to own Dbus service names
+    Own {
+        own: String,
+        allow: bool,
+        #[serde(skip)]
+        priority: u64,
+    },
+    /// Send rules allow services to send messages through the bus
+    Send {
+        #[serde(default)]
+        send_destination: String,
+        #[serde(default)]
+        send_interface: String,
+        #[serde(default)]
+        send_member: String,
+        #[serde(default)]
+        send_type: MessageType,
+        #[serde(default)]
+        send_path: String,
+        #[serde(default)]
+        send_broadcast: u32,
+        allow: bool,
+        #[serde(skip)]
+        priority: u64,
+    },
+    /// Receive rules allow services to receive messages from the bus
+    Receive {
+        #[serde(default)]
+        receive_sender: String,
+        #[serde(default)]
+        receive_path: String,
+        #[serde(default)]
+        receive_interface: String,
+        #[serde(default)]
+        receive_member: String,
+        #[serde(default)]
+        receive_type: MessageType,
+        #[serde(default)]
+        receive_broadcast: u32,
+        allow: bool,
+        #[serde(skip)]
+        priority: u64,
+    },
+}
+
+/// Represents the message type configured for the send and receive rules. The original dbus policy
+/// allows for MethodReturn and Error message types, however, in the dbus-launcher, rules with
+/// either message type are dropped and not serialized in the final policy
+///
+/// See:
+/// https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c#L439
+#[derive(
+    Debug, Deserialize, Serialize_repr, Clone, PartialEq, Default, Copy, ZVariantType, ZVariantValue,
+)]
+#[repr(u32)]
+#[serde(rename_all = "kebab-case")]
+pub enum MessageType {
+    // Not really invalid, as it is a valid value, but this is the name given by the launcher
+    // and it is the default value used when it isn't present in a send or receive rule
+    //
+    // See:
+    // https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/dbus/protocol.h#L35
+    #[default]
+    Invalid = 0,
+    MethodCall = 1,
+    Signal = 4,
+}
+
+impl Policy {
+    /// Returns a new policy constructed from the provided file and additional policies. It loads the
+    /// policies in the passed directory in lexicographic order
+    #[must_use = "policy construction result must be checked"]
+    pub(crate) fn new<U>(
+        policy_file: impl AsRef<Path>,
+        policies_dir: impl AsRef<Path>,
+        mut username_resolver: U,
+    ) -> Result<Self>
+    where
+        U: UsernameResolver,
+    {
+        let policy_file = policy_file.as_ref();
+        let policies_dir = policies_dir.as_ref();
+        let mut all_policies: Vec<PathBuf> = vec![policy_file.into()];
+
+        let mut toml_files: Vec<_> = fs::read_dir(policies_dir)
+            .context(error::ReadPathSnafu {
+                what: policies_dir.display().to_string(),
+            })?
+            .collect::<std::io::Result<Vec<_>>>()
+            .context(error::CollectPathsSnafu {
+                what: policies_dir.display().to_string(),
+            })?
+            .into_iter()
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("toml"))
+            .collect();
+
+        toml_files.sort();
+        all_policies.append(&mut toml_files);
+
+        // The first rule in processed by the launcher actually gets priority 3 because:
+        // - the dbus-launcher starts its priority counter at 1
+        // - the dbus-launcher inserts a default connect rule for the current user with priority 2
+        // Hence, use the same priority as the actual first rule that will be processed
+        let mut current_priority: u64 = 3u64;
+        let mut policy = Policy::default();
+
+        // Load all the additional policies that are found in the policies_dir so that all
+        // the users are validated while constructing the config object to stop as soon as possible
+        // if there is an invalid user.
+        for policy_file in all_policies {
+            load_one_policy(policy_file, &mut policy, &mut current_priority)?;
+        }
+        policy.validate()?;
+        policy.replace_uids(&mut username_resolver)?;
+
+        Ok(policy)
+    }
+
+    /// Sets the priorities for the rules of a policy, starting with the users' rules
+    pub(crate) fn set_rule_priorities(&mut self, current_priority: &mut u64) {
+        if let Some(user_policy) = &mut self.user {
+            for policy in user_policy.values_mut() {
+                for rule in &mut policy.rules {
+                    let priority = PRIORITY_BASE * DEFAULT_POLICY_CONTEXT_USER + *current_priority;
+                    rule.set_priority(priority);
+                    *current_priority += 1;
+                }
+            }
+        }
+        if let Some(default_rules) = &mut self.default {
+            for rule in &mut default_rules.rules {
+                let priority =
+                    PRIORITY_BASE * DEFAULT_POLICY_CONTEXT_MULTIPLIER + *current_priority;
+                rule.set_priority(priority);
+                *current_priority += 1;
+            }
+        }
+    }
+
+    /// Validates that the user contexts don't include connect rules
+    fn validate(&self) -> Result<()> {
+        if let Some(user_policy) = &self.user {
+            for (username, context) in user_policy.iter() {
+                ensure!(
+                    !context
+                        .rules
+                        .iter()
+                        .any(|rule| matches!(rule, Rule::ConnectUser { .. })),
+                    error::UserContextWithConnectRuleSnafu { username }
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Replaces the UIDs of the users that were found in the policies
+    fn replace_uids<U>(&mut self, username_resolver: &mut U) -> Result<()>
+    where
+        U: UsernameResolver,
+    {
+        // First, replace the users of all the connect rules in the default context
+        if let Some(default_context) = &mut self.default {
+            default_context
+                .rules
+                .iter_mut()
+                .try_for_each(|rule| match rule {
+                    Rule::ConnectUser { user, .. } => {
+                        *user = username_resolver.resolve(user)?.to_string();
+                        Ok(())
+                    }
+                    _ => Ok(()),
+                })?;
+        };
+
+        // Then, replace all the users of the users' context. Connect rules are not allowed
+        // in other contexts other than the default context, so the rules don't have to be modified
+        let users_contexts = self.user.take().unwrap_or_default();
+        let mut final_users_contexts = IndexMap::new();
+        for (user, policy) in users_contexts.into_iter() {
+            let uid = username_resolver.resolve(&user)?.to_string();
+            final_users_contexts.insert(uid, policy);
+        }
+        self.user = Some(final_users_contexts);
+
+        Ok(())
+    }
+
+    /// Prepares the policy before it is serialized. It determines what's the default connect rule
+    /// for each user:
+    /// - If the default context contains a connect rule for the user, use that
+    /// - By default, leave empty and let the serialization add the default
+    ///
+    /// Example 1:
+    ///
+    /// ```toml
+    /// # File 1
+    /// [default]
+    /// rules = [
+    ///     { allow=false, user="*" },    # Rule 1
+    ///     { allow=true, user="benny" }, # Rule 2
+    ///     { allow=true, user="buzz" }   # Rule 3
+    /// ]
+    ///
+    /// # File 2
+    /// [user.pixie]
+    /// rules = [
+    ///     #...
+    /// ]
+    /// ```
+    ///
+    /// After this function is called, the result is:
+    /// - Default context with only Rule 1
+    /// - New user context for user "benny", with Rule 2
+    /// - New user context for user "buzz", with Rule 3
+    /// - No rules are moved for user "pixie"
+    ///
+    /// Example 2:
+    ///
+    /// ```toml
+    /// # File 1
+    /// [user.benny]
+    /// rules = [
+    ///     #...
+    /// ]
+    ///
+    /// [user.buzz]
+    /// rules = [
+    ///     #...
+    /// ]
+    ///
+    /// After this function is called, no connect rules were moved around since
+    /// there weren't any connect rules found
+    /// ```
+    pub(crate) fn prepare(&mut self) -> Result<()> {
+        let mut connect_rules: Vec<Rule> = if let Some(default_policy) = &mut self.default {
+            default_policy
+                .rules
+                .extract_if(.., |rule| {
+                    // Extract ONLY connect rules, that aren't for the DEFAULT user
+                    if let Rule::ConnectUser { user, .. } = rule {
+                        *user != DEFAULT_USER_ID.to_string()
+                    } else {
+                        false
+                    }
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        if connect_rules.is_empty() {
+            return Ok(());
+        }
+
+        // Ensure there is a user policy to inject the rules
+        let mut user_policy = self.user.take().unwrap_or_default();
+
+        // Iterate over the connect_rules found for specific users, inserting a new user policy
+        // when it doesn't exist.
+        while let Some(rule) = connect_rules.pop() {
+            if let Rule::ConnectUser { ref user, .. } = rule {
+                let policy = user_policy.entry(user.to_owned()).or_default();
+                policy.rules.push(rule);
+            }
+        }
+        self.user = Some(user_policy);
+
+        Ok(())
+    }
+
+    /// Optimize the policy according to the optimization rules defined by the launcher. The purpose
+    /// of the optimization is to keep only one default connect rule, and at most one connect rule
+    /// for the user policy. This is important in case multiple files define connect rules for the
+    /// same user, the last rule must win.
+    ///
+    /// Example:
+    ///
+    /// ```toml
+    /// # File 1
+    /// [default]
+    /// rules = [
+    ///     { allow=false, user="*"  },   # Deny all users, RULE 1
+    ///     { allow=true, user="bob" },   # Allow bob, RULE 2
+    ///     { allow=true, user="pixie" }  # Allow pixie, RULE 3
+    /// ]
+    ///
+    /// # File 2
+    /// [default]
+    /// rules = [
+    ///     { allow=true, user="*" },     # Allow all users, RULE 4
+    /// ]
+    /// ```
+    ///
+    /// After `prepare`, there will be:
+    /// - 2 connect rules in `default` context (RULE 1 and RULE 4)
+    /// - 1 connect rule in user context `bob` (RULE 2)
+    /// - 1 connect rule in user context `pixie` (RULE 3)
+    ///
+    /// After the optimization, the result is:
+    /// - 1 connect rule in `default` context (RULE 4)
+    /// - 0 connect rules in user context `bob` (RULE 2 has a lower priority than RULE 4)
+    /// - 0 connect rules in user context `pixie` (RULE 3 has a lower priority than RULE 4)
+    ///
+    /// In this example:
+    ///
+    /// ```toml
+    /// [default]
+    /// rules = [
+    ///     { allow=true, user="*" },       # RULE 1
+    ///     { allow=false, user="*" },      # RULE 2
+    ///     { allow user="bob" },           # RULE 3
+    /// ]
+    ///
+    /// [user.lorax]
+    /// rules = []
+    /// ```
+    ///
+    /// After `prepare, there will be:
+    /// - 2 connect rules in `default` context (RULE 1 and RULE 2)
+    /// - 1 connect rule in user context `bob` (RULE 3)
+    ///
+    /// After the optimization:
+    /// - 1 connect rule in `default` context (RULE 2)
+    /// - 1 connect rule in user context `bob` (RULE 3)
+    /// - User context for `lorax` was removed
+    pub(crate) fn optimize(&mut self) {
+        // First, find the highest priority default connect rule
+        let priority_threshold = self
+            .default
+            .as_ref()
+            .map(|default_policy| find_priority_threshold(&default_policy.rules))
+            .unwrap_or_default();
+
+        // Then use the highest priority threshold to clean connect rules for both
+        // the default and user contexts
+        if let Some(default_policy) = &mut self.default {
+            clean_connect_rules(priority_threshold, &mut default_policy.rules);
+        };
+
+        if let Some(user_policy) = &mut self.user {
+            user_policy.values_mut().for_each(|policy| {
+                let mut user_priority_threshold = find_priority_threshold(&policy.rules);
+                if priority_threshold > user_priority_threshold {
+                    user_priority_threshold = priority_threshold;
+                }
+                clean_connect_rules(user_priority_threshold, &mut policy.rules);
+            });
+            // Remove any user contexts without any rules
+            user_policy.retain(|_, p| !p.rules.is_empty());
+        }
+    }
+}
+
+/// Loads the policy from the provided path, setting the priorities for the loaded rules
+fn load_one_policy(
+    policy_file: impl AsRef<Path>,
+    base_policy: &mut Policy,
+    current_priority: &mut u64,
+) -> Result<()> {
+    let policy_file = policy_file.as_ref();
+    let policy_content = std::fs::read_to_string(policy_file).context(error::ReadPathSnafu {
+        what: policy_file.display().to_string(),
+    })?;
+    let mut policy: Policy = toml::from_str(&policy_content).context(error::PolicyParseSnafu)?;
+    policy.set_rule_priorities(current_priority);
+
+    let default_policy = policy.default.take().unwrap_or_default();
+    let mut base_policy_default = base_policy.default.take().unwrap_or_default();
+    base_policy_default.rules.extend(default_policy.rules);
+    base_policy.default = Some(base_policy_default);
+
+    let user_policies = policy.user.take().unwrap_or_default();
+    let mut base_policy_user = base_policy.user.take().unwrap_or_default();
+    for (user, policy) in user_policies {
+        base_policy_user
+            .entry(user.to_owned())
+            .or_default()
+            .rules
+            .extend(policy.rules);
+    }
+    base_policy.user = Some(base_policy_user);
+
+    Ok(())
+}
+
+/// Retains the only connect rule that matches the priority threshold
+fn clean_connect_rules(priority_threshold: u64, rules: &mut Vec<Rule>) {
+    rules.retain(|r| !r.is_connect() || *r.get_priority() == priority_threshold)
+}
+
+/// Find the highest priority in the given rules, defaulting to 0 if the rules were empty
+fn find_priority_threshold(rules: &[Rule]) -> u64 {
+    let mut connect_rules: Vec<&Rule> = rules.iter().filter(|r| r.is_connect()).collect();
+    connect_rules.sort_by(|a, b| b.get_priority().cmp(a.get_priority()));
+    connect_rules
+        .first()
+        .map(|r| *r.get_priority())
+        .unwrap_or_default()
+}
+
+impl Rule {
+    /// Sets the priority of the rule
+    fn set_priority(&mut self, new_priority: u64) {
+        match self {
+            Self::ConnectUser { priority, .. } => *priority = new_priority,
+            Self::Own { priority, .. } => *priority = new_priority,
+            Self::Send { priority, .. } => *priority = new_priority,
+            Self::Receive { priority, .. } => *priority = new_priority,
+        }
+    }
+    /// Retrieves the priority of the rule
+    fn get_priority(&self) -> &u64 {
+        match self {
+            Self::ConnectUser { priority, .. } => priority,
+            Self::Own { priority, .. } => priority,
+            Self::Send { priority, .. } => priority,
+            Self::Receive { priority, .. } => priority,
+        }
+    }
+
+    /// Determines whether the current rule is a connect rule
+    fn is_connect(&self) -> bool {
+        matches!(self, Self::ConnectUser { .. })
+    }
+}
+
+impl Context {
+    /// Determines if the current context contains connect rules
+    pub(crate) fn has_connect_rule(&self) -> bool {
+        self.rules.iter().any(|r| r.is_connect())
+    }
+}
+
+pub(crate) trait UsernameResolver {
+    /// Resolves the provided username string to its corresponding UID
+    fn resolve(&mut self, username: &str) -> Result<u32>;
+}
+
+#[derive(Default)]
+/// Resolves usernames using the passwd file
+pub(crate) struct PasswdUsernameResolver {
+    cache: HashMap<String, u32>,
+}
+
+impl UsernameResolver for PasswdUsernameResolver {
+    fn resolve(&mut self, username: &str) -> Result<u32> {
+        debug!("Resolving username '{username}' to UID");
+
+        // Handle wildcard case like dbus-launcher does
+        if username == "*" {
+            debug!("Wildcard user '*' resolved to UID {DEFAULT_USER_ID}");
+            return Ok(DEFAULT_USER_ID);
+        }
+
+        if let Ok(uid) = username.parse::<u32>() {
+            debug!("Numeric username '{username}' resolved to UID {uid}");
+            return Ok(uid);
+        }
+
+        if let Some(uid) = self.cache.get(username) {
+            debug!("Resolving username '{username}' using cached value '{uid}'");
+            return Ok(*uid);
+        }
+
+        debug!("Looking up username '{username}'");
+        match nix::unistd::User::from_name(username) {
+            Ok(Some(user)) => {
+                let uid = user.uid.as_raw();
+                self.cache.insert(username.to_owned(), uid);
+                debug!("Username '{username}' resolved to UID {uid}");
+                Ok(uid)
+            }
+            Ok(None) => error::UserNotFoundSnafu {
+                username: username.to_string(),
+            }
+            .fail(),
+            Err(e) => Err(e).context(error::UserLookupFailedSnafu {
+                username: username.to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALICE_USER: u32 = 1;
+    const BOB_USER: u32 = 2;
+
+    struct TestUsernameResolver {}
+    impl UsernameResolver for TestUsernameResolver {
+        fn resolve(&mut self, username: &str) -> Result<u32> {
+            match username {
+                "*" => Ok(DEFAULT_USER_ID),
+                "alice" => Ok(ALICE_USER),
+                "bob" => Ok(BOB_USER),
+                _ => panic!("Unexpected user {username}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_priorities_set_per_policy() {
+        // Given A base policy configuration with default rules and additional policy files
+        let resolver = TestUsernameResolver {};
+        let policy = Policy::new("tests/data/main.toml", "tests/data/policies", resolver).unwrap();
+
+        // Then Rules should have correct priorities based on their context and order
+        let default_rules = policy.default.unwrap().rules;
+        let user_context = policy.user.unwrap();
+        let alice_rules = &user_context.get(&ALICE_USER.to_string()).unwrap().rules;
+
+        // Since current priority is 3 and the DEFAULT multiplier is 1, the priority is equal to
+        // the PRIORITY_BASE + 3
+        assert!(matches!(
+                default_rules.first().unwrap(), Rule::ConnectUser{ user, priority, .. }
+                if *user == DEFAULT_USER_ID.to_string() && *priority == PRIORITY_BASE + 3));
+
+        // Priority counter = 4, used in the first user rule found in the first file
+        assert!(matches!(
+                &alice_rules[0], Rule::Send { send_interface, priority, .. }
+                if send_interface == "org.example.First" && *priority == PRIORITY_BASE * DEFAULT_POLICY_CONTEXT_USER + 4
+        ));
+
+        // Priority counter = 7, used in the last rule found in the second file
+        assert!(matches!(
+                &alice_rules[1], Rule::Send { send_interface, priority, .. }
+                if send_interface == "org.example.SecondService" && *priority == PRIORITY_BASE * DEFAULT_POLICY_CONTEXT_USER + 7
+        ));
+    }
+
+    #[test]
+    fn test_additional_policies_loaded_in_order() {
+        // Given A base policy configuration and additional policy files in a directory
+        let resolver = TestUsernameResolver {};
+        let policy = Policy::new("tests/data/main.toml", "tests/data/policies", resolver).unwrap();
+
+        // The Rules should be merged in lexicographic order of filenames
+        let default_rules = &policy.default.unwrap().rules;
+        assert!(
+            matches!(&default_rules[0], Rule::ConnectUser { user,.. } if *user == DEFAULT_USER_ID.to_string())
+        );
+        assert!(matches!(&default_rules[2], Rule::Own { own, .. } if own == "org.example.Second"));
+
+        // Verify user rules are merged in order
+        let user_rules = policy.user.unwrap();
+        // This rule comes from the second file that was loaded
+        assert!(
+            matches!(&user_rules.get(&ALICE_USER.to_string()).unwrap().rules[1],
+            Rule::Send { send_interface, .. } if send_interface == "org.example.SecondService")
+        );
+    }
+
+    #[test]
+    fn test_prepare() {
+        // Given A policy with connect rules for specific users in the default context
+        // With this policy, after calling prepare, the result is
+        // - Default context contains Rule 1 and Rule 3
+        // - User context "alice" contains Rule 2
+        // - User context "bob" contains Rule 4
+        let base_config = format!(
+            r#"
+            [default]
+            rules = [
+                {{ allow = true, user = "{DEFAULT_USER_ID}" }},             # Rule 1
+                {{ allow = true, user = "alice" }},                         # Rule 2
+                {{ allow = true, own = "org.example.Service" }}             # Rule 3
+            ]
+
+            [user.bob]
+            rules = [
+                {{ allow = true, send_interface = "org.example.Bob" }}      # Rule 4
+            ]
+        "#,
+        );
+
+        let mut policy: Policy = toml::from_str(&base_config).unwrap();
+        policy.set_rule_priorities(&mut 1u64);
+
+        // When Preparing the policy to move user-specific connect rules
+        policy.prepare().unwrap();
+
+        // Then User-specific connect rules should be moved to their respective contexts
+        let default_rules = &policy.default.unwrap().rules;
+        let user_rules = policy.user.unwrap();
+
+        // Test default context has 2 rules (RULE 1 and RULE 3)
+        assert_eq!(default_rules.len(), 2);
+        // Test default context has default connect rule
+        assert!(
+            matches!(&default_rules[0], Rule::ConnectUser { user, .. } if user == &DEFAULT_USER_ID.to_string())
+        );
+
+        // Test RULE 2 was moved to her context
+        let alice_rules = &user_rules.get("alice").unwrap().rules;
+        assert_eq!(alice_rules.len(), 1);
+        assert!(matches!(&alice_rules[0], Rule::ConnectUser { user, .. } if user == "alice"));
+
+        // Test bob's existing rules are preserved (RULE 4)
+        let bob_rules = &user_rules.get("bob").unwrap().rules;
+        assert_eq!(bob_rules.len(), 1);
+        assert!(matches!(&bob_rules[0], Rule::Send { .. }));
+    }
+
+    #[test]
+    fn test_prepare_creates_user_contexts() {
+        let base_config = format!(
+            r#"
+            [default]
+            rules = [
+                {{ allow = true, user = "{DEFAULT_USER_ID}" }},     # RULE 1
+                {{ allow = true, user = "alice" }},                 # RULE 2
+                {{ allow = false, user = "bob" }}                   # RULE 3
+            ]
+        "#,
+        );
+
+        let mut policy: Policy = toml::from_str(&base_config).unwrap();
+
+        // Before prepare_policy, user should be None since we only defined default rules
+        assert!(policy.user.is_none());
+
+        policy.prepare().unwrap();
+
+        // Default should only have RULE 1
+        let default_rules = &policy.default.unwrap().rules;
+        assert_eq!(default_rules.len(), 1);
+        assert!(
+            matches!(&default_rules[0], Rule::ConnectUser { user, .. } if user == &DEFAULT_USER_ID.to_string())
+        );
+
+        // After prepare_policy, user contexts should be created for alice and bob
+        // Alice and Bob should have their connect rules moved to their contexts
+        let user_rules = policy.user.as_ref().unwrap();
+
+        // Alice gets RULE 2
+        let alice_rules = &user_rules.get("alice").unwrap().rules;
+        assert_eq!(alice_rules.len(), 1);
+        assert!(
+            matches!(&alice_rules[0], Rule::ConnectUser { user, allow: true, .. } if user == "alice")
+        );
+
+        // Bob gets RULE 3
+        let bob_rules = &user_rules.get("bob").unwrap().rules;
+        assert_eq!(bob_rules.len(), 1);
+        assert!(
+            matches!(&bob_rules[0], Rule::ConnectUser { user, allow: false, .. } if user == "bob")
+        );
+    }
+
+    #[test]
+    fn test_optimization() {
+        // With this policy, before the optimization:
+        // - Alice gets rule 1
+        // - Bob gets rule 2
+        // - Default context has rule 3 and 4
+        // - Charlie gets rule 5 and 6
+        // - Lorax doesn't have any rules
+        //
+        // After the optimization:
+        // - Default context only has rule 4
+        // - Charlie gets rule 6
+        // - Alice, Bob, and Lorax don't get any rules so their contexts are removed
+        let base_config = format!(
+            r#"
+            [default]
+            rules = [
+                {{ allow = true, user = "alice" }},                # RULE 1
+                {{ allow = false, user = "bob" }},                 # RULE 2
+                {{ allow = true, user = "{DEFAULT_USER_ID}" }},    # RULE 3
+                {{ allow = false, user = "{DEFAULT_USER_ID}" }},   # RULE 4
+                {{ allow = false, user = "charlie" }},             # RULE 5
+                {{ allow = true, user = "charlie" }}               # RULE 6
+            ]
+            [user.lorax]
+            rules = []
+        "#,
+        );
+
+        let mut policy: Policy = toml::from_str(&base_config).unwrap();
+        policy.set_rule_priorities(&mut 0u64);
+        policy.prepare().unwrap();
+        policy.optimize();
+
+        let default_rules = &policy.default.unwrap().rules;
+        let user_rules = policy.user.unwrap();
+
+        // Test default context only has one rule  (RULE 4)
+        assert_eq!(default_rules.len(), 1);
+        assert!(matches!(
+            &default_rules[0],
+            Rule::ConnectUser { allow: false, .. }
+        ));
+
+        // Charlie's rule (RULE 6) has higher priority than default (RULE 4)
+        let charlie_rules = &user_rules.get("charlie").unwrap().rules;
+        assert_eq!(charlie_rules.len(), 1);
+        assert!(matches!(
+            &charlie_rules[0],
+            Rule::ConnectUser { allow: true, .. }
+        ));
+
+        // Alice's (RULE 1) and Bob's (RULE 2) had lower priority than default, so their contexts are removed
+        // Lorax didn't have any rule
+        assert!(!user_rules.contains_key("alice"));
+        assert!(!user_rules.contains_key("bob"));
+        assert!(!user_rules.contains_key("lorax"));
+    }
+
+    #[test]
+    fn test_optimization_preserves_non_connect_rules() {
+        let base_config = format!(
+            r#"
+            [default]
+            rules = [
+                {{ allow = true, user = "alice" }},                         # RULE 1
+                {{ allow = false, user = "{DEFAULT_USER_ID}" }},            # RULE 2
+            ]
+
+            [user.alice]
+            rules = [
+                {{ allow = true, send_interface = "org.example.Alice" }},   # RULE 3
+                {{ allow = true, own = "org.example.AliceService" }}        # RULE 4
+            ]
+        "#,
+        );
+
+        let mut policy: Policy = toml::from_str(&base_config).unwrap();
+        policy.set_rule_priorities(&mut 0u64);
+        policy.prepare().unwrap();
+        policy.optimize();
+
+        let user_rules = policy.user.as_ref().unwrap();
+        let alice_rules = &user_rules.get("alice").unwrap().rules;
+
+        // Alice's connect rule (RULE 1) is removed because it has lower priority than RULE 2
+        let connect_rules: Vec<_> = alice_rules
+            .iter()
+            .filter(|r| matches!(r, Rule::ConnectUser { .. }))
+            .collect();
+        assert_eq!(connect_rules.len(), 0);
+
+        // Alice should keep her non-connect rules
+        let send_rules: Vec<_> = alice_rules
+            .iter()
+            .filter(|r| matches!(r, Rule::Send { .. }))
+            .collect();
+        // RULE 3
+        assert_eq!(send_rules.len(), 1);
+
+        let own_rules: Vec<_> = alice_rules
+            .iter()
+            .filter(|r| matches!(r, Rule::Own { .. }))
+            .collect();
+        // RULE 4
+        assert_eq!(own_rules.len(), 1);
+    }
+
+    #[test]
+    fn test_optimization_with_missing_default_connect_rule() {
+        // Since there isn't a connect rule for the default user, each user gets its own
+        // user context in the final policy
+        // All users keep one rule with verdict "true"
+        let base_config = r#"
+            [default]
+            rules = [
+                { allow=false, user="pixie" },
+                { allow=true, user="pixie" },
+                { allow=false, user="bob" },
+                { allow=true, user="bob" },
+                { allow=false, user="benny" },
+                { allow=true, user="benny" }
+            ]
+        "#;
+        let mut policy: Policy = toml::from_str(base_config).unwrap();
+        policy.set_rule_priorities(&mut 0u64);
+        policy.prepare().unwrap();
+        policy.optimize();
+        let user_context = policy.user.unwrap();
+
+        assert_eq!(user_context.get("pixie").unwrap().rules.len(), 1);
+        assert_eq!(user_context.get("bob").unwrap().rules.len(), 1);
+        assert_eq!(user_context.get("benny").unwrap().rules.len(), 1);
+
+        assert!(user_context
+            .values()
+            .all(|p| matches!(p.rules[0], Rule::ConnectUser { allow, .. } if allow)));
+    }
+
+    #[test]
+    fn test_user_context_fails_with_connect_rules() {
+        let base_config: &str = r#"
+
+        [user.pixie]
+        rules = [
+            { allow = true, user = "pixie" }
+        ]
+        "#;
+
+        let policy: Policy = toml::from_str(base_config).unwrap();
+        assert!(policy.validate().is_err());
+    }
+
+    #[test]
+    fn test_find_priority_threshold_returns_highest_priority() {
+        let rules: Vec<Rule> = vec![
+            Rule::ConnectUser {
+                allow: true,
+                user: "".to_owned(),
+                priority: 1,
+            },
+            Rule::ConnectUser {
+                allow: true,
+                user: "".to_owned(),
+                priority: 2,
+            },
+            Rule::ConnectUser {
+                allow: true,
+                user: "".to_owned(),
+                priority: 3,
+            },
+        ];
+        assert_eq!(find_priority_threshold(&rules), 3);
+    }
+
+    #[test]
+    fn test_find_priority_threshold_defaults_to_zero() {
+        let rules: Vec<Rule> = vec![];
+        assert_eq!(find_priority_threshold(&rules), 0);
+    }
+
+    #[test]
+    fn test_clean_connect_rules() {
+        let mut rules: Vec<Rule> = vec![
+            Rule::ConnectUser {
+                allow: true,
+                user: "".to_owned(),
+                priority: 1,
+            },
+            Rule::ConnectUser {
+                allow: true,
+                user: "".to_owned(),
+                priority: 2,
+            },
+            Rule::ConnectUser {
+                allow: true,
+                user: "".to_owned(),
+                priority: 3,
+            },
+        ];
+
+        clean_connect_rules(4, &mut rules);
+        assert!(rules.is_empty());
+    }
+}

--- a/sources/whippet/src/socket.rs
+++ b/sources/whippet/src/socket.rs
@@ -1,0 +1,165 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  Copyright (C) 2016-2023 Red Hat, Inc.
+ *  Copyright (C) 2023 David Rheinsberg <david@readahead.eu>
+ *  Copyright (C) 2023 Tom Gundersen <teg@jklm.no>
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Originally derived from:
+ *  https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/main.c#L104
+ *
+ *  Changes for Bottlerocket:
+ *    - Combine the referenced function with a simple implementation of sd_listen_fds
+ *      https://github.com/systemd/systemd-stable/blob/356c54394add8c6a1d52773852c23656590dc33b/src/libsystemd/sd-daemon/sd-daemon.c#L42
+ */
+
+//! Socket management and systemd integration.
+//!
+//! This module provides utilities for managing Unix sockets used for communication
+//! with dbus-broker and systemd, including socket activation and notification.
+
+use crate::error::{self, Result};
+use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
+use snafu::{ensure, ResultExt};
+use std::env;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::net::UnixDatagram;
+use std::path::Path;
+use tokio::net::UnixStream;
+
+/// The start of the file descriptors provided by systemd's socket activation
+const SD_LISTEN_FDS_START: u8 = 3;
+/// The path to the journal socket
+const JOURNAL_SOCKET_PATH: &str = "/run/systemd/journal/socket";
+
+const LISTEN_PID_ENVVAR: &str = "LISTEN_PID";
+const LISTEN_FDS_ENVVAR: &str = "LISTEN_FDS";
+const NOTIFY_SOCKET_ENVVAR: &str = "NOTIFY_SOCKET";
+
+/// Retrieves the systemd-provided listener socket file descriptor.
+///
+/// Validates that exactly one socket was provided via systemd socket activation
+/// and configures it with the required flags for dbus-broker operation.
+pub fn listener_socket() -> Result<u8> {
+    let listen_pid = std::env::var(LISTEN_PID_ENVVAR).context(error::MissingEnvVarSnafu {
+        what: LISTEN_PID_ENVVAR.to_string(),
+    })?;
+
+    let current_pid = std::process::id().to_string();
+    ensure!(
+        listen_pid == current_pid,
+        error::UnexpectedPidSnafu {
+            expected: current_pid,
+            found: listen_pid
+        }
+    );
+
+    let listen_fds = std::env::var(LISTEN_FDS_ENVVAR).context(error::MissingEnvVarSnafu {
+        what: LISTEN_FDS_ENVVAR.to_string(),
+    })?;
+
+    let fd_count: u32 = listen_fds
+        .parse()
+        .context(error::InvalidFileDescriptorCountSnafu { count: listen_fds })?;
+
+    ensure!(
+        fd_count == 1,
+        error::UnexpectedFileDescriptorCountSnafu { found: fd_count }
+    );
+
+    let fd = SD_LISTEN_FDS_START as RawFd;
+
+    // The listener socket has to be configured as O_NONBLOCK, otherwise clients that connect to
+    // the dbus socket will hang
+    set_nonblock(fd)?;
+
+    // Return the start of the file descriptors, as only one is expected
+    // See:
+    // https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/main.c#L104
+    Ok(SD_LISTEN_FDS_START)
+}
+
+/// Creates a Unix socket pair for dbus-broker controller communication.
+///
+/// Returns a pair of connected Unix stream sockets with CLOEXEC flags cleared
+/// to allow inheritance by the child process.
+#[must_use = "socket pair must be used for communication"]
+pub fn controller_pair() -> Result<(UnixStream, UnixStream)> {
+    let (stream1, stream2) = UnixStream::pair().context(error::SocketPairSnafu)?;
+
+    clear_cloexec(stream1.as_raw_fd())?;
+    clear_cloexec(stream2.as_raw_fd())?;
+
+    Ok((stream1, stream2))
+}
+
+/// Creates a Unix datagram socket connected to the systemd journal.
+///
+/// Establishes connection to the journal socket for dbus-broker logging
+/// and clears CLOEXEC to allow inheritance by the child process.
+#[must_use = "journal socket must be used for logging"]
+pub fn journal_socket() -> Result<UnixDatagram> {
+    let socket = UnixDatagram::unbound().context(error::JournalSocketSnafu)?;
+
+    socket
+        .connect(JOURNAL_SOCKET_PATH)
+        .context(error::JournalSocketSnafu)?;
+
+    // Clear CLOEXEC flag so dbus-broker can inherit the socket
+    clear_cloexec(socket.as_raw_fd())?;
+
+    Ok(socket)
+}
+
+/// Creates a Unix datagram socket for systemd service notifications.
+///
+/// Connects to the socket specified by the NOTIFY_SOCKET environment variable
+/// for sending service readiness notifications to systemd.
+#[must_use = "notification socket must be used to notify systemd"]
+pub fn notify_socket() -> Result<UnixDatagram> {
+    let notify_socket_path = env::var(NOTIFY_SOCKET_ENVVAR).context(error::MissingEnvVarSnafu {
+        what: NOTIFY_SOCKET_ENVVAR.to_string(),
+    })?;
+
+    let socket = UnixDatagram::unbound().context(error::SystemdNotifySocketSnafu)?;
+
+    socket
+        .connect(Path::new(&notify_socket_path))
+        .context(error::SystemdNotifySocketSnafu)?;
+
+    Ok(socket)
+}
+
+/// Clears the CLOEXEC flag on a file descriptor.
+///
+/// Allows the file descriptor to be inherited by child processes,
+/// which is required for dbus-broker socket inheritance.
+pub fn clear_cloexec(fd: RawFd) -> Result<()> {
+    let flags = fcntl(fd, FcntlArg::F_GETFD).context(error::GetFdFlagsSnafu { fd })?;
+
+    let mut fd_flags = FdFlag::from_bits_truncate(flags);
+    fd_flags.remove(FdFlag::FD_CLOEXEC);
+
+    nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_SETFD(fd_flags)).context(
+        error::SetFlagSnafu {
+            what: "CLOEXEC",
+            fd,
+        },
+    )?;
+
+    Ok(())
+}
+
+/// Sets the NONBLOCK flag for the file descriptor
+pub fn set_nonblock(fd: RawFd) -> Result<()> {
+    let current_flags = fcntl(fd, FcntlArg::F_GETFL).context(error::GetFdFlagsSnafu { fd })?;
+
+    let new_flags = OFlag::from_bits_truncate(current_flags) | OFlag::O_NONBLOCK;
+    nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_SETFL(new_flags)).context(
+        error::SetFlagSnafu {
+            fd,
+            what: "O_NONBLOCK",
+        },
+    )?;
+    Ok(())
+}

--- a/sources/whippet/tests/data/main.toml
+++ b/sources/whippet/tests/data/main.toml
@@ -1,0 +1,4 @@
+[default]
+rules = [
+    { allow = true, user = "*" }
+]

--- a/sources/whippet/tests/data/policies/01-first-policy.toml
+++ b/sources/whippet/tests/data/policies/01-first-policy.toml
@@ -1,0 +1,10 @@
+[user.alice]
+rules = [
+    { allow = true, send_interface = "org.example.First" }
+]
+
+[default]
+rules = [
+    { allow = true, own = "org.example.First" }
+]
+

--- a/sources/whippet/tests/data/policies/02-second-policy.toml
+++ b/sources/whippet/tests/data/policies/02-second-policy.toml
@@ -1,0 +1,14 @@
+[user.bob]
+rules = [
+    { allow = true, send_interface = "org.example.Second" }
+]
+
+[user.alice]
+rules = [
+    { allow = true, send_interface = "org.example.SecondService" }
+]
+
+[default]
+rules = [
+    { allow = true, own = "org.example.Second" }
+]


### PR DESCRIPTION
**Issue number:**

Part of #660

**Description of changes:**

This adds `whippet`, a minimal implementation of a dbus-launcher. The set of features implemented by whippet include:
- Systemd socket activation
- Policy parsing but using TOML

<details>

**Differences between the dbus launcher and whippet**

**No default connect rule for whippet’s user**

One of the key differences between the launcher and whippet is that whippet doesn’t insert a default connect rule, the reason for this is twofold:

* Whippet doesn’t have to interact with the bus, as it doesn’t support the features that require interactions with it
    * Dbus service activation
    * Reload configurations
* Bottlerocket’s default dbus policy allows all system users to connect to the bus
    * So instead of allowing whippet to connect to the bus by default, it only gets the permission if actually allowed by the policy

**Drop support for deprecated or unused rule configurations**

To keep whippet’s implementation as minimal as possible whippet only supports the rule fields that are actually used in Bottlerocket. Additionally, whippet removes fields marked as deprecated in the configuration file and policy rules, this includes

* In configuration file:
    * user: used to drop privileges to the selected user. whippet relies on systemd directives to drop this privilege.
    * auth: [this isn’t implemented](https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/config.c#L1173) in the dbus-launcher
    * listen: [this isn’t implemented](https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/config.c#L1170) in the dbus-launcher
* In Rules:
    * send_type/receive_type = method_return or error: the dbus-launcher [warns and ignores these values](https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c#L439)
    * Don’t support group, at_console, no_console or mandatory contexts, as they aren’t currently used in Bottlerocket

**Rule priority assignment**

In the dbus-launcher, rules are given a priority that is used to determine which rule wins when sending or receiving a message through the bus. The rules with the highest priorities win.

Whippet implements the priority assignment as close as possible to what the dbus-launcher does. However, there is a limitation on whippet’s implementation. The dbus-launcher assigns priorities to the rules in the order they appear, e.g. these rules:

```xml
<policy context="default">
    <allow user="*" />
    <deny send_path="*" />
</policy>

<policy user="root">
    <allow send_path="*" />
</policy>
```

Will get different priorities than the following rules, even though the actual permissions are identical:

```xml
<policy user="root">
    <allow send_path="*" />
</policy>

<policy context="default">
    <allow user="*" />
    <deny send_path="*" /> 
</policy>
```

This difference in order doesn’t affect the purpose of the policy, as the formula to calculate the rules guarantees that user rules will always get a higher priority to the default rules:

```
PRIORITY_BASE: u64 = u64::MAX / 7
priority = PRIORITY_BASE * <WEIGHT> + *current_priority

WEIGHT FOR DEFAULT = 1 (priority starts at 2635249153387078802)
WEIGHT FOR GROUP = 2 # not used in Bottlerocket
WEIGHT FOR USER = 3 (priority starts at 7905747460161236406)
```

For a default rule to overlap with the next context, there would have to be at least `2635249153387078802` rules. Bottlerocket has 204 rules in total.

**Generated priorities**

After re-arranging the configuration files for both whippet and the dbus-launcher to have the same order, and removing unused rules from the dbus-launcher configuration file (so that they are more deterministic), I confirmed:

|	|Policy size	|Default Policy Rules	|UID 0	|UID 192	|
|---	|---	|---	|---	|---	|
|whippet	|104375 bytes	|Own rules: 1, Send rules: 186, Recv rules: 6	|Own rules: 3, Send rules: 191, Recv rules: 9	|Own rules: 2, Send rules: 187, Recv rules: 7	|
|dbus-launcher	|104375 bytes	|Own rules: 1, Send rules: 186, Recv rules: 6	|Own rules: 3, Send rules: 191, Recv rules: 9	|Own rules: 2, Send rules: 187, Recv rules: 7	|

**Sample rules to demonstrate they got the same priority**

**Launcher**

```
Send rule 13: verdict=ALLOW, priority=2635249153387078828, name='org.freedesktop.login1', path='', interface='org.freedesktop.login1.Manager', member='GetSession',
```

**Whippet**

```
Send rule 13: verdict=ALLOW, priority=2635249153387078828, name='org.freedesktop.login1', path='', interface='org.freedesktop.login1.Manager', member='GetSession',
```

</details>

**NOTE FOR REVIEWERS**

Reviewers are advised to review in this order:
- `main.rs`
- `policy.rs`: contains information of how rules are assigned a priority, and provides examples and unit tests cases for better understanding
- `dbus_policy.rs`: contains information of how the default rules are passed to all the users in a policy
- `broker.rs`
- `child.rs`


**Testing done:**
In combination with #677 and #678: 

<details>

- Kubernetes 1.31, 6.1 Kernel, systemd 252, using whippet:

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "90a6e5c4f-dirty",
    "pretty_name": "Bottlerocket OS 1.47.0 (aws-k8s-1.31)",
    "variant_id": "aws-k8s-1.31",
    "version_id": "1.47.0"
  }
}
# whippet is running as the dbus-broker service
bash-5.1# systemctl status whippet.service
● whippet.service - D-Bus System Message Bus
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/whippet.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Fri 2025-10-10 05:06:52 UTC; 10min ago
TriggeredBy: ● dbus.socket
   Main PID: 1165 (whippet)
      Tasks: 6 (limit: 18904)
     Memory: 5.0M
        CPU: 146ms
     CGroup: /system.slice/whippet.service
             ├─1165 /usr/bin/whippet
             └─1170 /usr/bin/dbus-broker --log 12 --controller 11 --machine-id ec205cbda35e60eb68d2ca9ea40b8d61 --max-bytes 536870912 --max-fds 4096 --max-matches 16384

Oct 10 05:06:52 localhost whippet[1165]: 05:06:52 [INFO] read_commands; n_commands=1
Oct 10 05:06:52 localhost whippet[1165]: 05:06:52 [INFO] Using listener socket FD: 3
Oct 10 05:06:52 localhost whippet[1165]: 05:06:52 [INFO] Calling AddListener method
Oct 10 05:06:52 localhost whippet[1165]: 05:06:52 [INFO] socket reader;
Oct 10 05:06:52 localhost whippet[1165]: 05:06:52 [INFO] read_socket;
Oct 10 05:06:52 localhost whippet[1165]: 05:06:52 [INFO] read_socket;
Oct 10 05:06:52 localhost whippet[1165]: 05:06:52 [INFO] AddListener call completed successfully
Oct 10 05:06:52 localhost whippet[1165]: 05:06:52 [INFO] Policy applied successfully
Oct 10 05:06:52 localhost whippet[1165]: 05:06:52 [INFO] Notified systemd that service is ready
Oct 10 05:06:52 localhost systemd[1]: Started D-Bus System Message Bus.

bash-5.1# systemd-analyze --version
systemd 252 (252)
-PAM -AUDIT +SELINUX -APPARMOR -IMA -SMACK +SECCOMP -GCRYPT -GNUTLS +OPENSSL +ACL +BLKID -CURL -ELFUTILS -FIDO2 -IDN2 -IDN -IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK -PCRE2 -PWQUALITY -P11KIT -QRENCODE +TPM2 -BZIP2 -LZ4 -XZ -ZLIB -ZSTD -BPF_FRAMEWORK -XKBCOMMON -UTMP -SYSVINIT default-hierarchy=unified

# The dbus-broker-launcher package isn't installed when whippet is chosen
bash-5.1# grep "dbus-broker-launcher" /usr/share/bottlerocket/application-inventory.json
bash-5.1# grep "whippet" /usr/share/bottlerocket/application-inventory.json
      "Name": "whippet",
bash-5.1#
```
</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
