### PR TITLE
Third party package updates

### DIFF
--- a/packages/aws-otel-collector/Cargo.toml
+++ b/packages/aws-otel-collector/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws-observability/aws-otel-collector/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.43.3/aws-otel-collector-v0.43.3.tar.gz"
-sha512 = "5d9b8dd569c3130604b23ed9fc2fc38cce5d45a19167e62d6d0e55b97481a328ece9710a1b7a7fd5a6aa8251e60dfc9f580d974d7249c85d132d882798a9af23"
+url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.45.1/aws-otel-collector-v0.45.1.tar.gz"
+sha512 = "12cd5bab6c30c1a4e17e3379dbc360b4c021cafa7d168d4acdbb45bdae0121508f495baeef0518902437c791e01ebb1e8dcab59ca7ec423c5a9120a2f456db98"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/aws-otel-collector/aws-otel-collector.spec
+++ b/packages/aws-otel-collector/aws-otel-collector.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}aws-otel-collector
-Version: 0.43.3
+Version: 0.45.1
 Release: 1%{?dist}
 Epoch: 1
 Summary: AWS Distro for OpenTelemetry Collector
@@ -47,8 +47,6 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %build
 
 %set_cross_go_flags
-export GO_MAJOR="1.24"
-
 go build -ldflags "${GOLDFLAGS}" -o aws-otel-collector ./cmd/awscollector
 gofips build -ldflags "${GOLDFLAGS}" -o fips/aws-otel-collector ./cmd/awscollector
 

