### PR TITLE
Provide whippet and dbus-launcher configs

### DIFF
--- a/packages/systemd-252/org.freedesktop.login1.toml
+++ b/packages/systemd-252/org.freedesktop.login1.toml
@@ -1,0 +1,509 @@
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+allow = false
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Introspectable"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Peer"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "Get"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "GetAll"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSessionByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetUserByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListUsers"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListSeats"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListInhibitors"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Inhibit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetUserLinger"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ActivateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ActivateSessionOnSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "LockSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "UnlockSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "LockSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "UnlockSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "KillSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "KillUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "PowerOff"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "PowerOffWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Reboot"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "RebootWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Halt"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HaltWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Suspend"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Hibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HibernateWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HybridSleep"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HybridSleepWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendThenHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendThenHibernateWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanPowerOff"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanReboot"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHalt"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanSuspend"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHybridSleep"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanSuspendThenHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ScheduleShutdown"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CancelScheduledShutdown"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootParameter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootParameter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToFirmwareSetup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToFirmwareSetup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToBootLoaderMenu"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToBootLoaderMenu"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToBootLoaderEntry"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToBootLoaderEntry"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetWallMessage"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "AttachDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "FlushDevices"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "ActivateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchTo"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchToPrevious"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchToNext"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Activate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Lock"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Unlock"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetIdleHint"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetLockedHint"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "TakeControl"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "ReleaseControl"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetType"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "TakeDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "ReleaseDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "PauseDeviceComplete"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetBrightness"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.User"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.User"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetDisplay"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.login1"
+allow = true
+
+[[user.root.rules]]
+own = "org.freedesktop.login1"
+allow = true
+
+[[user.root.rules]]
+send_destination = "org.freedesktop.login1"
+allow = true
+
+[[user.root.rules]]
+receive_sender = "org.freedesktop.login1"
+allow = true

--- a/packages/systemd-252/org.freedesktop.network1.toml
+++ b/packages/systemd-252/org.freedesktop.network1.toml
@@ -1,0 +1,19 @@
+[[default.rules]]
+send_destination = "org.freedesktop.network1"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.network1"
+allow = true
+
+[[user.systemd-network.rules]]
+own = "org.freedesktop.network1"
+allow = true
+
+[[user.systemd-network.rules]]
+send_destination = "org.freedesktop.network1"
+allow = true
+
+[[user.systemd-network.rules]]
+receive_sender = "org.freedesktop.network1"
+allow = true

--- a/packages/systemd-252/org.freedesktop.resolve1.toml
+++ b/packages/systemd-252/org.freedesktop.resolve1.toml
@@ -1,0 +1,19 @@
+[[default.rules]]
+send_destination = "org.freedesktop.resolve1"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.resolve1"
+allow = true
+
+[[user.systemd-resolve.rules]]
+own = "org.freedesktop.resolve1"
+allow = true
+
+[[user.systemd-resolve.rules]]
+send_destination = "org.freedesktop.resolve1"
+allow = true
+
+[[user.systemd-resolve.rules]]
+receive_sender = "org.freedesktop.resolve1"
+allow = true

--- a/packages/systemd-252/org.freedesktop.systemd1.toml
+++ b/packages/systemd-252/org.freedesktop.systemd1.toml
@@ -1,0 +1,574 @@
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+allow = false
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Introspectable"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Peer"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "Get"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "GetAll"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByInvocationID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByControlGroup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LoadUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJob"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJobAfter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJobBefore"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnits"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsFiltered"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsByPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsByNames"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListJobs"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Subscribe"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Unsubscribe"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Dump"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpByFileDescriptor"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpUnitsMatchingPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpUnitsMatchingPatternsByFileDescriptor"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitFilesByPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitFileState"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetDefaultTarget"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitFileLinks"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LookupDynamicUserByName"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LookupDynamicUserByUID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetDynamicUsers"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Slice"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Scope"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Socket"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Mount"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Swap"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartUnitReplace"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StopUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "TryRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadOrRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadOrTryRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "BindMountUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "MountImageUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "KillUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ResetFailedUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetUnitProperties"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RefUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "UnrefUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartTransientUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "AttachProcessesToUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "CancelJob"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ClearJobs"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ResetFailed"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Reload"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Reexecute"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "EnableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DisableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReenableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LinkUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetUnitFilesWithMode"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "MaskUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "UnmaskUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RevertUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetDefaultTarget"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetAllUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "AddDependencyUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetShowStatus"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "Cancel"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "GetAfter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "GetBefore"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Start"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Stop"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Reload"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Restart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "TryRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ReloadOrRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ReloadOrTryRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ResetFailed"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "SetProperties"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Ref"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Unref"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "AttachProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "BindMount"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "MountImage"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Scope"
+send_member = "AttachProcesses"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+own = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+send_destination = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+receive_sender = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+receive_interface = "org.freedesktop.systemd1.Activator"
+receive_member = "ActivationRequest"
+allow = true

