### PR TITLE
build: bump bottlerocket sdk to v0.65.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v10.8.1 (2025-10-22)
+
+## Build Changes
+* Update `bottlerocket-sdk` from 0.65.0 to 0.65.1 ([#698])
+
+[#698]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/698
+
 # v10.8.0 (2025-10-15)
 
 ## OS Changes

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -4,7 +4,7 @@ project-vendor = "Bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.65.0"
+version = "0.65.1"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.65.0"
-digest = "g03GUrm333pxmItqDrr3kPVELf0gHj8An8Yz9/GG5Ms="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.65.1"
+digest = "zeBarGgXhYNUsJTDFhZFjEBetInWPlVBQ8oi2j0/IKk="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,5 +7,5 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.65.0"
+version = "0.65.1"
 vendor = "bottlerocket"

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "10.8.0"
+release-version = "10.8.1"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Bump sdk to v0.65.1 + prep 10.8.1 changelog.

**Testing done:**

Kit builds with new sdk on both archs.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
