### PR TITLE
Add `apiclient network configure` subcommand

### DIFF
--- a/sources/api/apiclient/README.md
+++ b/sources/api/apiclient/README.md
@@ -5,7 +5,7 @@ Current version: 0.1.0
 ## apiclient binary
 
 The `apiclient` binary provides high-level methods to interact with the Bottlerocket API.
-There's a [set](#set-mode) subcommand for changing settings, an [update](#update-mode) subcommand for updating the host, and an [exec](#exec-mode) subcommand for running commands in host containers.
+There's a [set](#set-mode) subcommand for changing settings, a [network configure](#network-configure) subcommand for configuring network settings, an [update](#update-mode) subcommand for updating the host, and an [exec](#exec-mode) subcommand for running commands in host containers.
 There's also a low-level [raw](#raw-mode) subcommand for direct interaction with the HTTP API.
 
 It talks to the Bottlerocket socket by default.
@@ -73,6 +73,52 @@ You can use JSON form to set it:
 
 ```shell
 apiclient set --json '{"motd": "42"}'
+```
+
+### Network configure
+
+This allows you to configure network settings by providing a network configuration file. The configuration will be applied at the next boot.
+
+The `network configure` command accepts input from different sources using URI schemes:
+
+#### File URI input
+
+You can specify a local file path using the `file://` URI scheme:
+
+```shell
+apiclient network configure file:///path/to/net.toml
+```
+
+#### Base64 encoded input
+
+For inline configuration, you can provide base64-encoded content:
+
+```shell
+apiclient network configure base64:dmVyc2lvbiA9IDIKCltldGgwXQpkaGNwNCA9IHRydWU=
+```
+
+This is particularly useful for automation and configuration management where you want to embed the network configuration directly in scripts or user data.
+
+#### Configuration format
+
+The `net.toml` file uses the same format that netdog supports. Here's an example:
+
+```toml
+version = 2
+
+[eth0]
+dhcp4 = true
+dhcp6 = false
+
+[eth1]
+static4 = ["192.168.1.100/24"]
+route = [{to = "default", via = "192.168.1.1"}]
+```
+
+After configuring the network settings, you'll need to reboot the system for the changes to take effect:
+
+```shell
+apiclient reboot
 ```
 
 ### Update mode
@@ -347,7 +393,7 @@ The results from each item in the report will be one of:
 ## apiclient library
 
 The apiclient library provides high-level methods to interact with the Bottlerocket API.  See
-the documentation for submodules [`apply`], [`exec`], [`get`], [`reboot`], [`report`], [`set`],
+the documentation for submodules [`apply`], [`exec`], [`get`], [`network`], [`reboot`], [`report`], [`set`],
 and [`update`] for high-level helpers.
 
 For more control, and to handle APIs without high-level wrappers, there are also 'raw' methods

--- a/sources/api/apiclient/README.tpl
+++ b/sources/api/apiclient/README.tpl
@@ -5,7 +5,7 @@ Current version: {{version}}
 ## apiclient binary
 
 The `apiclient` binary provides high-level methods to interact with the Bottlerocket API.
-There's a [set](#set-mode) subcommand for changing settings, an [update](#update-mode) subcommand for updating the host, and an [exec](#exec-mode) subcommand for running commands in host containers.
+There's a [set](#set-mode) subcommand for changing settings, a [network configure](#network-configure) subcommand for configuring network settings, an [update](#update-mode) subcommand for updating the host, and an [exec](#exec-mode) subcommand for running commands in host containers.
 There's also a low-level [raw](#raw-mode) subcommand for direct interaction with the HTTP API.
 
 It talks to the Bottlerocket socket by default.
@@ -73,6 +73,52 @@ You can use JSON form to set it:
 
 ```shell
 apiclient set --json '{"motd": "42"}'
+```
+
+### Network configure
+
+This allows you to configure network settings by providing a network configuration file. The configuration will be applied at the next boot.
+
+The `network configure` command accepts input from different sources using URI schemes:
+
+#### File URI input
+
+You can specify a local file path using the `file://` URI scheme:
+
+```shell
+apiclient network configure file:///path/to/net.toml
+```
+
+#### Base64 encoded input
+
+For inline configuration, you can provide base64-encoded content:
+
+```shell
+apiclient network configure base64:dmVyc2lvbiA9IDIKCltldGgwXQpkaGNwNCA9IHRydWU=
+```
+
+This is particularly useful for automation and configuration management where you want to embed the network configuration directly in scripts or user data.
+
+#### Configuration format
+
+The `net.toml` file uses the same format that netdog supports. Here's an example:
+
+```toml
+version = 2
+
+[eth0]
+dhcp4 = true
+dhcp6 = false
+
+[eth1]
+static4 = ["192.168.1.100/24"]
+route = [{to = "default", via = "192.168.1.1"}]
+```
+
+After configuring the network settings, you'll need to reboot the system for the changes to take effect:
+
+```shell
+apiclient reboot
 ```
 
 ### Update mode

--- a/sources/api/apiclient/src/lib.rs
+++ b/sources/api/apiclient/src/lib.rs
@@ -1,5 +1,5 @@
 //! The apiclient library provides high-level methods to interact with the Bottlerocket API.  See
-//! the documentation for submodules [`apply`], [`exec`], [`get`], [`reboot`], [`report`], [`set`],
+//! the documentation for submodules [`apply`], [`exec`], [`get`], [`network`], [`reboot`], [`report`], [`set`],
 //! and [`update`] for high-level helpers.
 //!
 //! For more control, and to handle APIs without high-level wrappers, there are also 'raw' methods
@@ -24,6 +24,7 @@ pub mod ephemeral_storage;
 pub mod exec;
 pub mod get;
 pub mod lockdown;
+pub mod network;
 pub mod reboot;
 pub mod report;
 pub mod set;

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -44,7 +44,7 @@ impl Default for Args {
 }
 
 /// Stores the usage mode specified by the user as a subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum Subcommand {
     Apply(ApplyArgs),
     Exec(ExecArgs),
@@ -60,13 +60,13 @@ enum Subcommand {
 }
 
 /// Stores user-supplied arguments for the 'apply' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct ApplyArgs {
     input_sources: Vec<String>,
 }
 
 /// Stores user-supplied arguments for the 'exec' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct ExecArgs {
     command: Vec<OsString>,
     target: String,
