### PR TITLE
Third party package updates

### DIFF
--- a/packages/iproute/Cargo.toml
+++ b/packages/iproute/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "http://kernel.org/pub/linux/utils/net/iproute2"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.15.0.tar.xz"
-sha512 = "1a438941cd939e1c8e32cfe8c40e6fd826c89185f1bb0c623eaad7380a66afd9fa9e0d7cdc5e5b193d2761b7dbdc78fd0811537eecc500be633730c32ff55ad4"
+url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.16.0.tar.xz"
+sha512 = "88930ea1a3a901594a69dc04e533bfd1de0f5b79f176dedb45f11f01035bd680edccc8e04e56d0922ee430580581c646473a3baa941254739878f7ab946f17df"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.15.0.tar.sign"
-sha512 = "5a1159f926c1543ac01d7981f87a66c9715ebecffe37bd3954aebfe9499db8591ca26448322a60c55fd4d48564f63730732c80f010c7da1268dc9db1e089b48e"
+url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.16.0.tar.sign"
+sha512 = "651a0096325c804ff01da4427abfbc3a72362980baa4869d60aa94aa944c04bcb535070ae8e05b4e7f6e1ac667873ad80f77532edec0ce7e3bf34d4457ee3854"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/iproute/iproute.spec
+++ b/packages/iproute/iproute.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}iproute
-Version: 6.15.0
+Version: 6.16.0
 Release: 1%{?dist}
 Summary: Tools for advanced IP routing and network device configuration
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/libnvme/Cargo.toml
+++ b/packages/libnvme/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-nvme/libnvme/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-nvme/libnvme/archive/v1.14/libnvme-1.14.tar.gz"
-sha512 = "96a1bbd6cea1e77381254e242e781b023416abfbf44c82a0aa6eb0b316b30316d32d0b91f441089a317cbae5b511f6b3eaab570624cbda2178f9dce4cb5dd288"
+url = "https://github.com/linux-nvme/libnvme/archive/v1.15/libnvme-1.15.tar.gz"
+sha512 = "7357685b3f47eda445387965420e7885a326a6b60b3da5af4a8bb942d4f924534babbde3d4aae8468c8a2f0ee4971f2896fadc133f4c387d59f9f620ed2450aa"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnvme/libnvme.spec
+++ b/packages/libnvme/libnvme.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libnvme
-Version: 1.14
+Version: 1.15
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for NVM Express

