### PR TITLE
Add `hwloc` to core kit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "glibc",
  "grep",
  "host-ctr",
+ "hwloc",
  "iproute",
  "iptables",
  "iputils",
@@ -406,6 +407,14 @@ name = "host-ctr"
 version = "0.1.0"
 dependencies = [
  "glibc",
+]
+
+[[package]]
+name = "hwloc"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "systemd-252",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
   "packages/host-ctr",
   "packages/iproute",
   "packages/iptables",
+  "packages/hwloc",
   "packages/iputils",
   "packages/kexec-tools",
   "packages/keyutils",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -49,6 +49,7 @@ findutils = { path = "../../packages/findutils" }
 glibc = { path = "../../packages/glibc" }
 grep = { path = "../../packages/grep" }
 host-ctr = { path = "../../packages/host-ctr" }
+hwloc = { path = "../../packages/hwloc" }
 iproute = { path = "../../packages/iproute" }
 iptables = { path = "../../packages/iptables" }
 iputils = { path = "../../packages/iputils" }

--- a/packages/hwloc/Cargo.toml
+++ b/packages/hwloc/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "hwloc"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://www.open-mpi.org/software/ompi/v5.0/"
+
+[[package.metadata.build-package.external-files]]
+url = "https://download.open-mpi.org/release/hwloc/v2.12/hwloc-2.12.2.tar.bz2"
+sha512 = "949d6c9d7b858ee58e477b15e6c06f57812872142fa1c7f3ef20aae2e4ef954135f839e8604404bfd0637fde99729c7d00211c8aee860dfde9ac60bba0e78aef"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+systemd-252 = { path = "../systemd-252" }

--- a/packages/hwloc/hwloc.spec
+++ b/packages/hwloc/hwloc.spec
@@ -1,0 +1,83 @@
+Name: %{_cross_os}hwloc
+Version: 2.12.2
+Release: 1%{?dist}
+Summary: Portable hardware locality library
+URL: https://www.open-mpi.org/projects/hwloc/
+License: BSD-3-Clause
+Source0: https://download.open-mpi.org/release/hwloc/v2.12/hwloc-%{version}.tar.bz2
+
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}systemd-devel
+
+%description
+%{summary}.
+
+%package tools
+Summary: Command line tools for the hwloc library
+Requires: %{name}
+
+%description tools
+%{summary}.
+
+%package devel
+Summary: hwloc development libraries and headers
+Requires: %{name}
+Requires: %{_cross_os}systemd-devel
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n hwloc-%{version} -p1
+
+%build
+%cross_configure \
+    --disable-cairo \
+    --disable-gl \
+    --disable-libxml2 \
+    --disable-opencl \
+    --disable-pci \
+    --disable-plugins \
+    --exec-prefix=%{_cross_prefix} \
+    --program-prefix=""
+
+%force_disable_rpath
+
+%make_build
+
+%install
+%make_install
+
+%files
+%license COPYING
+%{_cross_attribution_file}
+%{_cross_libdir}/libhwloc.so
+%{_cross_libdir}/libhwloc.so.*
+%exclude %{_cross_bindir}/lstopo
+%exclude %{_cross_bindir}/hwloc-compress-dir
+%exclude %{_cross_bindir}/hwloc-gather-topology
+%exclude %{_cross_datadir}
+%exclude %{_cross_mandir}
+
+%files tools
+%{_cross_bindir}/hwloc-annotate
+%{_cross_bindir}/hwloc-ls
+%{_cross_bindir}/hwloc-ps
+%{_cross_bindir}/hwloc-bind
+%{_cross_bindir}/hwloc-calc
+%{_cross_bindir}/hwloc-diff
+%{_cross_bindir}/hwloc-distrib
+%{_cross_bindir}/hwloc-info
+%{_cross_bindir}/hwloc-patch
+%{_cross_bindir}/lstopo-no-graphics
+# These are not on aarch64
+%if "%{_cross_arch}" == "x86_64"
+%{_cross_sbindir}/hwloc-dump-hwdata
+%{_cross_bindir}/hwloc-gather-cpuid
+%endif
+
+%files devel
+%{_cross_includedir}/hwloc.h
+%{_cross_includedir}/hwloc/*.h
+%{_cross_includedir}/hwloc/autogen/*.h
+%{_cross_pkgconfigdir}/*.pc


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/670

**Description of changes:**
Adds `hwloc` as package to the core kit. Also vend a devel package in case variants want to bind against hwloc as a build dependency rather than use the binaries. 


**Testing done:**
Built images with the binaries included. 

`hwloc-ls` is usable from `sheltie`:
```
bash-5.1# hwloc-ls
Machine (15GB total)
  Package L#0
    NUMANode L#0 (P#0 15GB)
    L3 L#0 (8192KB)
      L2 L#0 (512KB) + L1d L#0 (32KB) + L1i L#0 (32KB) + Core L#0
        PU L#0 (P#0)
        PU L#1 (P#2)
      L2 L#1 (512KB) + L1d L#1 (32KB) + L1i L#1 (32KB) + Core L#1
        PU L#2 (P#1)
        PU L#3 (P#3)
  Block(Disk) "nvme0n1"
  Block(Disk) "nvme2n1"
  Block(Disk) "nvme1n1"
  Net "eth1"
  Net "eth0"
```

Built an image and confirmed hwloc-ls will work from a container.
Specfile:
```
apiVersion: v1
kind: Pod
metadata:
  name: hwloc-pod
spec:
  containers:
  - name: hwloc
    image: ubuntu:24.04 # Has glibc 2.38 or later
    command: ['sh', '-c', 'echo "Hello, Kubernetes!" && sleep infinity']
    volumeMounts:
    - name: hwloc-binary
      mountPath: /usr/local/bin/hwloc-ls
      readOnly: true
  volumes:
  - name: hwloc-binary
    hostPath:
      path: /bin/hwloc-ls
      type: File
```
Output:
```
 $ kubectl exec -it hwloc-pod -- bash
root@hwloc-pod:/# hwloc-ls
Machine (15GB total)
  Package L#0
    NUMANode L#0 (P#0 15GB)
    L3 L#0 (8192KB)
      L2 L#0 (512KB) + L1d L#0 (32KB) + L1i L#0 (32KB) + Core L#0
        PU L#0 (P#0)
        PU L#1 (P#2)
      L2 L#1 (512KB) + L1d L#1 (32KB) + L1i L#1 (32KB) + Core L#1
        PU L#2 (P#1)
        PU L#3 (P#3)
  Block(Disk) "nvme0n1"
  Block(Disk) "nvme2n1"
  Block(Disk) "nvme1n1"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
