### PR TITLE
Third party package updates

### DIFF
--- a/packages/dbus-broker/Cargo.toml
+++ b/packages/dbus-broker/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://github.com/bus1/dbus-broker/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/bus1/dbus-broker/releases/download/v36/dbus-broker-36.tar.xz"
-sha512 = "47ff345e27ae2ba41f43a4a6eb09b813583ef43392d1dfa2fc1805578c0ed3a1e414c3eae63f78ca3806904dc017a138e283aa32ba973de51ed613050b244a0f"
+url = "https://github.com/bus1/dbus-broker/releases/download/v37/dbus-broker-37.tar.xz"
+sha512 = "9f7c8aa4fabd1fc2da7b521a742874dd0e54f12c24fd5b9a3cbc91e8de05b9d08299cb0b353b923a6b8e33be194222e0242b6ba7cad795a350e7d056b7303e13"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/bus1/dbus-broker/releases/download/v36/dbus-broker-36.tar.xz.asc"
-sha512 = "711e3db030cd8d3953e966c11d2afa4c543548f882d3364fc0b79b7cfb3b8d5ecb65b1148429acf80b5ee803305f27f80538bd2f4b30e98da97fd05eb6dc0344"
+url = "https://github.com/bus1/dbus-broker/releases/download/v37/dbus-broker-37.tar.xz.asc"
+sha512 = "7201751d2ebfe418cd5f5301e27c3d679526faa3b950bbcde385ef68dd29ec902ed29dc558d330a6270bbafe5df3efe72dfa47370eb5ce5f26cf41bfec5b399f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/dbus-broker/dbus-broker.spec
+++ b/packages/dbus-broker/dbus-broker.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}dbus-broker
-Version: 36
+Version: 37
 Release: 1%{?dist}
 Summary: D-BUS message broker
 License: Apache-2.0

--- a/packages/e2fsprogs/Cargo.toml
+++ b/packages/e2fsprogs/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.1/e2fsprogs-1.47.1.tar.xz"
-sha512 = "2ac51f7654a44adf3ee5a5e32cecd7f129e423bdf3074c60b22a7acdba131e7dd0bb2964c107a06ae133f51836272be166f5da1f996f67ceb6c22e2636117beb"
+url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.2/e2fsprogs-1.47.2.tar.xz"
+sha512 = "a32632e072e535bf164503cf9992a4da7ea971e80f8f84ead4e7bc8899a92c27e4670bdebef1de0187596672e44af7b96078888e0cd4eefa3e3f551344d434d8"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.1/e2fsprogs-1.47.1.tar.sign"
-sha512 = "35461f3e3a024cff7ad9b26cd7b76f9b061c48b335bb005d1e86cc3834950779750db901ce0c84e608f0cb74744e4052205dd3c5e06a57f52c17f3784bc00bf8"
+url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.2/e2fsprogs-1.47.2.tar.sign"
+sha512 = "cfc99e49d2623140d0f086c1f0e85f6df0fdb688d6d46efeb6e16101b42db32a63374582ab346eb1ba2b14bf2898c09bd6ddcb8afcaf89bf7e22c7ec8810f7bc"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}e2fsprogs
-Version: 1.47.1
+Version: 1.47.2
 Release: 1%{?dist}
 Epoch: 1
 Summary: Tools for managing ext2, ext3, and ext4 file systems