--- a/packages/systemd-252/systemd-252.spec
+++ b/packages/systemd-252/systemd-252.spec
@@ -10,6 +10,10 @@ Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later
 URL: https://www.freedesktop.org/wiki/Software/systemd
 Source0: https://github.com/systemd/systemd-stable/archive/v%{version}/systemd-stable-%{version}.tar.gz
+Source100: org.freedesktop.login1.toml
+Source101: org.freedesktop.network1.toml
+Source102: org.freedesktop.resolve1.toml
+Source103: org.freedesktop.systemd1.toml
 
 # Backport of upstream patches that make the netlink default timeout
 # configurable.  Bottlerocket carries this patch and configures the timeout in
@@ -343,6 +347,8 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/graphical.target
 ln -s  ../proc-sys-fs-binfmt_misc.mount \
   %{buildroot}%{_cross_unitdir}/sysinit.target.wants/proc-sys-fs-binfmt_misc.mount
 
+install -d %{buildroot}%{_cross_datadir}/whippet/policies.d
+install -p -m 0644 %{S:100} %{S:101} %{S:102} %{S:103} %{buildroot}%{_cross_datadir}/whippet/policies.d
 
 # Remove any README files.
 find %{buildroot} -type f -name README -print -delete
@@ -661,10 +667,13 @@ find %{buildroot} -type f -name README -print -delete
 %{_cross_tmpfilesdir}/var.conf
 %exclude %{_cross_tmpfilesdir}/x11.conf
 
-%{_cross_datadir}/dbus-1/services/org.freedesktop.systemd1.service
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.login1.conf
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.systemd1.conf
 %exclude %{_cross_datadir}/dbus-1/system-services
+%exclude %{_cross_datadir}/dbus-1/services/org.freedesktop.systemd1.service
+
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.login1.toml
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.systemd1.toml
 
 %dir %{_cross_factorydir}
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/issue
@@ -750,6 +759,7 @@ find %{buildroot} -type f -name README -print -delete
 %{_cross_unitdir}/systemd-networkd-wait-online@.service
 %{_cross_unitdir}/systemd-networkd.socket
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.network1.toml
 
 %files resolved
 %{_cross_bindir}/resolvectl
@@ -760,6 +770,7 @@ find %{buildroot} -type f -name README -print -delete
 %{_cross_tmpfilesdir}/systemd-resolve.conf
 %{_cross_unitdir}/systemd-resolved.service
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.resolve1.toml
 %exclude %{_cross_bindir}/systemd-resolve
 %exclude %{_cross_sbindir}/resolvconf
 