@@ -74,7 +74,7 @@ struct ExecArgs {
 }
 
 /// Stores user-supplied arguments for the 'get' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum GetArgs {
     Prefixes {
         include: Vec<String>,
@@ -85,7 +85,7 @@ enum GetArgs {
 }
 
 /// Stores user-supplied arguments for the 'raw' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct RawArgs {
     method: String,
     uri: String,
@@ -93,11 +93,11 @@ struct RawArgs {
 }
 
 /// Stores user-supplied arguments for the 'lockdown' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct LockdownArgs {}
 
 /// Stores user-supplied arguments for the 'reboot' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct RebootArgs {}
 
 /// Stores a vector of user-supplied key-value pairs for the 'set' subcommand.
@@ -107,14 +107,14 @@ pub struct SetKeyPairSettings {
 }
 
 /// Stores user-supplied arguments for the 'set' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum SetArgs {
     Simple(Vec<String>),
     Json(serde_json::Value),
 }
 
 /// Stores the 'update' subcommand specified by the user.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum UpdateSubcommand {
     Check(UpdateCheckArgs),
     Apply(UpdateApplyArgs),
@@ -122,7 +122,7 @@ enum UpdateSubcommand {
 }
 
 /// The available 'report' subcommands.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum ReportSubcommand {
     Cis(CisReportArgs),
     CisK8s(CisReportArgs),
@@ -130,35 +130,35 @@ enum ReportSubcommand {
 }
 
 /// Stores common user-supplied arguments for the cis report subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct CisReportArgs {
     level: Option<i32>,
     format: Option<String>,
 }
 
 /// Stores common user-supplied arguments for the fips report subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct FipsReportArgs {
     format: Option<String>,
 }
 
 /// Stores user-supplied arguments for the 'update check' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct UpdateCheckArgs {}
 
 /// Stores user-supplied arguments for the 'update apply' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct UpdateApplyArgs {
     check: bool,
     reboot: bool,
 }
 
 /// Stores user-supplied arguments for the 'update cancel' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct UpdateCancelArgs {}
 
 /// Stores the 'ephemeral-storage' subcommand specified by the user.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum EphemeralStorageSubcommand {
     Init(EphemeralStorageInitArgs),
     Bind(EphemeralStorageBindArgs),
@@ -168,7 +168,7 @@ enum EphemeralStorageSubcommand {
 }
 
 /// Stores user-supplied arguments for the 'ephemeral-storage init' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct EphemeralStorageInitArgs {
     disks: Option<Vec<String>>,
     ebs_volumes: Option<Vec<String>>,
@@ -177,24 +177,24 @@ struct EphemeralStorageInitArgs {
 }
 
 /// Stores user-supplied arguments for the 'ephemeral-storage bind' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct EphemeralStorageBindArgs {
     targets: Vec<String>,
 }
 /// Stores user-supplied arguments for the 'ephemeral-storage list-disks/list-ebs-volumes/list-dirs' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct EphemeralStorageFormatArgs {
     format: Option<String>,
 }
 
 /// Stores the 'network' subcommand specified by the user.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum NetworkSubcommand {
     Configure(NetworkConfigureArgs),
 }
 
 /// Stores user-supplied arguments for the 'network configure' subcommand.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct NetworkConfigureArgs {
     input_source: Option<String>,
 }
@@ -1604,12 +1604,10 @@ mod tests {
         assert_eq!(global_args.socket_path, "/run/api.sock");
 
         // Test network configure subcommand with no input source (stdin)
-        match subcommand {
-            Subcommand::Network(NetworkSubcommand::Configure(configure_args)) => {
-                assert_eq!(configure_args.input_source, None);
-            }
-            _ => panic!("Expected Network::Configure subcommand, got: {subcommand:?}"),
-        }
+        let expected = Subcommand::Network(NetworkSubcommand::Configure(NetworkConfigureArgs {
+            input_source: None,
+        }));
+        assert_eq!(subcommand, expected);
     }
 
     #[test_case("apiclient network configure file:///tmp/net.toml",
@@ -1644,15 +1642,10 @@ mod tests {
         assert_eq!(global_args.log_level, expected_args.log_level);
         assert_eq!(global_args.socket_path, expected_args.socket_path);
 
-        // Test network configure subcommand and extract input source
-        match subcommand {
-            Subcommand::Network(NetworkSubcommand::Configure(configure_args)) => {
-                assert_eq!(
-                    configure_args.input_source,
-                    Some(expected_input_source.to_string())
-                );
-            }
-            _ => panic!("Expected Network::Configure subcommand, got: {subcommand:?}"),
-        }
+        // Test network configure subcommand matches expected
+        let expected = Subcommand::Network(NetworkSubcommand::Configure(NetworkConfigureArgs {
+            input_source: Some(expected_input_source.to_string()),
+        }));
+        assert_eq!(subcommand, expected);
     }
 }

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -7,7 +7,8 @@
 // to the API, which is intended to be reusable by other crates.
 
 use apiclient::{
-    apply, ephemeral_storage, exec, get, lockdown, reboot, report, set, update, SettingsInput,
+    apply, ephemeral_storage, exec, get, lockdown, network, reboot, report, set, update,
+    SettingsInput,
 };
 use log::{info, log_enabled, trace, warn};
 use model::ephemeral_storage::{Filesystem, Preference};