--- a/packages/ethtool/Cargo.toml
+++ b/packages/ethtool/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/software/network/ethtool/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.14.tar.xz"
-sha512 = "05688e41044a3f263f4367149f9d775bc378f0f421685f415b30062ca74fa62acc0d5ee5aa74b2104429b5f1712fc2f12e120af0d5744c775c84fe8e777938a3"
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.15.tar.xz"
+sha512 = "f140095e7c9e38d8b151796eed1301e9e6ab93e82d3e35b8a524b4f5be7b219e707bd270af7398195081085778c61948e15b39462a6a6f44aad6ffcaaddc3644"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.14.tar.sign"
-sha512 = "b52cff3d89cc124549a0cddf5727cec36dd2c46a1cecc4754f8d016035c1d2e455b5fc2f4c86aafa5bb834247778c064dfc6b60eb492442531b3ce1a47a7a696"
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.15.tar.sign"
+sha512 = "085ebdf0c6a16a64002c60ed8de4b62e681b0d60ad8b9c6e0ad7f4ca0e51eb8eef3f8cab10d18e43e54c10578711d2cfbbb433cdae12a2ace65db5de53196c90"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ethtool/ethtool.spec
+++ b/packages/ethtool/ethtool.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}ethtool
-Version: 6.14
+Version: 6.15
 Release: 1%{?dist}
 Summary: Settings tool for Ethernet NICs
 License: GPL-2.0-only AND GPL-2.0-or-later

--- a/packages/pciutils/Cargo.toml
+++ b/packages/pciutils/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://www.kernel.org/pub/software/utils/pciutils/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.13.0.tar.gz"
-sha512 = "39cf4141c87c9a39fb42ec7a2412525f4283c62a1d1aa3533eb92bae4c59d3beb9a2ab1a9fcfe89b1f6cb8f0a011ef2f32fbed3111d357ce43d9569b3d0253d9"
+url = "https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.14.0.tar.gz"
+sha512 = "3b635274263fea621755b30a7c57348830957d8b4dfb9af69e14e269b07cc4a55a575acb092a5b6a66addb939c31082dfcb79a03531f34a31ea3c3ff7c7ce132"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/pciutils/pciutils.spec
+++ b/packages/pciutils/pciutils.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}pciutils
-Version: 3.13.0
+Version: 3.14.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: PCI bus related utilities

--- a/packages/util-linux/Cargo.toml
+++ b/packages/util-linux/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://www.kernel.org/pub/linux/utils/util-linux"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.4.tar.xz"
-sha512 = "0024955056ba7b4c54040a917f9919f49692e57ba6d42d17a6c29c1eefe88bf48b1214a545072b71c468829a63a8f15237f49733e9127c134e11126d1e435124"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.2.tar.xz"
+sha512 = "696c87e7cf185acc9b4b969ddade6155ea2945ae494eaecfd7b1f35d9607166cb09be79878fb793dd31b4d4dcac8c9be4be76af3886185db7ae8b58c303fb0cf"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.4.tar.sign"
-sha512 = "1ed2f8710a702e313d690c9c071c7a151df1cef7527a08ab4d1eda7a293239cf00392a78b21125df09f0af7249b473b1a51b92bb8e0494608db437c7ee4e0473"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.2.tar.sign"
+sha512 = "05ecccd24fbeea38a8579907629264550a309cfdfa63fa6eab756c0fc3cd182e9764101731424c1421d1ed950c2c1e41cf210abcd9c2837323c657292cdc9a0d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -1,5 +1,5 @@
-%global majorminor 2.40
-%global version %{majorminor}.4
+%global majorminor 2.41
+%global version %{majorminor}.2
 
 Name: %{_cross_os}util-linux
 Version: %{version}
@@ -205,11 +205,13 @@ done
 %{_cross_bindir}/unshare
 %{_cross_bindir}/uuidgen
 %{_cross_bindir}/uuidparse
+%exclude %{_cross_bindir}/bits
 %exclude %{_cross_bindir}/cal
 %exclude %{_cross_bindir}/col
 %exclude %{_cross_bindir}/colcrt
 %exclude %{_cross_bindir}/colrm
 %exclude %{_cross_bindir}/column
+%exclude %{_cross_bindir}/coresched
 %exclude %{_cross_bindir}/eject
 %exclude %{_cross_bindir}/enosys
 %exclude %{_cross_bindir}/exch


### PR DESCRIPTION
**Description of changes:**
* update `ethtool` to v6.15
* update `util-linux` to v2.41.2
* update `pciutils` to v3.14.0
* update `dbus-broker` to v37
* update `e2fsprogs` to v1.47.2


