### PR TITLE
packages: bump docker-engine from 25.0.12 to 25.0.13

### DIFF
--- a/packages/docker-engine/Cargo.toml
+++ b/packages/docker-engine/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v25.0.12/moby-25.0.12.tar.gz"
-sha512 = "8954a86e87be392988cb56c9f99ee3004033b0b82b2ed5c6c6064d3409fb1357db115aa9b6e5a9f49084e5fc2a596d52c8b958482eb1a21b91c6e6791d81d637"
+url = "https://github.com/moby/moby/archive/v25.0.13/moby-25.0.13.tar.gz"
+sha512 = "bf7254b2977e085eae717b09965f8f8865a89323c2f160d26fdceb8ef74d6871d24be391e4950683c4867bb68b728d9cd822165934c6abbf4ea67a7b24877287"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-engine/docker-engine.spec
+++ b/packages/docker-engine/docker-engine.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 25.0.12
+%global gover 25.0.13
 %global rpmver %{gover}
-%global gitrev b08a51fe16eed67de3861c03b363ba403643b12e
+%global gitrev 165516eb478021fdc99976e5aadc26bf73c1e51b
 
 %global source_date_epoch 1363394400
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Update third-party packages:
- `docker-engine` from from 25.0.12 to 25.0.13

**Testing done:**

ECS conformance tests pass on `aws-ecs-2` variant on both archs.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
