### PR TITLE
support kdump for zboot images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ name = "kexec-tools"
 version = "0.1.0"
 dependencies = [
  "glibc",
+ "libzstd",
 ]
 
 [[package]]

--- a/packages/kexec-tools/Cargo.toml
+++ b/packages/kexec-tools/Cargo.toml
@@ -12,12 +12,13 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/linux/utils/kernel/kexec"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.31.tar.xz"
-sha512 = "95cb7e7b33685497d72fab74fed2191e476c0574d6ad2333d9e22b95a94543b5fdafe0663282cfaebb8747cf696b7d34c308941ec1074b2b9f1ed440b32d7309"
+url = "https://mirrors.edge.kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.32.tar.xz"
+sha512 = "60f120f8e46b9fb5dcf5a5b344ee8b303878ba9f71d58a3eefa1c9f044a6a2192b285154b738970263384c6e7281a854cd48a185334c08141aa4e6cf08230654"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.31.tar.sign"
-sha512 = "cb964713ed282f575d29823a2110884f052d3b9149c25212a7e4ad3d3023713774a479923af99168db3598ec24480223708c32442555281e6daa42115717260b"
+url = "https://mirrors.edge.kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-2.0.32.tar.sign"
+sha512 = "2511ba969733648a1f657995abc82eff5550ef9fbc1713cf78e92b71a07cea1a6fe24a78b45f49ca893aade5e0b008d9c4e05a135a80384bffb9b140b71afb26"
 
 [build-dependencies]
 glibc = { path = "../glibc" }
+libzstd = { path = "../libzstd" }

--- a/packages/kexec-tools/kexec-tools.spec
+++ b/packages/kexec-tools/kexec-tools.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}kexec-tools
-Version: 2.0.31
+Version: 2.0.32
 Release: 1%{?dist}
 Epoch: 1
 Summary: Linux tool to load kernels from the running system
@@ -10,6 +10,8 @@ Source1: https://kernel.org/pub/linux/utils/kernel/kexec/kexec-tools-%{version}.
 Source2: gpgkey-E27CD9A1F5ACC2FF4BFE7285D7CF64696A374FBE.asc
 
 BuildRequires: %{_cross_os}glibc-devel
+BuildRequires: %{_cross_os}libzstd-devel
+Requires: %{_cross_os}libzstd
 
 %description
 %{summary}.

--- a/packages/release/load-crash-kernel.service
+++ b/packages/release/load-crash-kernel.service
@@ -1,8 +1,5 @@
 [Unit]
 Description=Load crash kernel
-# No kexec support yet for arm64's zstd-compressed zboot image on 6.12+
-ConditionKernelVersion=|<6.12
-ConditionArchitecture=|!arm64
 ConditionKernelCommandLine=crashkernel
 ConditionPathExists=!/proc/vmcore
 RefuseManualStart=true


### PR DESCRIPTION
**Issue number:**
Follow-up: #465

**Description of changes:**
Update to the new version of kexec-tools and build with zstd support, so that our 6.1 and 6.12 zboot kernels for aarch64 can be loaded.


**Testing done:**
Verified that the crash kernel is loaded on aarch64:
```
bash-5.2# uname -a
Linux ip-10-0-60-129.us-west-2.compute.internal 6.12.46 #1 SMP Tue Nov  4 17:36:46 UTC 2025 aarch64 GNU/Linux

bash-5.2# journalctl|grep -i crash
Nov 05 19:17:33 localhost kernel: crashkernel reserved: 0x00000000ec000000 - 0x00000000fc000000 (256 MB)
...
Nov 05 19:17:33 localhost kernel: pstore: Using crash dump compression: deflate
Nov 05 19:17:35 localhost systemd[1]: Starting Load crash kernel...
Nov 05 19:17:35 localhost prairiedog[1464]: 19:17:35 [INFO] Loading crash kernel
Nov 05 19:17:35 localhost prairiedog[1464]: 19:17:35 [INFO] Crash kernel loaded
Nov 05 19:17:35 localhost systemd[1]: Finished Load crash kernel.

bash-5.2# cat /sys/kernel/kexec_crash_loaded
1
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