--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.7.0/rolesanywhere-credential-helper-v1.7.0.tar.gz"
-sha512 = "31ca36cb156a7d02c18d4e277a83b22b6aba0bae8e043c9f58e82f00d9f5a9507788bde26bda8d19a8cfd3399e2d9c26f99f281e33b711bfdf8ca9afb4d048e5"
+url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.7.1/rolesanywhere-credential-helper-v1.7.1.tar.gz"
+sha512 = "fdbb6cc9a0ec15522edf0ad0c68291de5f6661f371a2bca6fd040d087bda018e9643229235fc59396e0a72229e4ce348f4d24872b63c1a6dde01d1907301c08d"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo rolesanywhere-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.7.0
+%global gover 1.7.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.30/Cargo.toml
+++ b/packages/ecr-credential-provider-1.30/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.30"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.30.8"
-path = "cloud-provider-aws-1.30.8.tar.gz"
-sha512 = "a81e0ec5980e7d3a86f95b82667de8e68b7a1281f44e41b7fe8675f134737cdf184b93788407a0c1ff91ee79985d818be869308218a7d15d53af220aa3973bce"
+url = "https://codeload.github.com/kubernetes/cloud-provider-aws/tar.gz/v1.30.9"
+path = "cloud-provider-aws-1.30.9.tar.gz"
+sha512 = "6c7fc505c2e30dcc1e6b7dcc0e49ba730b2180fe25f84724a29cccee881206b7be0429142c87d80e5c3be28f98b1b94224b0a0ad5a6b7ad4aa745b67fba59c71"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
+++ b/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.30.8
+%global gover 1.30.9
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.31/Cargo.toml
+++ b/packages/ecr-credential-provider-1.31/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.31"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.31.7.tar.gz"
-path = "cloud-provider-aws-1.31.7.tar.gz"
-sha512 = "b1b254a82a6b10cd8f6d912495415d3758bbb46ce3ff690bd052d4798ebdee0a13d65ac9b1c60997f943c0166fae0230f9be566b3ab0a3cd8f4473e7e828e075"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.31.8.tar.gz"
+path = "cloud-provider-aws-1.31.8.tar.gz"
+sha512 = "ae038089d45cc602fdfdd0a2a8bf80c9500273947215985a3522c81b0669298a7142a2381975bb9d0149dcd96a79b4b2d8b0767919e6872a1ebe5785f2fa4943"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
+++ b/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.31.7
+%global gover 1.31.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.32/Cargo.toml
+++ b/packages/ecr-credential-provider-1.32/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.32"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.32.4.tar.gz"
-path = "cloud-provider-aws-1.32.4.tar.gz"
-sha512 = "87c2638858d6d0c5e0f2d7741fcdf180bb9dff1535cce0354de20c4f5fffb41c7e8114b3ad2ac44c59f7171348b0c808c7db6c8707d15f929d8617b571df233b"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.32.5.tar.gz"
+path = "cloud-provider-aws-1.32.5.tar.gz"
+sha512 = "2f40bbdf596646451a5415a3b6f53a04f7ed788a7f129434c0b7c7c730f30468a3addd22566382f9e7645051737038634b032ac57947ab15b462a7b8bf3c6eec"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
+++ b/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.32.4
+%global gover 1.32.5
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.33/Cargo.toml
+++ b/packages/ecr-credential-provider-1.33/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.33"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.33.1.tar.gz"
-path = "cloud-provider-aws-1.33.1.tar.gz"
-sha512 = "80a4a224ed3131266303df4d6e7bf31d705e82f505cbb607717cec631504e69eba3d78bf92b84709c4812413732478c0bfc3d4db1566dd521aec2679c4ea6762"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.33.2.tar.gz"
+path = "cloud-provider-aws-1.33.2.tar.gz"
+sha512 = "45741eb57c9d4be0e7eb55a33f18fa948f6347f302e47e331be1bda2823275514fe8c5310df7be2125b1fce3af31fd9ff391be5ff5f48c4ccc5613a9a1ffc52d"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
+++ b/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.33.1
+%global gover 1.33.2
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.34/Cargo.toml
+++ b/packages/ecr-credential-provider-1.34/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.34"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.34.0.tar.gz"
-path = "cloud-provider-aws-1.34.0.tar.gz"
-sha512 = "2bdef11bc7180496b04d95f883961693a0e70cc4d8a284d6f5e5bc3c9b7cd5556a4383afee35dd4f70e982ec32406dc9d6adc838c9c1115086a5fa37d053650f"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.34.1.tar.gz"
+path = "cloud-provider-aws-1.34.1.tar.gz"
+sha512 = "92823dcf4ede0a946ffefa1734f23d38613dff6ea6d9f16c4166abf91bb0247a8a41cb9b51568d829caf62bb6382a1865161899b80827ff2924ea1723d76a4a1"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.34/ecr-credential-provider-1.34.spec
+++ b/packages/ecr-credential-provider-1.34/ecr-credential-provider-1.34.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.34.0
+%global gover 1.34.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.28/Cargo.toml
+++ b/packages/kubernetes-1.28/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.28"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/59/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
-sha512 = "54383bacab3f6947cfa32706a2da9bda4e7a38260e89501a3697df472dbad22d7948d3b3dba36bb106cd523b95869d1ea257b27bc052ec7e41d803d316a43667"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-28/releases/64/artifacts/kubernetes/v1.28.15/kubernetes-src.tar.gz"
+sha512 = "dfbb0210033b5228e71abafe89474c698ba55586639020a7659cf490c06862d048af7f81107bbcd986f1c8623af70dab35356ba07b33dbc3a102852615f955e5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.28/kubernetes-1.28.spec
+++ b/packages/kubernetes-1.28/kubernetes-1.28.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 59
+%global releasever 64
 %global gover 1.28.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/48/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
-sha512 = "70cf62549dde1ab659de0e4db9bdc8afa31dac617dc77e5a690ab6954d5b28c8584d71c7ef52f505fb185cb191bd4244d53e9f0e777df96ea74cdc80e349f903"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/53/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
+sha512 = "0811619778ba56b44de5fe8bc1c52b7c0aa8c27bc1a64c734279831d82399145f5effe6c5b725dc94fe121aca22d96d8697d145fda063cd3a07b6e1dae5dfc34"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 48
+%global releasever 53
 %global gover 1.29.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/41/artifacts/kubernetes/v1.30.14/kubernetes-src.tar.gz"
