### PR TITLE
Provide dbus-launcher as its own package

### DIFF
--- a/packages/dbus-broker/0002-meson.build-remove-condition-to-build-the-journal-ca.patch
+++ b/packages/dbus-broker/0002-meson.build-remove-condition-to-build-the-journal-ca.patch
@@ -1,0 +1,64 @@
+From 819952f36db9a27e3dff5c9db7344992263d111d Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Thu, 18 Sep 2025 01:55:32 +0000
+Subject: [PATCH] meson.build: remove condition to build the journal catalog
+
+Don't require the dbus-launcher to build the journal catalog
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ meson.build       | 6 +++++-
+ meson_options.txt | 1 +
+ src/meson.build   | 2 +-
+ 3 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 72e2b47..625c552 100644
+--- a/meson.build
++++ b/meson.build
+@@ -67,6 +67,11 @@ if use_docs
+ endif
+ 
+ #
++# Config: catalog (needed for both broker and launcher)
++#
++
++conf.set('catalogdir', get_option('catalogdir'))
++
+ # Config: launcher
+ #
+ 
+@@ -79,7 +84,6 @@ if use_launcher
+         add_project_arguments('-DSYSTEMUIDMAX=' + dep_systemd.get_variable('systemuidmax'), language: 'c')
+         conf.set('systemunitdir', dep_systemd.get_variable('systemdsystemunitdir'))
+         conf.set('userunitdir', dep_systemd.get_variable('systemduserunitdir'))
+-        conf.set('catalogdir', dep_systemd.get_variable('catalogdir'))
+ endif
+ 
+ #
+diff --git a/meson_options.txt b/meson_options.txt
+index 5227a93..bfc898c 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -7,3 +7,4 @@ option('reference-test', type: 'boolean', value: false, description: 'Run test s
+ option('selinux', type: 'boolean', value: false, description: 'SELinux support')
+ option('system-console-users', type: 'array', value: [], description: 'Additional set of names of system-users to be considered at-console')
+ option('tests', type: 'boolean', value: false, description: 'Include tests in the distribution')
++option('catalogdir', type: 'string', description: 'The target directory of the catalogdir')
+diff --git a/src/meson.build b/src/meson.build
+index 4b9bc71..33fc7f7 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -2,8 +2,8 @@
+ # target: subdirs
+ #
+ 
++subdir('catalog')
+ if use_launcher
+-        subdir('catalog')
+         subdir('units/system')
+         subdir('units/user')
+ endif
+-- 
+2.50.1
+

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -21,11 +21,23 @@ BuildRequires: %{_cross_os}systemd-devel
 Requires: %{_cross_os}libexpat
 Requires: %{_cross_os}libselinux
 Requires: %{_cross_os}systemd
+Requires: %{_cross_os}dbus-broker(launcher)
 
 # Work around an aliasing rules violation.
 Patch0001: 0001-c-utf8-disable-strict-aliasing-optimizations.patch
+# Allow building the journal catalogs when dbus-launcher is excluded
+Patch0002: 0002-meson.build-remove-condition-to-build-the-journal-ca.patch
 
 %description
+%{summary}.
+
+%package launcher
+Summary: Launcher for the D-BUS message broker
+Provides: %{_cross_os}dbus-broker(launcher) = 1:
+Conflicts: %{_cross_os}dbus-broker(launcher)
+Requires: %{name}
+
+%description launcher
 %{summary}.
 
 %prep
@@ -39,6 +51,7 @@ CONFIGURE_OPTS=(
  -Ddocs=false
  -Dlauncher=true
  -Dselinux=true
+ -Dcatalogdir=%{_cross_journalcatalogdir}
 )
 
 %cross_meson "${CONFIGURE_OPTS[@]}"
@@ -60,14 +73,16 @@ install -p -m 0644 %{S:13} %{buildroot}%{_cross_sysusersdir}/dbus.conf
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_bindir}/dbus-broker
-%{_cross_bindir}/dbus-broker-launch
 %dir %{_cross_datadir}/dbus-1
-%{_cross_datadir}/dbus-1/*
 %{_cross_journalcatalogdir}/dbus-broker.catalog
-%{_cross_journalcatalogdir}/dbus-broker-launch.catalog
 %{_cross_sysusersdir}/dbus.conf
-%{_cross_unitdir}/dbus-broker.service
 %{_cross_unitdir}/dbus.socket
 %exclude %{_cross_userunitdir}/dbus-broker.service
+
+%files launcher
+%{_cross_bindir}/dbus-broker-launch
+%{_cross_journalcatalogdir}/dbus-broker-launch.catalog
+%{_cross_datadir}/dbus-1/system.conf
+%{_cross_unitdir}/dbus-broker.service
 
 %changelog


### PR DESCRIPTION
**Issue number:**

Part of #660 

**Description of changes:**

Make the dbus-broker require the new 'dbus-launcher' capability, so that variants can choose what they use to launch the broker.

Break down the dbus-launcher-broker as its own package, which provides the 'dbus-launcher' capability with a higher epoch number so that it is installed by default.

Added a patch to allow install the generated journal catalogs, even when the `launcher` isn't built, in preparation for the expat removal.


**Testing done:**

I confirmed that without making changes to the existing variants, the `dbus-broker-launcher` package is selected by default as the `dbus-launcher` capability.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
