### PR TITLE
Add more k8s settings

### DIFF
--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -203,3 +203,4 @@ reservedMemory:
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
+enableDebuggingHandlers: false

--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -207,3 +207,6 @@ enableDebuggingHandlers: false
 {{#if settings.kubernetes.image-minimum-gc-age}}
 imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.max-parallel-image-pulls}}
+maxParallelImagePulls: {{settings.kubernetes.max-parallel-image-pulls}}
+{{/if}}

--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -204,3 +204,6 @@ reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
 enableDebuggingHandlers: false
+{{#if settings.kubernetes.image-minimum-gc-age}}
+imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
+{{/if}}

--- a/packages/kubernetes-1.28/kubelet-config
+++ b/packages/kubernetes-1.28/kubelet-config
@@ -114,7 +114,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{#if settings.kubernetes.cpu-manager-policy-options}}
 cpuManagerPolicyOptions:
 {{#each settings.kubernetes.cpu-manager-policy-options}}
+{{#if (eq this "full-pcpus-only")}}
     {{this}}: "true"
+{{/if}}
 {{/each}}
 {{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -203,3 +203,4 @@ reservedMemory:
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
+enableDebuggingHandlers: false

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -207,3 +207,8 @@ enableDebuggingHandlers: false
 {{#if settings.kubernetes.image-minimum-gc-age}}
 imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.image-maximum-gc-age}}
+imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
+{{/if}}
+featureGates:
+  ImageMaximumGCAge: true

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -210,5 +210,8 @@ imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{#if settings.kubernetes.image-maximum-gc-age}}
 imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.max-parallel-image-pulls}}
+maxParallelImagePulls: {{settings.kubernetes.max-parallel-image-pulls}}
+{{/if}}
 featureGates:
   ImageMaximumGCAge: true

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -204,3 +204,6 @@ reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
 enableDebuggingHandlers: false
+{{#if settings.kubernetes.image-minimum-gc-age}}
+imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
+{{/if}}

--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -114,7 +114,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{#if settings.kubernetes.cpu-manager-policy-options}}
 cpuManagerPolicyOptions:
 {{#each settings.kubernetes.cpu-manager-policy-options}}
+{{#if (eq this "full-pcpus-only")}}
     {{this}}: "true"
+{{/if}}
 {{/each}}
 {{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -220,3 +220,6 @@ imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{#if settings.kubernetes.image-maximum-gc-age}}
 imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.max-parallel-image-pulls}}
+maxParallelImagePulls: {{settings.kubernetes.max-parallel-image-pulls}}
+{{/if}}

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -213,3 +213,4 @@ failSwapOn: false
 memorySwap:
   swapBehavior: {{settings.kubernetes.memory-swap-behavior}}
 {{/if}}
+enableDebuggingHandlers: false

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -217,3 +217,6 @@ enableDebuggingHandlers: false
 {{#if settings.kubernetes.image-minimum-gc-age}}
 imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.image-maximum-gc-age}}
+imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
+{{/if}}

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -214,3 +214,6 @@ memorySwap:
   swapBehavior: {{settings.kubernetes.memory-swap-behavior}}
 {{/if}}
 enableDebuggingHandlers: false
+{{#if settings.kubernetes.image-minimum-gc-age}}
+imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
+{{/if}}

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -114,7 +114,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{#if settings.kubernetes.cpu-manager-policy-options}}
 cpuManagerPolicyOptions:
 {{#each settings.kubernetes.cpu-manager-policy-options}}
+{{#if (eq this "full-pcpus-only")}}
     {{this}}: "true"
+{{/if}}
 {{/each}}
 {{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -220,3 +220,6 @@ imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{#if settings.kubernetes.image-maximum-gc-age}}
 imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.max-parallel-image-pulls}}
+maxParallelImagePulls: {{settings.kubernetes.max-parallel-image-pulls}}
+{{/if}}

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -213,3 +213,4 @@ failSwapOn: false
 memorySwap:
   swapBehavior: {{settings.kubernetes.memory-swap-behavior}}
 {{/if}}
+enableDebuggingHandlers: false

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -217,3 +217,6 @@ enableDebuggingHandlers: false
 {{#if settings.kubernetes.image-minimum-gc-age}}
 imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.image-maximum-gc-age}}
+imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
+{{/if}}

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -214,3 +214,6 @@ memorySwap:
   swapBehavior: {{settings.kubernetes.memory-swap-behavior}}
 {{/if}}
 enableDebuggingHandlers: false
+{{#if settings.kubernetes.image-minimum-gc-age}}
+imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
+{{/if}}

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -114,7 +114,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{#if settings.kubernetes.cpu-manager-policy-options}}
 cpuManagerPolicyOptions:
 {{#each settings.kubernetes.cpu-manager-policy-options}}
+{{#if (eq this "full-pcpus-only")}}
     {{this}}: "true"
+{{/if}}
 {{/each}}
 {{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -114,7 +114,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{#if settings.kubernetes.cpu-manager-policy-options}}
 cpuManagerPolicyOptions:
 {{#each settings.kubernetes.cpu-manager-policy-options}}
+{{#if (or (eq this "full-pcpus-only") (eq this "strict-cpu-reservation"))}}
     {{this}}: "true"
+{{/if}}
 {{/each}}
 {{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -216,3 +216,4 @@ memorySwap:
 {{#if settings.kubernetes.single-process-oom-kill}}
 singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
 {{/if}}
+enableDebuggingHandlers: false

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -223,3 +223,6 @@ imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{#if settings.kubernetes.image-maximum-gc-age}}
 imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.max-parallel-image-pulls}}
+maxParallelImagePulls: {{settings.kubernetes.max-parallel-image-pulls}}
+{{/if}}

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -220,3 +220,6 @@ enableDebuggingHandlers: false
 {{#if settings.kubernetes.image-minimum-gc-age}}
 imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.image-maximum-gc-age}}
+imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
+{{/if}}

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -217,3 +217,6 @@ memorySwap:
 singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
 {{/if}}
 enableDebuggingHandlers: false
+{{#if settings.kubernetes.image-minimum-gc-age}}
+imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
+{{/if}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -216,5 +216,6 @@ memorySwap:
 {{#if settings.kubernetes.single-process-oom-kill}}
 singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
 {{/if}}
+enableDebuggingHandlers: false
 featureGates:
   DynamicResourceAllocation: true

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -114,7 +114,9 @@ cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
 {{#if settings.kubernetes.cpu-manager-policy-options}}
 cpuManagerPolicyOptions:
 {{#each settings.kubernetes.cpu-manager-policy-options}}
+{{#if (or (eq this "full-pcpus-only") (eq this "strict-cpu-reservation") (eq this "distribute-cpus-across-numa"))}}
     {{this}}: "true"
+{{/if}}
 {{/each}}
 {{/if}}
 {{#if settings.kubernetes.topology-manager-scope}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -223,6 +223,9 @@ imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{#if settings.kubernetes.image-maximum-gc-age}}
 imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.ids-per-pod}}
+idsPerPod: {{settings.kubernetes.ids-per-pod}}
+{{/if}}
 {{#if settings.kubernetes.max-parallel-image-pulls}}
 maxParallelImagePulls: {{settings.kubernetes.max-parallel-image-pulls}}
 {{/if}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -220,5 +220,8 @@ enableDebuggingHandlers: false
 {{#if settings.kubernetes.image-minimum-gc-age}}
 imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.image-maximum-gc-age}}
+imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
+{{/if}}
 featureGates:
   DynamicResourceAllocation: true

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -223,5 +223,8 @@ imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{#if settings.kubernetes.image-maximum-gc-age}}
 imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.max-parallel-image-pulls}}
+maxParallelImagePulls: {{settings.kubernetes.max-parallel-image-pulls}}
+{{/if}}
 featureGates:
   DynamicResourceAllocation: true

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -217,5 +217,8 @@ memorySwap:
 singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
 {{/if}}
 enableDebuggingHandlers: false
+{{#if settings.kubernetes.image-minimum-gc-age}}
+imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
+{{/if}}
 featureGates:
   DynamicResourceAllocation: true

--- a/packages/kubernetes-1.34/kubelet-config
+++ b/packages/kubernetes-1.34/kubelet-config
@@ -223,6 +223,9 @@ imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{#if settings.kubernetes.image-maximum-gc-age}}
 imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.ids-per-pod}}
+idsPerPod: {{settings.kubernetes.ids-per-pod}}
+{{/if}}
 {{#if settings.kubernetes.max-parallel-image-pulls}}
 maxParallelImagePulls: {{settings.kubernetes.max-parallel-image-pulls}}
 {{/if}}

--- a/packages/kubernetes-1.34/kubelet-config
+++ b/packages/kubernetes-1.34/kubelet-config
@@ -217,6 +217,9 @@ memorySwap:
 singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
 {{/if}}
 enableDebuggingHandlers: false
+{{#if settings.kubernetes.image-minimum-gc-age}}
+imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
+{{/if}}
 featureGates:
   DynamicResourceAllocation: true
   MutableCSINodeAllocatableCount: true

--- a/packages/kubernetes-1.34/kubelet-config
+++ b/packages/kubernetes-1.34/kubelet-config
@@ -216,6 +216,7 @@ memorySwap:
 {{#if settings.kubernetes.single-process-oom-kill}}
 singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
 {{/if}}
+enableDebuggingHandlers: false
 featureGates:
   DynamicResourceAllocation: true
   MutableCSINodeAllocatableCount: true

--- a/packages/kubernetes-1.34/kubelet-config
+++ b/packages/kubernetes-1.34/kubelet-config
@@ -223,6 +223,9 @@ imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{#if settings.kubernetes.image-maximum-gc-age}}
 imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.max-parallel-image-pulls}}
+maxParallelImagePulls: {{settings.kubernetes.max-parallel-image-pulls}}
+{{/if}}
 featureGates:
   DynamicResourceAllocation: true
   MutableCSINodeAllocatableCount: true

--- a/packages/kubernetes-1.34/kubelet-config
+++ b/packages/kubernetes-1.34/kubelet-config
@@ -220,6 +220,9 @@ enableDebuggingHandlers: false
 {{#if settings.kubernetes.image-minimum-gc-age}}
 imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
 {{/if}}
+{{#if settings.kubernetes.image-maximum-gc-age}}
+imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
+{{/if}}
 featureGates:
   DynamicResourceAllocation: true
   MutableCSINodeAllocatableCount: true

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "darling 0.20.11",
  "quote",
@@ -1363,8 +1363,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.12.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+version = "0.13.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "base64 0.22.1",
  "bottlerocket-model-derive",
@@ -1400,7 +1400,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1409,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-scalar",
  "darling 0.20.11",
@@ -1433,8 +1433,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.16.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+version = "0.17.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1455,6 +1455,7 @@ dependencies = [
  "settings-extension-dns",
  "settings-extension-ecs",
  "settings-extension-host-containers",
+ "settings-extension-image-verifier-plugins",
  "settings-extension-kernel",
  "settings-extension-kubelet-device-plugins",
  "settings-extension-kubernetes",
@@ -1485,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1498,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "serde",
 ]
@@ -1506,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -5049,7 +5050,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5062,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5075,7 +5076,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5089,7 +5090,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5102,7 +5103,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5115,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5128,7 +5129,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5141,7 +5142,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5157,7 +5158,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5170,7 +5171,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5183,7 +5184,20 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "settings-extension-image-verifier-plugins"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5196,7 +5210,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5209,7 +5223,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5221,8 +5235,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubernetes"
-version = "0.5.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+version = "0.6.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5236,7 +5250,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5249,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -5262,7 +5276,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5275,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5288,7 +5302,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5301,7 +5315,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5315,7 +5329,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5328,7 +5342,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5341,7 +5355,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.17.0#d1200d6433add777f696c0d44c6eba5543a46b5f"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -215,13 +215,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.16.0"
-version = "0.12.0"
+tag = "bottlerocket-settings-models-v0.17.0"
+version = "0.13.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.16.0"
-version = "0.16.0"
+tag = "bottlerocket-settings-models-v0.17.0"
+version = "0.17.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -230,7 +230,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.16.0"
+tag = "bottlerocket-settings-models-v0.17.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/4058
https://github.com/bottlerocket-os/bottlerocket/issues/4453
https://github.com/bottlerocket-os/bottlerocket/issues/4544
https://github.com/bottlerocket-os/bottlerocket/issues/4643
https://github.com/bottlerocket-os/bottlerocket/issues/4675

**Description of changes:**

Add the following settings to the relevant kubelet configs:
- `enableDebuggingHandlers`: Defaulting to `false` as [originally it's set to true](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#:~:text=0.%20Default%3A%20100-,enableDebuggingHandlers,-bool). I see [refs of this setting earlier than k8s 1.28](https://github.com/kubernetes/kubernetes/issues/64514), so adding this to all k8s versions we currently support -> 1.28-1.34
- `imageMinimumGCAge`: I see [refs of this setting earlier than k8s 1.28](https://discuss.kubernetes.io/t/kubelet-error-while-dialing-dial-unix-missing-address/21185), so adding this to all k8s versions we currently support -> 1.28-1.34
- `imageMaximumGCAge`:  [This is behind a feature gate in 1.29, but defaults to true 1.30+](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-graduated-or-deprecated-features:~:text=1.29-,ImageMaximumGCAge,-true)
- `maxParallelImagePulls`: [Added in k8s 1.27,](https://kubernetes.io/blog/2023/05/15/speed-up-pod-startup/#maximum-parallel-image-pulls-will-help-secure-your-node-from-overloading-on-image-pulling) so adding to all of our versions 1.28-1.34
- `idsperPod`: [Added in k8s 1.33](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/#id-count-for-each-of-pods), so only adding to 1.33 and 1.34 configs
- Beta options for [`cpu-manager-policy-options` ](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-policy-static--options)- all available by default without feature gate:
  - `strict-cpu-reservation` - 1.32 or higher
  - `distribute-cpus-across-numa` - 1.33 or higher
  - `prefer-align-cpus-by-uncorecache` - 1.34 or higher


Bump `settings-models` version to 0.17.0 which adds above settings: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/releases/tag/bottlerocket-settings-models-v0.17.0

Related:
* https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/104

**Testing done:**

See Testing Description section here: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/104


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
