### PR TITLE
ephemeral-storage: fix `bind` subcommand for multiple sequential calls

### DIFF
--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -129,8 +129,6 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         .map(|dir| dir.trim_end_matches("/").to_string())
         .collect();
 
-    let mount_point = format!("/mnt/{EPHEMERAL_MNT}");
-    let mount_point = Path::new(&mount_point);
     let allowed_dirs = allowed_bind_dirs(variant);
     for dir in &dirs {
         let exact_match = allowed_dirs.allowed_exact.contains(dir.as_str());
@@ -150,26 +148,32 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
             }
         )
     }
-    std::fs::create_dir_all(mount_point).context(error::MkdirSnafu {})?;
 
-    info!("mounting {device_name:?} as {mount_point:?}");
-    let output = Command::new(MOUNT)
-        .args([
-            OsString::from(device_name.clone()),
-            OsString::from(mount_point.as_os_str()),
-        ])
-        .output()
-        .context(error::ExecutionFailureSnafu { command: MOUNT })?;
+    let mount_point = format!("/mnt/{EPHEMERAL_MNT}");
+    if !is_mounted(&mount_point)? {
+        std::fs::create_dir_all(&mount_point).context(error::MkdirSnafu {})?;
+        info!("mounting {device_name} as {mount_point}");
+        let output = Command::new(MOUNT)
+            .args([
+                OsString::from(device_name.clone()),
+                OsString::from(&mount_point),
+            ])
+            .output()
+            .context(error::ExecutionFailureSnafu { command: MOUNT })?;
 
-    ensure!(
-        output.status.success(),
-        error::MountArrayFailureSnafu {
-            what: device_name,
-            dest: mount_point.to_string_lossy().to_string(),
-            output
-        }
-    );
+        ensure!(
+            output.status.success(),
+            error::MountArrayFailureSnafu {
+                what: device_name,
+                dest: &mount_point,
+                output
+            }
+        );
+    } else {
+        info!("device already mounted at {mount_point}, skipping mount");
+    }
 
+    let mount_point = Path::new(&mount_point);
     for dir in &dirs {
         // construct a directory name (E.g. /var/lib/kubelet => ._var_lib_kubelet) that will be
         // unique between the binding targets


### PR DESCRIPTION
Fix bind subcommand to work when called multiple times in sequence by checking if the mount point is already mounted before attempting to mount the device.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/657

**Description of changes:**
The `bind` subcommand would try to mount the ephemeral devices and then create the bind mount. This would be an issue if there is multiple sequential invocation of the subcommand.

The fix is simply check if the device is mounted and conditionally skip the `mount` operation.


**Testing done:**
Launched a `m5d.large` instance which supports 75GB instance store volume.

Before the fix, we are seeing
```
bash-5.1# apiclient ephemeral-storage init
bash-5.1# apiclient ephemeral-storage bind --dirs /var/lib/containerd /var/lib/kubelet /var/log/pods
bash-5.1# apiclient ephemeral-storage bind --dirs /var/lib/soci-snapshotter
Failed to initialize ephemeral storage: Failed POST request to '/actions/ephemeral-storage/bind': Status 500 when POSTing /actions/ephemeral-storage/bind: Unable to bind ephemeral storage: Failed to mount /dev/disk/ephemeral/nvme-Amazon_EC2_NVMe_Instance_Storage_AWS2527A05E587B4ED4D_1 to /mnt/.ephemeral: mount: /mnt/.ephemeral: /dev/nvme2n1 already mounted on /mnt/.ephemeral.
       dmesg(1) may have more information after failed mount system call.
```

With the fix, multiple calls of the subcommand succeeded. And the bonus here is that the subcommand is idempotent!
```
[ssm-user@control]$ apiclient ephemeral-storage init
[ssm-user@control]$ apiclient ephemeral-storage bind --dirs /var/lib/containerd /var/lib/kubelet /var/log/pods
[ssm-user@control]$ apiclient ephemeral-storage bind --dirs /var/lib/soci-snapshotter
[ssm-user@control]$ apiclient ephemeral-storage bind --dirs /var/lib/soci-snapshotter
``` 

I also verified that the bind mounts are correctly configured:
```
bash-5.1# lsblk
NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
loop0          7:0    0  384K  1 loop /x86_64-bottlerocket-linux-gnu/sys-root/usr/share/licenses
loop1          7:1    0 12.6M  1 loop /var/lib/kernel-devel/.overlay/lower
nvme0n1      259:0    0    2G  0 disk
|-nvme0n1p1  259:3    0    4M  0 part
|-nvme0n1p2  259:4    0    5M  0 part
|-nvme0n1p3  259:5    0   40M  0 part /boot
|-nvme0n1p4  259:6    0  920M  0 part
|-nvme0n1p5  259:8    0   10M  0 part
|-nvme0n1p6  259:9    0   25M  0 part
|-nvme0n1p7  259:10   0    5M  0 part
|-nvme0n1p8  259:11   0   40M  0 part
|-nvme0n1p9  259:12   0  920M  0 part
|-nvme0n1p10 259:13   0   10M  0 part
|-nvme0n1p11 259:14   0   25M  0 part
|-nvme0n1p12 259:15   0   41M  0 part /var/lib/bottlerocket
`-nvme0n1p13 259:16   0    1M  0 part
nvme2n1      259:1    0 69.8G  0 disk /var/lib/soci-snapshotter     <- The bind mounts
                                      /var/log/pods
                                      /var/lib/kubelet
                                      /var/lib/containerd
                                      /mnt/.ephemeral
nvme1n1      259:2    0   20G  0 disk
`-nvme1n1p1  259:17   0   20G  0 part /var
                                      /opt
                                      /mnt
                                      /local
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
