### PR TITLE
Bump k8s versions

### DIFF
--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.7.4/aws-iam-authenticator-0.7.4.tar.gz"
-sha512 = "d63aef6073728b9cc9152fa2c00cc9c3139efc7fa1721d8beda35a95a1235162cf8cfed3304327d9d4186bcaa85f0aa61c2cf61b67bbe66d3e0c07cce98a76eb"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.7.5/aws-iam-authenticator-0.7.5.tar.gz"
+sha512 = "9818dac7c6f651fb04b80e5ea363d2ce35dcc1988d78f67a0320f592ddff20fb286033bf6112f5e9a08736b3c341dab64895654f914b3a53a35f6c0ebd74fa91"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.7.4
+%global gover 0.7.5
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/containerd-1.7/Cargo.toml
+++ b/packages/containerd-1.7/Cargo.toml
@@ -13,8 +13,8 @@ package-name = "containerd-1.7"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.7.27/containerd-1.7.27.tar.gz"
-sha512 = "84d3c9e815694567aedcf556390530e9b06a2242c060b9c4a79f46ef4eba91d87a3b0f8142c38eb4d94e2d128ab72bc9b047a6d115f5d104fac29b09e1f7b080"
+url = "https://github.com/containerd/containerd/archive/v1.7.28/containerd-1.7.28.tar.gz"
+sha512 = "c4dc4631fbc84e29f165ce8283a5b4abf0cb0f5d891429f808b77462757e2b53c0579b4204fe5c1f1d89a91ddb045a4e5e8a1e7bf557b31585085afa26667df4"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/containerd-1.7/containerd-1.7.spec
+++ b/packages/containerd-1.7/containerd-1.7.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.7.27
+%global gover 1.7.28
 %global rpmver %{gover}
-%global gitrev 05044ec0a9a75232cad458027ca83437aae3f4da
+%global gitrev b98a3aace656320842a23f4a392a33f46af97866
 
 %global package_priority_epoch 2
 %global _dwz_low_mem_die_limit 0

--- a/packages/containerd-2.0/Cargo.toml
+++ b/packages/containerd-2.0/Cargo.toml
@@ -13,8 +13,8 @@ package-name = "containerd-2.0"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v2.0.5/containerd-2.0.5.tar.gz"
-sha512 = "af89a5c9ad5f931c5fee33c75c13c296fc9ec966f2c64ec244897695eebb365bcb542f6b431e60d4ef7213f0ea11d3a8896d1b7f033ed445e6b521b7ddbffe6f"
+url = "https://github.com/containerd/containerd/archive/v2.0.6/containerd-2.0.6.tar.gz"
+sha512 = "85b9f606e5b2cb958351206beb7df0d615d4e405e1752d849bd92d2df90485c505c10484e588d1ac7505c3d1063bd2922175439c9e4f9dd0ad2af6852cb97a48"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/containerd-2.0/containerd-2.0.spec
+++ b/packages/containerd-2.0/containerd-2.0.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 2.0.5
+%global gover 2.0.6
 %global rpmver %{gover}
-%global gitrev fb4c30d4ede3531652d86197bf3fc9515e5276d9
+%global gitrev 991cc3363c290ffd074e069f2b3034c7286ecbe0
 
 %global package_priority_epoch 1
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/54/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
-sha512 = "b77a68a5fe318c1e047f78ed8938d617e4c97062621be9cad498706f764d714fdd5d8ceb0c16a9665bd4b0811a29714ed46a55e9e36885e9aab8aad4297b5474"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/59/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
+sha512 = "54383bacab3f6947cfa32706a2da9bda4e7a38260e89501a3697df472dbad22d7948d3b3dba36bb106cd523b95869d1ea257b27bc052ec7e41d803d316a43667"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 54
+%global releasever 59
 %global gover 1.28.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/43/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
-sha512 = "2c2b59bc71ea5e7e0dcd5c80e3a72ec376cf646523e7afb524144668b7e6036a50df23cdc03e3f665284c08bc56e071bcb93e14e05e1e653dc4da83ea2c68afd"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/48/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
+sha512 = "70cf62549dde1ab659de0e4db9bdc8afa31dac617dc77e5a690ab6954d5b28c8584d71c7ef52f505fb185cb191bd4244d53e9f0e777df96ea74cdc80e349f903"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 43
+%global releasever 48
 %global gover 1.29.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/36/artifacts/kubernetes/v1.30.13/kubernetes-src.tar.gz"
