### PR TITLE
Drop expat

### DIFF
--- a/packages/dbus-broker/0002-meson.build-remove-condition-to-build-the-journal-ca.patch
+++ b/packages/dbus-broker/0002-meson.build-remove-condition-to-build-the-journal-ca.patch
@@ -1,0 +1,64 @@
+From 819952f36db9a27e3dff5c9db7344992263d111d Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Thu, 18 Sep 2025 01:55:32 +0000
+Subject: [PATCH] meson.build: remove condition to build the journal catalog
+
+Don't require the dbus-launcher to build the journal catalog
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ meson.build       | 6 +++++-
+ meson_options.txt | 1 +
+ src/meson.build   | 2 +-
+ 3 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 72e2b47..625c552 100644
+--- a/meson.build
++++ b/meson.build
+@@ -67,6 +67,11 @@ if use_docs
+ endif
+ 
+ #
++# Config: catalog (needed for both broker and launcher)
++#
++
++conf.set('catalogdir', get_option('catalogdir'))
++
+ # Config: launcher
+ #
+ 
+@@ -79,7 +84,6 @@ if use_launcher
+         add_project_arguments('-DSYSTEMUIDMAX=' + dep_systemd.get_variable('systemuidmax'), language: 'c')
+         conf.set('systemunitdir', dep_systemd.get_variable('systemdsystemunitdir'))
+         conf.set('userunitdir', dep_systemd.get_variable('systemduserunitdir'))
+-        conf.set('catalogdir', dep_systemd.get_variable('catalogdir'))
+ endif
+ 
+ #
+diff --git a/meson_options.txt b/meson_options.txt
+index 5227a93..bfc898c 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -7,3 +7,4 @@ option('reference-test', type: 'boolean', value: false, description: 'Run test s
+ option('selinux', type: 'boolean', value: false, description: 'SELinux support')
+ option('system-console-users', type: 'array', value: [], description: 'Additional set of names of system-users to be considered at-console')
+ option('tests', type: 'boolean', value: false, description: 'Include tests in the distribution')
++option('catalogdir', type: 'string', description: 'The target directory of the catalogdir')
+diff --git a/src/meson.build b/src/meson.build
+index 4b9bc71..33fc7f7 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -2,8 +2,8 @@
+ # target: subdirs
+ #
+ 
++subdir('catalog')
+ if use_launcher
+-        subdir('catalog')
+         subdir('units/system')
+         subdir('units/user')
+ endif
+-- 
+2.50.1
+

--- a/packages/dbus-broker/dbus-broker-launcher.conf
+++ b/packages/dbus-broker/dbus-broker-launcher.conf
@@ -1,0 +1,4 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dbus-broker-launch --scope system
+ExecReload=/usr/bin/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig

--- a/packages/dbus-broker/dbus-broker.service
+++ b/packages/dbus-broker/dbus-broker.service
@@ -15,8 +15,8 @@ LimitNOFILE=16384
 ProtectSystem=full
 PrivateTmp=true
 PrivateDevices=true
-ExecStart=/usr/bin/dbus-broker-launch --scope system
-ExecReload=/usr/bin/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig
+# Must be overriden by a drop-in
+ExecStart=/usr/bin/false
 
 [Install]
 Alias=dbus.service

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -12,6 +12,7 @@ Source11: dbus.socket
 Source12: dbus-1-system.conf
 Source13: dbus-sysusers.conf
 Source14: dbus-broker.service
+Source15: dbus-broker-launcher.conf
 
 BuildRequires: meson
 BuildRequires: %{_cross_os}glibc-devel
@@ -21,11 +22,23 @@ BuildRequires: %{_cross_os}systemd-devel
 Requires: %{_cross_os}libexpat
 Requires: %{_cross_os}libselinux
 Requires: %{_cross_os}systemd
+Requires: %{_cross_os}dbus-broker(launcher)
 
 # Work around an aliasing rules violation.
 Patch0001: 0001-c-utf8-disable-strict-aliasing-optimizations.patch
+# Allow building the journal catalogs when dbus-launcher is excluded
+Patch0002: 0002-meson.build-remove-condition-to-build-the-journal-ca.patch
 
 %description
+%{summary}.
+
+%package launcher
+Summary: A dbus-broker launcher
+Provides: %{_cross_os}dbus-broker(launcher) = 1:
+Conflicts: %{_cross_os}dbus-broker(launcher)
+Requires: %{name}
+
+%description launcher
 %{summary}.
 
 %prep
@@ -39,6 +52,7 @@ CONFIGURE_OPTS=(
  -Ddocs=false
  -Dlauncher=true
  -Dselinux=true
+ -Dcatalogdir=%{_cross_journalcatalogdir}
 )
 
 %cross_meson "${CONFIGURE_OPTS[@]}"
@@ -48,10 +62,12 @@ CONFIGURE_OPTS=(
 %cross_meson_install
 
 install -d %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_unitdir}/dbus-broker.service.d/
 install -p -m 0644 %{S:11} %{S:14} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_datadir}/dbus-1/{interfaces,services,system-services,system.d}
 install -p -m 0644 %{S:12} %{buildroot}%{_cross_datadir}/dbus-1/system.conf
