### PR TITLE
add libudev for bootstrapping purposes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "libudev"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+ "kmod",
+ "libacl",
+ "libattr",
+ "libcap",
+ "libseccomp",
+ "libselinux",
+ "libxcrypt",
+ "util-linux",
+]
+
+[[package]]
 name = "liburcu"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "glibc",
  "libaio",
  "libselinux",
+ "libudev",
  "util-linux",
 ]
 

--- a/packages/libcryptsetup/0001-pbkdf-check-whether-FIPS-is-enabled-at-runtime.patch
+++ b/packages/libcryptsetup/0001-pbkdf-check-whether-FIPS-is-enabled-at-runtime.patch
@@ -1,4 +1,4 @@
-From 246df3d2d990257de06ce8b2219a7f4f198e69cc Mon Sep 17 00:00:00 2001
+From d30aec8c423c9b9d6899bfa4c99985c5562e3c42 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Fri, 28 Mar 2025 21:29:04 +0000
 Subject: [PATCH] pbkdf: check whether FIPS is enabled at runtime
@@ -19,7 +19,7 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 12 insertions(+), 1 deletion(-)
 
 diff --git a/lib/utils_pbkdf.c b/lib/utils_pbkdf.c
-index b54509c8..37db5932 100644
+index 87e9419..bea4024 100644
 --- a/lib/utils_pbkdf.c
 +++ b/lib/utils_pbkdf.c
 @@ -8,6 +8,7 @@
@@ -30,7 +30,7 @@ index b54509c8..37db5932 100644
  
  #include "internal.h"
  
-@@ -185,8 +186,18 @@ int init_pbkdf_type(struct crypt_device *cd,
+@@ -192,8 +193,18 @@ int init_pbkdf_type(struct crypt_device *cd,
  	unsigned cpus;
  	uint32_t old_flags, memory_kb;
  	int r;
@@ -50,6 +50,3 @@ index b54509c8..37db5932 100644
  		if (pbkdf && strcmp(pbkdf->type, CRYPT_KDF_PBKDF2)) {
  			log_err(cd, _("Only PBKDF2 is supported in FIPS mode."));
  			return -EINVAL;
--- 
-2.48.1
-

--- a/packages/libcryptsetup/0002-build-replace-openssl-with-libcrypto-in-pkgconfig.patch
+++ b/packages/libcryptsetup/0002-build-replace-openssl-with-libcrypto-in-pkgconfig.patch
@@ -1,4 +1,4 @@
-From b25fb07213c0dfd91693bfa1ee375b8b26525734 Mon Sep 17 00:00:00 2001
+From 2949ceab1ea4618fcac5668a99f89dcb272c3875 Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Sat, 17 May 2025 18:01:33 +0000
 Subject: [PATCH] build: replace openssl with libcrypto in pkgconfig
@@ -9,10 +9,10 @@ Signed-off-by: Ben Cressey <bcressey@amazon.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure.ac b/configure.ac
-index a5535731..58019842 100644
+index 6a6c4df..a00dcc7 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -710,7 +710,7 @@ dnl pwquality is used only by tools
+@@ -717,7 +717,7 @@ dnl pwquality is used only by tools
  PKGMODULES="uuid devmapper json-c"
  case $with_crypto_backend in
  	gcrypt)  PKGMODULES="$PKGMODULES libgcrypt" ;;
@@ -21,6 +21,3 @@ index a5535731..58019842 100644
  	nss)     PKGMODULES="$PKGMODULES nss" ;;
  	nettle)  PKGMODULES="$PKGMODULES nettle" ;;
  esac
--- 
-2.49.0
-

--- a/packages/libcryptsetup/0003-random-quiet-message-about-FIPS-mode.patch
+++ b/packages/libcryptsetup/0003-random-quiet-message-about-FIPS-mode.patch
@@ -1,0 +1,29 @@
+From abb56fb487f9e4692d0eb6bbeae3f10f8a7f8445 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Sat, 25 Oct 2025 17:41:13 +0000
+Subject: [PATCH] random: quiet message about FIPS mode
+
+Since we always build with FIPS mode enabled, the message isn't very
+useful. It's also printed by other tools that depend on the library,
+where it can clutter up the output.
+
+Demote the message to debug level to make it less intrusive.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ lib/random.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/random.c b/lib/random.c
+index 06d2713..71acbf3 100644
+--- a/lib/random.c
++++ b/lib/random.c
+@@ -147,7 +147,7 @@ int crypt_random_init(struct crypt_device *ctx)
+ 		goto err;
+ 
+ 	if (crypt_fips_mode())
+-		log_verbose(ctx, _("Running in FIPS mode."));
++		log_dbg(ctx, _("Running in FIPS mode."));
+ 
+ 	random_initialised = 1;
+ 	return 0;