-sha512 = "5d7b13a6535dbf7e89d356efebc684f51eae72c5472a192ab073c13f6f7fe3931e4eaf0fc8c68e30d70369e6e6ba442ed631e4afd9c8f15289bcd8e48bfbda34"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/41/artifacts/kubernetes/v1.30.14/kubernetes-src.tar.gz"
+sha512 = "47cd609d72fca8e159e3ffbe4c2e4bf97c75c87ec9dffb946f06fcf5f61a064b97fdbcc2e07982ea265df8477139cc688e69e1496c0d4aa346f12486cfc8e0b5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 36
-%global gover 1.30.13
+%global releasever 41
+%global gover 1.30.14
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/25/artifacts/kubernetes/v1.31.9/kubernetes-src.tar.gz"
-sha512 = "9447a3e155c838abf4620ff4e2bac962294a1637f4f38d00a526355103037f4567655767dc0e43fd4f187f0bdd3fe93fa71f325fb2b618bb579979de23791bca"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/30/artifacts/kubernetes/v1.31.12/kubernetes-src.tar.gz"
+sha512 = "bd6da70922dd4d199b67a5ab2a18d3f523d62a24471925af21c15aeadd45c0d9010d649f7608343bdf69221637c1e7173c1141251e3a087fc28908ff99dba6d5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 25
-%global gover 1.31.9
+%global releasever 30
+%global gover 1.31.12
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.32/Cargo.toml
+++ b/packages/kubernetes-1.32/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.32"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/18/artifacts/kubernetes/v1.32.5/kubernetes-src.tar.gz"
-sha512 = "613445413f80a5ca0a7266bb086830154d77c7f0106e676c6d7d49f2bb9628e6ad8360e5399b02888d2d9a6fa25ea6ef1e4dbc5d690e8a9faa944374d240bfeb"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/23/artifacts/kubernetes/v1.32.8/kubernetes-src.tar.gz"
+sha512 = "ffb335f89cddca9504242e200dc65ba00f1bb189e68da6f5756479d65fa3a5c2525142434035b141477e90384f202d519b375ac2001fbcd7ff28bbd1cb36d4ba"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 18
-%global gover 1.32.5
+%global releasever 23
+%global gover 1.32.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.33/Cargo.toml
+++ b/packages/kubernetes-1.33/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.33"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/8/artifacts/kubernetes/v1.33.1/kubernetes-src.tar.gz"
-sha512 = "91d7adefad633900498d2531f41e4c9e8fc701264bcf0ebe9c6f3f6820303052efe653bc0c6ad171eb33abc4bf49745f2287461d81d3cfe1626071209ff53cfa"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/13/artifacts/kubernetes/v1.33.4/kubernetes-src.tar.gz"
+sha512 = "8989a7b86d0d6fb11dca662f98b0610d230e3941f26a51a07c8fd00692d7b9d7c2c5c238482a6a96e3c0f413d3c829d0b1d7168316b25e8141fd9baec4f5b00e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 8
-%global gover 1.33.1
+%global releasever 13
+%global gover 1.33.4
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.34/Cargo.toml
+++ b/packages/kubernetes-1.34/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.34"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/3/artifacts/kubernetes/v1.34.0/kubernetes-src.tar.gz"
-sha512 = "7580e3acf4bffb5a8d44d4751e6af0826b210b768db3b76032d85fa13c26082157bcd127ee1689a2e52605a74e586a6f16c07ab1aa41a80c3a6929d554caa855"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/4/artifacts/kubernetes/v1.34.0/kubernetes-src.tar.gz"
+sha512 = "835d2fcd347cc0723059f28f5ae53468fb3d9826c286d29fe915ea55afd103eb3340ab138e9f15333169b359dfdb05d502b28786735598c9a8ae3e648fe1cfb4"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.34/kubernetes-1.34.spec
+++ b/packages/kubernetes-1.34/kubernetes-1.34.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 3
+%global releasever 4
 %global gover 1.34.0
 %global rpmver %{gover}
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/649

**Description of changes:**
Update kubernetes packages:
- `kubernetes-1.34`
- `kubernetes-1.33`
- `kubernetes-1.32`
- `kubernetes-1.31`
- `kubernetes-1.30`
- `kubernetes-1.29`
- `kubernetes-1.28`

Update `aws-iam-authenticator` to 0.7.5

Update containerd packages:
- `containerd-1.7` to 1.7.28
- `containerd-2.0` to 2.0.6


**Testing done:**
  ### Conformance Test Results

   | Architecture | K8s Version | Test Status | Test Duration | Tests Passed | Tests Failed | Tests Skipped |
  |--------------|-------------|-------------|---------------|--------------|--------------|---------------|
  | x86-64       | 1.28        | ✅ Success   | ~1h 40m       | 380          | 0            | 7012          |
  | aarch64      | 1.28        | ✅ Success   | ~1h 40m       | 380          | 0            | 7012          |
  | x86-64       | 1.29        | ✅ Success   | ~1h 48m       | 388          | 0            | 7023          |
  | aarch64      | 1.29        | ✅ Success   | ~1h 50m       | 388          | 0            | 7023          |
  | x86-64       | 1.30        | ✅ Success   | ~1h 38m       | 402          | 0            | 6801          |
  | aarch64      | 1.30        | ✅ Success   | ~1h 42m       | 402          | 0            | 6801          |
  | x86-64       | 1.31        | ✅ Success   | ~1h 41m       | 404          | 0            | 6203          |
  | aarch64      | 1.31        | ✅ Success   | ~1h 46m       | 404          | 0            | 6203          |
  | x86-64       | 1.32        | ✅ Success   | ~1h 43m       | 411          | 0            | 6213          |
  | aarch64      | 1.32        | ✅ Success   | ~1h 45m       | 411          | 0            | 6213          |
  | x86-64       | 1.33        | ✅ Success   | ~1h 44m       | 419          | 0            | 6311          |
  | aarch64      | 1.33        | ✅ Success   | ~1h 47m       | 419          | 0            | 6311          |
  | x86-64       | 1.34        | ✅ Success   | ~1h 45m       | 424          | 0            | 6708          |
  | x86-64       | 1.34 (IPv6) | ✅ Success   | ~1h 55m       | 424          | 0            | 6708          |
  | aarch64      | 1.34        | ✅ Success   | ~1h 46m       | 424          | 0            | 6708          |
  | aarch64      | 1.34 (IPv6) | ✅ Success   | ~1h 59m       | 424          | 0            | 6708          |


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
