### PR TITLE
Bloodhound changes

### DIFF
--- a/packages/os/br03040101.json
+++ b/packages/os/br03040101.json
@@ -1,0 +1,5 @@
+{
+  "reason": "Test requires iptables FORWARD chain configuration that conflicts with Kubernetes networking architecture. Kubernetes manages its own iptables rules through kube-proxy and CNI plugins.",
+  "reference": "https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/540",
+  "status": "SKIP"
+}

--- a/packages/os/k8s04021000.json
+++ b/packages/os/k8s04021000.json
@@ -1,0 +1,5 @@
+{
+    "reason": "IAM (external) auth is used on Bottlerocket, so certificate rotation does not apply. See EKS CIS Benchmark.",
+    "reference": "https://docs.aws.amazon.com/eks/latest/userguide/security-iam.html",
+    "status": "PASS"
+}

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -34,6 +34,7 @@ Source19: host-containers-toml
 Source20: bottlerocket-fips-checks-metadata-json
 Source21: bootstrap-commands-toml
 Source22: dbus-1-system.toml
+Source23: br03040101.json
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -397,6 +398,7 @@ Conflicts: %{_cross_os}image-feature(no-host-containers)
 %package -n %{_cross_os}bloodhound
 Summary: Compliance check framework
 Requires: (%{_cross_os}bloodhound-k8s if %{_cross_os}variant-runtime(k8s))
+Requires: (%{_cross_os}bloodhound-k8s-overrides if %{_cross_os}variant-runtime(k8s))
 Requires: (%{_cross_os}bloodhound-fips if %{_cross_os}image-feature(fips))
 %description -n %{_cross_os}bloodhound
 %{summary}.
@@ -405,6 +407,12 @@ Requires: (%{_cross_os}bloodhound-fips if %{_cross_os}image-feature(fips))
 Summary: Compliance checks for Kubernetes
 Requires: (%{_cross_os}bloodhound and %{_cross_os}variant-runtime(k8s))
 %description -n %{_cross_os}bloodhound-k8s
+%{summary}.
+
+%package -n %{_cross_os}bloodhound-k8s-overrides
+Summary: CIS Test overrides for Kubernetes variants
+Requires: (%{_cross_os}bloodhound and %{_cross_os}variant-runtime(k8s))
+%description -n %{_cross_os}bloodhound-k8s-overrides
 %{summary}.
 
 %package -n %{_cross_os}bloodhound-fips
@@ -662,6 +670,7 @@ for p in \
     %{buildroot}%{_cross_libexecdir}/cis-checks/bottlerocket/${p}
 done
 install -m 0644 %{S:11} %{buildroot}%{_cross_libexecdir}/cis-checks/bottlerocket/metadata.json
+install -m 0644 %{S:23} %{buildroot}%{_cross_libexecdir}/cis-checks/bottlerocket/br03040101.json
 
 mkdir -p %{buildroot}%{_cross_libexecdir}/fips-checks/bottlerocket
 for p in \
@@ -927,10 +936,14 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %{_cross_bindir}/bloodhound
 %{_cross_bindir}/bottlerocket-cis-checks
 %{_cross_libexecdir}/cis-checks/bottlerocket
+%exclude %{_cross_libexecdir}/cis-checks/bottlerocket/br03040101.json
 
 %files -n %{_cross_os}bloodhound-k8s
 %{_cross_bindir}/kubernetes-cis-checks
 %{_cross_libexecdir}/cis-checks/kubernetes
+
+%files -n %{_cross_os}bloodhound-k8s-overrides
+%{_cross_libexecdir}/cis-checks/bottlerocket/br03040101.json
 
 %files -n %{_cross_os}bloodhound-fips
 %{_cross_bindir}/bottlerocket-fips-checks

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -35,6 +35,7 @@ Source20: bottlerocket-fips-checks-metadata-json
 Source21: bootstrap-commands-toml
 Source22: dbus-1-system.toml
 Source23: br03040101.json
+Source24: k8s04021000.json
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -695,6 +696,7 @@ for p in \
     %{buildroot}%{_cross_libexecdir}/cis-checks/kubernetes/${p}
 done
 install -m 0644 %{S:13} %{buildroot}%{_cross_libexecdir}/cis-checks/kubernetes/metadata.json
+install -m 0644 %{S:24} %{buildroot}%{_cross_libexecdir}/cis-checks/kubernetes/k8s04021000.json
 
 for p in apiclient ; do
   install -p -m 0755 %{__cargo_outdir_static}/${p} %{buildroot}%{_cross_bindir}
@@ -944,6 +946,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 
 %files -n %{_cross_os}bloodhound-k8s-overrides
 %{_cross_libexecdir}/cis-checks/bottlerocket/br03040101.json
+%{_cross_libexecdir}/cis-checks/kubernetes/k8s04021000.json
 
 %files -n %{_cross_os}bloodhound-fips
 %{_cross_bindir}/bottlerocket-fips-checks

--- a/sources/bloodhound/src/bin/kubernetes-cis-checks/checks.rs
+++ b/sources/bloodhound/src/bin/kubernetes-cis-checks/checks.rs
@@ -631,8 +631,6 @@ impl Checker for K8S04021200Checker {
             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-            "TLS_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_RSA_WITH_AES_128_GCM_SHA256",
         ]
         .into_iter()
         .collect();