**Testing done:**
#### ethtool
```
bash-5.1# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host noprefixroute
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP group default qlen 1000
    link/ether 0a:ad:8a:10:08:7d brd ff:ff:ff:ff:ff:ff
    altname enp0s5
    altname ens5
    inet 172.31.5.52/20 metric 1024 brd 172.31.15.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::8ad:8aff:fe10:87d/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
    link/ether 02:42:f8:df:99:72 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
       valid_lft forever preferred_lft forever
bash-5.1# ethtool --version
ethtool version 6.15
bash-5.1# ethtool eth0
Settings for eth0:
        Current message level: 0x000000f3 (243)
                               drv probe ifdown ifup rx_err tx_err
        Link detected: yes
```

#### util-linux
```
bash-5.1# lsblk --version
lsblk from util-linux 2.41.2
bash-5.1# findmnt
TARGET   SOURCE FSTYPE      OPTIONS
/        /dev/dm-0
|               erofs       ro,relatime,seclabel,user_xattr,acl,cache_strategy=readaround
|-/dev   devtmpfs
| |             devtmpfs    rw,relatime,seclabel,size=16106128k,nr_inodes=4026532,mode=755
| |-/dev/shm
| |      tmpfs  tmpfs       rw,nosuid,nodev,noexec,seclabel
| |-/dev/pts
| |      devpts devpts      rw,nosuid,noexec,relatime,seclabel,gid=5,mode=620,ptmxmode=000
| |-/dev/mqueue
| |      mqueue mqueue      rw,nosuid,nodev,noexec,relatime,seclabel
| `-/dev/hugepages
|        hugetlbfs
|               hugetlbfs   rw,relatime,seclabel,pagesize=2M
|-/proc  proc   proc        rw,nosuid,nodev,noexec,relatime
| `-/proc/sys/fs/binfmt_misc
|        binfmt_misc
|               binfmt_misc rw,nosuid,nodev,noexec,relatime
|-/sys   sysfs  sysfs       rw,nosuid,nodev,noexec,relatime,seclabel
| |-/sys/kernel/security
| |      securityfs
| |             securityfs  rw,nosuid,nodev,noexec,relatime
| |-/sys/fs/selinux
| |      selinuxfs
| |             selinuxfs   rw,nosuid,noexec,relatime
| |-/sys/fs/cgroup
| |      cgroup2
| |             cgroup2     rw,nosuid,nodev,noexec,relatime,seclabel
| |-/sys/fs/pstore
| |      pstore pstore      rw,nosuid,nodev,noexec,relatime,seclabel
| |-/sys/firmware/efi/efivars
| |      efivarfs
| |             efivarfs    rw,nosuid,nodev,noexec,relatime
| |-/sys/fs/bpf
| |      bpf    bpf         rw,nosuid,nodev,noexec,relatime,mode=700
| |-/sys/kernel/debug
| |      debugfs
| |             debugfs     rw,nosuid,nodev,noexec,relatime,seclabel
| |-/sys/kernel/tracing
| |      tracefs
| |             tracefs     rw,nosuid,nodev,noexec,relatime,seclabel
| |-/sys/kernel/config
| |      configfs
| |             configfs    rw,nosuid,nodev,noexec,relatime
| `-/sys/fs/fuse/connections
|        fusectl
|               fusectl     rw,nosuid,nodev,noexec,relatime
|-/run   tmpfs  tmpfs       rw,nosuid,nodev,noexec,seclabel,size=6443760k,nr_inodes=819200,mode=755
| |-/run/netdog
| |      tmpfs  tmpfs       rw,nosuid,nodev,noexec,noatime,context=system_u:object_r:lease_t:s0,mode=755
| |-/run/credentials/systemd-sysusers.service
| |      ramfs  ramfs       ro,nosuid,nodev,noexec,relatime,mode=700
| |-/run/credentials/systemd-tmpfiles-setup-dev.service
| |      ramfs  ramfs       ro,nosuid,nodev,noexec,relatime,mode=700
| |-/run/credentials/systemd-sysctl.service
| |      ramfs  ramfs       ro,nosuid,nodev,noexec,relatime,mode=700
| |-/run/credentials/systemd-tmpfiles-setup.service
| |      ramfs  ramfs       ro,nosuid,nodev,noexec,relatime,mode=700
| |-/run/host-containerd/io.containerd.runtime.v2.task/default/control/rootfs
| |      overlay
| |             overlay     rw,relatime,context=system_u:object_r:secret_t:s0,lowerdir=/var/lib/host-containerd/io.containerd.snapshotter.v1.overlayfs/snapshot
| `-/run/host-containerd/io.containerd.runtime.v2.task/default/admin/rootfs
|        overlay
|               overlay     rw,relatime,context=system_u:object_r:secret_t:s0,lowerdir=/var/lib/host-containerd/io.containerd.snapshotter.v1.overlayfs/snapshot
|-/etc   tmpfs  tmpfs       rw,nosuid,nodev,noexec,noatime,context=system_u:object_r:etc_t:s0,mode=755
| |-/etc/cni
| |      tmpfs  tmpfs       rw,nosuid,nodev,noexec,noatime,seclabel,mode=755
| |-/etc/containerd
| |      tmpfs  tmpfs       rw,nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=750
| |-/etc/host-containers
| |      tmpfs  tmpfs       rw,nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=750
| `-/etc/soci-snapshotter
|        tmpfs  tmpfs       rw,nosuid,nodev,noexec,noatime,context=system_u:object_r:etc_secret_t:s0,mode=750
|-/tmp   tmpfs  tmpfs       rw,nosuid,nodev,noexec,seclabel,nr_inodes=1048576
|-/root/.aws
|        tmpfs  tmpfs       rw,nosuid,nodev,noexec,noatime,context=system_u:object_r:secret_t:s0,mode=700
|-/boot  /dev/nvme1n1p3
|               ext4        ro,nosuid,nodev,noexec,noatime,seclabel
|-/local /dev/nvme0n1p1
| |             xfs         rw,nosuid,nodev,noatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,sunit=8,swidth=8,noquota
| |-/local/mnt
| |      /dev/dm-0[/srv]
| |             erofs       ro,nosuid,nodev,noexec,relatime,seclabel,user_xattr,acl,cache_strategy=readaround
| |-/local/opt
| |      /dev/dm-0[/srv]
| |             erofs       ro,nosuid,nodev,noexec,relatime,seclabel,user_xattr,acl,cache_strategy=readaround
| `-/local/var
|        /dev/dm-0[/srv]
|               erofs       ro,nosuid,nodev,noexec,relatime,seclabel,user_xattr,acl,cache_strategy=readaround
|-/mnt   /dev/nvme0n1p1[/mnt]
|               xfs         rw,nosuid,nodev,noatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,sunit=8,swidth=8,noquota
|-/opt   /dev/nvme0n1p1[/opt]
| |             xfs         rw,nosuid,nodev,noatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,sunit=8,swidth=8,noquota
| |-/opt/cni
| |      overlay
| |             overlay     rw,nosuid,nodev,noatime,context=system_u:object_r:cni_exec_t:s0,lowerdir=/usr/libexec/cni,upperdir=/var/lib/cni-plugins/.overlay/up
| `-/opt/csi
|        overlay
|               overlay     rw,nosuid,nodev,noatime,context=system_u:object_r:csi_exec_t:s0,lowerdir=/usr/libexec/csi,upperdir=/var/lib/csi-helpers/.overlay/up
|-/var   /dev/nvme0n1p1[/var]
| |             xfs         rw,nosuid,nodev,noatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,sunit=8,swidth=8,noquota
| |-/var/lib/bottlerocket
| |      /dev/nvme1n1p12
| |             ext4        rw,nosuid,nodev,noexec,noatime,context=system_u:object_r:private_t:s0
| `-/var/lib/kernel-devel/.overlay/lower
|        /dev/dm-0[/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/kernel-devel]
|               erofs       ro,relatime,seclabel,user_xattr,acl,cache_strategy=readaround
|-/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/modules
|        overlay
|               overlay     rw,nosuid,nodev,noexec,noatime,context=system_u:object_r:state_t:s0,lowerdir=/lib/modules,upperdir=/var/lib/kernel-modules/.overlay
`-/x86_64-bottlerocket-linux-gnu/sys-root/usr/src/kernels
         overlay
                overlay     rw,nosuid,nodev,noatime,context=system_u:object_r:state_t:s0,lowerdir=/var/lib/kernel-devel/.overlay/lower,upperdir=/var/lib/kernel