+install -p -m 0644 %{S:15} %{buildroot}%{_cross_unitdir}/dbus-broker.service.d/
 
 install -d %{buildroot}%{_cross_sysusersdir}
 install -p -m 0644 %{S:13} %{buildroot}%{_cross_sysusersdir}/dbus.conf
@@ -60,14 +76,17 @@ install -p -m 0644 %{S:13} %{buildroot}%{_cross_sysusersdir}/dbus.conf
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_bindir}/dbus-broker
-%{_cross_bindir}/dbus-broker-launch
 %dir %{_cross_datadir}/dbus-1
-%{_cross_datadir}/dbus-1/*
 %{_cross_journalcatalogdir}/dbus-broker.catalog
-%{_cross_journalcatalogdir}/dbus-broker-launch.catalog
 %{_cross_sysusersdir}/dbus.conf
-%{_cross_unitdir}/dbus-broker.service
 %{_cross_unitdir}/dbus.socket
+%{_cross_unitdir}/dbus-broker.service
 %exclude %{_cross_userunitdir}/dbus-broker.service
+
+%files launcher
+%{_cross_bindir}/dbus-broker-launch
+%{_cross_unitdir}/dbus-broker.service.d/dbus-broker-launcher.conf
+%{_cross_journalcatalogdir}/dbus-broker-launch.catalog
+%{_cross_datadir}/dbus-1/*
 
 %changelog

--- a/packages/systemd-252/org.freedesktop.login1.toml
+++ b/packages/systemd-252/org.freedesktop.login1.toml
@@ -1,0 +1,515 @@
+# Generated programatically, serde/toml doesn't allow to force the "compact"
+# format on serialization:
+# [user.root]
+# rules = []
+
+[[user.root.rules]]
+own = "org.freedesktop.login1"
+allow = true
+
+[[user.root.rules]]
+send_destination = "org.freedesktop.login1"
+allow = true
+
+[[user.root.rules]]
+receive_sender = "org.freedesktop.login1"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+allow = false
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Introspectable"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Peer"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "Get"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "GetAll"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSessionByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetUserByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListUsers"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListSeats"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListInhibitors"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Inhibit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetUserLinger"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ActivateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ActivateSessionOnSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "LockSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "UnlockSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "LockSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "UnlockSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "KillSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "KillUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "PowerOff"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "PowerOffWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Reboot"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "RebootWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Halt"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HaltWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Suspend"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Hibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HibernateWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HybridSleep"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HybridSleepWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendThenHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendThenHibernateWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanPowerOff"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanReboot"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHalt"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanSuspend"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHybridSleep"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanSuspendThenHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ScheduleShutdown"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CancelScheduledShutdown"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootParameter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootParameter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToFirmwareSetup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToFirmwareSetup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToBootLoaderMenu"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToBootLoaderMenu"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToBootLoaderEntry"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToBootLoaderEntry"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetWallMessage"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "AttachDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "FlushDevices"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "ActivateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchTo"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchToPrevious"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchToNext"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Activate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Lock"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Unlock"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetIdleHint"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetLockedHint"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "TakeControl"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "ReleaseControl"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetType"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "TakeDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "ReleaseDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "PauseDeviceComplete"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetBrightness"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.User"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.User"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetDisplay"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.login1"
+allow = true
+

--- a/packages/systemd-252/org.freedesktop.network1.toml
+++ b/packages/systemd-252/org.freedesktop.network1.toml
@@ -1,0 +1,24 @@
+# Generated programatically, serde/toml doesn't allow to force the "compact"
+# format on serialization:
+# [user.root]
+# rules = []
+
+[[user.systemd-network.rules]]
+own = "org.freedesktop.network1"
+allow = true
+
+[[user.systemd-network.rules]]
+send_destination = "org.freedesktop.network1"
+allow = true
+
+[[user.systemd-network.rules]]
+receive_sender = "org.freedesktop.network1"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.network1"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.network1"
+allow = true

--- a/packages/systemd-252/org.freedesktop.resolve1.toml
+++ b/packages/systemd-252/org.freedesktop.resolve1.toml
@@ -1,0 +1,24 @@
+# Generated programatically, serde/toml doesn't allow to force the "compact"
+# format on serialization:
+# [user.root]
+# rules = []
+
+[[user.systemd-resolve.rules]]
+own = "org.freedesktop.resolve1"
+allow = true
+
+[[user.systemd-resolve.rules]]
+send_destination = "org.freedesktop.resolve1"
+allow = true
+
+[[user.systemd-resolve.rules]]
+receive_sender = "org.freedesktop.resolve1"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.resolve1"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.resolve1"
+allow = true

--- a/packages/systemd-252/org.freedesktop.systemd1.toml
+++ b/packages/systemd-252/org.freedesktop.systemd1.toml
@@ -1,0 +1,579 @@
+# Generated programatically, serde/toml doesn't allow to force the "compact"
+# format on serialization:
+# [user.root]
+# rules = []
+
+[[user.root.rules]]
+own = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+send_destination = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+receive_sender = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+receive_interface = "org.freedesktop.systemd1.Activator"
+receive_member = "ActivationRequest"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+allow = false
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Introspectable"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Peer"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "Get"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "GetAll"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByInvocationID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByControlGroup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LoadUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJob"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJobAfter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJobBefore"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnits"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsFiltered"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsByPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsByNames"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListJobs"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Subscribe"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Unsubscribe"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Dump"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpByFileDescriptor"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpUnitsMatchingPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpUnitsMatchingPatternsByFileDescriptor"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitFilesByPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitFileState"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetDefaultTarget"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitFileLinks"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LookupDynamicUserByName"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LookupDynamicUserByUID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetDynamicUsers"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Slice"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Scope"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Socket"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Mount"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Swap"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartUnitReplace"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StopUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "TryRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadOrRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadOrTryRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "BindMountUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "MountImageUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "KillUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ResetFailedUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetUnitProperties"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RefUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "UnrefUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartTransientUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "AttachProcessesToUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "CancelJob"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ClearJobs"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ResetFailed"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Reload"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Reexecute"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "EnableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DisableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReenableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LinkUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetUnitFilesWithMode"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "MaskUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "UnmaskUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RevertUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetDefaultTarget"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetAllUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "AddDependencyUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetShowStatus"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "Cancel"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "GetAfter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "GetBefore"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Start"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Stop"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Reload"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Restart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "TryRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ReloadOrRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ReloadOrTryRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ResetFailed"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "SetProperties"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Ref"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Unref"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "AttachProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "BindMount"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "MountImage"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Scope"
+send_member = "AttachProcesses"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.systemd1"
+allow = true

--- a/packages/systemd-252/systemd-252.spec
+++ b/packages/systemd-252/systemd-252.spec
@@ -10,6 +10,10 @@ Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later
 URL: https://www.freedesktop.org/wiki/Software/systemd
 Source0: https://github.com/systemd/systemd-stable/archive/v%{version}/systemd-stable-%{version}.tar.gz
+Source100: org.freedesktop.login1.toml
+Source101: org.freedesktop.network1.toml
+Source102: org.freedesktop.resolve1.toml
+Source103: org.freedesktop.systemd1.toml
 
 # Backport of upstream patches that make the netlink default timeout
 # configurable.  Bottlerocket carries this patch and configures the timeout in
@@ -121,6 +125,7 @@ Requires: %{_cross_os}libselinux
 Requires: %{_cross_os}libtss2
 Requires: %{_cross_os}libuuid
 Requires: %{_cross_os}libxcrypt
+Requires: %{name}(dbus-config)
 
 Provides: %{_cross_os}systemd = %{package_priority_epoch}:
 Conflicts: %{_cross_os}systemd
@@ -156,6 +161,7 @@ Provides: %{_cross_os}systemd-devel = %{package_priority_epoch}:
 %package networkd
 Summary: Files for networkd
 Requires: %{name}
+Requires: %{name}-networkd(dbus-config)
 Provides: %{_cross_os}systemd-networkd = %{package_priority_epoch}:
 
 %description networkd
@@ -164,9 +170,38 @@ Provides: %{_cross_os}systemd-networkd = %{package_priority_epoch}:
 %package resolved
 Summary: Files for resolved
 Requires: %{name}
+Requires: %{name}-resolved(dbus-config)
 Provides: %{_cross_os}systemd-resolved = %{package_priority_epoch}:
 
 %description resolved
+%{summary}.
+
+%package dbus-launcher-config
+Summary: Dbus launcher configuration files
+Requires: %{name}
+Provides: %{name}(dbus-config) = 1:
+Provides: %{name}-resolved(dbus-config) = 1:
+Provides: %{name}-networkd(dbus-config) = 1:
+Conflicts: (%{_cross_os}whippet or %{name}-whippet-config)
+Conflicts: %{name}(dbus-config)
+Conflicts: %{name}-resolved(dbus-config)
+Conflicts: %{name}-networkd(dbus-config)
+
+%description dbus-launcher-config
+%{summary}.
+
+%package whippet-config
+Summary: Whippet configuration files
+Requires: %{name}
+Provides: %{name}(dbus-config) = 1:
+Provides: %{name}-resolved(dbus-config) = 0:
+Provides: %{name}-networkd(dbus-config) = 0:
+Conflicts: (%{_cross_os}dbus-broker-launcher or %{name}-dbus-launcher-config)
+Conflicts: %{name}(dbus-config)
+Conflicts: %{name}-resolved(dbus-config)
+Conflicts: %{name}-networkd(dbus-config)
+
+%description whippet-config
 %{summary}.
 
 %prep
@@ -343,9 +378,12 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/graphical.target
 ln -s  ../proc-sys-fs-binfmt_misc.mount \
   %{buildroot}%{_cross_unitdir}/sysinit.target.wants/proc-sys-fs-binfmt_misc.mount
 
+install -d %{buildroot}%{_cross_datadir}/whippet/policies.d
+install -p -m 0644 %{S:100} %{S:101} %{S:102} %{S:103} %{buildroot}%{_cross_datadir}/whippet/policies.d
 
 # Remove any README files.
 find %{buildroot} -type f -name README -print -delete
+
 
 %files
 %license LICENSE.GPL2 LICENSE.LGPL2.1
@@ -661,10 +699,6 @@ find %{buildroot} -type f -name README -print -delete
 %{_cross_tmpfilesdir}/var.conf
 %exclude %{_cross_tmpfilesdir}/x11.conf
 
-%{_cross_datadir}/dbus-1/services/org.freedesktop.systemd1.service
-%{_cross_datadir}/dbus-1/system.d/org.freedesktop.login1.conf
-%{_cross_datadir}/dbus-1/system.d/org.freedesktop.systemd1.conf
-%exclude %{_cross_datadir}/dbus-1/system-services
 
 %dir %{_cross_factorydir}
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/issue
@@ -749,7 +783,6 @@ find %{buildroot} -type f -name README -print -delete
 %{_cross_unitdir}/systemd-networkd-wait-online.service
 %{_cross_unitdir}/systemd-networkd-wait-online@.service
 %{_cross_unitdir}/systemd-networkd.socket
-%{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
 
 %files resolved
 %{_cross_bindir}/resolvectl
@@ -759,7 +792,6 @@ find %{buildroot} -type f -name README -print -delete
 %{_cross_sysusersdir}/systemd-resolve.conf
 %{_cross_tmpfilesdir}/systemd-resolve.conf
 %{_cross_unitdir}/systemd-resolved.service
-%{_cross_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
 %exclude %{_cross_bindir}/systemd-resolve
 %exclude %{_cross_sbindir}/resolvconf
 
@@ -782,3 +814,17 @@ find %{buildroot} -type f -name README -print -delete
 %{_cross_unitdir}/sysinit.target.wants/cryptsetup.target
 %{_cross_unitdir}/sysinit.target.wants/integritysetup.target
 %{_cross_unitdir}/sysinit.target.wants/veritysetup.target
+
+%files dbus-launcher-config
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.login1.conf
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.systemd1.conf
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
+%{_cross_datadir}/dbus-1/system-services
+%{_cross_datadir}/dbus-1/services/org.freedesktop.systemd1.service
+
+%files whippet-config
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.login1.toml
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.network1.toml
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.systemd1.toml
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.resolve1.toml

--- a/packages/systemd-257/org.freedesktop.login1.toml
+++ b/packages/systemd-257/org.freedesktop.login1.toml
@@ -1,0 +1,515 @@
+# Generated programatically, serde/toml doesn't allow to force the "compact"
+# format on serialization:
+# [user.root]
+# rules = []
+
+[[user.root.rules]]
+own = "org.freedesktop.login1"
+allow = true
+
+[[user.root.rules]]
+send_destination = "org.freedesktop.login1"
+allow = true
+
+[[user.root.rules]]
+receive_sender = "org.freedesktop.login1"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+allow = false
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Introspectable"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Peer"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "Get"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "GetAll"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSessionByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetUserByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListUsers"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListSeats"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListInhibitors"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Inhibit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetUserLinger"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ActivateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ActivateSessionOnSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "LockSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "UnlockSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "LockSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "UnlockSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "KillSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "KillUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "PowerOff"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "PowerOffWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Reboot"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "RebootWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Halt"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HaltWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Suspend"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Hibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HibernateWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HybridSleep"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HybridSleepWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendThenHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendThenHibernateWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanPowerOff"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanReboot"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHalt"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanSuspend"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHybridSleep"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanSuspendThenHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ScheduleShutdown"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CancelScheduledShutdown"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootParameter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootParameter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToFirmwareSetup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToFirmwareSetup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToBootLoaderMenu"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToBootLoaderMenu"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToBootLoaderEntry"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToBootLoaderEntry"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetWallMessage"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "AttachDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "FlushDevices"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "ActivateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchTo"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchToPrevious"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchToNext"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Activate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Lock"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Unlock"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetIdleHint"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetLockedHint"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "TakeControl"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "ReleaseControl"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetType"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "TakeDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "ReleaseDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "PauseDeviceComplete"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetBrightness"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.User"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.User"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetDisplay"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.login1"
+allow = true
+

--- a/packages/systemd-257/org.freedesktop.network1.toml
+++ b/packages/systemd-257/org.freedesktop.network1.toml
@@ -1,0 +1,24 @@
+# Generated programatically, serde/toml doesn't allow to force the "compact"
+# format on serialization:
+# [user.root]
+# rules = []
+
+[[user.systemd-network.rules]]
+own = "org.freedesktop.network1"
+allow = true
+
+[[user.systemd-network.rules]]
+send_destination = "org.freedesktop.network1"
+allow = true
+
+[[user.systemd-network.rules]]
+receive_sender = "org.freedesktop.network1"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.network1"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.network1"
+allow = true

--- a/packages/systemd-257/org.freedesktop.resolve1.toml
+++ b/packages/systemd-257/org.freedesktop.resolve1.toml
@@ -1,0 +1,24 @@
+# Generated programatically, serde/toml doesn't allow to force the "compact"
+# format on serialization:
+# [user.root]
+# rules = []
+
+[[user.systemd-resolve.rules]]
+own = "org.freedesktop.resolve1"
+allow = true
+
+[[user.systemd-resolve.rules]]
+send_destination = "org.freedesktop.resolve1"
+allow = true
+
+[[user.systemd-resolve.rules]]
+receive_sender = "org.freedesktop.resolve1"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.resolve1"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.resolve1"
+allow = true

--- a/packages/systemd-257/org.freedesktop.systemd1.toml
+++ b/packages/systemd-257/org.freedesktop.systemd1.toml
@@ -1,0 +1,579 @@
+# Generated programatically, serde/toml doesn't allow to force the "compact"
+# format on serialization:
+# [user.root]
+# rules = []
+
+[[user.root.rules]]
+own = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+send_destination = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+receive_sender = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+receive_interface = "org.freedesktop.systemd1.Activator"
+receive_member = "ActivationRequest"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+allow = false
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Introspectable"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Peer"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "Get"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "GetAll"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByInvocationID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByControlGroup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LoadUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJob"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJobAfter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJobBefore"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnits"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsFiltered"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsByPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsByNames"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListJobs"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Subscribe"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Unsubscribe"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Dump"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpByFileDescriptor"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpUnitsMatchingPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpUnitsMatchingPatternsByFileDescriptor"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitFilesByPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitFileState"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetDefaultTarget"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitFileLinks"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LookupDynamicUserByName"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LookupDynamicUserByUID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetDynamicUsers"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Slice"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Scope"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Socket"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Mount"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Swap"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartUnitReplace"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StopUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "TryRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadOrRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadOrTryRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "BindMountUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "MountImageUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "KillUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ResetFailedUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetUnitProperties"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RefUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "UnrefUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartTransientUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "AttachProcessesToUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "CancelJob"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ClearJobs"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ResetFailed"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Reload"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Reexecute"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "EnableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DisableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReenableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LinkUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetUnitFilesWithMode"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "MaskUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "UnmaskUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RevertUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetDefaultTarget"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetAllUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "AddDependencyUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetShowStatus"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "Cancel"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "GetAfter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "GetBefore"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Start"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Stop"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Reload"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Restart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "TryRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ReloadOrRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ReloadOrTryRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ResetFailed"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "SetProperties"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Ref"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Unref"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "AttachProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "BindMount"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "MountImage"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Scope"
+send_member = "AttachProcesses"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.systemd1"
+allow = true

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -10,6 +10,10 @@ Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later
 URL: https://www.freedesktop.org/wiki/Software/systemd
 Source0: https://github.com/systemd/systemd/archive/v%{version}/systemd-%{version}.tar.gz
+Source100: org.freedesktop.login1.toml
+Source101: org.freedesktop.network1.toml
+Source102: org.freedesktop.resolve1.toml
+Source103: org.freedesktop.systemd1.toml
 
 Source1: systemd-mount-rate-bootconfig.conf
 Source2: systemd-cgroup-legacy-force-bootconfig.conf
@@ -75,6 +79,7 @@ Requires: %{_cross_os}libseccomp
 Requires: %{_cross_os}libselinux
 Requires: %{_cross_os}libuuid
 Requires: %{_cross_os}libxcrypt
+Requires: %{name}(dbus-config)
 
 Provides: %{_cross_os}systemd = %{package_priority_epoch}:
 Conflicts: %{_cross_os}systemd
@@ -110,6 +115,7 @@ Provides: %{_cross_os}systemd-devel = %{package_priority_epoch}:
 %package networkd
 Summary: Files for networkd
 Requires: %{name}
+Requires: %{name}-networkd(dbus-config)
 Provides: %{_cross_os}systemd-networkd = %{package_priority_epoch}:
 
 %description networkd
@@ -118,9 +124,38 @@ Provides: %{_cross_os}systemd-networkd = %{package_priority_epoch}:
 %package resolved
 Summary: Files for resolved
 Requires: %{name}
+Requires: %{name}-resolved(dbus-config)
 Provides: %{_cross_os}systemd-resolved = %{package_priority_epoch}:
 
 %description resolved
+%{summary}.
+
+%package dbus-launcher-config
+Summary: Dbus launcher configuration files
+Requires: %{name}
+Provides: %{name}(dbus-config) = 1:
+Provides: %{name}-resolved(dbus-config) = 1:
+Provides: %{name}-networkd(dbus-config) = 1:
+Conflicts: (%{_cross_os}whippet or %{name}-whippet-config)
+Conflicts: %{name}(dbus-config)
+Conflicts: %{name}-resolved(dbus-config)
+Conflicts: %{name}-networkd(dbus-config)
+
+%description dbus-launcher-config
+%{summary}.
+
+%package whippet-config
+Summary: Whippet configuration files
+Requires: %{name}
+Provides: %{name}(dbus-config) = 1:
+Provides: %{name}-resolved(dbus-config) = 0:
+Provides: %{name}-networkd(dbus-config) = 0:
+Conflicts: (%{_cross_os}dbus-broker-launcher or %{name}-dbus-launcher-config)
+Conflicts: %{name}(dbus-config)
+Conflicts: %{name}-resolved(dbus-config)
+Conflicts: %{name}-networkd(dbus-config)
+
+%description whippet-config
 %{summary}.
 
 %prep
@@ -303,6 +338,9 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/graphical.target
 # since we exclude the automount unit.
 ln -s  ../proc-sys-fs-binfmt_misc.mount \
   %{buildroot}%{_cross_unitdir}/sysinit.target.wants/proc-sys-fs-binfmt_misc.mount
+
+install -d %{buildroot}%{_cross_datadir}/whippet/policies.d
+install -p -m 0644 %{S:100} %{S:101} %{S:102} %{S:103} %{buildroot}%{_cross_datadir}/whippet/policies.d
 
 # Remove any README files.
 find %{buildroot} -type f -name README -print -delete
@@ -674,11 +712,6 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %exclude %{_cross_tmpfilesdir}/legacy.conf
 %exclude %{_cross_tmpfilesdir}/x11.conf
 
-%{_cross_datadir}/dbus-1/services/org.freedesktop.systemd1.service
-%{_cross_datadir}/dbus-1/system.d/org.freedesktop.login1.conf
-%{_cross_datadir}/dbus-1/system.d/org.freedesktop.systemd1.conf
-%exclude %{_cross_datadir}/dbus-1/system-services
-
 %dir %{_cross_factorydir}
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/issue
 %{_cross_factorydir}%{_cross_sysconfdir}/locale.conf
@@ -764,7 +797,6 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %{_cross_unitdir}/systemd-networkd-wait-online.service
 %{_cross_unitdir}/systemd-networkd-wait-online@.service
 %{_cross_unitdir}/systemd-networkd.socket
-%{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
 
 %files resolved
 %{_cross_bindir}/resolvectl
@@ -773,6 +805,19 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %{_cross_sysusersdir}/systemd-resolve.conf
 %{_cross_tmpfilesdir}/systemd-resolve.conf
 %{_cross_unitdir}/systemd-resolved.service
-%{_cross_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
 %exclude %{_cross_bindir}/systemd-resolve
 %exclude %{_cross_sbindir}/resolvconf
+
+%files dbus-launcher-config
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.login1.conf
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.systemd1.conf
+%{_cross_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
+%{_cross_datadir}/dbus-1/system-services
+%{_cross_datadir}/dbus-1/services/org.freedesktop.systemd1.service
+
+%files whippet-config
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.login1.toml
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.network1.toml
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.systemd1.toml
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.resolve1.toml


### PR DESCRIPTION
**Issue number:**
Part of #660

**Description of changes:**

#661 added whippet, a minimal broker launcher. This series completes the work to remove both the dbus-launcher and libexpat. By dropping the dbus-launcher from the dbus-broker build, the dependency on systemd can be removed as well.

A patch was added to the dbus-broker project to allow building the journal catalogs for the broker in the absence of the dbus-launcher.

The dbus policies for systemd were programmatically generated. I have a personal preference on this format for the policies:

```toml
[default]
rules = [
   { allow = true, user = "*" }
]
```
But the serializers, really love the other format:

```toml
[[default.rules]]
allow = true
user = "*"
```

I didn't want to mess up with the serializers, so I just used the format they used by default. 

**Testing done:**

In combination with #661:
- [X] Confirmed instance boots
- [X] Confirmed instances join clusters
- [X] Confirmed pods run without issues
- [X] Confirmed the policy generated by whippet is identical to the policy generated by the dbus-launcher


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