--- a/sources/bloodhound/src/bin/kubernetes-cis-checks/main.rs
+++ b/sources/bloodhound/src/bin/kubernetes-cis-checks/main.rs
@@ -60,13 +60,7 @@ fn main() {
             level: 2,
         }),
         "k8s04020900" => Box::new(K8S04020900Checker {}),
-        // IAM (external) auth is used, so certificate rotation does not apply. See EKS CIS Benchmark.
-        "k8s04021000" => Box::new(ManualChecker {
-            name: cmd_name.to_string(),
-            title: "Ensure that the --rotate-certificates argument is not set to false (not valid for Bottlerocket)".to_string(),
-            id: "4.2.10".to_string(),
-            level: 1,
-        }),
+        "k8s04021000" => Box::new(K8S04021000Checker {}),
         "k8s04021100" => Box::new(K8S04021100Checker {}),
         "k8s04021200" => Box::new(K8S04021200Checker {}),
         "k8s04021300" => Box::new(K8S04021300Checker {}),

--- a/sources/bloodhound/src/main.rs
+++ b/sources/bloodhound/src/main.rs
@@ -21,7 +21,7 @@ If executing directly, run `bloodhound --help` for usage information.
 use bloodhound::args::*;
 use bloodhound::output::{JsonReportWriter, ReportWriter, TextReportWriter};
 use bloodhound::results::{
-    CheckStatus, CheckerMetadata, CheckerResult, ReportMetadata, ReportResults,
+    CheckStatus, CheckerMetadata, CheckerResult, OverrideConfig, ReportMetadata, ReportResults,
 };
 use std::collections::HashMap;
 use std::fs::{DirEntry, File};
@@ -36,7 +36,7 @@ const CHECKER_DISCOVERY_ERROR: i32 = 2;
 const REPORT_OUTPUT_ERROR: i32 = 3;
 const NO_CHECKS_RUN_ERROR: i32 = 4;
 
-/// Discovers the metadata information for the checkers being run or provides a default.
+/// Finds the metadata information for the checkers being run or provides a default.
 fn read_metadata(check_dir: &Path) -> ReportMetadata {
     let meta_path = check_dir.join("metadata.json");
 
@@ -54,25 +54,40 @@ fn read_metadata(check_dir: &Path) -> ReportMetadata {
     }
 }
 