@@ -49,6 +50,7 @@ enum Subcommand {
     Exec(ExecArgs),
     Get(GetArgs),
     Lockdown(LockdownArgs),
+    Network(NetworkSubcommand),
     Raw(RawArgs),
     Reboot(RebootArgs),
     Set(SetArgs),
@@ -185,6 +187,18 @@ struct EphemeralStorageFormatArgs {
     format: Option<String>,
 }
 
+/// Stores the 'network' subcommand specified by the user.
+#[derive(Debug)]
+enum NetworkSubcommand {
+    Configure(NetworkConfigureArgs),
+}
+
+/// Stores user-supplied arguments for the 'network configure' subcommand.
+#[derive(Debug)]
+struct NetworkConfigureArgs {
+    input_source: Option<String>,
+}
+
 /// Informs the user about proper usage of the program and exits.
 fn usage() -> ! {
     let msg = &format!(
@@ -203,6 +217,8 @@ fn usage() -> ! {
                                        or from stdin.
             get                        Retrieve and print settings.
             set                        Changes settings and applies them to the system.
+            network configure          Configures network settings from net.toml files at
+                                       given URIs.
             update check               Prints information about available updates.
             update apply               Applies available updates.
             update cancel              Deactivates an applied update.
@@ -247,6 +263,13 @@ fn usage() -> ! {
 
                                        If neither prefixes nor URI are specified, get will show
                                        settings and OS info.
+
+        network configure options:
+            [ URI ]                    URI to a network configuration file (TOML format)
+                                       to apply. Supports file:// and base64: URI schemes.
+                                       If no URI is specified, reads from stdin.
+                                       Configuration is written to /.bottlerocket/net.toml and
+                                       validated at next boot by netdog.
 
         set options:
             KEY=VALUE [KEY=VALUE ...]  The settings you want to set.  For example:
@@ -376,8 +399,8 @@ fn parse_args(args: impl Iterator<Item = String>) -> (Args, Subcommand) {
             }
 
             // Subcommands
-            "raw" | "apply" | "exec" | "get" | "lockdown" | "reboot" | "report" | "set"
-            | "update" | "ephemeral-storage"
+            "raw" | "apply" | "exec" | "get" | "lockdown" | "network" | "reboot" | "report"
+            | "set" | "update" | "ephemeral-storage"
                 if subcommand.is_none() && !arg.starts_with('-') =>
             {
                 subcommand = Some(arg)
@@ -395,6 +418,7 @@ fn parse_args(args: impl Iterator<Item = String>) -> (Args, Subcommand) {
         Some("exec") => (global_args, parse_exec_args(subcommand_args)),
         Some("get") => (global_args, parse_get_args(subcommand_args)),
         Some("lockdown") => (global_args, parse_lockdown_args(subcommand_args)),
+        Some("network") => (global_args, parse_network_args(subcommand_args)),
         Some("reboot") => (global_args, parse_reboot_args(subcommand_args)),
         Some("report") => (global_args, parse_report_args(subcommand_args)),
         Some("set") => (global_args, parse_set_args(subcommand_args)),
@@ -563,6 +587,42 @@ fn parse_lockdown_args(args: Vec<String>) -> Subcommand {
         usage_msg(format!("Unknown arguments: {}", args.join(", ")));
     }
     Subcommand::Lockdown(LockdownArgs {})
+}
+/// Parses the desired subcommand of 'network'.
+fn parse_network_args(args: Vec<String>) -> Subcommand {
+    let mut subcommand = None;
+    let mut subcommand_args = Vec::new();
+
+    for arg in args.into_iter() {
+        match arg.as_ref() {
+            // Subcommands
+            "configure" if subcommand.is_none() => subcommand = Some(arg),
+
+            // Other arguments are passed to the subcommand parser
+            _ => subcommand_args.push(arg),
+        }
+    }
+
+    match subcommand.as_deref() {
+        Some("configure") => parse_network_configure_args(subcommand_args),
+        _ => usage_msg("Missing or unknown subcommand for 'network'"),
+    }
+}
+
+/// Parses arguments for the 'network configure' subcommand.
+fn parse_network_configure_args(args: Vec<String>) -> Subcommand {
+    let mut input_source = None;
+
+    for arg in args.into_iter() {
+        if input_source.is_some() {
+            usage_msg("apiclient network configure takes only one input source URI.")
+        }
+        input_source = Some(arg);
+    }
+
+    Subcommand::Network(NetworkSubcommand::Configure(NetworkConfigureArgs {
+        input_source,
+    }))
 }
 
 /// Parses arguments for the 'reboot' subcommand.
@@ -1084,6 +1144,17 @@ async fn run() -> Result<()> {
                 .context(error::LockdownSnafu)?;
         }
 
+        Subcommand::Network(subcommand) => match subcommand {
+            NetworkSubcommand::Configure(configure_args) => {
+                let content = network::get_content(configure_args.input_source)
+                    .await
+                    .context(error::NetworkGetContentSnafu)?;
+                network::configure(&args.socket_path, content)
+                    .await
+                    .context(error::NetworkConfigureSnafu)?;
+            }
+        },
+
         Subcommand::Reboot(_reboot) => {
             reboot::reboot(&args.socket_path)
                 .await
@@ -1252,7 +1323,9 @@ async fn main() {
 }
 
 mod error {
-    use apiclient::{apply, ephemeral_storage, exec, get, lockdown, reboot, report, set, update};
+    use apiclient::{
+        apply, ephemeral_storage, exec, get, lockdown, network, reboot, report, set, update,
+    };
     use snafu::Snafu;
 
     #[derive(Debug, Snafu)]
@@ -1272,6 +1345,11 @@ mod error {
 
         #[snafu(display("Failed to lockdown: {}", source))]
         Lockdown { source: lockdown::Error },
+        #[snafu(display("Failed to get network configuration content: {}", source))]
+        NetworkGetContent { source: network::Error },
+
+        #[snafu(display("Failed to configure network: {}", source))]
+        NetworkConfigure { source: network::Error },
 
         #[snafu(display("Failed to reboot: {}", source))]
         Reboot { source: reboot::Error },
@@ -1513,6 +1591,68 @@ mod tests {
                 assert_eq!(canonicalize, false);
             }
             _ => panic!("Expected Get with Prefixes"),
+        }
+    }
+
+    #[test]
+    fn test_network_configure_parsing_stdin() {
+        // Test that network configure with no arguments defaults to stdin
+        let (global_args, subcommand) = parse_command_line("apiclient network configure");
+
+        // Test global arguments match expected defaults
+        assert_eq!(global_args.log_level, LevelFilter::Info);
+        assert_eq!(global_args.socket_path, "/run/api.sock");
+
+        // Test network configure subcommand with no input source (stdin)
+        match subcommand {
+            Subcommand::Network(NetworkSubcommand::Configure(configure_args)) => {
+                assert_eq!(configure_args.input_source, None);
+            }
+            _ => panic!("Expected Network::Configure subcommand, got: {subcommand:?}"),
+        }
+    }
+
+    #[test_case("apiclient network configure file:///tmp/net.toml",
+        global_args!(LevelFilter::Info),
+        "file:///tmp/net.toml";
+        "network configure with file URI")]
+    #[test_case("apiclient network configure base64:dmVyc2lvbiA9IDIKCltldGgwXQpkaGNwNCA9IHRydWU=",
+        global_args!(LevelFilter::Info),
+        "base64:dmVyc2lvbiA9IDIKCltldGgwXQpkaGNwNCA9IHRydWU=";
+        "network configure with base64 URI")]
+    #[test_case("apiclient -v network configure file:///tmp/net.toml",
+        global_args!(LevelFilter::Debug),
+        "file:///tmp/net.toml";
+        "verbose flag with network configure")]
+    #[test_case("apiclient --log-level error network configure base64:test",
+        global_args!(LevelFilter::Error),
+        "base64:test";
+        "log level with network configure")]
+    #[test_case("apiclient --socket-path /tmp/custom.sock network configure file:///etc/net.toml",
+        global_args!(LevelFilter::Info, "/tmp/custom.sock"),
+        "file:///etc/net.toml";
+        "custom socket path with network configure")]
+    fn test_network_configure_parsing(
+        cmd_str: &str,
+        expected_args: Args,
+        expected_input_source: &str,
+    ) {
+        // Given a command line string for network configure
+        let (global_args, subcommand) = parse_command_line(cmd_str);
+
+        // Test global arguments match expected values
+        assert_eq!(global_args.log_level, expected_args.log_level);
+        assert_eq!(global_args.socket_path, expected_args.socket_path);
+
+        // Test network configure subcommand and extract input source
+        match subcommand {
+            Subcommand::Network(NetworkSubcommand::Configure(configure_args)) => {
+                assert_eq!(
+                    configure_args.input_source,
+                    Some(expected_input_source.to_string())
+                );
+            }
+            _ => panic!("Expected Network::Configure subcommand, got: {subcommand:?}"),
         }
     }
 }

