### PR TITLE
Merge 10.9.0 release into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v10.9.0 (2025-11-05)
+
+## OS Changes
+* Update runc to v1.2.7 and include CVE patches ([#6813a59b], [#6e3d3e2e], [#f330515a])
+* containerd-2.1: fix image pull error when range-get request is ignored ([#702])
+
+[#6813a59b]: https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/6813a59bb4b681239f991217e835e43836242b32
+[#6e3d3e2e]: https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/6e3d3e2e563ec556b9fc51eb495a180b69bcf43b
+[#f330515a]: https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/f330515aacc658abdcd4c86b07b6e3ae22de8d13
+[#702]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/702
+
 # v10.8.1 (2025-10-22)
 
 ## Build Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "10.8.1"
+release-version = "10.9.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/packages/runc/.gitignore
+++ b/packages/runc/.gitignore
@@ -1,0 +1,1 @@
+v1.2.7-Additional-CVE-fixes.patch

--- a/packages/runc/1002-openat2-increase-retry-count-to-128.patch
+++ b/packages/runc/1002-openat2-increase-retry-count-to-128.patch
@@ -1,0 +1,31 @@
+From eb3873a7e0a0b66a87bed4a325204f17797ad077 Mon Sep 17 00:00:00 2001
+From: Matthew Yeazel <yeazelm@amazon.com>
+Date: Fri, 31 Oct 2025 14:46:27 +0000
+Subject: [PATCH] openat2: increase retry count to 128
+
+This is an application of 28c6340c68213ca07e2cc715f33495681ebd1792
+to the vendored library to avoid hitting limits at 32 instead of 128.
+
+---
+ .../pathrs-lite/internal/fd/openat2_linux.go                 | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/openat2_linux.go b/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/openat2_linux.go
+index 2305308..113be5f 100644
+--- a/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/openat2_linux.go
++++ b/vendor/github.com/cyphar/filepath-securejoin/pathrs-lite/internal/fd/openat2_linux.go
+@@ -34,7 +34,10 @@ func scopedLookupShouldRetry(how *unix.OpenHow, err error) bool {
+ 		(errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EXDEV))
+ }
+ 
+-const scopedLookupMaxRetries = 32
++// This is a fairly arbitrary limit we have just to avoid an attacker being
++// able to make us spin in an infinite retry loop -- callers can choose to
++// retry on EAGAIN if they prefer.
++const scopedLookupMaxRetries = 128
+ 
+ // Openat2 is an [Fd]-based wrapper around unix.Openat2, but with some retry
+ // logic in case of EAGAIN errors.
+-- 
+2.51.0
+

--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -21,6 +21,10 @@ url = "https://github.com/opencontainers/runc/releases/download/v1.2.7/runc.tar.
 path = "runc-v1.2.7.tar.xz.asc"
 sha512 = "78b5fb2800906aa756d83fdfe4c8a04b558e86d4167b86c059c6375a9cb58bf0b044160608bd02f7b6cb1c767f2a0c0ab0b400b61c1ccbb7ada9af8204289a38"
 
+[[package.metadata.build-package.external-files]]
+url = "https://cache.bottlerocket.aws/v1.2.7-Additional-CVE-fixes.patch/3ab3340d3564fdbc42d33dc556ff9bc9232f00cb6ac110eec345691b85f5a192a722d739736aca5d832c3f64a543795e9bb41dc970678977752cb581de469e5c/v1.2.7-Additional-CVE-fixes.patch"
+sha512 = "3ab3340d3564fdbc42d33dc556ff9bc9232f00cb6ac110eec345691b85f5a192a722d739736aca5d832c3f64a543795e9bb41dc970678977752cb581de469e5c"
+
 [build-dependencies]
 glibc = { path = "../glibc" }
 libseccomp = { path = "../libseccomp" }

--- a/packages/runc/Cargo.toml
+++ b/packages/runc/Cargo.toml
@@ -12,14 +12,14 @@ path = "../packages.rs"
 releases-url = "https://github.com/opencontainers/runc/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.2.6/runc.tar.xz"
-path = "runc-v1.2.6.tar.xz"
-sha512 = "772265769316e62d9f3d3e09eb48c6f7a1299bedede0a9472add430474b33758b5e723a33b5121411c20e15cd171e3133e80ab88b7a8c082327181be5507f65b"
+url = "https://github.com/opencontainers/runc/releases/download/v1.2.7/runc.tar.xz"
+path = "runc-v1.2.7.tar.xz"
+sha512 = "2049eab6c3c10aa9fabd4c929cc61834824e394dc6a2dabf50841d8c7b902a97dd0723e189f6ddfbe511b2dcb8a4b8dd378f405144fdcd66e500de7fa876dec6"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/opencontainers/runc/releases/download/v1.2.6/runc.tar.xz.asc"
-path = "runc-v1.2.6.tar.xz.asc"
-sha512 = "f6892bf5aa171cbbf6ef12f1453ac6a31e931a3d3a7a69c6a7c632250ab5136698b919a6a600c1faeb16d8945b3c42d1d203bafd566098b4c282dceebd08fdaf"
+url = "https://github.com/opencontainers/runc/releases/download/v1.2.7/runc.tar.xz.asc"
+path = "runc-v1.2.7.tar.xz.asc"
+sha512 = "78b5fb2800906aa756d83fdfe4c8a04b558e86d4167b86c059c6375a9cb58bf0b044160608bd02f7b6cb1c767f2a0c0ab0b400b61c1ccbb7ada9af8204289a38"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -22,6 +22,7 @@ Source3: gpgkey-C2428CD75720FACDCF76B6EA17DE5ECB75A1100E.asc
 
 # Patch for CVE fixes
 Source1001: v1.2.7-Additional-CVE-fixes.patch
+Source1002: 1002-openat2-increase-retry-count-to-128.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
@@ -57,6 +58,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 
 # Apply additional runc patches directly
 patch -p1 < %{S:1001}
+patch -p1 < %{S:1002}
 
 %build
 %cross_go_configure %{goimport}

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -1,8 +1,8 @@
 %global goproject github.com/opencontainers
 %global gorepo runc
 %global goimport %{goproject}/%{gorepo}
-%global commit 2c9f5602f0ba3d9da1c2596322dfc4e156844890
-%global gover 1.2.6
+%global commit 4774df387790afbddcd2fd905d70ecb8aec9c341
+%global gover 1.2.7
 
 %global _dwz_low_mem_die_limit 0
 
@@ -48,7 +48,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{summary}.
 
 %prep
-%{gpgverify} --data=%{S:0} --signature=%{S:1} --keyring=%{S:3}
+%{gpgverify} --data=%{S:0} --signature=%{S:1} --keyring=%{S:2}
 %autosetup -Sgit -n %{gorepo}-%{gover} -p1
 %cross_go_setup %{gorepo}-%{gover} %{goproject} %{goimport}
 

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -20,6 +20,9 @@ Source2: gpgkey-B64E4955B29FA3D463F2A9062897FAD2B7E9446F.asc
 # Kir Kolyshkin
 Source3: gpgkey-C2428CD75720FACDCF76B6EA17DE5ECB75A1100E.asc
 
+# Patch for CVE fixes
+Source1001: v1.2.7-Additional-CVE-fixes.patch
+
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libseccomp-devel
@@ -51,6 +54,9 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{gpgverify} --data=%{S:0} --signature=%{S:1} --keyring=%{S:2}
 %autosetup -Sgit -n %{gorepo}-%{gover} -p1
 %cross_go_setup %{gorepo}-%{gover} %{goproject} %{goimport}
+
+# Apply additional runc patches directly
+patch -p1 < %{S:1001}
 
 %build
 %cross_go_configure %{goimport}


### PR DESCRIPTION
**Description of changes:**
This merges the commits into develop from the 10.9.x that were used for the 10.9.0 release.

**Testing done:**
N/A


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
