### PR TITLE
packages: update libexpat to v2.7.2

### DIFF
--- a/advisories/10.5.0/BRSA-ja1ptrrpkcey.toml
+++ b/advisories/10.5.0/BRSA-ja1ptrrpkcey.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-ja1ptrrpkcey"
+title = "libexpat CVE-2025-59375"
+cve = "CVE-2025-59375"
+severity = "high"
+description = "A memory amplification vulnerability was found in libexpat where a specially crafted small XML input can trigger excessive dynamic memory allocations which could lead to denial-of-service through memory exhaustion."
+
+[[advisory.products]]
+package-name = "libexpat"
+patched-version = "2.7.2"
+patched-epoch = "1"
+
+[updateinfo]
+author = "kushupad"
+issue-date = 2025-09-22T21:55:47Z
+arches = ["aarch64", "x86_64"]
+version = "10.5.0"

--- a/packages/libexpat/Cargo.toml
+++ b/packages/libexpat/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://github.com/libexpat/libexpat/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/libexpat/libexpat/releases/download/R_2_7_0/expat-2.7.0.tar.xz"
-sha512 = "69fb19c2634821b657f550f609d0bcc6e45e9d903072bbc63e9a0bfc92ef7d04c6e1408dd39eb43eaa2951f28ae93dce4f796c9769253f440905db2d5606a4c7"
+url = "https://github.com/libexpat/libexpat/releases/download/R_2_7_2/expat-2.7.2.tar.xz"
+sha512 = "da64ae6d1762388873acbad9bc0edc80094c693bccacf89ca90d1626f53866c5e87c2019276e39643963d6479fb8a6d7b1f05f38caa1be84a24ff9d603449e38"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/libexpat/libexpat/releases/download/R_2_7_0/expat-2.7.0.tar.xz.asc"
-sha512 = "ef26db65fec81067a919182705008d724a09d00fb0c7c003f2d975a75600a5153e4264555510d5dc7292ec96866f0f15c4cb931002ff0bc6021c15626fa87364"
+url = "https://github.com/libexpat/libexpat/releases/download/R_2_7_2/expat-2.7.2.tar.xz.asc"
+sha512 = "4ec8466294b3cfcce7835f6a00ec91127ec1aa830eeb34f24ae6021af0ee6fef88ae3e4c7ad466f9ff537b68c2981c8816245e57bf65ff93001ac02d23b9f57c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libexpat/libexpat.spec
+++ b/packages/libexpat/libexpat.spec
@@ -1,4 +1,4 @@
-%global unversion 2_7_0
+%global unversion 2_7_2
 
 Name: %{_cross_os}libexpat
 Version: %(echo %{unversion} | sed 's/_/./g')


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Updates:
- `libexpat` from 2.7.0 to 2.7.2

**Testing done:**

- Core kit builds on both platforms
- Instance boots on both platforms, meaning `dbus-launcher` successfully used `expat` to parse XML

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