--- a/packages/nvme-cli/0001-plugins-amzn-Add-stats-support-for-EC2-local-storage.patch
+++ b/packages/nvme-cli/0001-plugins-amzn-Add-stats-support-for-EC2-local-storage.patch
@@ -1,0 +1,552 @@
+From ffb1b3e864661f3998e6ecd96b5bb559a7b39387 Mon Sep 17 00:00:00 2001
+From: Lingkai Zuo <lingkai@amazon.com>
+Date: Thu, 24 Apr 2025 23:55:35 +0000
+Subject: [PATCH] plugins/amzn: Add stats support for EC2 local storage
+ instance type
+
+This patch adds the stats support for EC2 local storage on top of EBS.
+
+For local storage, it supports a `--details / -d` option. In this mode
+it will print out detail io histograms for different block size ranges.
+
+Signed-off-by: Lingkai Zuo <lingkai@amazon.com>
+---
+ plugins/amzn/amzn-nvme.c | 416 ++++++++++++++++++++++++++++++++-------
+ 1 file changed, 346 insertions(+), 70 deletions(-)
+
+diff --git a/plugins/amzn/amzn-nvme.c b/plugins/amzn/amzn-nvme.c
+index 983c31bc..7a512657 100644
+--- a/plugins/amzn/amzn-nvme.c
++++ b/plugins/amzn/amzn-nvme.c
+@@ -16,7 +16,14 @@
+ #include "amzn-nvme.h"
+ 
+ #define AMZN_NVME_STATS_LOGPAGE_ID 0xD0
+-#define AMZN_NVME_STATS_MAGIC 0x3C23B510
++#define AMZN_NVME_STATS_DETAIL_IO_VERSION 1
++#define AMZN_NVME_EBS_STATS_MAGIC 0x3C23B510
++#define AMZN_NVME_LOCAL_STORAGE_STATS_MAGIC 0xEC2C0D7E
++#define AMZN_NVME_STATS_NUM_HISTOGRAM 8
++#define AMZN_NVME_STATS_NUM_IO_SIZES 8
++#define AMZN_NVME_STATS_NUM_HISTOGRAM_BINS 32
++#define AMZN_NVME_STATS_IO_SIZE_BUF_LEN 16
++#define AMZN_NVME_LOCAL_STORAGE_PREFIX "Amazon EC2 NVMe Instance Storage"
+ 
+ #define array_add_obj json_array_add_value_object
+ #define obj_add_array json_object_add_value_array
+@@ -24,6 +31,12 @@
+ #define obj_add_uint json_object_add_value_uint
+ #define obj_add_uint64 json_object_add_value_uint64
+ 
++enum amzn_nvme_operation {
++	AMZN_NVME_OP_READ = 0,
++	AMZN_NVME_OP_WRITE = 1,
++	AMZN_NVME_OP_MAX = 2,
++};
++
+ struct nvme_vu_id_ctrl_field {
+ 	__u8			bdev[32];
+ 	__u8			reserved0[992];
+@@ -40,10 +53,17 @@ struct amzn_latency_histogram {
+ 	__u64 num_bins;
+ 	struct amzn_latency_histogram_bin bins[64];
+ } __packed;
++struct amzn_latency_histogram_counts {
++	__u64 counts[AMZN_NVME_STATS_NUM_HISTOGRAM_BINS];
++};
++struct amzn_latency_io_histogram {
++	struct amzn_latency_histogram_counts read_io_histogram_counts;
++	struct amzn_latency_histogram_counts write_io_histogram_counts;
++};
+ 
+-struct amzn_latency_log_page {
++struct amzn_latency_log_page_base {
+ 	__u32 magic;
+-	__u32 reserved0;
++	__u32 version;
+ 	__u64 total_read_ops;
+ 	__u64 total_write_ops;
+ 	__u64 total_read_bytes;
+@@ -60,9 +80,25 @@ struct amzn_latency_log_page {
+ 	struct amzn_latency_histogram read_io_latency_histogram;
+ 	struct amzn_latency_histogram write_io_latency_histogram;
+ 
+-	__u8 reserved2[496];
++	__u32 num_of_hists;
++	__u32 hist_io_sizes[AMZN_NVME_STATS_NUM_IO_SIZES];
++	__u8 reserved0[460];
+ } __packed;
+ 
++struct amzn_latency_detail_io_histogram {
++	struct amzn_latency_io_histogram io_hist_array[AMZN_NVME_STATS_NUM_HISTOGRAM];
++} __packed;
++
++struct amzn_latency_log_page {
++	struct amzn_latency_log_page_base base;
++	struct amzn_latency_detail_io_histogram detail_io;
++} __packed;
++
++static bool is_local_storage(struct amzn_latency_log_page *log_page)
++{
++	return log_page->base.magic == AMZN_NVME_LOCAL_STORAGE_STATS_MAGIC;
++}
++
+ static void json_amzn_id_ctrl(struct nvme_vu_id_ctrl_field *id,
+ 	char *bdev,
+ 	struct json_object *root)
+@@ -97,6 +133,31 @@ static int id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *pl
+ 	return __id_ctrl(argc, argv, cmd, plugin, amzn_id_ctrl);
+ }
+ 
++/* this function converts the size (in uint32_t) into human readable string
++ * @param size: the size to be converted
++ * @param buf: the buffer to store the converted string
++ * @param buf_size: the size of the buffer
++ * @return: the converted string
++ */
++
++const char *format_size(uint32_t size, char *buf, size_t buf_size)
++{
++	if (size == UINT32_MAX)
++		return "max";
++
++	if (size == 0)
++		return "0";
++
++	if (size % (1024 * 1024) == 0)
++		snprintf(buf, buf_size, "%uM", (unsigned int)(size / (1024 * 1024)));
++	else if (size % 1024 == 0)
++		snprintf(buf, buf_size, "%uK", (unsigned int)(size / 1024));
++	else
++		snprintf(buf, buf_size, "%u", size);
++
++	return buf;
++}
++
+ static void amzn_print_latency_histogram(struct amzn_latency_histogram *hist)
+ {
+ 	printf("=================================\n");
+@@ -113,6 +174,115 @@ static void amzn_print_latency_histogram(struct amzn_latency_histogram *hist)
+ 	printf("=================================\n\n");
+ }
+ 
++static void amzn_print_io_stats(struct amzn_latency_log_page *log_page)
++{
++	struct amzn_latency_log_page_base *base = &log_page->base;
++
++	printf("Total Ops:\n");
++	printf("  Read: %"PRIu64"\n", (uint64_t)base->total_read_ops);
++	printf("  Write: %"PRIu64"\n", (uint64_t)base->total_write_ops);
++	printf("Total Bytes:\n");
++	printf("  Read: %"PRIu64"\n", (uint64_t)base->total_read_bytes);
++	printf("  Write: %"PRIu64"\n", (uint64_t)base->total_write_bytes);
++	printf("Total Time (us):\n");
++	printf("  Read: %"PRIu64"\n", (uint64_t)base->total_read_time);
++	printf("  Write: %"PRIu64"\n\n", (uint64_t)base->total_write_time);
++
++	if (is_local_storage(log_page)) {
++		printf("EC2 Instance Local Storage Performance Exceeded (us):\n");
++		printf("  IOPS: %"PRIu64"\n",
++				(uint64_t)base->ec2_instance_ebs_performance_exceeded_iops);
++		printf("  Throughput: %"PRIu64"\n\n",
++				(uint64_t)base->ec2_instance_ebs_performance_exceeded_tp);
++	} else {
++		printf("EBS Volume Performance Exceeded (us):\n");
++		printf("  IOPS: %"PRIu64"\n", (uint64_t)base->ebs_volume_performance_exceeded_iops);
++		printf("  Throughput: %"PRIu64"\n\n",
++				(uint64_t)base->ebs_volume_performance_exceeded_tp);
++		printf("EC2 Instance EBS Performance Exceeded (us):\n");
++		printf("  IOPS: %"PRIu64"\n",
++				(uint64_t)base->ec2_instance_ebs_performance_exceeded_iops);
++		printf("  Throughput: %"PRIu64"\n\n",
++				(uint64_t)base->ec2_instance_ebs_performance_exceeded_tp);
++
++	}
++
++	printf("Queue Length (point in time): %"PRIu64"\n\n",
++	       (uint64_t)base->volume_queue_length);
++}
++
++static void amzn_print_detail_io(struct amzn_latency_log_page *log)
++{
++	char from_buf[AMZN_NVME_STATS_IO_SIZE_BUF_LEN] = { 0 };
++	char to_buf[AMZN_NVME_STATS_IO_SIZE_BUF_LEN] = { 0 };
++	int io_size_low = 0;
++	int io_size_high = 0;
++	uint64_t upper_bound;
++	uint64_t lower_bound;
++	uint64_t hist_count;
++	int num_of_bin = log->base.write_io_latency_histogram.num_bins;
++	int num_of_hists = log->base.num_of_hists;
++	struct amzn_latency_histogram *latency_histogram = &log->base.write_io_latency_histogram;
++	enum amzn_nvme_operation op;
++
++	for (int i = 0; i < num_of_hists; i++) {
++		if (i == 0) {
++			io_size_low = 0;
++			io_size_high = log->base.hist_io_sizes[i];
++		} else {
++			io_size_low = log->base.hist_io_sizes[i - 1];
++			io_size_high = log->base.hist_io_sizes[i];
++		}
++
++		/* print the io size range of the histogram */
++		printf("=================================\n");
++		printf("IO Size Range:\n");
++		printf("(io_size_low: %s -> io_size_high: %s]\n",
++				format_size(io_size_low, from_buf, sizeof(from_buf)),
++				format_size(io_size_high, to_buf, sizeof(to_buf)));
++
++		/*
++		 * print io histogram for this size range. The bound is the same for
++		 * all the ranges
++		 */
++		for (op = AMZN_NVME_OP_READ; op < AMZN_NVME_OP_MAX; op++) {
++
++			if (op == AMZN_NVME_OP_READ)
++				printf("Read IO Latency Histogram\n");
++			else
++				printf("Write IO Latency Histogram\n");
++
++			for (int b = 0; b < num_of_bin; b++) {
++				upper_bound = latency_histogram->bins[b].upper;
++				lower_bound = latency_histogram->bins[b].lower;
++				hist_count = (op == AMZN_NVME_OP_READ) ?
++					log->detail_io.io_hist_array[i].read_io_histogram_counts.counts[b] :
++					log->detail_io.io_hist_array[i].write_io_histogram_counts.counts[b];
++
++
++				printf("[%-8"PRIu64" - %-8"PRIu64"] => %-8"PRIu64"\n",
++				       (uint64_t)lower_bound, (uint64_t)upper_bound,
++				       hist_count);
++			}
++
++		}
++	}
++}
++
++static void amzn_print_normal_stats(struct amzn_latency_log_page *log, bool detail)
++{
++	amzn_print_io_stats(log);
++
++	printf("Read IO Latency Histogram\n");
++	amzn_print_latency_histogram(&log->base.read_io_latency_histogram);
++
++	printf("Write IO Latency Histogram\n");
++	amzn_print_latency_histogram(&log->base.write_io_latency_histogram);
++
++	if (log->base.version == AMZN_NVME_STATS_DETAIL_IO_VERSION && detail)
++		amzn_print_detail_io(log);
++}
++
+ #ifdef CONFIG_JSONC
+ static void amzn_json_add_histogram(struct json_object *root,
+ 				    struct amzn_latency_histogram *hist)
+@@ -134,75 +304,164 @@ static void amzn_json_add_histogram(struct json_object *root,
+ 	}
+ }
+ 
+-static void amzn_print_json_stats(struct amzn_latency_log_page *log)
++static void amzn_json_add_io_stats(struct json_object *root,
++				   struct amzn_latency_log_page *log)
+ {
+-	struct json_object *root = json_create_object();
+-	struct json_object *r_hist = json_create_object();
+-	struct json_object *w_hist = json_create_object();
+-
+-	obj_add_uint64(root, "total_read_ops", log->total_read_ops);
+-	obj_add_uint64(root, "total_write_ops", log->total_write_ops);
+-	obj_add_uint64(root, "total_read_bytes", log->total_read_bytes);
+-	obj_add_uint64(root, "total_write_bytes", log->total_write_bytes);
+-	obj_add_uint64(root, "total_read_time", log->total_read_time);
+-	obj_add_uint64(root, "total_write_time", log->total_write_time);
++	struct amzn_latency_log_page_base *base = &log->base;
++
++	obj_add_uint64(root, "total_read_ops", base->total_read_ops);
++	obj_add_uint64(root, "total_write_ops", base->total_write_ops);
++	obj_add_uint64(root, "total_read_bytes", base->total_read_bytes);
++	obj_add_uint64(root, "total_write_bytes", base->total_write_bytes);
++	obj_add_uint64(root, "total_read_time", base->total_read_time);
++	obj_add_uint64(root, "total_write_time", base->total_write_time);
+ 	obj_add_uint64(root, "ebs_volume_performance_exceeded_iops",
+-		       log->ebs_volume_performance_exceeded_iops);
++		       base->ebs_volume_performance_exceeded_iops);
+ 	obj_add_uint64(root, "ebs_volume_performance_exceeded_tp",
+-		       log->ebs_volume_performance_exceeded_tp);
++		       base->ebs_volume_performance_exceeded_tp);
+ 	obj_add_uint64(root,
+ 		       "ec2_instance_ebs_performance_exceeded_iops",
+-		       log->ec2_instance_ebs_performance_exceeded_iops);
++		       base->ec2_instance_ebs_performance_exceeded_iops);
+ 	obj_add_uint64(root, "ec2_instance_ebs_performance_exceeded_tp",
+-		       log->ec2_instance_ebs_performance_exceeded_tp);
+-	obj_add_uint64(root, "volume_queue_length", log->volume_queue_length);
++			   base->ec2_instance_ebs_performance_exceeded_tp);
++	obj_add_uint64(root, "volume_queue_length", base->volume_queue_length);
++
++}
++
++/* This function prints the detail io histogram of multiple IO sizes
++ * For each IO size range, it prints both read and write histogram
++ * The histogram is divided into bins, and each bin has a lower and upper bound
++ * the bins are the same for all the histograms.
++ * This is an example of the output:
++ *  "histograms": [
++ *      {
++ *		"io_size_low": "512",
++ *		"io_size_high": "4k",
++ *		"read_histogram": {
++ *			"bins": [
++ *				....
++ *			{ "lower": 8, "upper": 16, "count": 40 }
++ *			]
++ *		},
++ *		"write_histogram": {
++ *			"bins": [
++ *			...
++ *			{ "lower": 8, "upper": 16, "count": 45 }
++ *				]
++ *			}
++ *	},
++ *		{
++ *		"io_size_low": "1024",
++ *		"io_size_high": "8k",
++ *		"read_histogram": {
++ *			"bins": [
++ *				....
++ *			]
++ *		},
++ *		"write_histogram": {
++ *			"bins": [
++ *				....
++ *			]
++ *		}
++ */
++static struct json_object *amzn_json_create_detail_io(struct amzn_latency_log_page *log)
++{
++	int io_size_low = 0;
++	int io_size_high = 0;
++	char from_buf[AMZN_NVME_STATS_IO_SIZE_BUF_LEN] = { 0 };
++	char to_buf[AMZN_NVME_STATS_IO_SIZE_BUF_LEN] = { 0 };
++	int num_of_bins = log->base.write_io_latency_histogram.num_bins;
++	int num_of_hists = log->base.num_of_hists;
++	struct amzn_latency_histogram *latency_histogram = &log->base.write_io_latency_histogram;
++
++	struct json_object *root = json_create_object();
++	struct json_object *io_hist_array = json_create_array();
++
++	obj_add_uint(root, "num_of_hists", num_of_hists);
++	obj_add_obj(root, "io_histograms", io_hist_array);
++
++
++	for (int i = 0; i < num_of_hists; i++) {
++		struct json_object *hist_object = json_create_object();
++
++		json_object_array_add(io_hist_array, hist_object);
++
++		if (i == 0) {
++			io_size_low = 0;
++			io_size_high = log->base.hist_io_sizes[i];
++		} else {
++			io_size_low = log->base.hist_io_sizes[i - 1];
++			io_size_high = log->base.hist_io_sizes[i];
++		}
++
++		json_object_add_value_string(hist_object, "io_size_low",
++			format_size(io_size_low, from_buf, sizeof(from_buf)));
++		json_object_add_value_string(hist_object, "io_size_high",
++			format_size(io_size_high, to_buf, sizeof(to_buf)));
++
++		for (int op = AMZN_NVME_OP_READ; op < AMZN_NVME_OP_MAX; op++) {
++			struct json_object *bin_array = json_create_array();
++			struct json_object *op_object = json_create_object();
++
++			json_object_add_value_uint64(op_object, "num_bins", num_of_bins);
++			json_object_object_add(op_object, "bins", bin_array);
++
++			if (op == AMZN_NVME_OP_READ)
++				obj_add_obj(hist_object, "read_io_latency_histogram", op_object);
++			else
++				obj_add_obj(hist_object, "write_io_latency_histogram", op_object);
++
++			for (int bin = 0; bin < num_of_bins; bin++) {
++				struct json_object *bin_object = json_create_object();
++
++				json_object_add_value_uint64(bin_object, "lower",
++							     latency_histogram->bins[bin].lower);
++				json_object_add_value_uint64(bin_object, "upper",
++							     latency_histogram->bins[bin].upper);
++				if (op == AMZN_NVME_OP_READ)
++					json_object_add_value_uint64(bin_object, "count",
++						log->detail_io.io_hist_array[i].read_io_histogram_counts.counts[bin]);
++				else
++					json_object_add_value_uint64(bin_object, "count",
++						log->detail_io.io_hist_array[i].write_io_histogram_counts.counts[bin]);
++
++				json_object_array_add(bin_array, bin_object);
++			}
++		}
++	}
++
++	return root;
++}
++
++static void amzn_print_json_stats(struct amzn_latency_log_page *log, bool detail)
++{
++	struct json_object *root = json_create_object();
++	struct json_object *r_hist = json_create_object();
++	struct json_object *w_hist = json_create_object();
++	struct json_object *detail_io;
++
++	amzn_json_add_io_stats(root, log);
+ 
+-	amzn_json_add_histogram(r_hist, &log->read_io_latency_histogram);
++	amzn_json_add_histogram(r_hist, &log->base.read_io_latency_histogram);
+ 	obj_add_obj(root, "read_io_latency_histogram", r_hist);
+-	amzn_json_add_histogram(w_hist, &log->write_io_latency_histogram);
++	amzn_json_add_histogram(w_hist, &log->base.write_io_latency_histogram);
+ 	obj_add_obj(root, "write_io_latency_histogram", w_hist);
+ 
++	if (log->base.version == AMZN_NVME_STATS_DETAIL_IO_VERSION && detail) {
++		detail_io = amzn_json_create_detail_io(log);
++		json_object_object_add(root, "latency_histograms", detail_io);
++	}
++
+ 	json_print_object(root, NULL);
+ 	printf("\n");
+ 
+ 	json_free_object(root);
+ }
++
+ #else /* CONFIG_JSONC */
+-#define amzn_print_json_stats(log)
++#define amzn_print_json_stats(log, detail)
+ #endif /* CONFIG_JSONC */
+ 
+-static void amzn_print_normal_stats(struct amzn_latency_log_page *log)
+-{
+-	printf("Total Ops:\n");
+-	printf("  Read: %"PRIu64"\n", (uint64_t)log->total_read_ops);
+-	printf("  Write: %"PRIu64"\n", (uint64_t)log->total_write_ops);
+-	printf("Total Bytes:\n");
+-	printf("  Read: %"PRIu64"\n", (uint64_t)log->total_read_bytes);
+-	printf("  Write: %"PRIu64"\n", (uint64_t)log->total_write_bytes);
+-	printf("Total Time (us):\n");
+-	printf("  Read: %"PRIu64"\n", (uint64_t)log->total_read_time);
+-	printf("  Write: %"PRIu64"\n\n", (uint64_t)log->total_write_time);
+-
+-	printf("EBS Volume Performance Exceeded (us):\n");
+-	printf("  IOPS: %"PRIu64"\n", (uint64_t)log->ebs_volume_performance_exceeded_iops);
+-	printf("  Throughput: %"PRIu64"\n\n",
+-	       (uint64_t)log->ebs_volume_performance_exceeded_tp);
+-	printf("EC2 Instance EBS Performance Exceeded (us):\n");
+-	printf("  IOPS: %"PRIu64"\n",
+-	       (uint64_t)log->ec2_instance_ebs_performance_exceeded_iops);
+-	printf("  Throughput: %"PRIu64"\n\n",
+-	       (uint64_t)log->ec2_instance_ebs_performance_exceeded_tp);
+-
+-	printf("Queue Length (point in time): %"PRIu64"\n\n",
+-	       (uint64_t)log->volume_queue_length);
+-
+-	printf("Read IO Latency Histogram\n");
+-	amzn_print_latency_histogram(&log->read_io_latency_histogram);
+-
+-	printf("Write IO Latency Histogram\n");
+-	amzn_print_latency_histogram(&log->write_io_latency_histogram);
+-}
+-
+ static int get_stats(int argc, char **argv, struct command *cmd,
+ 		     struct plugin *plugin)
+ {
+@@ -210,8 +469,9 @@ static int get_stats(int argc, char **argv, struct command *cmd,
+ 	struct nvme_dev *dev;
+ 	struct amzn_latency_log_page log = { 0 };
+ 	int rc;
+-	nvme_print_flags_t flags;
+-	int err;
++	nvme_print_flags_t flags = 0; // Initialize flags to 0
++	struct nvme_id_ctrl ctrl;
++	bool detail = false;
+ 
+ 	struct config {
+ 		char *output_format;
+@@ -224,12 +484,19 @@ static int get_stats(int argc, char **argv, struct command *cmd,
+ 	OPT_ARGS(opts) = {
+ 		OPT_FMT("output-format", 'o', &cfg.output_format,
+ 			"Output Format: normal|json"),
++		OPT_FLAG("details", 'd', &detail, "Detail IO histogram of each block size ranges"),
+ 		OPT_END()};
+ 
+ 	rc = parse_and_open(&dev, argc, argv, desc, opts);
+ 	if (rc)
+ 		return rc;
+ 
++	if (nvme_identify_ctrl(dev_fd(dev), &ctrl)) {
++		fprintf(stderr, "Failed to get identify controller\n");
++		rc = -errno;
++		goto done;
++	}
++
+ 	struct nvme_get_log_args args = {
+ 		.args_size = sizeof(args),
+ 		.fd = dev_fd(dev),
+@@ -242,34 +509,43 @@ static int get_stats(int argc, char **argv, struct command *cmd,
+ 		.uuidx = 0,
+ 		.csi = NVME_CSI_NVM,
+ 		.ot = false,
+-		.len = sizeof(log),
+-		.log = &log,
++		.log = (void *) &log,
+ 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+ 		.result = NULL,
+ 	};
+ 
++	if (!strncmp((char *)ctrl.mn, AMZN_NVME_LOCAL_STORAGE_PREFIX,
++		     strlen(AMZN_NVME_LOCAL_STORAGE_PREFIX)))
++		args.len = sizeof(log);
++	else
++		args.len = sizeof(log.base);
++
+ 	rc = nvme_get_log(&args);
+ 	if (rc != 0) {
+-		fprintf(stderr, "[ERROR] %s: Failed to get log page, rc = %d",
++		fprintf(stderr, "[ERROR] %s: Failed to get log page, rc = %d\n",
+ 			__func__, rc);
+-		return rc;
++		goto done;
+ 	}
+ 
+-	if (log.magic != AMZN_NVME_STATS_MAGIC) {
+-		fprintf(stderr, "[ERROR] %s: Not an EBS device", __func__);
+-		return -ENOTSUP;
++	if (log.base.magic != AMZN_NVME_EBS_STATS_MAGIC &&
++		log.base.magic != AMZN_NVME_LOCAL_STORAGE_STATS_MAGIC) {
++		fprintf(stderr, "[ERROR] %s: Not an EC2 device\n", __func__);
++		rc = -ENOTSUP;
++		goto done;
+ 	}
+ 
+-	err = validate_output_format(cfg.output_format, &flags);
+-	if (err < 0) {
++	rc = validate_output_format(cfg.output_format, &flags);
++	if (rc < 0) {
+ 		nvme_show_error("Invalid output format");
+-		return err;
++		goto done;
+ 	}
+ 
+ 	if (flags & JSON)
+-		amzn_print_json_stats(&log);
++		amzn_print_json_stats(&log, detail);
+ 	else
+-		amzn_print_normal_stats(&log);
++		amzn_print_normal_stats(&log, detail);
+ 
+-	return 0;
++done:
++	dev_close(dev);
++	return rc;
+ }
+-- 
+2.47.1
+

--- a/packages/nvme-cli/Cargo.toml
+++ b/packages/nvme-cli/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-nvme/nvme-cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-nvme/nvme-cli/archive/v2.14/nvme-cli-2.14.tar.gz"
-sha512 = "7f600ee719f06283e136427a0f9eb0b22412f7f4549c774768caff54150207ba87e2a431ea1569e5ed86a554aecd23c00c4e8c351aa0168a81807c86a0cb2edc"
+url = "https://github.com/linux-nvme/nvme-cli/archive/v2.15/nvme-cli-2.15.tar.gz"
+sha512 = "6f4c9fe52883df5424ba28d8b66b00e61f4b6f7226d7385f026c1d3b8aeb473bdf637102d9cf7e049349c4f7e61eccbb33f7400cc09056f74be03a80b7d51c0d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvme-cli/nvme-cli.spec
+++ b/packages/nvme-cli/nvme-cli.spec
@@ -1,11 +1,14 @@
 Name: %{_cross_os}nvme-cli
-Version: 2.14
+Version: 2.15
 Release: 1%{?dist}
 Epoch: 1
 Summary: CLI to interact with NVMe devices
 License: LGPL-2.1-only AND GPL-2.0-only AND CC0-1.0 AND MIT
 URL: https://github.com/linux-nvme/nvme-cli
 Source0: https://github.com/linux-nvme/nvme-cli/archive/v%{version}/nvme-cli-%{version}.tar.gz
+# This patch carries the necessary code for detailed performance stats on all NVMe local volumes.
+# Please verify and remove it in the next update.
+Patch0001: 0001-plugins-amzn-Add-stats-support-for-EC2-local-storage.patch
 
 BuildRequires: meson
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://strace.io/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.15/strace-6.15.tar.xz"
-sha512 = "5bb21b55d52aab6883821d4aea9449138d5efafac99f72b3831de710ed1ece11bb4a21b16fab97d772397213f43d06072e1d467ae03c38198ead0e65ddcd6ab5"
+url = "https://strace.io/files/6.16/strace-6.16.tar.xz"
+sha512 = "47d806e7a91537977a41b0289f896c4e36a2c2715554ea31df6c416de581b974d8826be1abf02999fd3ca2f90af122cfefe7c4f20c935026b84421aa8a516f96"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.15/strace-6.15.tar.xz.asc"
-sha512 = "c2c0098d9b415950c6f0591e2b8c59b96bb929df9270f5e256078d27e93b791f3bca2bf52f36d8ddf3b7354e711a94b4588b78a94da3327a35777c859808d993"
+url = "https://strace.io/files/6.16/strace-6.16.tar.xz.asc"
+sha512 = "cb4c71780a817ec6e0dcd0f994e91870b8a1ee26b2062fe51000414624343d05dce799c8677683264d9c051a20d4a40e028159282e979e4f3307447cecc16446"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 6.15
+Version: 6.16
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later

--- a/packages/xfsprogs/Cargo.toml
+++ b/packages/xfsprogs/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://mirrors.edge.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/"
 
 [[package.metadata.build-package.external-files]]
-url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.15.0.tar.xz"
-sha512 = "975c9c7fe476b02da50da74eb599f804f2b27a638a74b807e1f69d93d0d150d19bf6d5036601b96febe557a6c51065d8cf22eef5fda92a6d7f084ac1d7647496"
+url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.16.0.tar.xz"
+sha512 = "333ef39f38d0fa46742b7fd28ebc6482e90abb32e58634b3a93aa24f0202c55f4dc32f1b00a9859c6e64efada4d844c3a995a913520cb00d5e1a4f1a83da848d"
 
 [[package.metadata.build-package.external-files]]
-url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.15.0.tar.sign"
-sha512 = "02c6744de4663a03012c1f07fa6d26244cae3a8c1a1910a72cd7fcde7ba36fb3a8aee8314736bb88943356b6c82cf53712ee0714455351907322cbe033b15d1b"
+url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.16.0.tar.sign"
+sha512 = "26e9c923e0ae5ddc3bae434ec4eac9f86b0fb73cb5e692dcb42b19a000f119cf493feb850e4b02fa98b5e03017cb3c78caf9b7788e1e44709c4baac984a0c25c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/xfsprogs/xfsprogs.spec
+++ b/packages/xfsprogs/xfsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}xfsprogs
-Version: 6.15.0
+Version: 6.16.0
 Release: 1%{?dist}
 Summary: Utilities for managing the XFS filesystem
 License: GPL-2.0-only AND LGPL-2.1-only


### PR DESCRIPTION
**Description of changes:**
* Update `strace` v6.15 to v6.16
* update `iproute` v6.15.0 to v6.16.0
* update `nvme-cli` v2.14 to v2.15
  * added patch to support detailed performance stats on all NVMe local volumes
* update `libnvme` v1.14 to v1.15
* update `xfsprogs` v6.15.0 to v6.16.0

**Testing done:**
#### `strace` test
```
bash-5.1# strace -V
strace -- version 6.16
Copyright (c) 1991-2025 The strace developers <https://strace.io>.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Optional features enabled: no-m32-mpers no-mx32-mpers
bash-5.1# strace -c -p 1
strace: Process 1 attached
^Cstrace: Process 1 detached
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100.00    0.000002           2         1           gettid
------ ----------- ----------- --------- --------- ----------------
100.00    0.000002           2         1           total
```
#### `iproute` test
```
bash-5.1# ip -V
ip utility, iproute2-6.16.0
bash-5.1# ip address
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP group default qlen 1000
    link/ether 0a:0e:97:42:9a:5b brd ff:ff:ff:ff:ff:ff
    altname enp0s5
    altname ens5
    inet 172.31.15.246/20 metric 1024 brd 172.31.15.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::80e:97ff:fe42:9a5b/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
    link/ether 02:42:15:ec:df:17 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
       valid_lft forever preferred_lft forever
```
#### `nvme-cli` and `libnvme` test
* Before adding the patch
```
bash-5.1# nvme version
nvme version 2.15 (git 2.15)
libnvme version 1.15 (git 1.15)
bash-5.1# nvme list
Node                  Generic               SN                   Model                                    Namespace  Usage                      Format           FW Rev
--------------------- --------------------- -------------------- ---------------------------------------- ---------- -------------------------- ---------------- --------
/dev/nvme0n1          /dev/ng0n1            vol01acdf668371b3f29 Amazon Elastic Block Store               0x1          2.15  GB /   2.15  GB    512   B +  0 B   1.0
/dev/nvme1n1          /dev/ng1n1            vol098096bfa2bbda24d Amazon Elastic Block Store               0x1         21.47  GB /  21.47  GB    512   B +  0 B   1.0
/dev/nvme2n1          /dev/ng2n1            AWS2B50B42E23EF6A2D2 Amazon EC2 NVMe Instance Storage         0x1          2.50  TB /   2.50  TB    512   B +  0 B   0
bash-5.1# nvme amzn stats /dev/nvme2n1
[ERROR] get_stats: Not an EBS devicebash-5.1#
bash-5.1# nvme amzn stats /dev/nvme1n1
Total Ops:
  Read: 889
  Write: 11792
Total Bytes:
  Read: 19936256
  Write: 1233915392
Total Time (us):
  Read: 543399
  Write: 21647790

EBS Volume Performance Exceeded (us):
  IOPS: 0
  Throughput: 804708

EC2 Instance EBS Performance Exceeded (us):
  IOPS: 0
  Throughput: 0

Queue Length (point in time): 0

Read IO Latency Histogram
=================================
Lower       Upper        IO Count
=================================
[0        - 1       ] => 0
[1        - 2       ] => 0
[2        - 4       ] => 0
[4        - 8       ] => 0
[8        - 16      ] => 0
[16       - 32      ] => 0
[32       - 64      ] => 0
[64       - 128     ] => 0
[128      - 256     ] => 3
[256      - 512     ] => 149
[512      - 1024    ] => 709
[1024     - 2048    ] => 25
[2048     - 4096    ] => 2
[4096     - 8192    ] => 1
[8192     - 16384   ] => 0
[16384    - 32768   ] => 0
[32768    - 65536   ] => 0
[65536    - 131072  ] => 0
[131072   - 262144  ] => 0
[262144   - 524288  ] => 0
[524288   - 1048576 ] => 0
[1048576  - 2097152 ] => 0
[2097152  - 4194304 ] => 0
[4194304  - 8388608 ] => 0
[8388608  - 16777216] => 0
[16777216 - 33554432] => 0
[33554432 - 67108864] => 0
[67108864 - 18446744073709551615] => 0
=================================

Write IO Latency Histogram
=================================
Lower       Upper        IO Count
=================================
[0        - 1       ] => 0
[1        - 2       ] => 0
[2        - 4       ] => 0
[4        - 8       ] => 0
[8        - 16      ] => 0
[16       - 32      ] => 0
[32       - 64      ] => 0
[64       - 128     ] => 0
[128      - 256     ] => 68
[256      - 512     ] => 1923
[512      - 1024    ] => 3880
[1024     - 2048    ] => 2440
[2048     - 4096    ] => 2838
[4096     - 8192    ] => 376
[8192     - 16384   ] => 246
[16384    - 32768   ] => 21
[32768    - 65536   ] => 0
[65536    - 131072  ] => 0
[131072   - 262144  ] => 0
[262144   - 524288  ] => 0
[524288   - 1048576 ] => 0
[1048576  - 2097152 ] => 0
[2097152  - 4194304 ] => 0
[4194304  - 8388608 ] => 0
[8388608  - 16777216] => 0
[16777216 - 33554432] => 0
[33554432 - 67108864] => 0
[67108864 - 18446744073709551615] => 0
=================================
```
* After adding the patch
```
bash-5.1# nvme list
Node                  Generic               SN                   Model                                    Namespace  Usage                      Format           FW Rev
--------------------- --------------------- -------------------- ---------------------------------------- ---------- -------------------------- ---------------- --------
/dev/nvme0n1          /dev/ng0n1            vol00761c8be8c5f3844 Amazon Elastic Block Store               0x1          2.15  GB /   2.15  GB    512   B +  0 B   1.0
/dev/nvme1n1          /dev/ng1n1            vol01b96b0abbaa926d4 Amazon Elastic Block Store               0x1         21.47  GB /  21.47  GB    512   B +  0 B   1.0
/dev/nvme2n1          /dev/ng2n1            AWS14BE4082584B141CB Amazon EC2 NVMe Instance Storage         0x1          2.50  TB /   2.50  TB    512   B +  0 B   0
bash-5.1# nvme amzn stats /dev/nvme2n1
Total Ops:
  Read: 67
  Write: 0
Total Bytes:
  Read: 1101824
  Write: 0
Total Time (us):
  Read: 4284
  Write: 0

EC2 Instance Local Storage Performance Exceeded (us):
  IOPS: 0
  Throughput: 0

Queue Length (point in time): 1

Read IO Latency Histogram
=================================
Lower       Upper        IO Count
=================================
[0        - 1       ] => 0
[1        - 2       ] => 0
[2        - 4       ] => 0
[4        - 8       ] => 0
[8        - 16      ] => 0
[16       - 32      ] => 0
[32       - 64      ] => 27
[64       - 128     ] => 16
[128      - 256     ] => 22
[256      - 512     ] => 1
[512      - 1024    ] => 1
[1024     - 2048    ] => 0
[2048     - 4096    ] => 0
[4096     - 8192    ] => 0
[8192     - 16384   ] => 0
[16384    - 32768   ] => 0
[32768    - 65536   ] => 0
[65536    - 131072  ] => 0
[131072   - 262144  ] => 0
[262144   - 524288  ] => 0
[524288   - 1048576 ] => 0
[1048576  - 2097152 ] => 0
[2097152  - 4194304 ] => 0
[4194304  - 8388608 ] => 0
[8388608  - 16777216] => 0
[16777216 - 33554432] => 0
[33554432 - 67108864] => 0
[67108864 - 18446744073709551615] => 0
=================================

Write IO Latency Histogram
=================================
Lower       Upper        IO Count
=================================
[0        - 1       ] => 0
[1        - 2       ] => 0
[2        - 4       ] => 0
[4        - 8       ] => 0
[8        - 16      ] => 0
[16       - 32      ] => 0
[32       - 64      ] => 0
[64       - 128     ] => 0
[128      - 256     ] => 0
[256      - 512     ] => 0
[512      - 1024    ] => 0
[1024     - 2048    ] => 0
[2048     - 4096    ] => 0
[4096     - 8192    ] => 0
[8192     - 16384   ] => 0
[16384    - 32768   ] => 0
[32768    - 65536   ] => 0
[65536    - 131072  ] => 0
[131072   - 262144  ] => 0
[262144   - 524288  ] => 0
[524288   - 1048576 ] => 0
[1048576  - 2097152 ] => 0
[2097152  - 4194304 ] => 0
[4194304  - 8388608 ] => 0
[8388608  - 16777216] => 0
[16777216 - 33554432] => 0
[33554432 - 67108864] => 0
[67108864 - 18446744073709551615] => 0
=================================

bash-5.1# nvme amzn stats /dev/nvme1n1
Total Ops:
  Read: 928
  Write: 10619
Total Bytes:
  Read: 20235264
  Write: 1194807296
Total Time (us):
  Read: 670277
  Write: 25607950

EBS Volume Performance Exceeded (us):
  IOPS: 0
  Throughput: 159439

EC2 Instance EBS Performance Exceeded (us):
  IOPS: 0
  Throughput: 0

Queue Length (point in time): 0

Read IO Latency Histogram
=================================
Lower       Upper        IO Count
=================================
[0        - 1       ] => 0
[1        - 2       ] => 0
[2        - 4       ] => 0
[4        - 8       ] => 0
[8        - 16      ] => 0
[16       - 32      ] => 0
[32       - 64      ] => 0
[64       - 128     ] => 2
[128      - 256     ] => 5
[256      - 512     ] => 195
[512      - 1024    ] => 667
[1024     - 2048    ] => 40
[2048     - 4096    ] => 3
[4096     - 8192    ] => 16
[8192     - 16384   ] => 0
[16384    - 32768   ] => 0
[32768    - 65536   ] => 0
[65536    - 131072  ] => 0
[131072   - 262144  ] => 0
[262144   - 524288  ] => 0
[524288   - 1048576 ] => 0
[1048576  - 2097152 ] => 0
[2097152  - 4194304 ] => 0
[4194304  - 8388608 ] => 0
[8388608  - 16777216] => 0
[16777216 - 33554432] => 0
[33554432 - 67108864] => 0
[67108864 - 18446744073709551615] => 0
=================================

Write IO Latency Histogram
=================================
Lower       Upper        IO Count
=================================
[0        - 1       ] => 0
[1        - 2       ] => 0
[2        - 4       ] => 0
[4        - 8       ] => 0
[8        - 16      ] => 0
[16       - 32      ] => 0
[32       - 64      ] => 0
[64       - 128     ] => 0
[128      - 256     ] => 123
[256      - 512     ] => 3304
[512      - 1024    ] => 1717
[1024     - 2048    ] => 2177
[2048     - 4096    ] => 1785
[4096     - 8192    ] => 893
[8192     - 16384   ] => 463
[16384    - 32768   ] => 124
[32768    - 65536   ] => 29
[65536    - 131072  ] => 4
[131072   - 262144  ] => 0
[262144   - 524288  ] => 0
[524288   - 1048576 ] => 0
[1048576  - 2097152 ] => 0
[2097152  - 4194304 ] => 0
[4194304  - 8388608 ] => 0
[8388608  - 16777216] => 0
[16777216 - 33554432] => 0
[33554432 - 67108864] => 0
[67108864 - 18446744073709551615] => 0
=================================

```
#### `xfsprogs` test

* kernel-6.1
```
bash-5.1# mkfs.xfs -V
Parameters parsed from config file /usr/share/xfsprogs/mkfs/default.conf successfully
mkfs.xfs version 6.16.0
bash-5.1# mkfs.xfs -N -f /dev/nvme2n1
Parameters parsed from config file /usr/share/xfsprogs/mkfs/default.conf successfully
meta-data=/dev/nvme2n1           isize=512    agcount=4, agsize=152587890 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=0
         =                       exchange=0   metadir=0
data     =                       bsize=4096   blocks=610351560, imaxpct=5
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1, parent=0
log      =internal log           bsize=4096   blocks=298023, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
         =                       rgcount=0    rgsize=0 extents
         =                       zoned=0      start=0 reserved=0
bash-5.1# cat /usr/share/xfsprogs/mkfs/default.conf
# V5 features that were the mkfs defaults when the upstream Linux 6.1 LTS
# kernel was released at the end of 2022.

[metadata]
bigtime=1
crc=1
finobt=1
inobtcount=1
metadir=0
reflink=1
rmapbt=0
autofsck=0

[inode]
sparse=1
nrext64=0
exchange=0

[naming]
parent=0
bash-5.1# uname -r
6.1.150
```
* kernel-6.12
```
bash-5.1# mkfs.xfs -N -f /dev/nvme2n1
Parameters parsed from config file /usr/share/xfsprogs/mkfs/default.conf successfully
meta-data=/dev/nvme2n1           isize=512    agcount=4, agsize=152587890 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=1
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=1
         =                       exchange=0   metadir=0
data     =                       bsize=4096   blocks=610351560, imaxpct=5
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1, parent=0
log      =internal log           bsize=4096   blocks=298023, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
         =                       rgcount=0    rgsize=0 extents
         =                       zoned=0      start=0 reserved=0
bash-5.1# cat /usr/share/xfsprogs/mkfs/default.conf
# V5 features that were the mkfs defaults when the upstream Linux 6.12 LTS
# kernel was released at the end of 2024.

[metadata]
bigtime=1
crc=1
finobt=1
inobtcount=1
metadir=0
reflink=1
rmapbt=1
autofsck=0

[inode]
sparse=1
nrext64=1
exchange=0

[naming]
parent=0
bash-5.1# uname -r
6.12.40
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