--- a/packages/systemd-257/org.freedesktop.login1.toml
+++ b/packages/systemd-257/org.freedesktop.login1.toml
@@ -1,0 +1,545 @@
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+allow = false
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Introspectable"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Peer"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "Get"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "GetAll"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSessionByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetUserByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "GetSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListSessionsEx"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListUsers"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListSeats"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ListInhibitors"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Inhibit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetUserLinger"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ActivateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ActivateSessionOnSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "LockSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "UnlockSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "LockSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "UnlockSessions"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "KillSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "KillUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateUser"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "TerminateSeat"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "PowerOff"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "PowerOffWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Reboot"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "RebootWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Halt"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HaltWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Suspend"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Hibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HibernateWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HybridSleep"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "HybridSleepWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendThenHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SuspendThenHibernateWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "Sleep"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanPowerOff"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanReboot"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHalt"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanSuspend"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanHybridSleep"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanSuspendThenHibernate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanSleep"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ScheduleShutdown"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CancelScheduledShutdown"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootParameter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootParameter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToFirmwareSetup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToFirmwareSetup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToBootLoaderMenu"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToBootLoaderMenu"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "CanRebootToBootLoaderEntry"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetRebootToBootLoaderEntry"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "SetWallMessage"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "AttachDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "FlushDevices"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Manager"
+send_member = "ReleaseSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "ActivateSession"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchTo"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchToPrevious"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Seat"
+send_member = "SwitchToNext"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Activate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Lock"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Unlock"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetIdleHint"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetLockedHint"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "TakeControl"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "ReleaseControl"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetType"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetClass"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "TakeDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "ReleaseDevice"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "PauseDeviceComplete"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetBrightness"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetDisplay"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.Session"
+send_member = "SetTTY"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.User"
+send_member = "Terminate"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.login1"
+send_interface = "org.freedesktop.login1.User"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.login1"
+allow = true
+
+[[user.root.rules]]
+own = "org.freedesktop.login1"
+allow = true
+
+[[user.root.rules]]
+send_destination = "org.freedesktop.login1"
+allow = true
+
+[[user.root.rules]]
+receive_sender = "org.freedesktop.login1"
+allow = true

--- a/packages/systemd-257/org.freedesktop.network1.toml
+++ b/packages/systemd-257/org.freedesktop.network1.toml
@@ -1,0 +1,19 @@
+[[default.rules]]
+send_destination = "org.freedesktop.network1"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.network1"
+allow = true
+
+[[user.systemd-network.rules]]
+own = "org.freedesktop.network1"
+allow = true
+
+[[user.systemd-network.rules]]
+send_destination = "org.freedesktop.network1"
+allow = true
+
+[[user.systemd-network.rules]]
+receive_sender = "org.freedesktop.network1"
+allow = true

--- a/packages/systemd-257/org.freedesktop.resolve1.toml
+++ b/packages/systemd-257/org.freedesktop.resolve1.toml
@@ -1,0 +1,19 @@
+[[default.rules]]
+send_destination = "org.freedesktop.resolve1"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.resolve1"
+allow = true
+
+[[user.systemd-resolve.rules]]
+own = "org.freedesktop.resolve1"
+allow = true
+
+[[user.systemd-resolve.rules]]
+send_destination = "org.freedesktop.resolve1"
+allow = true
+
+[[user.systemd-resolve.rules]]
+receive_sender = "org.freedesktop.resolve1"
+allow = true

--- a/packages/systemd-257/org.freedesktop.systemd1.toml
+++ b/packages/systemd-257/org.freedesktop.systemd1.toml
@@ -1,0 +1,610 @@
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+allow = false
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Introspectable"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Peer"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "Get"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.DBus.Properties"
+send_member = "GetAll"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByPID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByInvocationID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByControlGroup"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitByPIDFD"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LoadUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJob"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJobAfter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetJobBefore"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnits"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsFiltered"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsByPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitsByNames"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListJobs"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Subscribe"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Unsubscribe"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Dump"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpByFileDescriptor"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpUnitsMatchingPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DumpUnitsMatchingPatternsByFileDescriptor"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ListUnitFilesByPatterns"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitFileState"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetDefaultTarget"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetUnitFileLinks"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LookupDynamicUserByName"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LookupDynamicUserByUID"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "GetDynamicUsers"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Slice"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Scope"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Socket"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Mount"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Swap"
+send_member = "GetProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartUnitReplace"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StopUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "TryRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadOrRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReloadOrTryRestartUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "BindMountUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "MountImageUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "KillUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "QueueSignalUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ResetFailedUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetUnitProperties"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RefUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "UnrefUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "StartTransientUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "AttachProcessesToUnit"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "CancelJob"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ClearJobs"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ResetFailed"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Reload"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "Reexecute"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "EnableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "EnableUnitFilesWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DisableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DisableUnitFilesWithFlags"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "DisableUnitFilesWithFlagsAndInstallInfo"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "ReenableUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "LinkUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetUnitFilesWithMode"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "MaskUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "UnmaskUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "RevertUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetDefaultTarget"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "PresetAllUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "AddDependencyUnitFiles"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Manager"
+send_member = "SetShowStatus"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "Cancel"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "GetAfter"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Job"
+send_member = "GetBefore"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Start"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Stop"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Reload"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Restart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "TryRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ReloadOrRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ReloadOrTryRestart"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Kill"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "QueueSignal"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "ResetFailed"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "SetProperties"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Ref"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Unit"
+send_member = "Unref"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "AttachProcesses"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "BindMount"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Service"
+send_member = "MountImage"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.systemd1"
+send_interface = "org.freedesktop.systemd1.Scope"
+send_member = "AttachProcesses"
+allow = true
+
+[[default.rules]]
+receive_sender = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+own = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+send_destination = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+receive_sender = "org.freedesktop.systemd1"
+allow = true
+
+[[user.root.rules]]
+receive_interface = "org.freedesktop.systemd1.Activator"
+receive_member = "ActivationRequest"
+allow = true

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -10,6 +10,10 @@ Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later
 URL: https://www.freedesktop.org/wiki/Software/systemd
 Source0: https://github.com/systemd/systemd/archive/v%{version}/systemd-%{version}.tar.gz