--- a/sources/api/apiclient/src/network.rs
+++ b/sources/api/apiclient/src/network.rs
@@ -1,0 +1,295 @@
+//! This module implements network configuration API calls.
+//! It supports sourcing `net.toml` configuration files from the filesystem or base64 encoded strings.
+
+use base64::{engine, Engine};
+use snafu::{OptionExt, ResultExt};
+use std::path::Path;
+use tokio::io::AsyncReadExt;
+use url::Url;
+
+/// Configures network settings by sending the provided content to the API server.
+///
+/// The configuration will be applied at the next boot - a reboot is required for changes to take effect.
+pub async fn configure<P>(socket_path: P, content: String) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    let uri = "/actions/network/configure";
+    let method = "POST";
+    let (_status, _body) = crate::raw_request(&socket_path, uri, method, Some(content))
+        .await
+        .context(error::ConfigureRequestSnafu { uri, method })?;
+
+    Ok(())
+}
+
+/// Retrieves the network configuration content from the given source URI.
+///
+/// Supports file:// and base64: URI schemes. If no input source is provided, reads from stdin.
+pub async fn get_content<S>(input_source: Option<S>) -> Result<String>
+where
+    S: Into<String>,
+{
+    match input_source {
+        Some(source) => get_content_from_source(source.into()).await,
+        None => get_content_with_stdin(tokio::io::stdin()).await,
+    }
+}
+
+/// Reads all content from an async reader into a string.
+///
+/// Generic reader interface allows flexible input sources and testing with mock data.
+async fn get_content_with_stdin<R>(mut reader: R) -> Result<String>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut output = String::new();
+    reader
+        .read_to_string(&mut output)
+        .await
+        .context(error::StdinReadSnafu)?;
+    Ok(output)
+}
+
+/// Retrieves network configuration content from a source URI.
+///
+/// Supports file:// and base64: URI schemes.
+async fn get_content_from_source(input_source: String) -> Result<String> {
+    if let Some(base64_data) = input_source.strip_prefix("base64:") {
+        return get_content_from_base64(base64_data, &input_source);
+    }
+
+    let uri = Url::parse(&input_source).context(error::UriSnafu {
+        input_source: &input_source,
+    })?;
+
+    match uri.scheme() {
+        "file" => get_content_from_file(uri, &input_source).await,
+        scheme => error::UnsupportedUriSchemeSnafu {
+            input_source: &input_source,
+            scheme,
+        }
+        .fail(),
+    }
+}
+
+/// Decodes and returns content from a base64-encoded string.
+fn get_content_from_base64(base64_data: &str, input_source: &str) -> Result<String> {
+    let decoded_bytes = engine::general_purpose::STANDARD
+        .decode(base64_data.as_bytes())
+        .context(error::Base64DecodeSnafu { input_source })?;
+
+    String::from_utf8(decoded_bytes).context(error::Base64Utf8Snafu { input_source })
+}
+
+/// Reads content from a file URI.
+async fn get_content_from_file(uri: Url, input_source: &str) -> Result<String> {
+    let path = uri
+        .to_file_path()
+        .ok()
+        .context(error::FileUriSnafu { input_source })?;
+    tokio::fs::read_to_string(path)
+        .await
+        .context(error::FileReadSnafu { input_source })
+}
+
+mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub enum Error {
+        #[snafu(display("Failed to decode base64 from '{}': {}", input_source, source))]
+        Base64Decode {
+            input_source: String,
+            source: base64::DecodeError,
+        },
+
+        #[snafu(display(
+            "Base64 content from '{}' is not valid UTF-8: {}",
+            input_source,
+            source
+        ))]
+        Base64Utf8 {
+            input_source: String,
+            source: std::string::FromUtf8Error,
+        },
+
+        #[snafu(display("Failed to {} network configuration to '{}': {}", method, uri, source))]
+        ConfigureRequest {
+            uri: String,
+            method: String,
+            #[snafu(source(from(crate::Error, Box::new)))]
+            source: Box<crate::Error>,
+        },
+
+        #[snafu(display("Failed to read given file '{}': {}", input_source, source))]
+        FileRead {
+            input_source: String,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Invalid file URI '{}'", input_source))]
+        FileUri { input_source: String },
+
+        #[snafu(display("Failed to read from stdin: {}", source))]
+        StdinRead { source: std::io::Error },
+
+        #[snafu(display(
+            "Unsupported URI scheme '{}' in '{}'. Only file:// and base64: schemes are supported",
+            scheme,
+            input_source
+        ))]
+        UnsupportedUriScheme {
+            input_source: String,
+            scheme: String,
+        },
+
+        #[snafu(display("Invalid URI '{}': {}", input_source, source))]
+        Uri {
+            input_source: String,
+            source: url::ParseError,
+        },
+    }
+}
+
+pub use error::Error;
+pub type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine, Engine};
+    use test_case::test_case;
+
+    #[tokio::test]
+    async fn test_get_content_stdin() {
+        use std::io::Cursor;
+
+        // Given network config content to simulate stdin input
+        let test_content = r"version = 2
+
+[eth0]
+dhcp4 = true
+primary = true
+";
+        let mock_stdin = tokio::io::BufReader::new(Cursor::new(test_content.as_bytes()));
+
+        // When reading from mock stdin
+        let result = get_content_with_stdin(mock_stdin).await;
+
+        // Then content should be read successfully
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), test_content);
+    }
+
+    #[tokio::test]
+    async fn test_get_content_stdin_empty() {
+        use std::io::Cursor;
+
+        // Given empty stdin
+        let mock_stdin = tokio::io::BufReader::new(Cursor::new(b""));
+
+        // When reading from empty mock stdin
+        let result = get_content_with_stdin(mock_stdin).await;
+
+        // Then should return empty string successfully
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn test_stdin_vs_uri_behavior() {
+        use std::io::Cursor;
+
+        let content = r"version = 2
+
+[eth0]
+dhcp4 = true";
+        let mock_stdin = tokio::io::BufReader::new(Cursor::new(content.as_bytes()));
+
+        // Test that stdin reader works
+        let stdin_result = get_content_with_stdin(mock_stdin).await;
+
+        // Test that Some input uses URI processing
+        let uri_result =
+            get_content(Some("base64:dmVyc2lvbiA9IDIKCltldGgwXQpkaGNwNCA9IHRydWU=")).await;
+
+        assert!(stdin_result.is_ok());
+        assert!(uri_result.is_ok());
+        assert_eq!(stdin_result.unwrap(), content);
+        assert_eq!(uri_result.unwrap(), content);
+    }
+
+    #[tokio::test]
+    async fn test_get_content_base64() {
+        // Given a valid TOML network configuration encoded in base64
+        let test_content = "version = 2\n\n[eth0]\ndhcp4 = true\n";
+        let encoded = engine::general_purpose::STANDARD.encode(test_content.as_bytes());
+        let base64_uri = format!("base64:{}", encoded);
+
+        // Then get content from the base64 URI
+        let result = get_content(Some(base64_uri)).await;
+
+        // Then the content should be successfully decoded
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), test_content);
+    }
+
+    #[tokio::test]
+    async fn test_get_content_base64_invalid() {
+        // Given an invalid base64 string that cannot be decoded
+        // When attempting to get content from the malformed base64 URI
+        let result = get_content(Some("base64:invalid!@#$")).await;
+
+        // Then the operation should fail with a base64 decode error
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to decode base64"));
+    }
+
+    #[tokio::test]
+    async fn test_get_content_base64_invalid_utf8() {
+        // Given a valid base64 string that decodes to invalid UTF-8 bytes
+        let invalid_bytes = vec![0xFF, 0xFE, 0xFD];
+        let encoded = engine::general_purpose::STANDARD.encode(&invalid_bytes);
+        let base64_uri = format!("base64:{}", encoded);
+
+        // When attempting to get content from the base64 URI
+        let result = get_content(Some(base64_uri)).await;
+
+        // Then the operation should fail with a UTF-8 validation error
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not valid UTF-8"));
+    }
+
+    #[tokio::test]
+    async fn test_uri_parsing() {
+        // Given an invalid URI string that cannot be parsed
+        // When attempting to get content from the malformed URI
+        let result = get_content(Some("invalid-uri")).await;
+
+        // Then the operation should fail with a URI parsing error
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid URI"));
+    }
+
+    #[test_case("http://example.com/net.toml", "http"; "http uri rejected")]
+    #[test_case("https://example.com/net.toml", "https"; "https uri rejected")]
+    #[test_case("s3://bucket/net.toml", "s3"; "s3 uri rejected")]
+    #[test_case("ftp://ftp.example.com/net.toml", "ftp"; "ftp uri rejected")]
+    #[test_case("data:text/plain;charset=utf-8,version=2", "data"; "data uri rejected")]
+    #[tokio::test]
+    async fn test_unsupported_uri_schemes_rejected(uri: &str, expected_scheme: &str) {
+        // When attempting to get content from an unsupported URI scheme
+        let result = get_content(Some(uri)).await;
+
+        // Then the operation should fail with an unsupported URI scheme error
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains(&format!("Unsupported URI scheme '{expected_scheme}'")));
+        assert!(error_msg.contains("Only file:// and base64: schemes are supported"));
+    }
+}

