### PR TITLE
systemd: build cryptsetup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,8 +1038,11 @@ dependencies = [
  "libacl",
  "libattr",
  "libcap",
+ "libcrypto",
+ "libcryptsetup",
  "libseccomp",
  "libselinux",
+ "libtss2",
  "libxcrypt",
  "util-linux",
 ]

--- a/packages/systemd-257/9012-openssl-util-build-without-ui.patch
+++ b/packages/systemd-257/9012-openssl-util-build-without-ui.patch
@@ -1,0 +1,53 @@
+From cbd9ff7231882d22e79c69b333d5394bcdc144e8 Mon Sep 17 00:00:00 2001
+From: Vighnesh Maheshwari <vighmah@amazon.com>
+Date: Thu, 16 Oct 2025 10:00:47 -0700
+Subject: [PATCH] openssl-util: build without ui.h
+
+Remove some code that depends on openssl/ui.h which is not provided by
+aws-lc. This can probably be submitted upstream.
+
+Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>
+---
+ src/shared/openssl-util.h | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/shared/openssl-util.h b/src/shared/openssl-util.h
+index e25a175a80..784e764058 100644
+--- a/src/shared/openssl-util.h
++++ b/src/shared/openssl-util.h
+@@ -41,6 +41,9 @@ int parse_openssl_key_source_argument(const char *argument, char **private_key_s
+ #  ifndef OPENSSL_NO_UI_CONSOLE
+ #    include <openssl/ui.h>
+ #  endif
++#  ifndef OPENSSL_HMAC_H
++#    include <openssl/hmac.h>
++#  endif
+ #  include <openssl/x509v3.h>
+ #  ifndef OPENSSL_VERSION_MAJOR
+ /* OPENSSL_VERSION_MAJOR macro was added in OpenSSL 3. Thus, if it doesn't exist,  we must be before OpenSSL 3. */
+@@ -151,7 +154,9 @@ int digest_and_sign(const EVP_MD *md, EVP_PKEY *privkey, const void *data, size_
+ typedef struct X509 X509;
+ typedef struct EVP_PKEY EVP_PKEY;
+ typedef struct EVP_MD EVP_MD;
++#  ifndef OPENSSL_NO_UI_CONSOLE
+ typedef struct UI_METHOD UI_METHOD;
++#  endif
+ typedef struct ASN1_TYPE ASN1_TYPE;
+ typedef struct ASN1_STRING ASN1_STRING;
+
+@@ -182,10 +187,16 @@ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(EVP_PKEY*, EVP_PKEY_free, NULL);
+ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(ASN1_TYPE*, ASN1_TYPE_free, NULL);
+ DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(ASN1_STRING*, ASN1_STRING_free, NULL);
+
++#ifndef OPENSSL_NO_UI_CONSOLE
+ struct OpenSSLAskPasswordUI {
+         AskPasswordRequest request;
+         UI_METHOD *method;
+ };
++#else
++struct OpenSSLAskPasswordUI {
++        AskPasswordRequest request;
++};
++#endif /* OPENSSL_NO_UI_CONSOLE */
+
+ OpenSSLAskPasswordUI* openssl_ask_password_ui_free(OpenSSLAskPasswordUI *ui);

--- a/packages/systemd-257/9013-fix-openssl-aws-lc-divergence-in-data-types.patch
+++ b/packages/systemd-257/9013-fix-openssl-aws-lc-divergence-in-data-types.patch
@@ -1,0 +1,67 @@
+From 8c72615cbc39cbfeaa907ec70cb8b1ce8ec6d2c3 Mon Sep 17 00:00:00 2001
+From: Vighnesh Maheshwari <vighmah@amazon.com>
+Date: Mon, 30 Jun 2025 21:55:27 +0000
+Subject: [PATCH] move unsigned long to uint32_t - openssl vs aws-lc
+ divergence
+
+Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>
+---
+ src/resolve/resolved-dns-dnssec.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/src/resolve/resolved-dns-dnssec.c b/src/resolve/resolved-dns-dnssec.c
+index 6d32b2d798..2f6f49cc7f 100644
+--- a/src/resolve/resolved-dns-dnssec.c
++++ b/src/resolve/resolved-dns-dnssec.c
+@@ -1,5 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
++#include <inttypes.h>
++
+ #include "alloc-util.h"
+ #include "dns-domain.h"
+ #include "fd-util.h"
+@@ -151,7 +153,7 @@ static int dnssec_rsa_verify_raw(
+         r = EVP_PKEY_verify(ctx, signature, signature_size, data, data_size);
+         if (r < 0)
+                 return log_debug_errno(SYNTHETIC_ERRNO(EIO),
+-                                       "Signature verification failed: 0x%lx", ERR_get_error());
++                                       "Signature verification failed: %"PRIx32, ERR_get_error());
+
+ #  pragma GCC diagnostic pop
+ #else
+@@ -338,7 +340,7 @@ static int dnssec_ecdsa_verify_raw(
+
+         if (EC_KEY_set_public_key(eckey, p) <= 0)
+                 return log_debug_errno(SYNTHETIC_ERRNO(EIO),
+-                                       "EC_POINT_bn2point failed: 0x%lx", ERR_get_error());
++                                       "EC_POINT_bn2point failed: %"PRIx32, ERR_get_error());
+
+         assert(EC_KEY_check_key(eckey) == 1);
+
+@@ -363,7 +365,7 @@ static int dnssec_ecdsa_verify_raw(
+         k = ECDSA_do_verify(data, data_size, sig, eckey);
+         if (k < 0)
+                 return log_debug_errno(SYNTHETIC_ERRNO(EIO),
+-                                       "Signature verification failed: 0x%lx", ERR_get_error());
++                                       "Signature verification failed: %"PRIx32, ERR_get_error());
+
+ #  pragma GCC diagnostic pop
+ #else
+@@ -514,7 +516,7 @@ static int dnssec_eddsa_verify_raw(
+         evkey = EVP_PKEY_new_raw_public_key(EVP_PKEY_ED25519, NULL, key, key_size);
+         if (!evkey)
+                 return log_debug_errno(SYNTHETIC_ERRNO(EIO),
+-                                       "EVP_PKEY_new_raw_public_key failed: 0x%lx", ERR_get_error());
++                                       "EVP_PKEY_new_raw_public_key failed: %"PRIx32, ERR_get_error());
+
+         pctx = EVP_PKEY_CTX_new(evkey, NULL);
+         if (!pctx)
+@@ -534,7 +536,7 @@ static int dnssec_eddsa_verify_raw(
+         r = EVP_DigestVerify(ctx, signature, signature_size, data, data_size);
+         if (r < 0)
+                 return log_debug_errno(SYNTHETIC_ERRNO(EIO),
+-                                       "Signature verification failed: 0x%lx", ERR_get_error());
++                                       "Signature verification failed: %"PRIx32, ERR_get_error());
+
+         return r;

--- a/packages/systemd-257/9014-remove-NID_sm2.patch
+++ b/packages/systemd-257/9014-remove-NID_sm2.patch
@@ -1,0 +1,22 @@
+From 84cb90f65888d27dadd215c682f990a5f82094c2 Mon Sep 17 00:00:00 2001
+From: Vighnesh Maheshwari <vighmah@amazon.com>
+Date: Mon, 16 Jun 2025 22:31:17 +0000
+Subject: [PATCH] remove NID_sm2 support
+
+Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>
+---
+ src/shared/tpm2-util.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git i/src/shared/tpm2-util.c w/src/shared/tpm2-util.c
+index 15dd98f0ab..b2d55a95c3 100644
+--- i/src/shared/tpm2-util.c
++++ w/src/shared/tpm2-util.c
+@@ -4358,7 +4358,6 @@ static const struct {
+         { TPM2_ECC_NIST_P256, NID_X9_62_prime256v1, },
+         { TPM2_ECC_NIST_P384, NID_secp384r1,        },
+         { TPM2_ECC_NIST_P521, NID_secp521r1,        },
+-        { TPM2_ECC_SM2_P256,  NID_sm2,              },
+ };
+
+ static int tpm2_ecc_curve_from_openssl_curve_id(int openssl_ecc_curve_id, TPM2_ECC_CURVE *ret) {

--- a/packages/systemd-257/9015-disable-sb-sign.patch
+++ b/packages/systemd-257/9015-disable-sb-sign.patch
@@ -1,0 +1,47 @@
+From b6338d1be8abd778ca7f23b3b1f620efa15bd545 Mon Sep 17 00:00:00 2001
+From: Vighnesh Maheshwari <vighmah@amazon.com>
+Date: Wed, 2 Jul 2025 17:17:41 +0000
+Subject: [PATCH] Disable systemd-sbsign
+
+Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>
+---
+ meson.build            | 1 +
+ meson_options.txt      | 3 +++
+ src/sbsign/meson.build | 1 +
+ 3 files changed, 5 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index 7ede6f7a96..156be96348 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1707,6 +1707,7 @@ foreach term : ['analyze',
+                 'randomseed',
+                 'resolve',
+                 'rfkill',
++                'sbsign',
+                 'smack',
+                 'sysext',
+                 'sysusers',
+diff --git a/meson_options.txt b/meson_options.txt
+index aedc37413d..7a649cc1ba 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -551,3 +551,6 @@ option('vmlinux-h-path', type : 'string', value : '',
+ 
+ option('default-mountfsd-trusted-directories', type : 'boolean', value: false,
+        description : 'controls whether mountfsd should apply a relaxed policy on DDIs in system DDI directories')
++
++option('sbsign', type : 'boolean', value: false,
++       description : 'controls whether systemd-sbsign is built')
+diff --git a/src/sbsign/meson.build b/src/sbsign/meson.build
+index b6e0dbcde9..261bc4ec42 100644
+--- a/src/sbsign/meson.build
++++ b/src/sbsign/meson.build
+@@ -5,6 +5,7 @@ executables += [
+                 'name' : 'systemd-sbsign',
+                 'conditions' : [
+                         'HAVE_OPENSSL',
++                        'ENABLE_SBSIGN',
+                 ],
+                 'sources' : files('sbsign.c'),
+                 'dependencies' : libopenssl,

--- a/packages/systemd-257/9016-bootctl-disable-secure-boot-autoenroll.patch
+++ b/packages/systemd-257/9016-bootctl-disable-secure-boot-autoenroll.patch
@@ -1,0 +1,23 @@
+From ea520d8acb4dd0e07ddca292d1f502fe3373064c Mon Sep 17 00:00:00 2001
+From: Vighnesh Maheshwari <vighmah@amazon.com>
+Date: Wed, 8 Oct 2025 13:57:12 -0700
+Subject: [PATCH] bootctl: disable secure-boot autoenroll
+
+Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>
+---
+ src/bootctl/bootctl-install.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/bootctl/bootctl-install.c b/src/bootctl/bootctl-install.c
+index c2b2faef3b..5960efd055 100644
+--- a/src/bootctl/bootctl-install.c
++++ b/src/bootctl/bootctl-install.c
+@@ -609,7 +609,7 @@ static int efi_timestamp(EFI_TIME *ret) {
+ #endif
+
+ static int install_secure_boot_auto_enroll(const char *esp, X509 *certificate, EVP_PKEY *private_key) {
+-#if HAVE_OPENSSL
++#if 0
+         int r;
+
+         _cleanup_free_ uint8_t *dercert = NULL;

--- a/packages/systemd-257/9017-meson-set-DOPENSSL_NO_UI_CONSOLE-when-using-openssl.patch
+++ b/packages/systemd-257/9017-meson-set-DOPENSSL_NO_UI_CONSOLE-when-using-openssl.patch
@@ -1,0 +1,39 @@
+From f602a8397813ee3a4c339b108f48bc146185a8be Mon Sep 17 00:00:00 2001
+From: Vighnesh Maheshwari <vighmah@amazon.com>
+Date: Wed, 15 Oct 2025 15:32:19 -0700
+Subject: [PATCH] meson: set DOPENSSL_NO_UI_CONSOLE when using openssl
+
+Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>
+---
+ meson.build       | 4 ++++
+ meson_options.txt | 2 ++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index 103febfd70..ae5cfc0428 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1389,6 +1389,10 @@ libopenssl = dependency('openssl',
+                         required : get_option('openssl'))
+ conf.set10('HAVE_OPENSSL', libopenssl.found())
+
++if get_option('opensslui').disabled()
++        userspace_c_args += '-DOPENSSL_NO_UI_CONSOLE=1'
++endif
++
+ libp11kit = dependency('p11-kit-1',
+                        version : '>= 0.23.3',
+                        required : get_option('p11kit'))
+diff --git a/meson_options.txt b/meson_options.txt
+index aedc37413d..7b17b0c990 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -439,6 +439,8 @@ option('gnutls', type : 'feature', deprecated : { 'true' : 'enabled', 'false' :
+        description : 'gnutls support')
+ option('openssl', type : 'feature', deprecated : { 'true' : 'enabled', 'false' : 'disabled' },
+        description : 'openssl support')
++option('opensslui', type : 'feature', value : 'disabled',
++       description : 'openssl ui support')
+ option('cryptolib', type : 'combo', choices : ['auto', 'openssl', 'gcrypt'],
+        description : 'whether to use openssl or gcrypt where both are supported')
+ option('p11kit', type : 'feature', deprecated : { 'true' : 'enabled', 'false' : 'disabled' },

--- a/packages/systemd-257/Cargo.toml
+++ b/packages/systemd-257/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/systemd/systemd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd/archive/v257.7/systemd-257.7.tar.gz"
-sha512 = "fdc7c0153432b261ad8018c869dc714ce1d6d2a8428bdec46f7c5f120b196d3a553a375ae433f0c166c57b6e8b3c56549f585349b7b6ff83c2a86a32982d8411"
+url = "https://github.com/systemd/systemd/archive/v257.9/systemd-257.9.tar.gz"
+sha512 = "23b3d2764e0f990d8373068ccb41177793413bc193f7bd34e38b03d6fc3cd32d07c86e9dcbf07e32904075bb5eeca208f65beab04d628ac0e0b81ba87a975c1b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/systemd-257/Cargo.toml
+++ b/packages/systemd-257/Cargo.toml
@@ -21,7 +21,10 @@ kmod = { path = "../kmod" }
 libacl = { path = "../libacl" }
 libattr = { path = "../libattr" }
 libcap = { path = "../libcap" }
+libcrypto = { path = "../libcrypto" }
+libcryptsetup = { path = "../libcryptsetup" }
 libseccomp = { path = "../libseccomp" }
 libselinux = { path = "../libselinux" }
+libtss2 = { path = "../libtss2" }
 libxcrypt = { path = "../libxcrypt" }
 util-linux = { path = "../util-linux" }

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -71,6 +71,10 @@ Patch9014: 9014-remove-NID_sm2.patch
 # by aws-lc
 Patch9015: 9015-disable-sb-sign.patch
 
+# Stub out install_secure_boot_auto_enroll since it depends on PKCS7. Instead
+# default to the EOPNOTSUPP condition with a debug log
+Patch9016: 9016-bootctl-disable-secure-boot-autoenroll.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -67,6 +67,10 @@ Patch9013: 9013-fix-openssl-aws-lc-divergence-in-data-types.patch
 # Remove unsupported NID_sm2 cipher
 Patch9014: 9014-remove-NID_sm2.patch
 
+# Disable sb-sign since that has a dependency on PKCS7 which is not provided
+# by aws-lc
+Patch9015: 9015-disable-sb-sign.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -64,6 +64,9 @@ Patch9012: 9012-openssl-util-build-without-ui.patch
 # Fix data type mismatch between aws-lc and openssl
 Patch9013: 9013-fix-openssl-aws-lc-divergence-in-data-types.patch
 
+# Remove unsupported NID_sm2 cipher
+Patch9014: 9014-remove-NID_sm2.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -57,6 +57,10 @@ Patch9010: 9010-meson-replace-openssl-dependency-with-libcrypto.patch
 # policy
 Patch9011: 9011-suppress-log-for-units-with-mode-0044.patch
 
+# Remove some code that depends on openssl/ui.h which is not provided by
+# aws-lc
+Patch9012: 9012-openssl-util-build-without-ui.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -61,6 +61,9 @@ Patch9011: 9011-suppress-log-for-units-with-mode-0044.patch
 # aws-lc
 Patch9012: 9012-openssl-util-build-without-ui.patch
 
+# Fix data type mismatch between aws-lc and openssl
+Patch9013: 9013-fix-openssl-aws-lc-divergence-in-data-types.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -75,6 +75,9 @@ Patch9015: 9015-disable-sb-sign.patch
 # default to the EOPNOTSUPP condition with a debug log
 Patch9016: 9016-bootctl-disable-secure-boot-autoenroll.patch
 
+# Patch meson to set OPENSSL_NO_UI_CONSOLE CFLAGS for the build
+Patch9017: 9017-meson-set-DOPENSSL_NO_UI_CONSOLE-when-using-openssl.patch
+
 BuildRequires: gperf
 BuildRequires: intltool
 BuildRequires: meson

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -4,7 +4,7 @@
 %global package_priority_epoch 0
 
 Name: %{_cross_os}systemd-257
-Version: 257.7
+Version: 257.9
 Release: 1%{?dist}
 Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -87,10 +87,13 @@ BuildRequires: %{_cross_os}libacl-devel
 BuildRequires: %{_cross_os}libattr-devel
 BuildRequires: %{_cross_os}libblkid-devel
 BuildRequires: %{_cross_os}libcap-devel
+BuildRequires: %{_cross_os}libcrypto-devel
+BuildRequires: %{_cross_os}libcryptsetup-devel
 BuildRequires: %{_cross_os}libfdisk-devel
 BuildRequires: %{_cross_os}libmount-devel
 BuildRequires: %{_cross_os}libseccomp-devel
 BuildRequires: %{_cross_os}libselinux-devel
+BuildRequires: %{_cross_os}libtss2-devel
 BuildRequires: %{_cross_os}libuuid-devel
 BuildRequires: %{_cross_os}libxcrypt-devel
 
@@ -99,10 +102,13 @@ Requires: %{_cross_os}libacl
 Requires: %{_cross_os}libattr
 Requires: %{_cross_os}libblkid
 Requires: %{_cross_os}libcap
+Requires: %{_cross_os}libcrypto
+Requires: %{_cross_os}libcryptsetup
 Requires: %{_cross_os}libfdisk
 Requires: %{_cross_os}libmount
 Requires: %{_cross_os}libseccomp
 Requires: %{_cross_os}libselinux
+Requires: %{_cross_os}libtss2
 Requires: %{_cross_os}libuuid
 Requires: %{_cross_os}libxcrypt
 
@@ -305,11 +311,13 @@ CONFIGURE_OPTS=(
  -Dstoragetm=false
  -Dukify=disabled
 
- -Dlibcryptsetup=disabled
- -Dlibcryptsetup-plugins=disabled
- -Dopenssl=disabled
- -Dtpm2=disabled
- -Dtpm=false
+ -Dlibcryptsetup=enabled
+ -Dlibcryptsetup-plugins=enabled
+ -Dopenssl=enabled
+ -Dtpm2=enabled
+ -Dtpm=true
+ -Dsbsign=false
+ -Dopensslui=disabled
 )
 
 %cross_meson "${CONFIGURE_OPTS[@]}"
@@ -598,6 +606,8 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 # Exclude remote filesystem targets.
 %exclude %{_cross_unitdir}/remote-fs-pre.target
 %exclude %{_cross_unitdir}/remote-fs.target
+%exclude %{_cross_unitdir}/remote-cryptsetup.target
+%exclude %{_cross_unitdir}/remote-veritysetup.target
 
 # Exclude user-related functionality.
 %exclude %{_cross_unitdir}/user-runtime-dir@.service
@@ -611,6 +621,7 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %exclude %{_cross_libdir}/systemd/user-preset/90-systemd.preset
 
 # Exclude units related to the initrd.
+%exclude %{_cross_unitdir}/initrd-root-device.target.wants
 %exclude %{_cross_unitdir}/initrd-root-fs.target.wants
 
 # Exclude repart service since we have custom repart logic.
@@ -632,6 +643,21 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %exclude %{_cross_unitdir}/system-update-pre.target
 %exclude %{_cross_unitdir}/system-update.target
 %exclude %{_cross_unitdir}/systemd-update-done.service
+
+# Exclude functionality related to pcrextend
+%exclude %{_cross_libdir}/pcrlock.d/350-action-efi-application.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/400-secureboot-separator.pcrlock.d/300-0x00000000.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/400-secureboot-separator.pcrlock.d/600-0xffffffff.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/500-separator.pcrlock.d/300-0x00000000.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/500-separator.pcrlock.d/600-0xffffffff.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/700-action-efi-exit-boot-services.pcrlock.d/300-present.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/700-action-efi-exit-boot-services.pcrlock.d/600-absent.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/750-enter-initrd.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/800-leave-initrd.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/850-sysinit.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/900-ready.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/950-shutdown.pcrlock
+%exclude %{_cross_libdir}/pcrlock.d/990-final.pcrlock
 
 %dir %{_cross_libdir}/udev
 %{_cross_libdir}/udev/ata_id
@@ -806,3 +832,28 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %{_cross_datadir}/dbus-1/system.d/org.freedesktop.resolve1.conf
 %exclude %{_cross_bindir}/systemd-resolve
 %exclude %{_cross_sbindir}/resolvconf
+
+%files cryptsetup
+%{_cross_bindir}/systemd-cryptenroll
+%{_cross_bindir}/systemd-cryptsetup
+%{_cross_libdir}/cryptsetup/libcryptsetup-token-systemd-tpm2.so
+%{_cross_libdir}/systemd/systemd-cryptsetup
+%{_cross_libdir}/systemd/systemd-integritysetup
+%{_cross_libdir}/systemd/systemd-keyutil
+%{_cross_libdir}/systemd/systemd-measure
+%{_cross_libdir}/systemd/systemd-pcrlock
+%{_cross_libdir}/systemd/systemd-veritysetup
+%{_cross_systemdgeneratordir}/systemd-cryptsetup-generator
+%{_cross_systemdgeneratordir}/systemd-integritysetup-generator
+%{_cross_systemdgeneratordir}/systemd-veritysetup-generator
+%{_cross_unitdir}/cryptsetup.target
+%{_cross_unitdir}/cryptsetup-pre.target
+%{_cross_unitdir}/integritysetup.target
+%{_cross_unitdir}/integritysetup-pre.target
+%{_cross_unitdir}/veritysetup.target
+%{_cross_unitdir}/veritysetup-pre.target
+%{_cross_unitdir}/*cryptsetup.slice
+%{_cross_unitdir}/sysinit.target.wants/cryptsetup.target
+%{_cross_unitdir}/sysinit.target.wants/integritysetup.target
+%{_cross_unitdir}/sysinit.target.wants/veritysetup.target
+%{_cross_unitdir}/system-systemd\x2dveritysetup.slice


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/536

**Description of changes:**
- Build `systemd-cryptsetup` for `systemd-257`
- Also update `systemd-257` to the latest upstream release.
   - This is required since upstream has added support to build `systemd` without `openssl/ui.h` which is a requirement to build `systemd-cryptsetup`

**Testing done:**

All testing was done on an aws-k8s-1.34(-nvidia) variant

- No errors in the journalctl logs:
   ```
   Oct 10 17:29:29 localhost kernel: Run /sbin/init as init process
   Oct 10 17:29:29 localhost kernel:   with arguments:
   Oct 10 17:29:29 localhost kernel:     /sbin/init
   Oct 10 17:29:29 localhost kernel:     systemd.log_target=journal-or-kmsg
   Oct 10 17:29:29 localhost kernel:     systemd.log_color=0
   Oct 10 17:29:29 localhost kernel:     systemd.show_status=true
   Oct 10 17:29:29 localhost kernel:   with environment:
   Oct 10 17:29:29 localhost kernel:     HOME=/
   Oct 10 17:29:29 localhost kernel:     TERM=linux
   Oct 10 17:29:29 localhost kernel:     SYSTEMD_DEFAULT_MOUNT_RATE_LIMIT_BURST=25
   Oct 10 17:29:29 localhost kernel:     SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1
   Oct 10 17:29:29 localhost kernel:     BOOT_IMAGE=(hd0,gpt3)/vmlinuz
   Oct 10 17:29:29 localhost kernel:     selinux=1
   Oct 10 17:29:29 localhost kernel:     enforcing=1
   .
   .
   .
   Oct 10 17:29:29 localhost systemd[1]: systemd 257.9 running in system mode (-PAM -AUDIT +SELINUX -APPARMOR -IMA +IPE -SMACK +SECCOMP -GCRYPT -GNUTLS +OPENSSL +ACL +BLKID -CURL -ELFUTILS -FIDO2 -IDN2 -IDN -IPTC +KMOD +LIBCRYPTSETUP +LIBCRYPTSETUP_PLUGINS +LIBFDISK -PCRE2 -PWQUALITY -P11KIT -QRENCODE +TPM2 -BZIP2 -LZ4 -XZ -ZLIB -ZSTD -BPF_FRAMEWORK -BTF -XKBCOMMON -UTMP -SYSVINIT -LIBARCHIVE)
   ```


- Tested a few systemd commands without error
   ```
   bash-5.1# systemd-analyze
   Startup finished in 798ms (firmware) + 644ms (loader) + 2.376s (kernel) + 13.863s (userspace) = 17.682s
   multi-user.target reached after 13.824s in userspace.

   bash-5.1# systemctl restart kubelet
   bash-5.1# systemctl status kubelet
   ● kubelet.service - Kubelet
        Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; preset: enabled)
       Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
                └─00-aws-config.conf
                /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service.d
                └─dockershim-symlink.conf
                /etc/systemd/system/kubelet.service.d
                └─exec-start.conf
                /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service.d
                └─make-kubelet-dirs.conf, prestart-load-pause-ctr.conf
       Active: active (running) since Fri 2025-10-10 17:35:03 UTC; 1s ago
    Invocation: 8b9155cd79764e9193afb39a475e60b2
          Docs: https://github.com/kubernetes/kubernetes
       Process: 4957 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT (code=exited, status=0/SUCCESS)
       Process: 4958 ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock (code=exited, status=0/SUCCESS)
       Process: 4961 ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet/providers/secrets-store /var/lib/kubelet/node-feature-discovery/features.d (code=exited, status=0/SUCCESS)
       Process: 4963 ExecStartPre=/usr/bin/ctr --namespace=k8s.io image import --all-platforms /usr/libexec/kubernetes/kubernetes-pause.tar (code=exited, status=0/SUCCESS)
       Process: 4969 ExecStartPre=/usr/bin/ctr --namespace=k8s.io image label localhost/kubernetes/pause:0.1.0 io.cri-containerd.pinned=pinned (code=exited, status=0/SUCCESS)
      Main PID: 4974 (kubelet)
         Tasks: 11 (limit: 9313)
        Memory: 30.5M (peak: 38M)
           CPU: 381ms
        CGroup: /runtime.slice/kubelet.service
                └─4974 /usr/bin/kubelet --cloud-provider external --kubeconfig /etc/kubernetes/kubelet/kubeconfig --config /etc/kubernetes/kubelet/config --container-runtime-endpoint=unix:///run/containerd/containerd.sock --containerd=/run/containerd/containerd.sock --root-dir /var/lib/kubelet --cert-dir /var/lib/kubel…

   ```


- No unit files showing any errors
   ```
   bash-5.1# systemctl | grep -e "error" -e "ERROR" -e "Error" -e "failed" -e "FAILED" -e  "Failed"
   bash-5.1#
   ```

- The instance joins the cluster as expected

- Basic workloads are launched on the node correctly

- Tested neuron instances:
   ```
   bash-5.1# systemctl status modprobe@neuron
   ● modprobe@neuron.service - Load Kernel Module neuron
        Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/modprobe@.service; static)
       Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
                └─00-aws-config.conf
                /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/modprobe@.service.d
                └─10-remain-after-exit.conf
                /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/modprobe@neuron.service.d
                └─neuron.conf
        Active: active (exited) since Fri 2025-10-10 18:30:49 UTC; 4min 33s ago
    Invocation: dd5a2c8f3c434733be23f8067fc24207
          Docs: man:modprobe(8)
      Main PID: 1306 (code=exited, status=0/SUCCESS)
      Mem peak: 2.8M
           CPU: 39ms

   Oct 10 18:30:49 localhost systemd[1]: Finished Load Kernel Module neuron.
   Notice: journal has been rotated since unit was started, output may be incomplete.
   ```

   ```
   % kubectl get nodes "-o=custom-columns=NAME:.metadata.name,NeuronCore:.status.allocatable.aws\.amazon\.com/neuroncore"
   NAME                                          NeuronCore
   ip-192-168-70-48.us-west-2.compute.internal   2
   ```


- Tested Neuron Workloads:
   ```
   === RUN   TestNeuronNodes/multi-node
       neuron_test.go:157: Skipping feature "multi-node": name not matched
   --- PASS: TestNeuronNodes (360.09s)
       --- PASS: TestNeuronNodes/single-node (360.09s)
           --- PASS: TestNeuronNodes/single-node/Single_node_test_Job_succeeds (360.02s)
      --- SKIP: TestNeuronNodes/multi-node (0.00s)
   PASS
   ok      github.com/aws/aws-k8s-tester/test/cases/neuron 431.977s
   ```


- Nvidia instances working as expected:
   ```
   bash-5.1# nvidia-smi
   Fri Oct 10 21:23:46 2025
   +-----------------------------------------------------------------------------------------+
   | NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
   +-----------------------------------------+------------------------+----------------------+
   | GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
   | Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
   |                                         |                        |               MIG M. |
   |=========================================+========================+======================|
   |   0  Tesla T4                       On  |   00000000:00:1E.0 Off |                    0 |
   | N/A   31C    P8              9W /   70W |       0MiB /  15360MiB |      0%      Default |
   |                                         |                        |                  N/A |
   +-----------------------------------------+------------------------+----------------------+
   
   +-----------------------------------------------------------------------------------------+
   | Processes:                                                                              |
   |  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
   |        ID   ID                                                               Usage      |
   |=========================================================================================|
   |  No running processes found                                                             |
   +-----------------------------------------------------------------------------------------+
   ```

- Basic Nvidia workload tests worked as expected.


- Ran basic scale testing by launching ~100 g4dn.xlarge, m5.large, c6i.large, r7a.large, 

- [x] Soak testing with an AMI

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