-sha512 = "47cd609d72fca8e159e3ffbe4c2e4bf97c75c87ec9dffb946f06fcf5f61a064b97fdbcc2e07982ea265df8477139cc688e69e1496c0d4aa346f12486cfc8e0b5"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/46/artifacts/kubernetes/v1.30.14/kubernetes-src.tar.gz"
+sha512 = "fa908d1814934290b20dc9bfcb6d991cbc406859861aa3faaac80238666bcb7093971d36e45ba055f14fdca8958366e046f9e7fd2dfb52cf525d30c3ba80fcfc"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 41
+%global releasever 46
 %global gover 1.30.14
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/30/artifacts/kubernetes/v1.31.12/kubernetes-src.tar.gz"
-sha512 = "bd6da70922dd4d199b67a5ab2a18d3f523d62a24471925af21c15aeadd45c0d9010d649f7608343bdf69221637c1e7173c1141251e3a087fc28908ff99dba6d5"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/35/artifacts/kubernetes/v1.31.13/kubernetes-src.tar.gz"
+sha512 = "47efaeb019c807842bd7510529040b8f2de2aff4cc6cbef61624fc3f839ae51e30b994908a14ca5c292bd76ef3a98c326792490a1c1f26fc7d6f1daa8e3307d9"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 30
-%global gover 1.31.12
+%global releasever 35
+%global gover 1.31.13
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.32/Cargo.toml
+++ b/packages/kubernetes-1.32/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.32"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/23/artifacts/kubernetes/v1.32.8/kubernetes-src.tar.gz"
-sha512 = "ffb335f89cddca9504242e200dc65ba00f1bb189e68da6f5756479d65fa3a5c2525142434035b141477e90384f202d519b375ac2001fbcd7ff28bbd1cb36d4ba"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/28/artifacts/kubernetes/v1.32.9/kubernetes-src.tar.gz"
+sha512 = "628fee8bcad1d8e5c0c1e9ad31486c438a2d8dd13aea94c8706ddcd79ebed9229c2ce97c9e399aa5b4a7551e1d9e901f3bd3168110dadb381986448dc82237f0"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 23
-%global gover 1.32.8
+%global releasever 28
+%global gover 1.32.9
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.33/Cargo.toml
+++ b/packages/kubernetes-1.33/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.33"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/13/artifacts/kubernetes/v1.33.4/kubernetes-src.tar.gz"
-sha512 = "8989a7b86d0d6fb11dca662f98b0610d230e3941f26a51a07c8fd00692d7b9d7c2c5c238482a6a96e3c0f413d3c829d0b1d7168316b25e8141fd9baec4f5b00e"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/18/artifacts/kubernetes/v1.33.5/kubernetes-src.tar.gz"
+sha512 = "aa37480cdba5026631750000ad4f9b4f2667abe009148b81e3d622ae56cb7b9daecbb8b03f0e03d3c68f507219a44e8436ddc54b2591dd07e0eaf3b61ca400d6"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 13
-%global gover 1.33.4
+%global releasever 18
+%global gover 1.33.5
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.34/Cargo.toml
+++ b/packages/kubernetes-1.34/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.34"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/4/artifacts/kubernetes/v1.34.0/kubernetes-src.tar.gz"
-sha512 = "835d2fcd347cc0723059f28f5ae53468fb3d9826c286d29fe915ea55afd103eb3340ab138e9f15333169b359dfdb05d502b28786735598c9a8ae3e648fe1cfb4"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/9/artifacts/kubernetes/v1.34.1/kubernetes-src.tar.gz"
+sha512 = "e817c51c212e6a2d21ea04d2cba43be06e884bd0928364a00b31a3f9d053c5f42e9e3ba1e61d0fde66fc6736f53e1dc2c62316d1f67431e78eb6e88827fd54ea"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.34/kubernetes-1.34.spec
+++ b/packages/kubernetes-1.34/kubernetes-1.34.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 4
-%global gover 1.34.0
+%global releasever 9
+%global gover 1.34.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
**Description of changes:**
ecr-credential-provider
* update ecr-credential-provider to v1.30.9
* update ecr-credential-provider to v1.31.8
* update ecr-credential-provider to v1.32.5
* update ecr-credential-provider to v1.33.2
* update ecr-credential-provider to v1.34.1

kubelet
* update kubernetes-1.28
* update kubernetes-1.29
* update kubernetes-1.30
* update kubernetes-1.31 to v1.31.13
* update kubernetes-1.32 to v1.32.9
* update kubernetes-1.33 to v1.33.5
* update kubernetes-1.34 to v1.34.1

Others
* update aws-otel-collector to v0.45.1
* update aws-signing-helper to v1.7.1

**Testing done:**
1. bottlerocket-core-kit builds and Instances bootup
2. Conformance tests passed for both arches - k8s-1.28-1.34
3. nvidia-smoke-test passed for both arches
4. ecr-credential-provider test as described here - https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/531


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
