### PR TITLE
Downgrade systemd warning

### DIFF
--- a/packages/systemd-252/9019-suppress-log-for-units-with-mode-0044.patch
+++ b/packages/systemd-252/9019-suppress-log-for-units-with-mode-0044.patch
@@ -1,0 +1,24 @@
+From 9661998efe53eb43a4d9738ba55a0055ac5a6dc0 Mon Sep 17 00:00:00 2001
+From: Vighnesh Maheshwari <vighmah@amazon.com>
+Date: Tue, 30 Sep 2025 16:29:14 -0700
+Subject: [PATCH] suppress log for units with mode != 0044
+
+Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>
+---
+ src/basic/fs-util.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basic/fs-util.c b/src/basic/fs-util.c
+index d71c07c78c..630f34c29e 100644
+--- a/src/basic/fs-util.c
++++ b/src/basic/fs-util.c
+@@ -337,7 +337,7 @@ int stat_warn_permissions(const char *path, const struct stat *st) {
+                 log_warning("Configuration file %s is marked world-writable. Please remove world writability permission bits. Proceeding anyway.", path);
+
+         if (getpid_cached() == 1 && (st->st_mode & 0044) != 0044)
+-                log_warning("Configuration file %s is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.", path);
++                log_debug("Configuration file %s is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.", path);
+
+         return 0;
+ }
+

--- a/packages/systemd-252/systemd-252.spec
+++ b/packages/systemd-252/systemd-252.spec
@@ -88,6 +88,11 @@ Patch9017: 9017-dissect-image-disable-openssl-support.patch
 # unneeded dependency on libssl.
 Patch9018: 9018-meson-replace-openssl-dependency-with-libcrypto.patch
 
+# Downgrade warning logs for unit files with permission not set to 0044 since
+# it does not apply to Bottlerocket where the API is restricted by the SELinux
+# policy
+Patch9019: 9019-suppress-log-for-units-with-mode-0044.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson

--- a/packages/systemd-257/9011-suppress-log-for-units-with-mode-0044.patch
+++ b/packages/systemd-257/9011-suppress-log-for-units-with-mode-0044.patch
@@ -1,0 +1,23 @@
+From 46888cf78a87749e4a6f30095e37fbe7941b8bf3 Mon Sep 17 00:00:00 2001
+From: Vighnesh Maheshwari <vighmah@amazon.com>
+Date: Wed, 1 Oct 2025 14:08:57 -0700
+Subject: [PATCH] suppress log for units with mode != 0044
+
+Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>
+---
+ src/basic/fs-util.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basic/fs-util.c b/src/basic/fs-util.c
+index 4ede324c34..4ebc2d8689 100644
+--- a/src/basic/fs-util.c
++++ b/src/basic/fs-util.c
+@@ -354,7 +354,7 @@ int stat_warn_permissions(const char *path, const struct stat *st) {
+                 log_warning("Configuration file %s is marked world-writable. Please remove world writability permission bits. Proceeding anyway.", path);
+ 
+         if (getpid_cached() == 1 && (st->st_mode & 0044) != 0044)
+-                log_warning("Configuration file %s is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.", path);
++                log_debug("Configuration file %s is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.", path);
+ 
+         return 0;
+ }

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -52,6 +52,11 @@ Patch9009: 9009-dissect-image-disable-openssl-support.patch
 # unneeded dependency on libssl.
 Patch9010: 9010-meson-replace-openssl-dependency-with-libcrypto.patch
 
+# Downgrade warning logs for unit files with permission not set to 0044 since
+# it does not apply to Bottlerocket where the API is restricted by the SELinux
+# policy
+Patch9011: 9011-suppress-log-for-units-with-mode-0044.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #574

**Description of changes:**

Add a patch to both version of systemd to move a warning log to debug instead

**Testing done:**

Tested by grepping the journal on instances with systemd-252 and systemd-257:

#### k8s 1.32 (systemd-252)

Before:

```bash
bash-5.1# journalctl | grep world
Oct 01 22:13:50 ip-192-168-90-130.us-west-2.compute.internal systemd[1]: Configuration file /etc/systemd/system/kubelet.service.d/exec-start.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
Oct 01 22:13:50 ip-192-168-90-130.us-west-2.compute.internal systemd[1]: Configuration file /etc/systemd/system/kubelet.service.d/exec-start.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
Oct 01 22:13:53 ip-192-168-90-130.us-west-2.compute.internal kubelet[1284]: I1001 22:13:53.183898    1284 desired_state_of_world_populator.go:150] "Desired state populator starts to run"
Oct 01 22:13:54 ip-192-168-90-130.us-west-2.compute.internal kubelet[1284]: I1001 22:13:54.184812    1284 desired_state_of_world_populator.go:158] "Finished populating initial desired state of world"
```


After:

```bash
bash-5.1# journalctl | grep world
Oct 01 22:11:03 ip-192-168-88-90.us-west-2.compute.internal kubelet[1291]: I1001 22:11:03.746614    1291 desired_state_of_world_populator.go:150] "Desired state populator starts to run"
Oct 01 22:11:04 ip-192-168-88-90.us-west-2.compute.internal kubelet[1291]: I1001 22:11:04.747913    1291 desired_state_of_world_populator.go:158] "Finished populating initial desired state of world"
```


#### k8s 1.34 (systemd-257)

Before:

```bash
[root@admin]# sheltie
bash-5.1# journalctl | grep world
Oct 01 22:22:17 ip-192-168-71-17.us-west-2.compute.internal systemd[1]: Configuration file /etc/systemd/system/kubelet.service.d/exec-start.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
Oct 01 22:22:17 ip-192-168-71-17.us-west-2.compute.internal systemd[1]: Configuration file /etc/systemd/system/kubelet.service.d/exec-start.conf is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
Oct 01 22:22:20 ip-192-168-71-17.us-west-2.compute.internal kubelet[1727]: I1001 22:22:20.165646    1727 desired_state_of_world_populator.go:146] "Desired state populator starts to run"
Oct 01 22:22:21 ip-192-168-71-17.us-west-2.compute.internal kubelet[1727]: I1001 22:22:21.166076    1727 desired_state_of_world_populator.go:154] "Finished populating initial desired state of world"
```

After:

```bash
bash-5.1# journalctl | grep world
Oct 01 22:29:12 ip-192-168-91-47.us-west-2.compute.internal kubelet[1719]: I1001 22:29:12.788000    1719 desired_state_of_world_populator.go:146] "Desired state populator starts to run"
Oct 01 22:29:13 ip-192-168-91-47.us-west-2.compute.internal kubelet[1719]: I1001 22:29:13.788727    1719 desired_state_of_world_populator.go:154] "Finished populating initial desired state of world"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