--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -220,6 +220,18 @@ pub enum Error {
 
     // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
+    // Network configuration errors
+    #[snafu(display("Network configuration content is not valid UTF-8"))]
+    NetworkConfigContent { source: std::string::FromUtf8Error },
+
+    #[snafu(display("Failed to validate network configuration: {}", source))]
+    NetworkConfigValidation { source: std::io::Error },
+
+    #[snafu(display("Invalid network configuration: {}", stderr))]
+    NetworkConfigInvalid { stderr: String },
+
+    // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
     // Update related errors
     #[snafu(display("Unable to start the update dispatcher: {} ", source))]
     UpdateDispatcher { source: io::Error },

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -14,7 +14,7 @@ use actix_web::{
 use datastore::{serialize_scalar, Committed, FilesystemDataStore, Key, KeyType, Value};
 use error::Result;
 use http::StatusCode;
-use log::info;
+use log::{debug, info};
 use model::ephemeral_storage::{Bind, Init};
 use model::generator::{RawSettingsGenerator, Strength};
 use model::{ConfigurationFiles, Model, Report, Services, Settings};
@@ -24,6 +24,7 @@ use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{set_permissions, File, Permissions};
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
@@ -36,7 +37,7 @@ use tokio::process::Command as AsyncCommand;
 const BLOODHOUND_BIN: &str = "/usr/bin/bloodhound";
 const BLOODHOUND_K8S_CHECKS: &str = "/usr/libexec/cis-checks/kubernetes";
 const BLOODHOUND_FIPS_CHECKS: &str = "/usr/libexec/fips-checks/bottlerocket";
-
+const NETDOG_BIN: &str = "/usr/bin/netdog";
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
 
 // sd_notify helper
@@ -137,6 +138,7 @@ where
                     .route("/prepare-update", web::post().to(prepare_update))
                     .route("/activate-update", web::post().to(activate_update))
                     .route("/deactivate-update", web::post().to(deactivate_update))
+                    .route("/network/configure", web::post().to(configure_network))
                     .route(
                         "/ephemeral-storage/init",
                         web::post().to(initialize_ephemeral_storage),
@@ -687,6 +689,43 @@ async fn reboot() -> Result<HttpResponse> {
     Ok(HttpResponse::NoContent().finish())
 }
 
+/// Configures network settings by invoking netdog commit.
+/// The configuration will be applied at next boot - a reboot is required for changes to take effect.
+async fn configure_network(body: web::Bytes) -> Result<HttpResponse> {
+    debug!("Configuring network settings");
+
+    // Convert the body bytes to a UTF-8 string
+    let content = String::from_utf8(body.to_vec()).context(error::NetworkConfigContentSnafu)?;
+
+    info!("Invoking netdog commit to validate and write network configuration");
+
+    // Validate and write net.toml using netdog commit
+    let validation_result = std::process::Command::new(NETDOG_BIN)
+        .arg("commit")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            if let Some(stdin) = child.stdin.as_mut() {
+                stdin.write_all(content.as_bytes())?;
+            }
+            child.wait_with_output()
+        })
+        .context(error::NetworkConfigValidationSnafu)?;
+
+    if !validation_result.status.success() {
+        let stderr = String::from_utf8_lossy(&validation_result.stderr);
+        error!(
+            "netdog commit failed: network configuration validation failed: {}",
+            stderr
+        );
+        return error::NetworkConfigInvalidSnafu { stderr }.fail();
+    }
+
+    Ok(HttpResponse::NoContent().finish())
+}
+
 /// Gets the set of report types supported by this host.
 async fn list_reports() -> Result<ReportListResponse> {
     // Add each report to list response when adding a new handler
@@ -965,6 +1004,9 @@ impl ResponseError for error::Error {
             InvalidPrefix { .. } => StatusCode::BAD_REQUEST,
             DeserializeJson { .. } => StatusCode::BAD_REQUEST,
             InvalidKeyPair { .. } => StatusCode::BAD_REQUEST,
+            NetworkConfigContent { .. } => StatusCode::BAD_REQUEST,
+            NetworkConfigValidation { .. } => StatusCode::BAD_REQUEST,
+            NetworkConfigInvalid { .. } => StatusCode::BAD_REQUEST,
 
             // 404 Not Found
             MissingData { .. } => StatusCode::NOT_FOUND,

--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -722,6 +722,30 @@ paths:
         423:
           description: "Update write lock held. Try again in a moment"
 
+  /actions/network/configure:
+    post:
+      summary: "Configure network settings from net.toml content"
+      operationId: "configure_network"
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+            example: |
+              version = 2
+
+              [eth0]
+              dhcp4 = true
+              primary = true
+      responses:
+        204:
+          description: "Network configuration successfully written"
+        400:
+          description: "Invalid UTF-8 content or malformed configuration"
+        500:
+          description: "Server error writing configuration"
+
   /updates/status:
     get:
       summary: "Get update status"

--- a/sources/models/src/ephemeral_storage.rs
+++ b/sources/models/src/ephemeral_storage.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
 /// Supported filesystems for ephemeral storage
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum Filesystem {
     Xfs,
     Ext4,
@@ -19,7 +19,7 @@ impl Display for Filesystem {
 }
 
 /// Storage type preferences for ephemeral storage
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Preference {
     pub ephemeral_disk: bool,
     pub ebs_volume: bool,

--- a/sources/netdog/Cargo.toml
+++ b/sources/netdog/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_plain.workspace = true
 snafu.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 toml = { workspace = true, features = ["preserve_order"] }
 

--- a/sources/netdog/src/cli/commit.rs
+++ b/sources/netdog/src/cli/commit.rs
@@ -1,0 +1,72 @@
+use crate::cli::{error, Result};
+use argh::FromArgs;
+use snafu::ResultExt;
+use std::io::Read;
+use std::path::Path;
+use tempfile::NamedTempFile;
+
+/// Validate and commit network configuration from stdin
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "commit")]
+pub struct CommitArgs {}
+
+pub fn run(_args: CommitArgs) -> Result<()> {
+    let mut content = String::new();
+    std::io::stdin()
+        .read_to_string(&mut content)
+        .context(error::StdinReadSnafu)?;
+
+    crate::net_config::deserialize_config(&content).context(error::NetConfigStdinParseSnafu)?;
+
+    let config_dir = Path::new("/.bottlerocket");
+    let config_file = config_dir.join("net.toml");
+
+    if !config_dir.exists() {
+        return error::NetConfigDirMissingSnafu { path: config_dir }.fail();
+    }
+
+    let tempfile = NamedTempFile::new_in(config_dir).context(error::CreateTempFileSnafu {
+        path: config_dir.to_path_buf(),
+    })?;
+
+    std::fs::write(tempfile.path(), &content).context(error::WriteTempFileSnafu)?;
+
+    // Ensure configuration changes are atomic to prevent partial writes
+    tempfile
+        .persist(&config_file)
+        .context(error::PersistTempFileSnafu { path: config_file })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_commit_invalid_version() {
+        let invalid_config = "version = 99\n\n[eth0]\ndhcp4 = true";
+        let mut stdin = Cursor::new(invalid_config.as_bytes());
+
+        let mut content = String::new();
+        stdin.read_to_string(&mut content).unwrap();
+
+        let result = crate::net_config::deserialize_config(&content);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_commit_valid_config() {
+        let valid_config = "version = 3\n\n[enp0s16]\ndhcp4 = true\ndhcp6 = false\nprimary = true\n\n[enp0s17]\ndhcp4 = true\ndhcp6 = false";
+        let mut stdin = Cursor::new(valid_config.as_bytes());
+
+        let mut content = String::new();
+        stdin.read_to_string(&mut content).unwrap();
+
+        let result = crate::net_config::deserialize_config(&content);
+
+        assert!(result.is_ok());
+    }
+}

--- a/sources/netdog/src/cli/mod.rs
+++ b/sources/netdog/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod commit;
 pub(crate) mod generate_hostname;
 pub(crate) mod generate_net_config;
 pub(crate) mod node_ip;
@@ -10,6 +11,7 @@ use crate::{
     DEFAULT_NET_CONFIG_FILE, KERNEL_CMDLINE, PRIMARY_INTERFACE, PRIMARY_MAC_ADDRESS,
     PRIMARY_SYSCTL_CONF, SYSCTL_MARKER_FILE, SYSTEMD_SYSCTL, SYS_CLASS_NET, USR_NET_CONFIG_FILE,
 };
+pub(crate) use commit::CommitArgs;
 pub(crate) use generate_hostname::GenerateHostnameArgs;
 pub(crate) use generate_net_config::GenerateNetConfigArgs;
 pub(crate) use node_ip::NodeIpArgs;
@@ -318,6 +320,30 @@ mod error {
             target: PathBuf,
             link: PathBuf,
             source: io::Error,
+        },
+
+        #[snafu(display("Failed to read from stdin: {}", source))]
+        StdinRead { source: std::io::Error },
+
+        #[snafu(display("Failed to parse network config from stdin: {}", source))]
+        NetConfigStdinParse { source: net_config::Error },
+
+        #[snafu(display("Network config directory '{}' does not exist", path.display()))]
+        NetConfigDirMissing { path: PathBuf },
+
+        #[snafu(display("Failed to create temp file in '{}': {}", path.display(), source))]
+        CreateTempFile {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to write to temp file: {}", source))]
+        WriteTempFile { source: std::io::Error },
+
+        #[snafu(display("Failed to persist temp file to '{}': {}", path.display(), source))]
+        PersistTempFile {
+            path: PathBuf,
+            source: tempfile::PersistError,
         },
     }
 }

--- a/sources/netdog/src/main.rs
+++ b/sources/netdog/src/main.rs
@@ -70,6 +70,7 @@ struct Args {
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand)]
 enum SubCommand {
+    Commit(cli::CommitArgs),
     NodeIp(cli::NodeIpArgs),
     GenerateHostname(cli::GenerateHostnameArgs),
     GenerateNetConfig(cli::GenerateNetConfigArgs),
@@ -81,6 +82,7 @@ enum SubCommand {
 async fn run() -> cli::Result<()> {
     let args: Args = argh::from_env();
     match args.subcommand {
+        SubCommand::Commit(args) => cli::commit::run(args)?,
         SubCommand::NodeIp(_) => cli::node_ip::run()?,
         SubCommand::GenerateHostname(_) => cli::generate_hostname::run().await?,
         SubCommand::GenerateNetConfig(_) => cli::generate_net_config::run()?,

--- a/sources/netdog/src/net_config/mod.rs
+++ b/sources/netdog/src/net_config/mod.rs
@@ -103,7 +103,7 @@ where
 
 /// Deserialize the network config, using the version key to determine which config struct to
 /// deserialize into
-fn deserialize_config(config_str: &str) -> Result<Box<dyn Interfaces>> {
+pub fn deserialize_config(config_str: &str) -> Result<Box<dyn Interfaces>> {
     #[derive(Debug, Deserialize)]
     struct ConfigToml {
         version: u8,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/713

**Description of changes:**
Adds `apiclient network configure <URI>` command to configure network settings at runtime. The implementation includes:

  - API Server: `New /network/configure` POST endpoint that validates and writes net.toml content to `/.bottlerocket/net.toml`
  - API Client: New `network configure` subcommand supporting `file://` and `base64:` URI schemes
  - Input validation: UTF-8 validation, base64 decoding, and file access with proper error handling
  - Documentation: Updated README template and module documentation

**Testing done:**

**1. Tested the change via `bootstrap-commands` using `base64` scheme**
Started `metal-dev` with command
```bash
./tools/start-local-vm --variant metal-dev --arch $(uname -m) --inject-file net.toml --inject-file user-data.toml
```

My initial `net.toml` only has configurations for a single interface
```
version = 3

[enp0s16]
dhcp4 = true
primary = true
```

My `user-data.toml` uses `bootstrap-commands`
```
[settings.bootstrap-commands.setup-network-inline]
commands = [
  ["apiclient", "network", "configure", "base64:dmVyc2lvbiA9IDMKCltlbnAwczE2XQpkaGNwNCA9IHRydWUKZGhjcDYgPSBmYWxzZQpwcmltYXJ5ID0gdHJ1ZQoKW2VucDBzMTddCmRoY3A0ID0gdHJ1ZQpkaGNwNiA9IGZhbHNlCg=="],
  ["apiclient", "reboot"]
]
mode = "once"
essential = true
```
Where the base64 encoded net.toml is 
```bash
echo "dmVyc2lvbiA9IDMKCltlbnAwczE2XQpkaGNwNCA9IHRydWUKZGhjcDYgPSBmYWxzZQpwcmltYXJ5ID0gdHJ1ZQoKW2VucDBzMTddCmRoY3A0ID0gdHJ1ZQpkaGNwNiA9IGZhbHNlCg==" | 
base64 -d

version = 3

[enp0s16]
dhcp4 = true
dhcp6 = false
primary = true

[enp0s17]
dhcp4 = true
dhcp6 = false
```

Confirmed that the node automatically rebooted and the net.toml was written to the desired path /.bottlerocket/net.toml
```bash
bash-5.2# cat /.bottlerocket/net.toml 
version = 3

[enp0s16]
dhcp4 = true
dhcp6 = false
primary = true

[enp0s17]
dhcp4 = true
dhcp6 = false
```

And both interfaces were brought up
```bash
ip link show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: enp0s16: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff
3: enp0s17: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether 52:54:00:12:34:57 brd ff:ff:ff:ff:ff:ff
4: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default 
    link/ether 02:42:f1:1e:86:ce brd ff:ff:ff:ff:ff:ff
bash-5.2# cat /etc/systemd/network/10-enp0s16.network
```

**2. Tested the change via `bootstrap-container` using `file://` scheme**
Used similar setup as 1. with `metal-dev`. Only difference is the `user-data.toml`
```toml
[settings.bootstrap-containers.setup-network-file]
source = "public.ecr.aws/bottlerocket/bottlerocket-bootstrap:v0.2.8"
mode = "once"
user-data = "IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLWV1CgojIENoZWNrIHJlYm9vdCBtYXJrZXIgZmlyc3QgLSBza2lwIGlmIGFscmVhZHkgcHJvY2Vzc2VkCklOU1RBTkNFX1JFQk9PVEVEPS8uYm90dGxlcm9ja2V0L2Jvb3RzdHJhcC1jb250YWluZXJzL2N1cnJlbnQvcmVib290ZWQKaWYgWyAtZiAiJElOU1RBTkNFX1JFQk9PVEVEIiBdOyB0aGVuCiAgICBlY2hvICJDb25maWd1cmF0aW9uIGFscmVhZHkgcHJvY2Vzc2VkIgogICAgZXhpdCAwCmZpCgplY2hvICJTZXR0aW5nIHVwIG5ldHdvcmsgY29uZmlndXJhdGlvbiB2aWEgZmlsZTovLyBzY2hlbWUuLi4iCgojIENyZWF0ZSB0aGUgZXhhY3QgbmV0d29yayBjb25maWd1cmF0aW9uCmNhdCA+IC90bXAvbmV0d29yay1jb25maWcudG9tbCA8PCAnSU5ORVJFT0YnCnZlcnNpb24gPSAzCgpbZW5wMHMxNl0KZGhjcDQgPSB0cnVlCmRoY3A2ID0gZmFsc2UKcHJpbWFyeSA9IHRydWUKCltlbnAwczE3XQpkaGNwNCA9IHRydWUKZGhjcDYgPSBmYWxzZQpJTk5FUkVPRgoKZWNobyAiTmV0d29yayBjb25maWd1cmF0aW9uIGNyZWF0ZWQ6IgpjYXQgL3RtcC9uZXR3b3JrLWNvbmZpZy50b21sCgplY2hvICJBcHBseWluZyBuZXR3b3JrIGNvbmZpZ3VyYXRpb24gdXNpbmcgZmlsZTovLyBzY2hlbWUuLi4iCmFwaWNsaWVudCBuZXR3b3JrIGNvbmZpZ3VyZSBmaWxlOi8vL3RtcC9uZXR3b3JrLWNvbmZpZy50b21sCgplY2hvICJOZXR3b3JrIGNvbmZpZ3VyYXRpb24gYXBwbGllZCBzdWNjZXNzZnVsbHkiCgojIE1hcmsgYXMgcHJvY2Vzc2VkIHRvIHByZXZlbnQgcmVib290IGxvb3AKdG91Y2ggIiRJTlNUQU5DRV9SRUJPT1RFRCIKCmVjaG8gIlJlYm9vdGluZyB0byBhcHBseSBuZXR3b3JrIGNoYW5nZXMuLi4iCmFwaWNsaWVudCByZWJvb3QK"
```

Where the encoded user-data here is:
```bash
#!/usr/bin/env bash
set -eu

# Check reboot marker first - skip if already processed
INSTANCE_REBOOTED=/.bottlerocket/bootstrap-containers/current/rebooted
if [ -f "$INSTANCE_REBOOTED" ]; then
    echo "Configuration already processed"
    exit 0
fi

echo "Setting up network configuration via file:// scheme..."

# Create the exact network configuration
cat > /tmp/network-config.toml << 'INNEREOF'
version = 3

[enp0s16]
dhcp4 = true
dhcp6 = false
primary = true

[enp0s17]
dhcp4 = true
dhcp6 = false
INNEREOF

echo "Network configuration created:"
cat /tmp/network-config.toml

echo "Applying network configuration using file:// scheme..."
apiclient network configure file:///tmp/network-config.toml

echo "Network configuration applied successfully"

# Mark as processed to prevent reboot loop
touch "$INSTANCE_REBOOTED"

echo "Rebooting to apply network changes..."
apiclient reboot
```

With this approach a network-config.toml file was created within the container at `/tmp/network-config.toml` and we then used `apiclient network configure file:///tmp/network-config.toml` to configure the net.toml.

Note that for bootstrap-containers, a **marker file** is needed to prevent reboot loop. The reboot happens during the execution of the bootstrap script so the subsequent process that turns the `once` mode to `off` will never happen. 

`systemd-inhibit` [command](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/packages/os/bootstrap-commands.service#L12) we used for bootstrap-commands is something we can look into which could be a way to avoid the usage of marker file. 

@KCSesh - Contribution: 

**1. Re-Rean the `bootstrap-commands` using `base64` scheme**

**2. Re-ran: Tested the change via `bootstrap-container` using `file://` scheme**
Note: Running this test multiple times required: `--force-extract`, to clean PRIVATE partition marker file

**3. Validated STDIN**

```
apiclient network configure <<EOF
version = 2
[eth0]
dhcp4 = true
primary = true
EOF
```

**4. Tested invalid input**
<details>

Invalid Version:
```
bash-5.2# journalctl -u bootstrap-commands
Nov 11 23:35:45 localhost systemd[1]: Starting Bootstrap Commands...
Nov 11 23:35:46 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1351]: 23:35:46 [INFO] Processing bootstrap command 'setup-network-invalid-version' ...
Nov 11 23:35:46 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1351]: 23:35:46 [WARN] Bootstrap command failed to execute 'apiclient' failed - stderr: Failed to configure network: Failed to POST network configuration to '/actions/network/configure': Status 400 when POSTing /actions/network/configure: Invalid network configuration: Failed to parse network config from stdin: Invalid network configuration: Unknown network config version: 99
Nov 11 23:35:46 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1351]: Bootstrap command 'setup-network-invalid-version' failed.
Nov 11 23:35:46 ip-10-0-2-15.us-west-2.compute.internal systemd-inhibit[1345]: /usr/bin/bootstrap-commands failed with exit status 1.
Nov 11 23:35:46 ip-10-0-2-15.us-west-2.compute.internal systemd[1]: bootstrap-commands.service: Main process exited, code=exited, status=1/FAILURE
Nov 11 23:35:46 ip-10-0-2-15.us-west-2.compute.internal systemd[1]: bootstrap-commands.service: Failed with result 'exit-code'.
Nov 11 23:35:46 ip-10-0-2-15.us-west-2.compute.internal systemd[1]: Failed to start Bootstrap Commands.

bash-5.2# journalctl -u apiserver
...
Nov 11 23:35:46 ip-10-0-2-15.us-west-2.compute.internal apiserver[1251]: 23:35:46 [INFO] Invoking netdog commit to validate and write network configuration
Nov 11 23:35:46 ip-10-0-2-15.us-west-2.compute.internal apiserver[1251]: 23:35:46 [ERROR] Netdog commit failed: Network configuration validation failed: Failed to parse network config from stdin: Invalid network configuration: Unknown network config version: 99

```

Unknown field: 

```
bash-5.2# journalctl -u bootstrap-commands
Nov 11 23:37:54 localhost systemd[1]: Starting Bootstrap Commands...
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1336]: 23:37:54 [INFO] Processing bootstrap command 'setup-network-unknown-field' ...
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1336]: 23:37:54 [WARN] Bootstrap command failed to execute 'apiclient' failed - stderr: Failed to configure network: Failed to POST network configuration to '/actions/network/configure': Status 400 when POSTing /actions/network/configure: Invalid network configuration: Failed to parse network config from stdin: Failed to parse network config: TOML parse error at line 2, column 7
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1336]:   |
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1336]: 2 | hello=hi
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1336]:   |       ^
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1336]: invalid string
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1336]: expected `"`, `'`
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal bootstrap-commands[1336]: Bootstrap command 'setup-network-unknown-field' failed.
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal systemd-inhibit[1330]: /usr/bin/bootstrap-commands failed with exit status 1.
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal systemd[1]: bootstrap-commands.service: Main process exited, code=exited, status=1/FAILURE
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal systemd[1]: bootstrap-commands.service: Failed with result 'exit-code'.
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal systemd[1]: Failed to start Bootstrap Commands.

bash-5.2# journalctl -u apiserver
...
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal apiserver[1238]: 23:37:54 [INFO] Invoking netdog commit to validate and write network configuration
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal apiserver[1238]: 23:37:54 [ERROR] Netdog commit failed: Network configuration validation failed: Failed to parse network config from stdin: Failed to parse network config: TOML parse error at line 2, column 7
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal apiserver[1238]:   |
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal apiserver[1238]: 2 | hello=hi
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal apiserver[1238]:   |       ^
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal apiserver[1238]: invalid string
Nov 11 23:37:54 ip-10-0-2-15.us-west-2.compute.internal apiserver[1238]: expected `"`, `'`
bash-5.2#

```

Invalid stdin:

```
# Starting point: 
bash-5.2# cat /.bottlerocket/net.toml
version = 3

[enp0s16]
dhcp4 = true
dhcp6 = false
primary = true

[enp0s17]
dhcp4 = true
dhcp6 = false

# Apply incorrect net.toml:
bash-5.2# apiclient network configure <<EOF
version = 3

[enp0s17]
dhcp5 = true
dhcp6 = false
EOF

[  191.895006] apiserver[1238]: 16:06:56 [ERROR] netdog commit failed: network configuration validation failed: Failed to parse network config from stdin: Failed to parse network config: data did not match any variant of untagged enum NetworkDeviceV1
Failed to configure network: Failed to POST network configuration to '/actions/network/configure': Status 400 when POSTing /actions/network/configure: Invalid network configuration: Failed to parse network config from stdin: Failed to parse network config: data did not match any variant of untagged enum NetworkDeviceV1

# No change to file: 
bash-5.2# cat /.bottlerocket/net.toml
version = 3

[enp0s16]
dhcp4 = true
dhcp6 = false
primary = true

[enp0s17]
dhcp4 = true
dhcp6 = false
bash-5.2#
```

</details>



**5. Verified new tmp approach, with admin-container and inotify on metal:**
```
[root@admin]# apiclient network configure <<EOF
> version = 3
> [enp0s16]
> dhcp4 = true
> dhcp6 = false
> primary = true
> EOF
IN_CREATE: /.bottlerocket/rootfs/.bottlerocket/.tmpZkeAI5
IN_OPEN: /.bottlerocket/rootfs/.bottlerocket/.tmpZkeAI5
IN_MODIFY: /.bottlerocket/rootfs/.bottlerocket/.tmpZkeAI5
IN_OPEN: /.bottlerocket/rootfs/.bottlerocket/.tmpZkeAI5
IN_MODIFY: /.bottlerocket/rootfs/.bottlerocket/.tmpZkeAI5
IN_CLOSE_WRITE: /.bottlerocket/rootfs/.bottlerocket/.tmpZkeAI5
IN_MOVED_FROM: /.bottlerocket/rootfs/.bottlerocket/.tmpZkeAI5
IN_MOVED_TO: /.bottlerocket/rootfs/.bottlerocket/net.toml
IN_CLOSE_WRITE: /.bottlerocket/rootfs/.bottlerocket/net.toml
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