-/// Discover all executable checker files for the given directory.
-/// By looking at the provided path, this does some basic checks and filtering
-/// to find the executable files that appear to be bloodhound checkers.
-/// It will parse the checker metadata to provide a mapping between a filesystem
-/// path and a specific check, including only those checkers that are within the
-/// request compliance level.
-fn find_checkers(check_dir: &PathBuf, level: u8) -> HashMap<String, CheckerMetadata> {
+/// Find executable checkers and matching override files in the given directory.
+///
+/// Uses two-pass approach: first finds checker executables, then looks for
+/// matching `{test_name}.json` override files to avoid parsing metadata.json.
+fn find_directory_contents(
+    check_dir: &Path,
+    level: u8,
+) -> (
+    HashMap<String, CheckerMetadata>,
+    HashMap<String, OverrideConfig>,
+) {
+    let (checkers, test_names) = find_checkers(check_dir, level);
+    let overrides = find_overrides(check_dir, &test_names);
+    (checkers, overrides)
+}
+
+/// Find all executable checker files in the directory.
+///
+/// Returns both the checker metadata map and list of test names for override lookup.
+fn find_checkers(check_dir: &Path, level: u8) -> (HashMap<String, CheckerMetadata>, Vec<String>) {
     let entries: Vec<DirEntry> = fs::read_dir(check_dir)
         .unwrap()
         .filter_map(|file| file.ok())
         .collect();
-    let mut result = HashMap::new();
+    let mut checkers = HashMap::new();
+    let mut test_names = Vec::new();
 
     for entry in entries {
         if let Ok(file_metadata) = fs::metadata(entry.path()) {
-            // Filter out any subdirectories
             if file_metadata.is_dir() {
                 continue;
             }
+
+            let path = entry.path();
 
             // Skip any files that are not executable
             if file_metadata.permissions().mode() & 0o111 == 0 {
@@ -81,35 +96,95 @@ fn find_checkers(check_dir: &PathBuf, level: u8) -> HashMap<String, CheckerMetad
 
             // It's an executable file, make sure it implements our expected checker interface
             let metadata;
-            if let Ok(output) = Command::new(entry.path()).arg("metadata").output() {
+            if let Ok(output) = Command::new(&path).arg("metadata").output() {
                 metadata = String::from_utf8_lossy(&output.stdout).to_string();
             } else {
-                eprintln!(
-                    "{:?} does not appear to be a checker executable",
-                    entry.path()
-                );
+                eprintln!("{path:?} does not appear to be a checker executable");
                 continue;
             }
 
             if let Ok(checker_data) = serde_json::from_str::<CheckerMetadata>(&metadata) {
                 if checker_data.level <= level {
-                    result.insert(
-                        // Assuming here that we will never have non-ASCII characters in our usage
-                        entry.path().as_os_str().to_string_lossy().to_string(),
-                        checker_data,
-                    );
+                    test_names.push(checker_data.name.clone());
+                    checkers.insert(path.to_string_lossy().to_string(), checker_data);
                 }
             } else {
-                eprintln!("Unable to parse checker metadata from {:?}", entry.path());
+                eprintln!("Unable to parse checker metadata from {path:?}");
             }
         }
     }
 
-    result
+    (checkers, test_names)
 }
 
-/// Processes the output results from calling an individual checker. Results of
-/// parsing the checker output are added to the overall execution report.
+/// Find override files matching the given test names.
+///
+/// Looks for `{test_name}.json` files and parses them as override configurations.
+fn find_overrides(check_dir: &Path, test_names: &[String]) -> HashMap<String, OverrideConfig> {
+    let mut overrides = HashMap::new();
+    for test_name in test_names {
+        let override_path = check_dir.join(format!("{test_name}.json"));
+        if override_path.exists() {
+            match load_override_config(&override_path) {
+                Ok(override_config) => {
+                    overrides.insert(test_name.clone(), override_config);
+                }
+                Err(err) => {
+                    eprintln!("Warning: Failed to load override file {override_path:?}: {err}");
+                }
+            }
+        }
+    }
+    overrides
+}
+
+/// Load and parse an override configuration file.
+///
+/// Reads the JSON file and parses it into an OverrideConfig struct.
+fn load_override_config(path: &Path) -> Result<OverrideConfig, Box<dyn std::error::Error>> {
+    let file_content = fs::read_to_string(path)?;
+    let override_config = serde_json::from_str(&file_content)?;
+    Ok(override_config)
+}
+
+/// Find an override entry for the given test name.
+///
+/// Looks up override configuration by test name (filename-based).
+fn find_override_for_test<'a>(
+    overrides: &'a HashMap<String, OverrideConfig>,
+    test_name: &str,
+) -> Option<&'a OverrideConfig> {
+    overrides.get(test_name)
+}
+
+/// Apply an override to a test result.
+///
+/// Creates an override result with the specified status and reason.
+fn apply_override(
+    report: &mut ReportResults,
+    data: CheckerMetadata,
+    override_config: &OverrideConfig,
+) {
+    let override_status = match override_config.status.as_str() {
+        "PASS" => CheckStatus::PASS,
+        "FAIL" => CheckStatus::FAIL,
+        "SKIP" => CheckStatus::SKIP,
+        _ => CheckStatus::SKIP, // Default to skip for unknown statuses
+    };
+
+    report.add_result(
+        data,
+        CheckerResult {
+            status: CheckStatus::OVERRIDE(Box::new(override_status)),
+            error: String::new(),
+            override_reason: Some(override_config.reason.clone()),
+        },
+    );
+}
+
+/// Process output from a checker executable and add results to the report.
+///
+/// Parses checker output as JSON and converts to CheckerResult format.
 fn process_checker_results(output: Output, data: CheckerMetadata, report: &mut ReportResults) {
     if output.status.success() {
         let check_output = String::from_utf8_lossy(&output.stdout).to_string();
@@ -125,6 +200,7 @@ fn process_checker_results(output: Output, data: CheckerMetadata, report: &mut R
         CheckerResult {
             status: CheckStatus::SKIP,
             error: check_output,
+            override_reason: None,
         },
     );
 }
@@ -139,15 +215,15 @@ fn get_output(output: &Option<String>) -> Result<Box<dyn Write>, Error> {
 fn main() {
     let args: Arguments = argh::from_env();
 
-    // Discover all checkers in checks directory
+    // Find all checkers in checks directory
     let check_dir = PathBuf::from(args.check_dir);
     if !check_dir.is_dir() {
         eprintln!("Checker path {check_dir:?} is not a directory!");
         std::process::exit(CHECKER_DISCOVERY_ERROR);
     }
 
-    // Look through the directory and find any checkers, then filter out checks based on input
-    let checkers = find_checkers(&check_dir, args.level);
+    // Look through the directory and find any checkers and overrides, then filter out checks based on input
+    let (checkers, overrides) = find_directory_contents(&check_dir, args.level);
     if checkers.is_empty() {
         eprintln!("No checkers found in {check_dir:?}!");
         std::process::exit(CHECKER_DISCOVERY_ERROR);
@@ -158,7 +234,9 @@ fn main() {
 
     // Execute each checker and capture results
     for (checker, data) in checkers {
-        if let Ok(output) = Command::new(checker).output() {
+        if let Some(override_config) = find_override_for_test(&overrides, &data.name) {
+            apply_override(&mut report, data, override_config);
+        } else if let Ok(output) = Command::new(checker).output() {
             process_checker_results(output, data, &mut report);
         } else {
             // Something failed in execution, mark as skipped with message
@@ -168,6 +246,7 @@ fn main() {
                 CheckerResult {
                     status: CheckStatus::SKIP,
                     error: msg,
+                    override_reason: None,
                 },
             );
         }
@@ -194,5 +273,138 @@ fn main() {
         // alert on something like this as it may be a sign of a larger problem.
         eprintln!("Warning: No checks were able to run");
         std::process::exit(NO_CHECKS_RUN_ERROR);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_find_directory_contents_with_valid_override() {
+        // GIVEN: A directory with a mock checker and matching override JSON file
+        // WHEN: find_directory_contents is called
+        // THEN: Override should be parsed and returned correctly
+
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create mock checker executable
+        let checker_script = r#"#!/bin/bash
+if [ "$1" = "metadata" ]; then
+    echo '{"name": "test123", "id": "test123", "level": 1, "title": "Test Check", "mode": "Automatic"}'
+else
+    echo '{"status": "PASS", "error": ""}'
+fi
+"#;
+        let checker_path = temp_dir.path().join("test123");
+        fs::write(&checker_path, checker_script).unwrap();
+        fs::set_permissions(&checker_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let override_json = r#"{
+            "reason": "Test reason",
+            "status": "SKIP"
+        }"#;
+
+        fs::write(temp_dir.path().join("test123.json"), override_json).unwrap();
+
+        let (checkers, overrides) = find_directory_contents(&temp_dir.path().to_path_buf(), 1);
+
+        assert_eq!(checkers.len(), 1);
+        assert_eq!(overrides.len(), 1);
+        assert!(overrides.contains_key("test123"));
+
+        let override_config = &overrides["test123"];
+        assert_eq!(override_config.reason, "Test reason");
+    }
+
+    #[test]
+    fn test_find_directory_contents_ignores_metadata_json() {
+        // GIVEN: A directory with metadata.json and other non-override JSON files
+        // WHEN: find_directory_contents is called
+        // THEN: Non-override JSON files should be ignored
+
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create metadata.json (should be ignored)
+        let metadata_json = r#"{"version": "1.0", "description": "metadata file"}"#;
+        fs::write(temp_dir.path().join("metadata.json"), metadata_json).unwrap();
+
+        // Create other JSON file (should be ignored)
+        let other_json = r#"{"some": "data"}"#;
+        fs::write(temp_dir.path().join("other.json"), other_json).unwrap();
+
+        let (checkers, overrides) = find_directory_contents(&temp_dir.path().to_path_buf(), 1);
+
+        assert!(checkers.is_empty());
+        assert!(overrides.is_empty());
+    }
+
+    #[test]
+    fn test_find_directory_contents_no_overrides() {
+        // GIVEN: A directory with no JSON files
+        // WHEN: find_directory_contents is called
+        // THEN: No overrides should be returned (backward compatibility)
+
+        let temp_dir = TempDir::new().unwrap();
+
+        let (checkers, overrides) = find_directory_contents(&temp_dir.path().to_path_buf(), 1);
+
+        assert!(checkers.is_empty());
+        assert!(overrides.is_empty());
+    }
+
+    #[test]
+    fn test_find_directory_contents_multiple_overrides() {
+        // GIVEN: A directory with multiple checkers and matching override files
+        // WHEN: find_directory_contents is called
+        // THEN: All valid overrides should be parsed
+
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create first checker and override
+        let checker1_script = r#"#!/bin/bash
+if [ "$1" = "metadata" ]; then
+    echo '{"name": "test1", "id": "test1", "level": 1, "title": "Test 1", "mode": "Automatic"}'
+else
+    echo '{"status": "PASS", "error": ""}'
+fi
+"#;
+        let checker1_path = temp_dir.path().join("test1");
+        fs::write(&checker1_path, checker1_script).unwrap();
+        fs::set_permissions(&checker1_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let override1_json = r#"{
+            "reason": "Reason 1",
+            "status": "SKIP"
+        }"#;
+
+        // Create second checker and override
+        let checker2_script = r#"#!/bin/bash
+if [ "$1" = "metadata" ]; then
+    echo '{"name": "test2", "id": "test2", "level": 1, "title": "Test 2", "mode": "Automatic"}'
+else
+    echo '{"status": "PASS", "error": ""}'
+fi
+"#;
+        let checker2_path = temp_dir.path().join("test2");
+        fs::write(&checker2_path, checker2_script).unwrap();
+        fs::set_permissions(&checker2_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let override2_json = r#"{
+            "reason": "Reason 2",
+            "status": "SKIP"
+        }"#;
+
+        fs::write(temp_dir.path().join("test1.json"), override1_json).unwrap();
+        fs::write(temp_dir.path().join("test2.json"), override2_json).unwrap();
+
+        let (checkers, overrides) = find_directory_contents(&temp_dir.path().to_path_buf(), 1);
+
+        assert_eq!(checkers.len(), 2);
+        assert_eq!(overrides.len(), 2);
+        assert!(overrides.contains_key("test1"));
+        assert!(overrides.contains_key("test2"));
     }
 }

--- a/sources/bloodhound/src/output.rs
+++ b/sources/bloodhound/src/output.rs
@@ -1,6 +1,6 @@
 use std::io::{Error, Write};
 
-use crate::results::ReportResults;
+use crate::results::{CheckStatus, ReportResults};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -26,14 +26,26 @@ impl ReportWriter for TextReportWriter {
         writeln!(output, "{:17}{}", "Start time:", report.timestamp)?;
         writeln!(output)?;
 
+        let mut exceptions = Vec::new();
+
         for test_result in report.results.values() {
+            let (status_display, mode_display) = match &test_result.result.status {
+                CheckStatus::OVERRIDE(embedded_status) => {
+                    if let Some(reason) = &test_result.result.override_reason {
+                        exceptions.push((test_result.metadata.id.clone(), reason.clone()));
+                    }
+                    (embedded_status.to_string(), "Exception".to_string())
+                }
+                _ => (
+                    test_result.result.status.to_string(),
+                    test_result.metadata.mode.to_string(),
+                ),
+            };
+
             writeln!(
                 output,
                 "[{}] {:9} {} ({})",
-                test_result.result.status,
-                test_result.metadata.id,
-                test_result.metadata.title,
-                test_result.metadata.mode
+                status_display, test_result.metadata.id, test_result.metadata.title, mode_display
             )?;
         }
 
@@ -43,7 +55,17 @@ impl ReportWriter for TextReportWriter {
         writeln!(output, "{:17}{}", "Skipped:", report.skipped)?;
         writeln!(output, "{:17}{}", "Total checks:", report.total)?;
         writeln!(output)?;
-        writeln!(output, "Compliance check result: {}", report.status)
+        writeln!(output, "Compliance check result: {}", report.status)?;
+
+        if !exceptions.is_empty() {
+            writeln!(output)?;
+            writeln!(output, "Exceptions:")?;
+            for (test_id, reason) in exceptions {
+                writeln!(output, "*  {test_id} {reason}")?;
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -54,5 +76,114 @@ impl ReportWriter for JsonReportWriter {
     fn write(&self, report: &ReportResults, output: &mut dyn Write) -> Result<(), Error> {
         let json = serde_json::to_string(&report)?;
         writeln!(output, "{json}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::results::{CheckStatus, CheckerMetadata, CheckerResult, Mode, ReportMetadata};
+    use std::io::Cursor;
+
+    #[test]
+    fn test_text_output_with_overrides() {
+        // GIVEN: A report with regular tests and various override statuses
+        // WHEN: TextReportWriter writes the report
+        // THEN: Overrides should show embedded status with Exception mode and appear in Exceptions section
+
+        let metadata = ReportMetadata {
+            name: None,
+            version: None,
+            url: None,
+        };
+        let mut report = ReportResults::new(1, metadata);
+
+        // Add regular passing test
+        let pass_metadata = CheckerMetadata {
+            name: "test_regular".to_string(),
+            id: "1.1.1".to_string(),
+            level: 1,
+            title: "Regular test".to_string(),
+            mode: Mode::Automatic,
+        };
+        report.add_result(
+            pass_metadata,
+            CheckerResult {
+                status: CheckStatus::PASS,
+                error: String::new(),
+                override_reason: None,
+            },
+        );
+
+        // Add override with PASS status
+        let override_pass_metadata = CheckerMetadata {
+            name: "test_pass".to_string(),
+            id: "2.2.2".to_string(),
+            level: 1,
+            title: "Override pass test".to_string(),
+            mode: Mode::Automatic,
+        };
+        report.add_result(
+            override_pass_metadata,
+            CheckerResult {
+                status: CheckStatus::OVERRIDE(Box::new(CheckStatus::PASS)),
+                error: String::new(),
+                override_reason: Some("Override reason for pass".to_string()),
+            },
+        );
+
+        // Add override with FAIL status
+        let override_fail_metadata = CheckerMetadata {
+            name: "test_fail".to_string(),
+            id: "3.3.3".to_string(),
+            level: 1,
+            title: "Override fail test".to_string(),
+            mode: Mode::Automatic,
+        };
+        report.add_result(
+            override_fail_metadata,
+            CheckerResult {
+                status: CheckStatus::OVERRIDE(Box::new(CheckStatus::FAIL)),
+                error: String::new(),
+                override_reason: Some("Override reason for fail".to_string()),
+            },
+        );
+
+        // Add override with SKIP status
+        let override_skip_metadata = CheckerMetadata {
+            name: "test_skip".to_string(),
+            id: "4.4.4".to_string(),
+            level: 1,
+            title: "Override skip test".to_string(),
+            mode: Mode::Automatic,
+        };
+        report.add_result(
+            override_skip_metadata,
+            CheckerResult {
+                status: CheckStatus::OVERRIDE(Box::new(CheckStatus::SKIP)),
+                error: String::new(),
+                override_reason: Some("Override reason for skip".to_string()),
+            },
+        );
+
+        let writer = TextReportWriter {};
+        let mut output = Cursor::new(Vec::new());
+        writer.write(&report, &mut output).unwrap();
+
+        let output_str = String::from_utf8(output.into_inner()).unwrap();
+
+        // Verify regular test shows as PASS
+        assert!(output_str.contains("[PASS] 1.1.1     Regular test (Automatic)"));
+
+        // Verify overrides show their embedded status with Exception mode
+        assert!(output_str.contains("[PASS] 2.2.2     Override pass test (Exception)"));
+        assert!(output_str.contains("[FAIL] 3.3.3     Override fail test (Exception)"));
+        assert!(output_str.contains("[SKIP] 4.4.4     Override skip test (Exception)"));
+
+        // Verify Exceptions section contains all override reasons
+        assert!(output_str.contains("Exceptions:"));
+        assert!(output_str.contains("*  2.2.2 Override reason for pass"));
+        assert!(output_str.contains("*  3.3.3 Override reason for fail"));
+        assert!(output_str.contains("*  4.4.4 Override reason for skip"));
     }
 }

--- a/sources/bloodhound/src/output.rs
+++ b/sources/bloodhound/src/output.rs
@@ -186,4 +186,75 @@ mod tests {
         assert!(output_str.contains("*  3.3.3 Override reason for fail"));
         assert!(output_str.contains("*  4.4.4 Override reason for skip"));
     }
+
+    #[test]
+    fn test_json_output_with_overrides() {
+        // GIVEN: A report with regular tests and override statuses
+        // WHEN: JsonReportWriter writes the report
+        // THEN: Status should be flattened strings and override reasons should appear in error field
+
+        let metadata = ReportMetadata {
+            name: Some("Test Benchmark".to_string()),
+            version: Some("1.0".to_string()),
+            url: Some("https://example.com".to_string()),
+        };
+        let mut report = ReportResults::new(1, metadata);
+
+        // Add regular FAIL result
+        let fail_metadata = CheckerMetadata {
+            name: "br03030100".to_string(),
+            id: "3.3.1".to_string(),
+            level: 2,
+            title: "Ensure SCTP is disabled".to_string(),
+            mode: Mode::Automatic,
+        };
+        report.add_result(
+            fail_metadata,
+            CheckerResult {
+                status: CheckStatus::FAIL,
+                error: "modprobe for sctp is not disabled".to_string(),
+                override_reason: None,
+            },
+        );
+
+        // Add OVERRIDE result with reason
+        let override_metadata = CheckerMetadata {
+            name: "br03040101".to_string(),
+            id: "3.4.1.1".to_string(),
+            level: 2,
+            title: "Ensure IPv4 default deny firewall policy".to_string(),
+            mode: Mode::Automatic,
+        };
+        report.add_result(
+            override_metadata,
+            CheckerResult {
+                status: CheckStatus::OVERRIDE(Box::new(CheckStatus::SKIP)),
+                error: "".to_string(),
+                override_reason: Some("Test requires iptables configuration".to_string()),
+            },
+        );
+
+        let writer = JsonReportWriter {};
+        let mut output = Cursor::new(Vec::new());
+        writer.write(&report, &mut output).unwrap();
+
+        let json_output = String::from_utf8(output.into_inner()).unwrap();
+        let json_value: serde_json::Value = serde_json::from_str(&json_output).unwrap();
+
+        // Verify regular FAIL result has string status and original error
+        let fail_result = &json_value["results"]["br03030100"];
+        assert_eq!(fail_result["status"], "FAIL");
+        assert_eq!(fail_result["error"], "modprobe for sctp is not disabled");
+
+        // Verify OVERRIDE result has flattened status and override reason in error field
+        let override_result = &json_value["results"]["br03040101"];
+        assert_eq!(override_result["status"], "SKIP");
+        assert_eq!(
+            override_result["error"],
+            "Test requires iptables configuration"
+        );
+
+        // Verify override_reason field is not present
+        assert!(override_result.get("override_reason").is_none());
+    }
 }

--- a/sources/bloodhound/src/results.rs
+++ b/sources/bloodhound/src/results.rs
@@ -13,7 +13,7 @@ pub struct ReportMetadata {
     pub url: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Default)]
 pub enum CheckStatus {
     /// Successfully verified to be in the expected state.
     PASS,
@@ -22,6 +22,8 @@ pub enum CheckStatus {
     /// Unable to verify state, manual verification required.
     #[default]
     SKIP,
+    /// Test was overridden, contains the original status that would have been returned.
+    OVERRIDE(Box<CheckStatus>),
 }
 
 impl fmt::Display for CheckStatus {
@@ -67,6 +69,8 @@ impl fmt::Display for CheckerMetadata {
 pub struct CheckerResult {
     pub status: CheckStatus,
     pub error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub override_reason: Option<String>,
 }
 
 impl fmt::Display for CheckerResult {
@@ -74,6 +78,18 @@ impl fmt::Display for CheckerResult {
         let output = serde_json::to_string(&self).unwrap_or_default();
         write!(f, "{output}")
     }
+}
+
+/// Configuration for overriding specific compliance tests.
+///
+/// This structure defines how specific tests can be skipped or modified
+/// through JSON configuration files placed alongside test executables.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OverrideConfig {
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
+    pub status: String,
 }
 
 /// The Checker trait defines the interface for a compliance check. Checkers are
@@ -102,6 +118,7 @@ impl Checker for ManualChecker {
         CheckerResult {
             error: "Manual check, see benchmark for audit details.".to_string(),
             status: CheckStatus::SKIP,
+            override_reason: None,
         }
     }
 
@@ -177,6 +194,24 @@ impl ReportResults {
             CheckStatus::SKIP => {
                 self.skipped += 1;
             }
+            CheckStatus::OVERRIDE(ref inner_status) => match **inner_status {
+                CheckStatus::FAIL => {
+                    self.failed += 1;
+                    self.status = CheckStatus::FAIL;
+                }
+                CheckStatus::PASS => {
+                    self.passed += 1;
+                    if self.status == CheckStatus::SKIP {
+                        self.status = CheckStatus::PASS;
+                    }
+                }
+                CheckStatus::SKIP => {
+                    self.skipped += 1;
+                }
+                CheckStatus::OVERRIDE(_) => {
+                    self.skipped += 1;
+                }
+            },
         }
         self.results
             .insert(metadata.name.clone(), IndividualResult { metadata, result });

--- a/sources/bloodhound/src/results.rs
+++ b/sources/bloodhound/src/results.rs
@@ -134,12 +134,44 @@ impl Checker for ManualChecker {
 }
 
 /// Used to help serialize output into simpler JSON structure.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct IndividualResult {
-    #[serde(flatten)]
     pub metadata: CheckerMetadata,
-    #[serde(flatten)]
     pub result: CheckerResult,
+}
+
+impl Serialize for IndividualResult {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut state = serializer.serialize_struct("IndividualResult", 7)?;
+
+        // Serialize metadata fields
+        state.serialize_field("name", &self.metadata.name)?;
+        state.serialize_field("id", &self.metadata.id)?;
+        state.serialize_field("level", &self.metadata.level)?;
+        state.serialize_field("title", &self.metadata.title)?;
+        state.serialize_field("mode", &self.metadata.mode)?;
+
+        // Handle status - flatten OVERRIDE to just the inner status
+        let status_str = match &self.result.status {
+            CheckStatus::OVERRIDE(inner_status) => inner_status.to_string(),
+            status => status.to_string(),
+        };
+        state.serialize_field("status", &status_str)?;
+
+        // Handle error - use override_reason if available, otherwise use error
+        let error_str = match &self.result.override_reason {
+            Some(reason) => reason,
+            None => &self.result.error,
+        };
+        state.serialize_field("error", error_str)?;
+
+        state.end()
+    }
 }
 
 /// ReportResults are the overall compliance checking containing the results of


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #540

**Description of changes:**
Adds the ability for bloodhound test overrides to exist, with reasoning, and optional messaging in the case of skipped tests. Additionally, overrides 2 tests:
* Bottlerocket 03040101 if running on kubernetes variants will now be overridden to skip with an explanation
* Kubernetes 04021000 was already set to automatically pass, but has been switched to use the new override system

Finally, we've removed the RSA ciphers no longer considered secure by the latest kubernetes CIS benchmark from k8s 04021200

**Testing done:**

Run tests:
```
[ssm-user@control]$ apiclient exec report cis -l 2
ctr: container "report" in namespace "default": not found
[ssm-user@control]$ apiclient report cis -l 2
Benchmark name:  CIS Bottlerocket Benchmark
Version:         v1.0.0
Reference:       https://www.cisecurity.org/benchmark/bottlerocket
Benchmark level: 2
Start time:      2025-10-20T22:08:02.530202650Z

[FAIL] 1.1.1.1   Ensure mounting of udf filesystems is disabled (Automatic)
[SKIP] 1.2.1     Ensure software update repositories are configured (Manual)
[PASS] 1.3.1     Ensure dm-verity is configured (Automatic)
[PASS] 1.4.1     Ensure setuid programs do not create core dumps (Automatic)
[PASS] 1.4.2     Ensure address space layout randomization (ASLR) is enabled (Automatic)
[PASS] 1.4.3     Ensure unprivileged eBPF is disabled (Automatic)
[PASS] 1.4.4     Ensure user namespaces are disabled (Automatic)
[PASS] 1.5.1     Ensure SELinux is configured (Automatic)
[PASS] 1.5.2     Ensure Lockdown is configured (Automatic)
[SKIP] 1.6       Ensure updates, patches, and additional security software are installed (Manual)
[PASS] 2.1.1.1   Ensure chrony is configured (Automatic)
[FAIL] 3.1.1     Ensure packet redirect sending is disabled (Automatic)
[PASS] 3.2.1     Ensure source routed packets are not accepted (Automatic)
[FAIL] 3.2.2     Ensure ICMP redirects are not accepted (Automatic)
[FAIL] 3.2.3     Ensure secure ICMP redirects are not accepted (Automatic)
[FAIL] 3.2.4     Ensure suspicious packets are logged (Automatic)
[PASS] 3.2.5     Ensure broadcast ICMP requests are ignored (Automatic)
[PASS] 3.2.6     Ensure bogus ICMP responses are ignored (Automatic)
[PASS] 3.2.7     Ensure TCP SYN Cookies is enabled (Automatic)
[FAIL] 3.3.1     Ensure SCTP is disabled (Automatic)
[SKIP] 3.4.1.1   Ensure IPv4 default deny firewall policy (Exception)
[FAIL] 3.4.1.2   Ensure IPv4 loopback traffic is configured (Automatic)
[SKIP] 3.4.1.3   Ensure IPv4 outbound and established connections are configured (Manual)
[FAIL] 3.4.2.1   Ensure IPv6 default deny firewall policy (Automatic)
[FAIL] 3.4.2.2   Ensure IPv6 loopback traffic is configured (Automatic)
[SKIP] 3.4.2.3   Ensure IPv6 outbound and established connections are configured (Manual)
[PASS] 4.1.1.1   Ensure journald is configured to write logs to persistent disk (Automatic)
[PASS] 4.1.2     Ensure permissions on journal files are configured (Automatic)

Passed:          14
Failed:          9
Skipped:         5
Total checks:    28

Compliance check result: FAIL

Exceptions:
*  3.4.1.1 Test requires iptables FORWARD chain configuration that conflicts with Kubernetes networking architecture. Kubernetes manages its own iptables rules through kube-proxy and CNI plugins.
[ssm-user@control]$ apiclient report cis-k8s -l 2
Benchmark name:  CIS Kubernetes Benchmark (Worker Node)
Version:         v1.11.1
Reference:       https://www.cisecurity.org/benchmark/kubernetes
Benchmark level: 2
Start time:      2025-10-20T22:08:10.965751661Z

[PASS] 4.1.1     Ensure that the kubelet service file permissions are set to 600 or more restrictive (Automatic)
[PASS] 4.1.2     Ensure that the kubelet service file ownership is set to root:root (Automatic)
[SKIP] 4.1.3     If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)
[SKIP] 4.1.4     If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)
[PASS] 4.1.5     Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automatic)
[PASS] 4.1.6     Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automatic)
[PASS] 4.1.7     Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automatic)
[PASS] 4.1.8     Ensure that the client certificate authorities file ownership is set to root:root (Automatic)
[PASS] 4.1.9     If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Automatic)
[PASS] 4.1.10    If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Automatic)
[PASS] 4.2.1     Ensure that the --anonymous-auth argument is set to false (Automatic)
[PASS] 4.2.2     Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automatic)
[PASS] 4.2.3     Ensure that the --client-ca-file argument is set as appropriate (Automatic)
[PASS] 4.2.4     Verify that if defined, readOnlyPort is set to 0 (Automatic)
[PASS] 4.2.5     Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automatic)
[PASS] 4.2.6     Ensure that the --make-iptables-util-chains argument is set to true (Automatic)
[SKIP] 4.2.7     Ensure that the --hostname-override argument is not set (not valid for Bottlerocket) (Manual)
[SKIP] 4.2.8     Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)
[PASS] 4.2.9     Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automatic)
[PASS] 4.2.10    Ensure that the --rotate-certificates argument is not set to false (Exception)
[PASS] 4.2.11    Verify that the RotateKubeletServerCertificate argument is set to true (Automatic)
[PASS] 4.2.12    Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automatic)
[PASS] 4.2.13    Ensure that a limit is set on pod PIDs (Automatic)
[FAIL] 4.2.14    Ensure that the --seccomp-default parameter is set to true (Automatic)
[SKIP] 4.2.15    Ensure that the --IPAddressDeny is set to any (Manual)
[SKIP] 4.3.1     Ensure that the kube-proxy metrics service is bound to localhost (Manual)

Passed:          19
Failed:          1
Skipped:         6
Total checks:    26

Compliance check result: FAIL

Exceptions:
*  4.2.10 IAM (external) auth is used on Bottlerocket, so certificate rotation does not apply. See EKS CIS Benchmark.
```

Check to ensure overrides are on kubernetes variants, but not ECS variants:


```
ec2-user /mnt   20:31  ❯ cd bottlerocket-k8s-1.33/usr/libexec/cis-checks/

ec2-user …/usr/libexec/cis-checks   20:31  ❯ ls
bottlerocket  kubernetes

ec2-user …/usr/libexec/cis-checks   20:31  ❯ ls bottlerocket/
br01010101  br01030100  br01040200  br01040400  br01050200  br02010101  br03020100  br03020300  br03020500  br03020700  br03040101       br03040102  br03040201  br03040203  br04010200
br01020100  br01040100  br01040300  br01050100  br01060000  br03010100  br03020200  br03020400  br03020600  br03030100  br03040101.json  br03040103  br03040202  br04010101  metadata.json

ec2-user …/usr/libexec/cis-checks   20:31  ❯ ls kubernetes/
k8s04010100  k8s04010300  k8s04010500  k8s04010700  k8s04010900  k8s04020100  k8s04020300  k8s04020500  k8s04020700  k8s04020900  k8s04021000.json  k8s04021200  k8s04021400  k8s04030100
k8s04010200  k8s04010400  k8s04010600  k8s04010800  k8s04011000  k8s04020200  k8s04020400  k8s04020600  k8s04020800  k8s04021000  k8s04021100       k8s04021300  k8s04021500  metadata.json

ec2-user …/usr/libexec/cis-checks   20:31  ❯ ....

ec2-user /mnt/bottlerocket-k8s-1.33   20:31  ❯ ..

ec2-user /mnt   20:31  ❯ ls
bottlerocket-ecs-2  bottlerocket-k8s-1.33  bottlerocket-root

ec2-user /mnt   20:31  ❯ cd bottlerocket-ecs-2/usr/libexec/cis-checks/

ec2-user …/usr/libexec/cis-checks   20:31  ❯ ls
bottlerocket

ec2-user …/usr/libexec/cis-checks   20:31  ❯ ls bottlerocket/
br01010101  br01030100  br01040200  br01040400  br01050200  br02010101  br03020100  br03020300  br03020500  br03020700  br03040101  br03040103  br03040202  br04010101  metadata.json
br01020100  br01040100  br01040300  br01050100  br01060000  br03010100  br03020200  br03020400  br03020600  br03030100  br03040102  br03040201  br03040203  br04010200
```

json output sample: 

```
   "error": ""
    },
    "br03030100": {
      "name": "br03030100",
      "id": "3.3.1",
      "level": 2,
      "title": "Ensure SCTP is disabled",
      "mode": "Automatic",
      "status": "FAIL",
      "error": "modprobe for sctp is not disabled"
    },
    "br03040101": {
      "name": "br03040101",
      "id": "3.4.1.1",
      "level": 2,
      "title": "Ensure IPv4 default deny firewall policy",
      "mode": "Automatic",
      "status": "SKIP",
      "error": "Test requires iptables FORWARD chain configuration that conflicts with Kubernetes networking architecture. Kubernetes manages its own iptables rules through kube-proxy and CNI plugins."
    },
    "br03040102": {
      "name": "br03040102",
      "id": "3.4.1.2",
      "level": 2,
      "title": "Ensure IPv4 loopback traffic is configured",
      "mode": "Automatic",
      "status": "FAIL",
      "error": "Unable to find expected iptables INPUT values"
    },
    "br03040103": {
      "name": "br03040103",
      "id": "3.4.1.3",
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
