### PR TITLE
containerd-2.1: fix image pull error when range-get request is ignored 

### DIFF
--- a/packages/containerd-2.1/1002-Ensure-errContentRangeIgnored-error-when-range-get-r.patch
+++ b/packages/containerd-2.1/1002-Ensure-errContentRangeIgnored-error-when-range-get-r.patch
@@ -1,0 +1,54 @@
+From ca3de4fe7b3219d1d2f8ac9482b93b0e63b52801 Mon Sep 17 00:00:00 2001
+From: Henry Wang <henwang@amazon.com>
+Date: Tue, 9 Sep 2025 18:56:34 +0000
+Subject: [PATCH] Ensure errContentRangeIgnored error when range-get request is
+ ignored by registry
+
+Signed-off-by: Henry Wang <henwang@amazon.com>
+---
+ core/remotes/docker/fetcher.go      | 2 +-
+ core/remotes/docker/fetcher_test.go | 1 +
+ core/remotes/docker/resolver.go     | 4 ++--
+ 3 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/core/remotes/docker/fetcher.go b/core/remotes/docker/fetcher.go
+index 90542e2e7..59c0e3dd8 100644
+--- a/core/remotes/docker/fetcher.go
++++ b/core/remotes/docker/fetcher.go
+@@ -459,7 +459,7 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
+ 	if err := r.Acquire(ctx, 1); err != nil {
+ 		return nil, err
+ 	}
+-	resp, err := req.doWithRetries(ctx, lastHost, withErrorCheck, withOffsetCheck(offset))
++	resp, err := req.doWithRetries(ctx, lastHost, withErrorCheck, withOffsetCheck(offset, parallelism))
+ 	switch err {
+ 	case nil:
+ 		// all good
+diff --git a/core/remotes/docker/fetcher_test.go b/core/remotes/docker/fetcher_test.go
+index c88067b10..bfb06ff41 100644
+--- a/core/remotes/docker/fetcher_test.go
++++ b/core/remotes/docker/fetcher_test.go
+@@ -247,6 +247,7 @@ func TestFetcherOpenParallel(t *testing.T) {
+ 	sendContentLength = true
+ 
+ 	ignoreContentRange = true
++	checkReader(0)
+ 	checkReader(25)
+ 	ignoreContentRange = false
+ 
+diff --git a/core/remotes/docker/resolver.go b/core/remotes/docker/resolver.go
+index 1c0f7c484..05bebd36c 100644
+--- a/core/remotes/docker/resolver.go
++++ b/core/remotes/docker/resolver.go
+@@ -659,9 +659,9 @@ func withErrorCheck(r *request, resp *http.Response) error {
+ 
+ var errContentRangeIgnored = errors.New("content range requests ignored")
+ 
+-func withOffsetCheck(offset int64) doChecks {
++func withOffsetCheck(offset, parallelism int64) doChecks {
+ 	return func(r *request, resp *http.Response) error {
+-		if offset == 0 {
++		if parallelism <= 1 && offset == 0 {
+ 			return nil
+ 		}
+ 		if resp.StatusCode == http.StatusPartialContent {

--- a/packages/containerd-2.1/containerd-2.1.spec
+++ b/packages/containerd-2.1/containerd-2.1.spec
@@ -38,6 +38,7 @@ Source1000: clarify.toml
 
 # Patch to support moving from containerd-1.7 to 2.x
 Patch1001: 1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
+Patch1002: 1002-Ensure-errContentRangeIgnored-error-when-range-get-r.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Based on upstream PR: https://github.com/containerd/containerd/pull/12291

We can remove this patch when a containerd `2.1.5` is released.

This patch addresses an issue where containerd was not properly returning the errContentRangeIgnored error when range-get requests are ignored by the registry or storage backend using the new image transfer service.

The fix ensures that the appropriate error is returned to maintain consistent error handling behavior for range requests that cannot be processed.

**Testing done:**

Pulled a large public image which produced an image pull error using the latest BottlerocketAMI, and compared it to an AMI with this patch:

```
NAMESPACE     NAME                            READY   STATUS             RESTARTS   AGE
default       chunk-size-test                 0/1     ImagePullBackOff   0          20m
default       chunk-size-test-works           1/1     Running            0          20m
```

Fixes the error:

```
Oct 31 16:34:47 ip-192-168-33-112.us-west-2.compute.internal containerd[1668]: time="2025-10-31T16:34:47.238985039Z" level=error msg="PullImage \"<REMOVED>\" failed" error="rpc error: code = FailedPrecondition desc = failed to pull and unpack image \"REMOVED": failed commit on ref \"layer-sha256:93d2483178866c842abf3264e0bb0dcd323a08e0449eff6e4a32e8d6d4607aa1\": \"layer-sha256:93d2483178866c842abf3264e0bb0dcd323a08e0449eff6e4a32e8d6d4607aa1\" failed size validation: 25165824 != 18775130: failed precondition"
```

Setting: `settings.container-runtime.concurrent-download-chunk-size=0` would also mitigate this error as it bypasses the concurrent logic where the error exists. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