+Source100: org.freedesktop.login1.toml
+Source101: org.freedesktop.network1.toml
+Source102: org.freedesktop.resolve1.toml
+Source103: org.freedesktop.systemd1.toml
 
 Source1: systemd-mount-rate-bootconfig.conf
 Source2: systemd-cgroup-legacy-force-bootconfig.conf
@@ -303,6 +307,9 @@ rm -f %{buildroot}%{_cross_libdir}/systemd/{system,user}/graphical.target
 # since we exclude the automount unit.
 ln -s  ../proc-sys-fs-binfmt_misc.mount \
   %{buildroot}%{_cross_unitdir}/sysinit.target.wants/proc-sys-fs-binfmt_misc.mount
+
+install -d %{buildroot}%{_cross_datadir}/whippet/policies.d
+install -p -m 0644 %{S:100} %{S:101} %{S:102} %{S:103} %{buildroot}%{_cross_datadir}/whippet/policies.d
 
 # Remove any README files.
 find %{buildroot} -type f -name README -print -delete
@@ -674,10 +681,13 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %exclude %{_cross_tmpfilesdir}/legacy.conf
 %exclude %{_cross_tmpfilesdir}/x11.conf
 
-%{_cross_datadir}/dbus-1/services/org.freedesktop.systemd1.service
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.login1.conf
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.systemd1.conf
 %exclude %{_cross_datadir}/dbus-1/system-services
+%exclude %{_cross_datadir}/dbus-1/services/org.freedesktop.systemd1.service
+
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.login1.toml
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.systemd1.toml
 
 %dir %{_cross_factorydir}
 %exclude %{_cross_factorydir}%{_cross_sysconfdir}/issue
@@ -765,6 +775,7 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %{_cross_unitdir}/systemd-networkd-wait-online@.service
 %{_cross_unitdir}/systemd-networkd.socket
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.network1.conf
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.network1.toml
 
 %files resolved
 %{_cross_bindir}/resolvectl
@@ -774,5 +785,6 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %{_cross_tmpfilesdir}/systemd-resolve.conf
 %{_cross_unitdir}/systemd-resolved.service
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
+%{_cross_datadir}/whippet/policies.d/org.freedesktop.resolve1.toml
 %exclude %{_cross_bindir}/systemd-resolve
 %exclude %{_cross_sbindir}/resolvconf


### PR DESCRIPTION
**Issue number:**

Part of #660

**Description of changes:**

This series provides the `whippet` policies translated from the configurations provided by systemd for `logind`, `networkd` and `resolved`.

As part of this change, the XML configurations for the `dbus-launcher` are now provided in a subpackage, so that the correct configurations are selected depending on the packages available in the variant. 

**Testing done:**

In combination with #677 and #661:

- I modified the `aws-dev` variant, to include `whippet` in the list of installed packages. I confirmed that the `whippet` configuration files were installed and the `dbus-launcher` configuration files weren't
- Without modifications to the `aws-k8s-1.33` variant, I confirmed that the `dbus-launcher` configuration files were installed, and the `whippet` configuration files weren't


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