```

#### pci-utils
```
bash-5.1# lspci --version
lspci version 3.14.0
bash-5.1# lspci
00:00.0 Host bridge: Intel Corporation 440FX - 82441FX PMC [Natoma]
00:01.0 ISA bridge: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II]
00:01.3 Non-VGA unclassified device: Intel Corporation 82371AB/EB/MB PIIX4 ACPI (rev 08)
00:03.0 VGA compatible controller: Amazon.com, Inc. Device 1111
00:04.0 Non-Volatile memory controller: Amazon.com, Inc. NVMe EBS Controller
00:05.0 Ethernet controller: Amazon.com, Inc. Elastic Network Adapter (ENA)
00:1e.0 Non-Volatile memory controller: Amazon.com, Inc. NVMe EBS Controller
00:1f.0 Non-Volatile memory controller: Amazon.com, Inc. NVMe SSD Controller
```

#### dbus-broker
bottlerocket-core-kit builds and instance boots as shown below
```
bash-5.1# dbus-broker --version
dbus-broker 37
bash-5.1# dbus-broker
dbus-broker: controller file-descriptor not a socket -- '3'
bash-5.1# systemctl status dbus-broker.service
● dbus-broker.service - D-Bus System Message Bus
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/dbus-broker.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Wed 2025-10-01 23:37:44 UTC; 5h 34min ago
TriggeredBy: ● dbus.socket
       Docs: https://github.com/bus1/dbus-broker
   Main PID: 1540 (dbus-broker-lau)
      Tasks: 2 (limit: 37702)
     Memory: 2.2M
        CPU: 106ms
     CGroup: /system.slice/dbus-broker.service
             ├─1540 /usr/bin/dbus-broker-launch --scope system
             └─1541 dbus-broker --log 10 --controller 9 --machine-id ec2da3dab207c70080aa1fca59cd755a --max-bytes 536870912 --max-fds 4096 --max-matches 16384

Oct 01 23:37:44 localhost systemd[1]: Starting D-Bus System Message Bus...
Oct 01 23:37:44 localhost systemd[1]: Started D-Bus System Message Bus.
Oct 01 23:37:44 localhost dbus-broker-launch[1540]: Ready
```

#### e2fsprogs
```
bash-5.1# mkfs.ext4 -V
mke2fs 1.47.2 (1-Jan-2025)
        Using EXT2FS Library version 1.47.2
bash-5.1# mkfs.ext4 /dev/nvme2n1
mke2fs 1.47.2 (1-Jan-2025)
Discarding device blocks: done
Creating filesystem with 610351562 4k blocks and 152592384 inodes
Filesystem UUID: 2a26d753-cb5a-439f-aeb9-1fcd7b198959
Superblock backups stored on blocks:
        32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208,
        4096000, 7962624, 11239424, 20480000, 23887872, 71663616, 78675968,
        102400000, 214990848, 512000000, 550731776

Allocating group tables: done
Writing inode tables: done
Creating journal (262144 blocks): done
Writing superblocks and filesystem accounting information: done

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
