### PR TITLE
fix: only fetch pending settings if they'll be logged

### DIFF
--- a/sources/api/settings-committer/src/main.rs
+++ b/sources/api/settings-committer/src/main.rs
@@ -201,8 +201,11 @@ async fn run() -> Result<()> {
     // SimpleLogger will send errors to stderr and anything less to stdout.
     SimpleLogger::init(args.log_level, LogConfig::default()).context(error::LoggerSnafu)?;
 
-    info!("Checking pending settings.");
-    check_pending_settings(&args.socket_path, &args.transaction).await;
+    if args.log_level >= LevelFilter::Debug {
+        // We log the pending settings at Debug, so only fetch them if they won't be filtered.
+        info!("Checking pending settings.");
+        check_pending_settings(&args.socket_path, &args.transaction).await;
+    }
 
     info!("Committing settings.");
     commit_pending_settings(&args.socket_path, &args.transaction).await?;


### PR DESCRIPTION
check_pending_settings logs the fetched settings at debug level. So, if our log level is lower, don't bother fetching since it will have no visible output.

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
