### PR TITLE
Prep 10.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v10.7.1 (2025-10-06)
+
+### Third Party Package Updates
+
+- Add a patch for `libnvidia-container` to support glibc ([#687])
+
+[#687]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/687
+
 # v10.7.0 (2025-10-02)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "10.7.0"
+release-version = "10.7.1"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/packages/libnvidia-container/0005-Add-clock_gettime-to-allowed-syscalls.patch
+++ b/packages/libnvidia-container/0005-Add-clock_gettime-to-allowed-syscalls.patch
@@ -1,0 +1,29 @@
+From d401dd5a8621565e040839a5d525cb4ba124cc37 Mon Sep 17 00:00:00 2001
+From: Evan Lezar <elezar@nvidia.com>
+Date: Wed, 1 Oct 2025 15:17:56 +0200
+Subject: [PATCH] Add clock_gettime to allowed syscalls
+
+This change adds clock_gettime to the allowed syscalls when running
+ldconfig under seccomp. This seems to be required for newer glibc
+versions.
+
+Signed-off-by: Evan Lezar <elezar@nvidia.com>
+---
+ src/nvc_ldcache.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/nvc_ldcache.c b/src/nvc_ldcache.c
+index 0535090d..a345d870 100644
+--- a/src/nvc_ldcache.c
++++ b/src/nvc_ldcache.c
+@@ -272,6 +272,7 @@ limit_syscalls(struct error *err)
+                 SCMP_SYS(brk),
+                 SCMP_SYS(chdir),
+                 SCMP_SYS(chmod),
++                SCMP_SYS(clock_gettime),
+                 SCMP_SYS(close),
+                 SCMP_SYS(execve),
+                 SCMP_SYS(execveat),
+-- 
+2.51.0
+

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -18,6 +18,7 @@ Patch0001: 0001-use-shared-libtirpc.patch
 Patch0002: 0002-use-prefix-from-environment.patch
 Patch0003: 0003-keep-debug-symbols.patch
 Patch0004: 0004-makefile-avoid-ldconfig-when-cross-compiling.patch
+Patch0005: 0005-Add-clock_gettime-to-allowed-syscalls.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libelf-devel


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/685

**Description of changes:**
- Port `libnvidia-container` patch to support latest glibc


**Testing done:**
- Nvidia variants boot up as expected
- No errors in sample nvidia workloads


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