--- a/packages/libcryptsetup/libcryptsetup.spec
+++ b/packages/libcryptsetup/libcryptsetup.spec
@@ -77,6 +77,7 @@ autoreconf -fi
   --enable-internal-argon2 \
   --enable-internal-sse-argon2 \
   --enable-selinux \
+  --enable-udev \
   --enable-veritysetup \
   --with-crypto_backend=openssl \
   --with-luks2-pbkdf=pbkdf2 \

--- a/packages/libcryptsetup/libcryptsetup.spec
+++ b/packages/libcryptsetup/libcryptsetup.spec
@@ -15,6 +15,9 @@ Patch0001: 0001-pbkdf-check-whether-FIPS-is-enabled-at-runtime.patch
 # cryptsetup only depends on libcrypto, not libssl.
 Patch0002: 0002-build-replace-openssl-with-libcrypto-in-pkgconfig.patch
 
+# Quiet warning about FIPS mode.
+Patch0003: 0003-random-quiet-message-about-FIPS-mode.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libblkid-devel
 BuildRequires: %{_cross_os}libcrypto-devel

--- a/packages/libdevmapper/Cargo.toml
+++ b/packages/libdevmapper/Cargo.toml
@@ -23,4 +23,5 @@ sha512 = "de081006558f8ef998cbfbacc1b887d43702a39bc3dd6dd2a9e59ffd0481889921ef49
 glibc = { path = "../glibc" }
 libselinux = { path = "../libselinux" }
 libaio = { path = "../libaio" }
+libudev = { path = "../libudev" }
 util-linux = { path = "../util-linux" }

--- a/packages/libdevmapper/libdevmapper.spec
+++ b/packages/libdevmapper/libdevmapper.spec
@@ -12,9 +12,11 @@ BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libaio-devel
 BuildRequires: %{_cross_os}libblkid-devel
 BuildRequires: %{_cross_os}libselinux-devel
+BuildRequires: %{_cross_os}libudev-devel
 Requires: %{_cross_os}libaio
 Requires: %{_cross_os}libblkid
 Requires: %{_cross_os}libselinux
+Requires: %{_cross_os}libudev
 
 %description
 %{summary}.
@@ -22,6 +24,7 @@ Requires: %{_cross_os}libselinux
 %package devel
 Summary: Files for development using the library for device mapper
 Requires: %{name}
+Requires: %{_cross_os}libudev-devel
 
 %description devel
 %{summary}.
@@ -54,6 +57,7 @@ Requires: %{name}
   --enable-pkgconfig \
   --enable-selinux \
   --enable-udev_rules \
+  --enable-udev_sync \
   --with-user= \
   --with-group= \
   --with-device-uid=0 \

--- a/packages/libudev/Cargo.toml
+++ b/packages/libudev/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "libudev"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/systemd/systemd-stable/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/systemd/systemd-stable/archive/v252.39/systemd-stable-252.39.tar.gz"
+sha512 = "0a24faf0dd6da9d5b55dafab332bdd40bfb90f643bd6caa3b6ecfcb8feaeabe51b1cf007f033e8d9ea3f52efdb4722ed63816b31646d70b99c22eb1eb2705450"
+
+[build-dependencies]
+glibc = { path = "../glibc" }
+kmod = { path = "../kmod" }
+libacl = { path = "../libacl" }
+libattr = { path = "../libattr" }
+libcap = { path = "../libcap" }
+libseccomp = { path = "../libseccomp" }
+libselinux = { path = "../libselinux" }
+libxcrypt = { path = "../libxcrypt" }
+util-linux = { path = "../util-linux" }

