### PR TITLE
amazon-ssm-agent: bump to v3.3.3185.0

### DIFF
--- a/packages/amazon-ssm-agent/0001-agent-Add-config-to-make-shell-optional.patch
+++ b/packages/amazon-ssm-agent/0001-agent-Add-config-to-make-shell-optional.patch
@@ -1,10 +1,13 @@
-From 096dad878552ea342ddad9f3132453fd7cc4e08b Mon Sep 17 00:00:00 2001
+From fe944258e663e182404f2fa2d6bbefc36a97854b Mon Sep 17 00:00:00 2001
 From: Kush Upadhyay <kushupad@amazon.com>
-Date: Mon, 7 Oct 2024 09:13:38 +0000
+Date: Tue, 7 Oct 2025 11:39:00 +0000
 Subject: [PATCH] agent: Add config to make shell optional
 
 Signed-off-by: Kush Upadhyay <kushupad@amazon.com>
+[Update to 3.3.2746.0]
 Signed-off-by: Yutong Sun <yutongsu@amazon.com>
+[Update to 3.3.3185.0]
+Signed-off-by: Kush Upadhyay <kushupad@amazon.com>
 ---
  agent/appconfig/appconfig.go         |  1 +
  agent/appconfig/contracts.go         |  2 ++
@@ -12,7 +15,7 @@ Signed-off-by: Yutong Sun <yutongsu@amazon.com>
  3 files changed, 28 insertions(+), 11 deletions(-)
 
 diff --git a/agent/appconfig/appconfig.go b/agent/appconfig/appconfig.go
-index 6b278f50..2013cf92 100644
+index e848450..3a90745 100644
 --- a/agent/appconfig/appconfig.go
 +++ b/agent/appconfig/appconfig.go
 @@ -120,6 +120,7 @@ func DefaultConfig() SsmagentConfig {
@@ -20,11 +23,11 @@ index 6b278f50..2013cf92 100644
  		OrchestrationDirectoryCleanup:         DefaultOrchestrationDirCleanup,
  		SessionHandshakeTimeoutSeconds:        DefaultSessionHandshakeTimeoutSeconds,
 +		UseShell:                              false,
+ 		CredentialRetryMaxSleepSeconds:        DefaultCredentialRetryMaxSleepSeconds,
  	}
  	agent := AgentInfo{
- 		Name:                                    "amazon-ssm-agent",
 diff --git a/agent/appconfig/contracts.go b/agent/appconfig/contracts.go
-index 69501310..bf42380f 100644
+index 7142151..997406a 100644
 --- a/agent/appconfig/contracts.go
 +++ b/agent/appconfig/contracts.go
 @@ -55,6 +55,8 @@ type SsmCfg struct {
@@ -33,11 +36,11 @@ index 69501310..bf42380f 100644
  	OrchestrationDirectoryCleanup string
 +	// Flag for shell dependency
 +	UseShell bool
+ 	// Max sleep duration in seconds for credential retry before attempting to refresh credentials on failure
+ 	CredentialRetryMaxSleepSeconds int
  }
- 
- // AgentInfo represents metadata for amazon-ssm-agent
 diff --git a/agent/plugins/runscript/runscript.go b/agent/plugins/runscript/runscript.go
-index c89bf92a..b56e973a 100644
+index c89bf92..b56e973 100644
 --- a/agent/plugins/runscript/runscript.go
 +++ b/agent/plugins/runscript/runscript.go
 @@ -177,23 +177,37 @@ func (p *Plugin) runCommands(pluginID string, pluginInput RunScriptPluginInput,
@@ -89,6 +92,3 @@ index c89bf92a..b56e973a 100644
  	// Execute Command
  	exitCode, err := p.CommandExecuter.NewExecute(p.Context, workingDir, output.GetStdoutWriter(), output.GetStderrWriter(), cancelFlag, executionTimeout, commandName, commandArguments, pluginInput.Environment)
  
--- 
-2.47.0
-

--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ssm-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.2746.0/amazon-ssm-agent-3.3.2746.0.tar.gz"
-sha512 = "a0f2af7cf5cb9a8466f6ec8ed79fa3f4f00633c43d772624bdf1f71dc75967e760a997a7e37138bbc2197945848a9278fec0c2f21146945849bda64b8803b6dc"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.3185.0/amazon-ssm-agent-3.3.3185.0.tar.gz"
+sha512 = "527044b12aa84bb1a748628c94c02eb4633d26dfe4c96763cd82656a6c0de610e75b8110b944c10d134ad198b564a416f53424bc823f5a3fb846d5fc4f47dc59"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.3.2746.0
+Version: 3.3.3185.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0
@@ -68,6 +68,8 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-plugin-bin)
 %autosetup -n %{gorepo}-%{version} -p1
 
 %build
+export GO_MAJOR="1.24"
+
 %set_cross_go_flags
 
 go build -ldflags "${GOLDFLAGS}" -o amazon-ssm-agent \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Update `amazon-ssm-agent` from `3.3.2746.0` to `3.3.3185.0`:
- Needed to recreate the patch as a few files it edits were updated upstream
- Needed to add line to use Go 1.24 to build agent

**Testing done:**

Internal conformance tests pass for `aws-ecs-2` variant on both platforms.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