--- a/packages/libudev/libudev.spec
+++ b/packages/libudev/libudev.spec
@@ -1,0 +1,71 @@
+# Skip check-rpaths since we expect them for systemd.
+%global __brp_check_rpaths %{nil}
+
+Name: %{_cross_os}libudev
+Version: 252.39
+Release: 1%{?dist}
+Summary: System and Service Manager
+License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later
+URL: https://www.freedesktop.org/wiki/Software/systemd
+Source0: https://github.com/systemd/systemd-stable/archive/v%{version}/systemd-stable-%{version}.tar.gz
+
+BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}kmod-devel
+BuildRequires: %{_cross_os}libacl-devel
+BuildRequires: %{_cross_os}libattr-devel
+BuildRequires: %{_cross_os}libblkid-devel
+BuildRequires: %{_cross_os}libcap-devel
+BuildRequires: %{_cross_os}libfdisk-devel
+BuildRequires: %{_cross_os}libmount-devel
+BuildRequires: %{_cross_os}libseccomp-devel
+BuildRequires: %{_cross_os}libselinux-devel
+BuildRequires: %{_cross_os}libuuid-devel
+BuildRequires: %{_cross_os}libxcrypt-devel
+
+# Discourage dnf from picking this bootstrap package during image builds.
+Conflicts: %{_cross_os}filesystem
+Conflicts: %{_cross_os}release
+Conflicts: %{_cross_os}systemd
+
+%description
+%{summary}.
+
+%package devel
+Summary: Files for development using the System and Service Manager
+Requires: %{name}
+Requires: %{_cross_os}libcap
+
+%description devel
+%{summary}.
+
+%prep
+%autosetup -n systemd-stable-%{version} -p1
+
+%build
+CONFIGURE_OPTS=(
+ -Dmode=release
+
+ -Drootprefix='%{_cross_prefix}'
+ -Drootlibdir='%{_cross_libdir}'
+
+ -Dpkgconfigdatadir='%{_cross_pkgconfigdir}'
+ -Dpkgconfiglibdir='%{_cross_pkgconfigdir}'
+)
+
+%cross_meson "${CONFIGURE_OPTS[@]}"
+%cross_meson_build
+
+%install
+%cross_meson_install
+
+find %{buildroot} \( -type f -o -type l \) ! -name '*libudev*' -delete
+
+%files
+%license LICENSE.GPL2 LICENSE.LGPL2.1
+%{_cross_attribution_file}
+%{_cross_libdir}/libudev.so.*
+
+%files devel
+%{_cross_libdir}/libudev.so
+%{_cross_includedir}/libudev.h
+%{_cross_pkgconfigdir}/libudev*.pc

--- a/packages/systemd-252/systemd-252.spec
+++ b/packages/systemd-252/systemd-252.spec
@@ -132,6 +132,7 @@ Requires: %{_cross_os}libuuid
 Requires: %{_cross_os}libxcrypt
 
 Provides: %{_cross_os}systemd = %{package_priority_epoch}:
+Provides: %{_cross_os}libudev = %{package_priority_epoch}:
 Conflicts: %{_cross_os}systemd
 
 %description
@@ -158,6 +159,7 @@ Provides: %{_cross_os}systemd-cryptsetup = %{package_priority_epoch}:
 Summary: Files for development using the System and Service Manager
 Requires: %{name}
 Provides: %{_cross_os}systemd-devel = %{package_priority_epoch}:
+Provides: %{_cross_os}libudev-devel = %{package_priority_epoch}:
 
 %description devel
 %{summary}.

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -117,6 +117,7 @@ Requires: %{_cross_os}libuuid
 Requires: %{_cross_os}libxcrypt
 
 Provides: %{_cross_os}systemd = %{package_priority_epoch}:
+Provides: %{_cross_os}libudev = %{package_priority_epoch}:
 Conflicts: %{_cross_os}systemd
 
 %description
@@ -143,6 +144,7 @@ Provides: %{_cross_os}systemd-cryptsetup = %{package_priority_epoch}:
 Summary: Files for development using the System and Service Manager
 Requires: %{name}
 Provides: %{_cross_os}systemd-devel = %{package_priority_epoch}:
+Provides: %{_cross_os}libudev-devel = %{package_priority_epoch}:
 
 %description devel
 %{summary}.


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/4680

**Description of changes:**
Add a bootstrap build of systemd for the purpose of providing libudev to packages that are dependencies of the final systemd package. This is required to build `libdevmapper` and `libcryptsetup` with udev support, which improves the coordination between the kernel and userspace when adding devices.

Also add a bonus patch to quiet the message about FIPS mode.


**Testing done:**
`dmsetup` shows that the udev synchronization commands are available:
```
# dmsetup udevcookies
Cookie       Semid      Value      Last semop time           Last change time
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
