### PR TITLE
add rottweiler to manage storage encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "rdma-core",
  "readline",
  "release",
+ "rottweiler",
  "runc",
  "selinux-policy",
  "socat",
@@ -986,6 +987,13 @@ dependencies = [
 [[package]]
 name = "release"
 version = "0.0.0"
+
+[[package]]
+name = "rottweiler"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
 
 [[package]]
 name = "runc"

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -121,6 +121,7 @@ procps = { path = "../../packages/procps" }
 rdma-core = { path = "../../packages/rdma-core" }
 readline = { path = "../../packages/readline" }
 release = { path = "../../packages/release" }
+rottweiler = { path = "../../packages/rottweiler" }
 runc = { path = "../../packages/runc" }
 selinux-policy = { path = "../../packages/selinux-policy" }
 socat = { path = "../../packages/socat" }

--- a/packages/rottweiler/Cargo.toml
+++ b/packages/rottweiler/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rottweiler"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+source-groups = [
+    "rottweiler",
+    "generate-readme",
+]
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/rottweiler/rottweiler.spec
+++ b/packages/rottweiler/rottweiler.spec
@@ -1,0 +1,34 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+Name: %{_cross_os}rottweiler
+Version: 0.1.0
+Release: 1%{?dist}
+Summary: Bottlerocket storage encryption helper
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+
+BuildRequires: %{_cross_os}glibc-devel
+Requires: %{_cross_os}cryptsetup
+Requires: %{_cross_os}systemd-cryptsetup
+Requires: %{_cross_os}tpm2-tools
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p rottweiler
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+install -p -m 0755 %{__cargo_outdir}/rottweiler %{buildroot}%{_cross_bindir}
+ln -s rottweiler %{buildroot}%{_cross_bindir}/rw
+
+%files
+%{_cross_bindir}/rottweiler
+%{_cross_bindir}/rw

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -46,6 +46,7 @@
 (filecon "/.*/usr/bin/apiserver" file api_exec)
 (filecon "/.*/usr/bin/early-boot-config" file api_exec)
 (filecon "/.*/usr(/fips)?/bin/migrator" file api_exec)
+(filecon "/.*/usr/bin/rottweiler" file api_exec)
 (filecon "/.*/usr/bin/storewolf" file api_exec)
 (filecon "/.*/usr(/fips)?/bin/cfsignal" file api_exec)
 (filecon "/.*/usr/bin/thar-be-settings" file api_exec)

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1352,6 +1352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bottlerocket-image-features"
+version = "0.1.0"
+dependencies = [
+ "envy",
+ "generate-readme",
+ "serde",
+ "snafu",
+]
+
+[[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
 source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.16.0#eed641b1a6ad238ef0782c7bfb8caa153dd1c5be"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2879,6 +2879,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4576,6 +4585,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rottweiler"
+version = "0.1.0"
+dependencies = [
+ "argh",
+ "bottlerocket-image-features",
+ "envy",
+ "generate-readme",
+ "hex",
+ "hkdf",
+ "nix 0.26.4",
+ "serde",
+ "sha2",
+ "snafu",
+ "walkdir",
+ "zeroize",
 ]
 
 [[package]]
@@ -7170,6 +7197,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "zerotrie"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -71,6 +71,8 @@ members = [
 
     "retry-read",
 
+    "rottweiler",
+
     "updater/block-party",
     "updater/signpost",
     "updater/update_metadata",
@@ -147,7 +149,9 @@ gptman = { version = "1", default-features = false }
 handlebars = "4"
 h2 = "0.4"
 headers = "0.4"
+hex = "0.4"
 hex-literal = "0.4"
+hkdf = { version = "0.12", default-features = false }
 http = "0.2"
 httparse = "1"
 httptest = "0.15"
@@ -189,6 +193,7 @@ serde_json = "1"
 serde_plain = "1"
 serde_yaml = "0.9"
 serde_repr = "0.1"
+sha2 = "0.10"
 shell-words = "1"
 shlex = "1"
 signal-hook = "0.3"
@@ -212,6 +217,7 @@ url = "2"
 walkdir = "2.5"
 which = "4"
 zbus = { version = "5.11", default-features = false }
+zeroize = { version = "1", default-features = false }
 zvariant = "5.7"
 x509-parser = "0.16"
 base64 = "0.22"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -26,6 +26,8 @@ members = [
 
     "bootstrap-commands",
 
+    "bottlerocket-image-features",
+
     "bottlerocket-release",
 
     "brush",
@@ -85,6 +87,7 @@ members = [
 apiclient = { version = "0.1", path = "api/apiclient", default-features = false }
 aws-smithy-experimental = { version = "0.1", path = "aws-smithy-experimental" }
 block-party = { version = "0.1", path = "updater/block-party" }
+bottlerocket-image-features = { version = "0.1", path = "bottlerocket-image-features" }
 bottlerocket-release = { version = "0.1", path = "bottlerocket-release" }
 constants = { version = "0.1", path = "constants" }
 datastore = { version = "0.1", path = "api/datastore" }

--- a/sources/bottlerocket-image-features/Cargo.toml
+++ b/sources/bottlerocket-image-features/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bottlerocket-image-features"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[dependencies]
+envy.workspace = true
+serde = { workspace = true, features = ["derive"] }
+snafu.workspace = true
+
+[build-dependencies]
+generate-readme.workspace = true

--- a/sources/bottlerocket-image-features/README.md
+++ b/sources/bottlerocket-image-features/README.md
@@ -1,0 +1,49 @@
+# bottlerocket-image-features
+
+Current version: 0.1.0
+
+## Introduction
+
+*bottlerocket-image-features* is a library for parsing Bottlerocket image feature flags
+from the system configuration file.
+
+### Overview
+
+This crate provides functionality to read and parse the `/usr/share/bottlerocket/image-features.env`
+file, which contains feature flags that control various aspects of the Bottlerocket system.
+
+### Features
+
+Currently supported feature flags:
+
+- `IN_PLACE_UPDATES` - Controls whether in-place updates are enabled (default: true)
+- `ENCRYPTED_STORAGE` - Controls whether encrypted storage is enabled (default: false)
+
+### Usage
+
+```rust
+use bottlerocket_image_features::parse_image_features;
+
+let features = parse_image_features()?;
+if features.in_place_updates {
+    println!("In-place updates are enabled");
+}
+```
+
+### File Format
+
+The image features file uses a simple key=value format with support for:
+- Comments (lines starting with `#`)
+- Empty lines (ignored)
+- Quoted or unquoted values
+- Boolean values ("true" or "false")
+
+Example:
+```
+# Image feature configuration
+IN_PLACE_UPDATES="true"
+```
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/sources/bottlerocket-image-features/README.tpl
+++ b/sources/bottlerocket-image-features/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/lib.rs`.

--- a/sources/bottlerocket-image-features/build.rs
+++ b/sources/bottlerocket-image-features/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    generate_readme::from_lib().unwrap();
+}

--- a/sources/bottlerocket-image-features/src/lib.rs
+++ b/sources/bottlerocket-image-features/src/lib.rs
@@ -1,0 +1,152 @@
+/*!
+# Introduction
+
+*bottlerocket-image-features* is a library for parsing Bottlerocket image feature flags
+from the system configuration file.
+
+## Overview
+
+This crate provides functionality to read and parse the `/usr/share/bottlerocket/image-features.env`
+file, which contains feature flags that control various aspects of the Bottlerocket system.
+
+## Features
+
+Currently supported feature flags:
+
+- `IN_PLACE_UPDATES` - Controls whether in-place updates are enabled (default: true)
+- `ENCRYPTED_STORAGE` - Controls whether encrypted storage is enabled (default: false)
+
+## Usage
+
+```rust,ignore
+use bottlerocket_image_features::parse_image_features;
+
+let features = parse_image_features()?;
+if features.in_place_updates {
+    println!("In-place updates are enabled");
+}
+```
+
+## File Format
+
+The image features file uses a simple key=value format with support for:
+- Comments (lines starting with `#`)
+- Empty lines (ignored)
+- Quoted or unquoted values
+- Boolean values ("true" or "false")
+
+Example:
+```text
+# Image feature configuration
+IN_PLACE_UPDATES="true"
+```
+*/
+
+use serde::Deserialize;
+use snafu::prelude::*;
+use std::fs;
+
+type Result<T> = std::result::Result<T, snafu::Whatever>;
+
+const IMAGE_FEATURES_FILE: &str = "/usr/share/bottlerocket/image-features.env";
+
+#[derive(Deserialize)]
+pub struct ImageFeatures {
+    #[serde(default = "default_true")]
+    pub in_place_updates: bool,
+    #[serde(default)]
+    pub encrypted_storage: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Parse image features from the env file
+pub fn parse_image_features() -> Result<ImageFeatures> {
+    if !std::path::Path::new(IMAGE_FEATURES_FILE).exists() {
+        return Ok(ImageFeatures {
+            in_place_updates: true,
+            encrypted_storage: false,
+        });
+    }
+
+    let content = fs::read_to_string(IMAGE_FEATURES_FILE)
+        .with_whatever_context(|_| format!("failed to read {}", IMAGE_FEATURES_FILE))?;
+
+    parse_image_features_from_str(&content)
+}
+
+/// Parse image features from a string (useful for testing)
+pub fn parse_image_features_from_str(content: &str) -> Result<ImageFeatures> {
+    let pairs: Vec<(String, String)> = content
+        .lines()
+        .filter_map(|line| {
+            if line.starts_with('#') || line.trim().is_empty() {
+                return None;
+            }
+            let mut parts = line.splitn(2, '=');
+            let key = parts.next()?;
+            let mut value = parts.next()?;
+            if value.starts_with('"') {
+                value = &value[1..];
+            }
+            if value.ends_with('"') {
+                value = &value[..value.len() - 1];
+            }
+            Some((key.to_owned(), value.to_owned()))
+        })
+        .collect();
+
+    envy::from_iter(pairs).with_whatever_context(|_| "failed to parse image features")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_env_line_with_quotes() {
+        let content = r#"IN_PLACE_UPDATES="false""#;
+        let features = parse_image_features_from_str(content).unwrap();
+        assert_eq!(features.in_place_updates, false);
+    }
+
+    #[test]
+    fn test_parse_env_line_without_quotes() {
+        let content = "IN_PLACE_UPDATES=false";
+        let features = parse_image_features_from_str(content).unwrap();
+        assert_eq!(features.in_place_updates, false);
+    }
+
+    #[test]
+    fn test_parse_env_ignores_comments() {
+        let content = r#"# This is a comment
+IN_PLACE_UPDATES="true"
+# Another comment"#;
+        let features = parse_image_features_from_str(content).unwrap();
+        assert_eq!(features.in_place_updates, true);
+    }
+
+    #[test]
+    fn test_parse_env_ignores_empty_lines() {
+        let content = r#"
+IN_PLACE_UPDATES="false"
+
+"#;
+        let features = parse_image_features_from_str(content).unwrap();
+        assert_eq!(features.in_place_updates, false);
+    }
+
+    #[test]
+    fn test_default_true() {
+        assert_eq!(default_true(), true);
+    }
+
+    #[test]
+    fn test_default_when_missing() {
+        let content = "";
+        let features = parse_image_features_from_str(content).unwrap();
+        assert_eq!(features.in_place_updates, true);
+    }
+}

--- a/sources/rottweiler/Cargo.toml
+++ b/sources/rottweiler/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rottweiler"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[dependencies]
+argh.workspace = true
+bottlerocket-image-features.workspace = true
+envy.workspace = true
+hex.workspace = true
+hkdf = { workspace = true, features = ["std"] }
+nix = { workspace = true, features = ["fs", "ioctl", "mount"] }
+serde = { workspace = true, features = ["derive"] }
+sha2.workspace = true
+snafu.workspace = true
+walkdir.workspace = true
+zeroize = { workspace = true, features = ["alloc", "derive"] }
+
+[build-dependencies]
+generate-readme.workspace = true

--- a/sources/rottweiler/README.md
+++ b/sources/rottweiler/README.md
@@ -1,0 +1,46 @@
+# rottweiler
+
+Current version: 0.1.0
+
+## Introduction
+
+*rottweiler* is Bottlerocket's storage encryption helper. It provides a unified
+interface for encrypting and managing encrypted storage resources including:
+
+- Block devices (using LUKS)
+- Directories (using fscrypt)
+- TPM PCR measurements
+
+### Commands
+
+#### Key Management
+- `generate-key <key-id>` - Generate an encryption key
+
+#### Block Device Operations
+- `encrypt block-device <path> <key-id>` - Encrypt a block device using LUKS
+- `attach block-device <path> <key-id>` - Attach an encrypted block device
+- `detach block-device <path>` - Detach an encrypted block device
+- `resize block-device <path> <key-id>` - Resize a LUKS block device
+- `check block-device <path> encrypted|unencrypted` - Check block device encryption state
+
+#### Directory Operations
+- `encrypt directory <path> <key-id>` - Encrypt a directory using fscrypt
+- `lock directory <path>` - Lock an encrypted directory (remove key)
+- `unlock directory <path> <key-id>` - Unlock an encrypted directory (add key)
+- `check directory <path> encrypted|unencrypted` - Check directory encryption state
+
+#### TPM Measurement Operations
+- `measure settings` - Measure OS settings into PCR 8
+- `measure kernel-command-line` - Measure kernel command line into PCR 9
+- `measure pcrphase <phase>` - Measure boot phase into PCR 11
+  - Valid phases: `sysinit`, `preconfigured`, `configured`, `ready`, `shutdown`, `final`
+
+### Aliases
+
+For convenience, the following aliases are supported:
+- `dir` can be used instead of `directory`
+- `bdev` can be used instead of `block-device`
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/rottweiler/README.tpl
+++ b/sources/rottweiler/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/rottweiler/build.rs
+++ b/sources/rottweiler/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    generate_readme::from_main().unwrap();
+}

--- a/sources/rottweiler/src/block_device.rs
+++ b/sources/rottweiler/src/block_device.rs
@@ -1,0 +1,77 @@
+use snafu::prelude::*;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use crate::{key, system};
+
+type Result<T> = std::result::Result<T, snafu::Whatever>;
+
+/// Encrypt a block device with LUKS2 using the specified key
+pub fn encrypt(path: PathBuf, key_id: String) -> Result<()> {
+    let device = path
+        .to_str()
+        .with_whatever_context(|| format!("path is not valid UTF-8: '{}'", path.display()))?;
+
+    let key_bytes = key::load(key_id)?;
+
+    system::cryptsetup_luks_format(device, &key_bytes)
+}
+
+/// Attach (unlock) an encrypted block device, creating a device mapper entry
+pub fn attach(path: PathBuf, key_id: String) -> Result<()> {
+    let volume_name = filename(&path)?;
+
+    let source_device = path
+        .to_str()
+        .with_whatever_context(|| format!("path is not valid UTF-8: '{}'", path.display()))?;
+
+    let key_bytes = key::load(key_id)?;
+
+    system::systemd_cryptsetup_attach(volume_name, source_device, &key_bytes)
+}
+
+/// Detach (lock) an encrypted block device, removing the device mapper entry
+pub fn detach(path: PathBuf) -> Result<()> {
+    let volume_name = filename(&path)?;
+
+    system::systemd_cryptsetup_detach(volume_name)
+}
+
+/// Resize a LUKS2 encrypted block device to match the underlying device size
+pub fn resize(path: PathBuf, key_id: String) -> Result<()> {
+    let volume_name = filename(&path)?;
+
+    let key_bytes = key::load(key_id)?;
+
+    system::cryptsetup_resize(volume_name, &key_bytes)
+}
+
+const LUKS2_MAGIC: &[u8; 6] = b"LUKS\xba\xbe";
+const LUKS2_VERSION: u16 = 2;
+
+/// Check if a block device is LUKS2 encrypted by reading its header
+pub fn is_encrypted(path: PathBuf) -> Result<bool> {
+    let mut file = std::fs::File::open(&path)
+        .with_whatever_context(|_| format!("failed to open '{}'", path.display()))?;
+
+    let mut header = [0u8; 8];
+    file.read_exact(&mut header)
+        .with_whatever_context(|_| format!("failed to read header from '{}'", path.display()))?;
+
+    if &header[..6] == LUKS2_MAGIC {
+        let version = u16::from_be_bytes([header[6], header[7]]);
+        if version == LUKS2_VERSION {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+/// Extract filename from path as UTF-8 string
+fn filename(path: &Path) -> Result<&str> {
+    path.file_name()
+        .with_whatever_context(|| format!("failed to extract filename from '{}'", path.display()))?
+        .to_str()
+        .with_whatever_context(|| format!("filename is not valid UTF-8: '{}'", path.display()))
+}

--- a/sources/rottweiler/src/directory.rs
+++ b/sources/rottweiler/src/directory.rs
@@ -1,0 +1,62 @@
+use snafu::{Whatever, prelude::*};
+use std::path::PathBuf;
+
+use crate::fscrypt::*;
+use crate::key;
+
+type Result<T> = std::result::Result<T, Whatever>;
+
+/// Encrypt a directory with fscrypt using the specified key
+pub fn encrypt(path: PathBuf, key_id: String) -> Result<()> {
+    // Remove the directory if it exists since any content cannot be trusted
+    if path.exists() {
+        std::fs::remove_dir_all(&path).with_whatever_context(|_| {
+            format!("failed to remove directory '{}'", path.display())
+        })?;
+    }
+
+    std::fs::create_dir_all(&path)
+        .with_whatever_context(|_| format!("failed to create directory '{}'", path.display()))?;
+
+    let key_bytes = key::load(key_id)?;
+    let private_key = FscryptPrivateKey::from_bytes(&key_bytes)
+        .with_whatever_context(|_| "failed to parse key")?;
+    let public_key: FscryptPublicKey = private_key.into();
+
+    public_key
+        .encrypt_directory(&path)
+        .with_whatever_context(|_| format!("failed to encrypt directory '{}'", path.display()))?;
+
+    Ok(())
+}
+
+/// Lock an encrypted directory by removing its key from the kernel keyring
+pub fn lock(path: PathBuf) -> Result<()> {
+    let key = FscryptPublicKey::from_directory(&path)
+        .with_whatever_context(|_| format!("failed to read key id from '{}'", path.display()))?;
+
+    key.lock_directory(&path)
+        .with_whatever_context(|_| format!("failed to lock directory '{}'", path.display()))?;
+
+    Ok(())
+}
+
+/// Unlock an encrypted directory by adding its key to the kernel keyring
+pub fn unlock(path: PathBuf, key_id: String) -> Result<()> {
+    let key_bytes = key::load(key_id)?;
+    let key = FscryptPrivateKey::from_bytes(&key_bytes)
+        .with_whatever_context(|_| "failed to parse key")?;
+
+    key.unlock_directory(&path)
+        .with_whatever_context(|_| format!("failed to unlock directory '{}'", path.display()))?;
+
+    Ok(())
+}
+
+/// Check if a directory is encrypted with fscrypt
+pub fn is_encrypted(path: PathBuf) -> Result<bool> {
+    match FscryptPublicKey::from_directory(&path) {
+        Ok(_) => Ok(true),
+        Err(_) => Ok(false),
+    }
+}

--- a/sources/rottweiler/src/fscrypt.rs
+++ b/sources/rottweiler/src/fscrypt.rs
@@ -1,0 +1,295 @@
+use std::os::fd::AsRawFd;
+use std::path::Path;
+
+use hkdf::Hkdf;
+use nix::{ioctl_read, ioctl_readwrite};
+use sha2::Sha512;
+use snafu::prelude::*;
+use zeroize::ZeroizeOnDrop;
+
+use crate::mount_point::MountPoint;
+
+type Result<T> = std::result::Result<T, snafu::Whatever>;
+
+/// Public key for fscrypt operations (contains only the key identifier)
+pub struct FscryptPublicKey {
+    identifier: [u8; 16],
+}
+
+impl FscryptPublicKey {
+    /// Read the encryption policy from a directory and extract the key identifier
+    pub fn from_directory(path: &Path) -> Result<Self> {
+        let policy = FscryptGetPolicyExArg::from_path(path)?;
+        Ok(Self {
+            identifier: policy.key_identifier(),
+        })
+    }
+
+    /// Remove the encryption key from the kernel keyring, locking the directory
+    pub fn lock_directory(&self, path: &Path) -> Result<()> {
+        let mount_point = MountPoint::from_path(path).with_whatever_context(|_| {
+            format!("Failed to find mount point for '{}'", path.display())
+        })?;
+        let mount_fd = mount_point.open()?;
+        let mut remove_key = FscryptRemoveKey::new(self.identifier);
+        unsafe { remove_encryption_key_all_users(mount_fd.as_raw_fd(), &mut remove_key) }
+            .with_whatever_context(|_| {
+                format!("Failed to remove encryption key for '{}'", path.display())
+            })?;
+        Ok(())
+    }
+
+    /// Set the encryption policy on a directory
+    pub fn encrypt_directory(&self, path: &Path) -> Result<()> {
+        let mut policy = FscryptPolicyV2::new(self.identifier);
+        let dir_fd = std::fs::File::open(path)
+            .with_whatever_context(|_| format!("Failed to open directory '{}'", path.display()))?;
+        let argptr = &mut policy as *mut FscryptPolicyV2 as *mut FscryptPolicyV1Ioctl;
+        unsafe { set_encryption_policy(dir_fd.as_raw_fd(), argptr) }.with_whatever_context(
+            |_| format!("Failed to set encryption policy for '{}'", path.display()),
+        )?;
+        Ok(())
+    }
+}
+
+/// Private key for fscrypt operations (contains the key identifier and raw key material)
+#[derive(ZeroizeOnDrop)]
+pub struct FscryptPrivateKey {
+    identifier: [u8; 16],
+    raw: Vec<u8>,
+}
+
+impl FscryptPrivateKey {
+    /// Create a private key from raw key bytes, deriving the key identifier
+    pub fn from_bytes(raw: &[u8]) -> Result<Self> {
+        let identifier = calculate_key_identifier(raw)?;
+        Ok(Self {
+            identifier,
+            raw: raw.to_vec(),
+        })
+    }
+
+    /// Add the encryption key to the kernel keyring, unlocking the directory
+    pub fn unlock_directory(&self, path: &Path) -> Result<()> {
+        let mount_point = MountPoint::from_path(path).with_whatever_context(|_| {
+            format!("Failed to find mount point for '{}'", path.display())
+        })?;
+        let mount_fd = mount_point.open()?;
+        let mut add_key = FscryptAddKey::new(&self.raw)?;
+        let argptr = &mut add_key as *mut FscryptAddKey as *mut FscryptAddKeyIoctl;
+        unsafe { add_encryption_key(mount_fd.as_raw_fd(), argptr) }.with_whatever_context(
+            |_| format!("Failed to add encryption key for '{}'", path.display()),
+        )?;
+        Ok(())
+    }
+}
+
+impl From<FscryptPrivateKey> for FscryptPublicKey {
+    fn from(private: FscryptPrivateKey) -> Self {
+        Self {
+            identifier: private.identifier,
+        }
+    }
+}
+
+const FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER: u32 = 2;
+const FSCRYPT_MODE_AES_256_XTS: u8 = 1;
+const FSCRYPT_MODE_AES_256_CTS: u8 = 4;
+const FSCRYPT_POLICY_FLAGS_PAD_32: u8 = 3;
+const FSCRYPT_POLICY_V2: u8 = 2;
+const FSCRYPT_MAX_KEY_SIZE: usize = 64;
+
+/// Ioctl struct for FS_IOC_SET_ENCRYPTION_POLICY (ioctl 19).
+/// Corresponds to kernel's fscrypt_policy_v1. Used for ioctl definition
+/// to get correct ioctl number, even when setting v2 policies.
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct FscryptPolicyV1Ioctl {
+    version: u8,
+    contents_encryption_mode: u8,
+    filenames_encryption_mode: u8,
+    flags: u8,
+    master_key_descriptor: [u8; 8],
+}
+
+/// V2 encryption policy struct. Corresponds to kernel's fscrypt_policy_v2.
+/// Contains the actual policy data passed to FS_IOC_SET_ENCRYPTION_POLICY.
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct FscryptPolicyV2 {
+    version: u8,
+    contents_encryption_mode: u8,
+    filenames_encryption_mode: u8,
+    flags: u8,
+    __reserved: [u8; 4],
+    master_key_identifier: [u8; 16],
+}
+
+impl FscryptPolicyV2 {
+    fn new(key_identifier: [u8; 16]) -> Self {
+        Self {
+            version: FSCRYPT_POLICY_V2,
+            contents_encryption_mode: FSCRYPT_MODE_AES_256_XTS,
+            filenames_encryption_mode: FSCRYPT_MODE_AES_256_CTS,
+            flags: FSCRYPT_POLICY_FLAGS_PAD_32,
+            __reserved: [0; 4],
+            master_key_identifier: key_identifier,
+        }
+    }
+}
+
+#[repr(C)]
+union FscryptPolicy {
+    version: u8,
+    v2: FscryptPolicyV2,
+}
+
+#[repr(C)]
+union FscryptKeySpecifierU {
+    __reserved: [u8; 32],
+    identifier: [u8; 16],
+}
+
+#[repr(C)]
+struct FscryptKeySpecifier {
+    type_: u32,
+    __reserved: u32,
+    u: FscryptKeySpecifierU,
+}
+
+/// Get policy argument struct. Corresponds to kernel's fscrypt_get_policy_ex_arg.
+/// Contains the full policy union for FS_IOC_GET_ENCRYPTION_POLICY_EX.
+#[repr(C)]
+struct FscryptGetPolicyExArg {
+    policy_size: u64,
+    policy: FscryptPolicy,
+}
+
+/// Ioctl struct for FS_IOC_GET_ENCRYPTION_POLICY_EX (ioctl 22).
+/// Packed struct with just size + version, matching kernel's ioctl definition (__u8[9]).
+#[repr(C, packed)]
+struct FscryptGetPolicyExArgIoctl {
+    policy_size: u64,
+    version: u8,
+}
+
+impl FscryptGetPolicyExArg {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            policy_size: u64::try_from(std::mem::size_of::<FscryptPolicyV2>())
+                .with_whatever_context(|_| "Policy size too large")?,
+            policy: FscryptPolicy {
+                version: FSCRYPT_POLICY_V2,
+            },
+        })
+    }
+
+    fn from_path(path: &Path) -> Result<Self> {
+        let dir = std::fs::File::open(path)
+            .with_whatever_context(|_| format!("Failed to open directory '{}'", path.display()))?;
+        let mut arg = Self::new()?;
+        let argptr = &mut arg as *mut FscryptGetPolicyExArg as *mut FscryptGetPolicyExArgIoctl;
+        unsafe { get_encryption_policy_ex(dir.as_raw_fd(), argptr) }
+            .with_whatever_context(|_| "Failed to get encryption policy")?;
+        Ok(arg)
+    }
+
+    fn key_identifier(&self) -> [u8; 16] {
+        unsafe { self.policy.v2.master_key_identifier }
+    }
+}
+
+/// Remove key argument struct. Corresponds to kernel's fscrypt_remove_key_arg.
+/// Used directly for both ioctl definition and data (no separate ioctl variant needed).
+#[repr(C)]
+struct FscryptRemoveKey {
+    key_spec: FscryptKeySpecifier,
+    removal_status_flags: u32,
+    __reserved: [u32; 5],
+}
+
+impl FscryptRemoveKey {
+    fn new(key_identifier: [u8; 16]) -> Self {
+        Self {
+            key_spec: FscryptKeySpecifier {
+                type_: FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER,
+                __reserved: 0,
+                u: FscryptKeySpecifierU {
+                    identifier: key_identifier,
+                },
+            },
+            removal_status_flags: 0,
+            __reserved: [0; 5],
+        }
+    }
+}
+
+/// Ioctl struct for FS_IOC_ADD_ENCRYPTION_KEY (ioctl 23).
+/// Base struct without the raw key bytes. Corresponds to kernel's fscrypt_add_key_arg
+/// without the flexible array member.
+#[repr(C)]
+struct FscryptAddKeyIoctl {
+    key_spec: FscryptKeySpecifier,
+    raw_size: u32,
+    key_id: u32,
+    __reserved: [u32; 8],
+}
+
+/// Add key argument struct with raw key bytes. Corresponds to kernel's fscrypt_add_key_arg
+/// with the flexible array member (raw[]) included as a fixed-size array.
+#[repr(C)]
+#[derive(ZeroizeOnDrop)]
+struct FscryptAddKey {
+    #[zeroize(skip)]
+    key_spec: FscryptKeySpecifier,
+    raw_size: u32,
+    key_id: u32,
+    __reserved: [u32; 8],
+    raw: [u8; FSCRYPT_MAX_KEY_SIZE],
+}
+
+impl FscryptAddKey {
+    fn new(key: &[u8]) -> Result<Self> {
+        if key.is_empty() || key.len() > FSCRYPT_MAX_KEY_SIZE {
+            snafu::whatever!("key must be between 1 and {} bytes", FSCRYPT_MAX_KEY_SIZE);
+        }
+
+        let mut raw = [0u8; FSCRYPT_MAX_KEY_SIZE];
+        raw[..key.len()].copy_from_slice(key);
+
+        let key_identifier = calculate_key_identifier(key)?;
+
+        Ok(Self {
+            key_spec: FscryptKeySpecifier {
+                type_: FSCRYPT_KEY_SPEC_TYPE_IDENTIFIER,
+                __reserved: 0,
+                u: FscryptKeySpecifierU {
+                    identifier: key_identifier,
+                },
+            },
+            raw_size: u32::try_from(key.len()).with_whatever_context(|_| "Key size too large")?,
+            key_id: 0,
+            __reserved: [0; 8],
+            raw,
+        })
+    }
+}
+
+ioctl_readwrite!(
+    get_encryption_policy_ex,
+    b'f',
+    22,
+    FscryptGetPolicyExArgIoctl
+);
+ioctl_readwrite!(remove_encryption_key_all_users, b'f', 25, FscryptRemoveKey);
+ioctl_readwrite!(add_encryption_key, b'f', 23, FscryptAddKeyIoctl);
+ioctl_read!(set_encryption_policy, b'f', 19, FscryptPolicyV1Ioctl);
+
+/// Calculate the fscrypt key identifier from raw key bytes using HKDF-SHA512
+fn calculate_key_identifier(key: &[u8]) -> Result<[u8; 16]> {
+    let hkdf = Hkdf::<Sha512>::new(None, key);
+    let mut output = [0u8; 16];
+    hkdf.expand(b"fscrypt\x00\x01", &mut output)
+        .with_whatever_context(|_| "Failed to derive key identifier")?;
+    Ok(output)
+}

--- a/sources/rottweiler/src/fscrypt.rs
+++ b/sources/rottweiler/src/fscrypt.rs
@@ -32,6 +32,10 @@ impl FscryptPublicKey {
         })?;
         let mount_fd = mount_point.open()?;
         let mut remove_key = FscryptRemoveKey::new(self.identifier);
+        // SAFETY: The ioctl requires a valid file descriptor and a pointer to fscrypt_remove_key_arg.
+        // - `mount_fd` is a valid open file descriptor
+        // - `remove_key` is properly initialized with repr(C) layout matching the kernel struct
+        // - The kernel copies data with copy_from_user/copy_to_user, so no lifetime issues
         unsafe { remove_encryption_key_all_users(mount_fd.as_raw_fd(), &mut remove_key) }
             .with_whatever_context(|_| {
                 format!("Failed to remove encryption key for '{}'", path.display())
@@ -45,6 +49,11 @@ impl FscryptPublicKey {
         let dir_fd = std::fs::File::open(path)
             .with_whatever_context(|_| format!("Failed to open directory '{}'", path.display()))?;
         let argptr = &mut policy as *mut FscryptPolicyV2 as *mut FscryptPolicyV1Ioctl;
+        // SAFETY: The ioctl requires a valid file descriptor and a pointer to a policy struct.
+        // - `dir_fd` is a valid open file descriptor for the directory
+        // - The kernel reads the version field first (via get_user), then copies the full struct
+        // - Both FscryptPolicyV2 and FscryptPolicyV1Ioctl are repr(C) and start with version field
+        // - The cast is safe because the kernel interprets the data based on the version field
         unsafe { set_encryption_policy(dir_fd.as_raw_fd(), argptr) }.with_whatever_context(
             |_| format!("Failed to set encryption policy for '{}'", path.display()),
         )?;
@@ -77,6 +86,11 @@ impl FscryptPrivateKey {
         let mount_fd = mount_point.open()?;
         let mut add_key = FscryptAddKey::new(&self.raw)?;
         let argptr = &mut add_key as *mut FscryptAddKey as *mut FscryptAddKeyIoctl;
+        // SAFETY: The ioctl requires a valid file descriptor and a pointer to fscrypt_add_key_arg.
+        // - `mount_fd` is a valid open file descriptor for the mount point
+        // - `add_key` is properly initialized with repr(C) layout matching the kernel struct
+        // - The cast is safe: FscryptAddKey contains FscryptAddKeyIoctl fields plus raw[] array
+        // - The kernel uses copy_from_user to read the struct including the raw key bytes
         unsafe { add_encryption_key(mount_fd.as_raw_fd(), argptr) }.with_whatever_context(
             |_| format!("Failed to add encryption key for '{}'", path.display()),
         )?;
@@ -159,6 +173,7 @@ struct FscryptKeySpecifier {
 
 /// Get policy argument struct. Corresponds to kernel's fscrypt_get_policy_ex_arg.
 /// Contains the full policy union for FS_IOC_GET_ENCRYPTION_POLICY_EX.
+/// This is the "uninitialized" state before the ioctl is called.
 #[repr(C)]
 struct FscryptGetPolicyExArg {
     policy_size: u64,
@@ -184,18 +199,38 @@ impl FscryptGetPolicyExArg {
         })
     }
 
-    fn from_path(path: &Path) -> Result<Self> {
+    fn from_path(path: &Path) -> Result<FscryptRetrievedPolicy> {
         let dir = std::fs::File::open(path)
             .with_whatever_context(|_| format!("Failed to open directory '{}'", path.display()))?;
         let mut arg = Self::new()?;
         let argptr = &mut arg as *mut FscryptGetPolicyExArg as *mut FscryptGetPolicyExArgIoctl;
+        // SAFETY: The ioctl requires a valid file descriptor and a pointer to fscrypt_get_policy_ex_arg.
+        // - `dir` is a valid open file descriptor for the directory
+        // - `arg` is properly initialized with policy_size and version fields
+        // - The kernel first copies policy_size from userspace, then copies the full policy back
+        // - Both structs are repr(C) and share the same initial layout (policy_size field)
+        // - Verified against kernel implementation in fs/crypto/policy.c (fscrypt_ioctl_get_policy_ex)
         unsafe { get_encryption_policy_ex(dir.as_raw_fd(), argptr) }
             .with_whatever_context(|_| "Failed to get encryption policy")?;
-        Ok(arg)
+        Ok(FscryptRetrievedPolicy { inner: arg })
     }
+}
 
+/// Policy retrieved from the kernel via FS_IOC_GET_ENCRYPTION_POLICY_EX.
+/// This type guarantees the policy union has been populated by the kernel.
+struct FscryptRetrievedPolicy {
+    inner: FscryptGetPolicyExArg,
+}
+
+impl FscryptRetrievedPolicy {
     fn key_identifier(&self) -> [u8; 16] {
-        unsafe { self.policy.v2.master_key_identifier }
+        // SAFETY: Accessing union field is safe because:
+        // - FscryptRetrievedPolicy can only be constructed after a successful ioctl
+        // - The kernel's fscrypt_ioctl_get_policy_ex writes the policy based on what's stored
+        // - The kernel implementation (fs/crypto/policy.c) guarantees the v2 variant is active
+        //   when the stored policy version is v2
+        // - The type system enforces this method is only callable on kernel-populated policies
+        unsafe { self.inner.policy.v2.master_key_identifier }
     }
 }
 
@@ -293,3 +328,58 @@ fn calculate_key_identifier(key: &[u8]) -> Result<[u8; 16]> {
         .with_whatever_context(|_| "Failed to derive key identifier")?;
     Ok(output)
 }
+
+// Compile-time validation of struct layouts against kernel definitions
+// These assertions ensure our repr(C) structs match the kernel's C structs exactly.
+const _: () = {
+    use std::mem::{align_of, offset_of, size_of};
+
+    // struct fscrypt_policy_v1: 1 + 1 + 1 + 1 + 8 = 12 bytes
+    const _: () = assert!(size_of::<FscryptPolicyV1Ioctl>() == 12);
+    const _: () = assert!(align_of::<FscryptPolicyV1Ioctl>() == 1);
+
+    // struct fscrypt_policy_v2: 1 + 1 + 1 + 1 + 1 + 3 + 16 = 24 bytes
+    const _: () = assert!(size_of::<FscryptPolicyV2>() == 24);
+    const _: () = assert!(align_of::<FscryptPolicyV2>() == 1);
+    const _: () = assert!(offset_of!(FscryptPolicyV2, version) == 0);
+    const _: () = assert!(offset_of!(FscryptPolicyV2, contents_encryption_mode) == 1);
+    const _: () = assert!(offset_of!(FscryptPolicyV2, filenames_encryption_mode) == 2);
+    const _: () = assert!(offset_of!(FscryptPolicyV2, flags) == 3);
+    const _: () = assert!(offset_of!(FscryptPolicyV2, __reserved) == 4);
+    const _: () = assert!(offset_of!(FscryptPolicyV2, master_key_identifier) == 8);
+
+    // struct fscrypt_key_specifier: 4 + 4 + 32 = 40 bytes
+    const _: () = assert!(size_of::<FscryptKeySpecifier>() == 40);
+    const _: () = assert!(align_of::<FscryptKeySpecifier>() == 4);
+    const _: () = assert!(offset_of!(FscryptKeySpecifier, type_) == 0);
+    const _: () = assert!(offset_of!(FscryptKeySpecifier, __reserved) == 4);
+    const _: () = assert!(offset_of!(FscryptKeySpecifier, u) == 8);
+
+    // struct fscrypt_add_key_arg (without raw[]): 40 + 4 + 4 + 32 = 80 bytes
+    const _: () = assert!(size_of::<FscryptAddKeyIoctl>() == 80);
+    const _: () = assert!(align_of::<FscryptAddKeyIoctl>() == 4);
+    const _: () = assert!(offset_of!(FscryptAddKey, key_spec) == 0);
+    const _: () = assert!(offset_of!(FscryptAddKey, raw_size) == 40);
+    const _: () = assert!(offset_of!(FscryptAddKey, key_id) == 44);
+    const _: () = assert!(offset_of!(FscryptAddKey, __reserved) == 48);
+    const _: () = assert!(offset_of!(FscryptAddKey, raw) == 80);
+
+    // struct fscrypt_add_key_arg with raw[64]: 80 + 64 = 144 bytes
+    const _: () = assert!(size_of::<FscryptAddKey>() == 144);
+    const _: () = assert!(align_of::<FscryptAddKey>() == 4);
+
+    // struct fscrypt_remove_key_arg: 40 + 4 + 20 = 64 bytes
+    const _: () = assert!(size_of::<FscryptRemoveKey>() == 64);
+    const _: () = assert!(align_of::<FscryptRemoveKey>() == 4);
+    const _: () = assert!(offset_of!(FscryptRemoveKey, key_spec) == 0);
+    const _: () = assert!(offset_of!(FscryptRemoveKey, removal_status_flags) == 40);
+    const _: () = assert!(offset_of!(FscryptRemoveKey, __reserved) == 44);
+
+    // struct fscrypt_get_policy_ex_arg: 8 + max(1, 12, 24) = 32 bytes
+    const _: () = assert!(size_of::<FscryptGetPolicyExArg>() == 32);
+    const _: () = assert!(align_of::<FscryptGetPolicyExArg>() == 8);
+
+    // __u8[9] for ioctl definition: 8 + 1 = 9 bytes (packed)
+    const _: () = assert!(size_of::<FscryptGetPolicyExArgIoctl>() == 9);
+    const _: () = assert!(align_of::<FscryptGetPolicyExArgIoctl>() == 1);
+};

--- a/sources/rottweiler/src/key.rs
+++ b/sources/rottweiler/src/key.rs
@@ -1,0 +1,59 @@
+use snafu::prelude::*;
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use zeroize::Zeroizing;
+
+use crate::system;
+
+type Result<T> = std::result::Result<T, snafu::Whatever>;
+
+const DEV_RANDOM: &str = "/dev/random";
+const KEYSTORE: &str = "/.bottlerocket/keystore";
+const KEY_SIZE: usize = 64;
+
+/// Generate a random encryption key and encrypt it with TPM2 PCRs 7+14
+pub fn generate(key_id: String) -> Result<()> {
+    if !key_id
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        whatever!("key_id must contain only alphanumerics, dashes, and underscores");
+    }
+
+    let key_path = PathBuf::from(KEYSTORE).join(&key_id);
+
+    // Skip generation if key already exists
+    if key_path.exists() {
+        return Ok(());
+    }
+
+    let mut random_bytes = Zeroizing::new(vec![0u8; KEY_SIZE]);
+
+    let mut random = fs::File::open(DEV_RANDOM)
+        .with_whatever_context(|_| format!("failed to open {}", DEV_RANDOM))?;
+
+    random
+        .read_exact(&mut random_bytes)
+        .with_whatever_context(|_| "failed to read random bytes")?;
+
+    let encrypted = system::systemd_creds_encrypt(&key_id, &random_bytes)?;
+
+    fs::create_dir_all(KEYSTORE)
+        .with_whatever_context(|_| format!("failed to create keystore directory '{}'", KEYSTORE))?;
+
+    fs::write(&key_path, encrypted)
+        .with_whatever_context(|_| format!("failed to write key to '{}'", key_path.display()))?;
+
+    Ok(())
+}
+
+/// Load and decrypt a TPM2-encrypted key from the keystore
+pub fn load(key_id: String) -> Result<Zeroizing<Vec<u8>>> {
+    let key_path = PathBuf::from(KEYSTORE).join(&key_id);
+
+    let encrypted = fs::read(&key_path)
+        .with_whatever_context(|_| format!("failed to read key from '{}'", key_path.display()))?;
+
+    system::systemd_creds_decrypt(&key_id, &encrypted)
+}

--- a/sources/rottweiler/src/main.rs
+++ b/sources/rottweiler/src/main.rs
@@ -1,0 +1,515 @@
+/*!
+# Introduction
+
+*rottweiler* is Bottlerocket's storage encryption helper. It provides a unified
+interface for encrypting and managing encrypted storage resources including:
+
+- Block devices (using LUKS)
+- Directories (using fscrypt)
+- TPM PCR measurements
+
+## Commands
+
+### Key Management
+- `generate-key <key-id>` - Generate an encryption key
+
+### Block Device Operations
+- `encrypt block-device <path> <key-id>` - Encrypt a block device using LUKS
+- `attach block-device <path> <key-id>` - Attach an encrypted block device
+- `detach block-device <path>` - Detach an encrypted block device
+- `resize block-device <path> <key-id>` - Resize a LUKS block device
+- `check block-device <path> encrypted|unencrypted` - Check block device encryption state
+
+### Directory Operations
+- `encrypt directory <path> <key-id>` - Encrypt a directory using fscrypt
+- `lock directory <path>` - Lock an encrypted directory (remove key)
+- `unlock directory <path> <key-id>` - Unlock an encrypted directory (add key)
+- `check directory <path> encrypted|unencrypted` - Check directory encryption state
+
+### TPM Measurement Operations
+- `measure settings` - Measure OS settings into PCR 8
+- `measure kernel-command-line` - Measure kernel command line into PCR 9
+- `measure pcrphase <phase>` - Measure boot phase into PCR 11
+  - Valid phases: `sysinit`, `preconfigured`, `configured`, `ready`, `shutdown`, `final`
+
+## Aliases
+
+For convenience, the following aliases are supported:
+- `dir` can be used instead of `directory`
+- `bdev` can be used instead of `block-device`
+*/
+
+use argh::FromArgs;
+use snafu::Whatever;
+use std::path::{Path, PathBuf};
+
+mod block_device;
+mod directory;
+mod fscrypt;
+mod key;
+mod measure;
+mod mount_point;
+mod system;
+
+type Result<T> = std::result::Result<T, Whatever>;
+
+#[snafu::report]
+fn main() -> Result<()> {
+    // Support aliases: "dir" -> "directory", "bdev" -> "block-device"
+    // Only replace in resource-type subcommand positions
+    let mut args: Vec<String> = std::env::args().collect();
+    if args.len() >= 3 {
+        let verb = args.get(1).map(|s| s.as_str());
+        let resource_pos = match verb {
+            Some("encrypt" | "attach" | "detach" | "resize" | "lock" | "unlock" | "check") => {
+                Some(2)
+            }
+            _ => None,
+        };
+        if let Some(pos) = resource_pos
+            && let Some(arg) = args.get_mut(pos)
+        {
+            if arg == "dir" {
+                *arg = "directory".to_string();
+            } else if arg == "bdev" {
+                *arg = "block-device".to_string();
+            }
+        }
+    }
+    let args: Args = match Args::from_args(
+        &[args[0].as_str()],
+        &args[1..].iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+    ) {
+        Ok(args) => args,
+        Err(early_exit) => {
+            println!("{}", early_exit.output);
+            std::process::exit(match early_exit.status {
+                Ok(()) => 0,
+                Err(()) => 1,
+            });
+        }
+    };
+
+    match args.command {
+        Command::GenerateKey(cmd) => key::generate(cmd.key_id),
+        Command::Encrypt(cmd) => match cmd.resource {
+            EncryptResource::BlockDevice(cmd) => block_device::encrypt(cmd.path, cmd.key_id),
+            EncryptResource::Directory(cmd) => directory::encrypt(cmd.path, cmd.key_id),
+        },
+        Command::Attach(cmd) => match cmd.resource {
+            AttachResource::BlockDevice(cmd) => block_device::attach(cmd.path, cmd.key_id),
+        },
+        Command::Detach(cmd) => match cmd.resource {
+            DetachResource::BlockDevice(cmd) => block_device::detach(cmd.path),
+        },
+        Command::Resize(cmd) => match cmd.resource {
+            ResizeResource::BlockDevice(cmd) => block_device::resize(cmd.path, cmd.key_id),
+        },
+        Command::Lock(cmd) => match cmd.resource {
+            LockResource::Directory(cmd) => directory::lock(cmd.path),
+        },
+        Command::Unlock(cmd) => match cmd.resource {
+            UnlockResource::Directory(cmd) => directory::unlock(cmd.path, cmd.key_id),
+        },
+        Command::Check(cmd) => match cmd.resource {
+            CheckResource::BlockDevice(cmd) => {
+                let path = cmd.path;
+                match cmd.state {
+                    CheckBlockDeviceState::Encrypted(_) => handle_check(
+                        block_device::is_encrypted(path.clone())?,
+                        "block device",
+                        &path,
+                        true,
+                        "encrypted",
+                    ),
+                    CheckBlockDeviceState::Unencrypted(_) => handle_check(
+                        block_device::is_encrypted(path.clone())?,
+                        "block device",
+                        &path,
+                        false,
+                        "encrypted",
+                    ),
+                }
+            }
+            CheckResource::Directory(cmd) => {
+                let path = cmd.path;
+                match cmd.state {
+                    CheckDirectoryState::Encrypted(_) => handle_check(
+                        directory::is_encrypted(path.clone())?,
+                        "directory",
+                        &path,
+                        true,
+                        "encrypted",
+                    ),
+                    CheckDirectoryState::Unencrypted(_) => handle_check(
+                        directory::is_encrypted(path.clone())?,
+                        "directory",
+                        &path,
+                        false,
+                        "encrypted",
+                    ),
+                }
+            }
+        },
+        Command::Measure(cmd) => match cmd.resource {
+            MeasureResource::Settings(_) => measure::os_settings(),
+            MeasureResource::KernelCommandLine(_) => measure::kernel_command_line(),
+            MeasureResource::Pcrphase(cmd) => measure::pcrphase(&cmd.phase.to_string()),
+        },
+    }
+}
+
+/// Handle status checks, printing the result and exiting with appropriate code.
+///
+/// Returns Ok(()) if the actual state matches the expected state, otherwise exits with code 1.
+fn handle_check(
+    actual: bool,
+    resource_type: &str,
+    path: &Path,
+    expected: bool,
+    state_name: &str,
+) -> Result<()> {
+    let state = if actual {
+        state_name
+    } else {
+        &format!("not {}", state_name)
+    };
+    println!("{} '{}' is {}", resource_type, path.display(), state);
+
+    match (actual, expected) {
+        (true, true) | (false, false) => Ok(()),
+        _ => std::process::exit(1),
+    }
+}
+
+#[derive(FromArgs)]
+/// Storage encryption helper
+struct Args {
+    #[argh(subcommand)]
+    command: Command,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum Command {
+    GenerateKey(GenerateKeyCmd),
+    Encrypt(EncryptCmd),
+    Attach(AttachCmd),
+    Detach(DetachCmd),
+    Resize(ResizeCmd),
+    Lock(LockCmd),
+    Unlock(UnlockCmd),
+    Check(CheckCmd),
+    Measure(MeasureCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "generate-key")]
+/// Generate an encryption key
+struct GenerateKeyCmd {
+    #[argh(positional)]
+    key_id: String,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "encrypt")]
+/// Encrypt a resource
+struct EncryptCmd {
+    #[argh(subcommand)]
+    resource: EncryptResource,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum EncryptResource {
+    BlockDevice(EncryptBlockDeviceCmd),
+    Directory(EncryptDirectoryCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "block-device")]
+/// Encrypt a block device using LUKS
+struct EncryptBlockDeviceCmd {
+    #[argh(positional)]
+    path: PathBuf,
+
+    #[argh(positional)]
+    key_id: String,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "directory")]
+/// Encrypt a directory using fscrypt
+struct EncryptDirectoryCmd {
+    #[argh(positional)]
+    path: PathBuf,
+
+    #[argh(positional)]
+    key_id: String,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "attach")]
+/// Attach an encrypted resource
+struct AttachCmd {
+    #[argh(subcommand)]
+    resource: AttachResource,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum AttachResource {
+    BlockDevice(AttachBlockDeviceCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "block-device")]
+/// Attach an encrypted block device
+struct AttachBlockDeviceCmd {
+    #[argh(positional)]
+    path: PathBuf,
+
+    #[argh(positional)]
+    key_id: String,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "detach")]
+/// Detach an encrypted resource
+struct DetachCmd {
+    #[argh(subcommand)]
+    resource: DetachResource,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum DetachResource {
+    BlockDevice(DetachBlockDeviceCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "block-device")]
+/// Detach an encrypted block device
+struct DetachBlockDeviceCmd {
+    #[argh(positional)]
+    path: PathBuf,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "resize")]
+/// Resize a resource
+struct ResizeCmd {
+    #[argh(subcommand)]
+    resource: ResizeResource,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum ResizeResource {
+    BlockDevice(ResizeBlockDeviceCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "block-device")]
+/// Resize a LUKS block device
+struct ResizeBlockDeviceCmd {
+    #[argh(positional)]
+    path: PathBuf,
+
+    #[argh(positional)]
+    key_id: String,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "lock")]
+/// Lock a resource
+struct LockCmd {
+    #[argh(subcommand)]
+    resource: LockResource,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum LockResource {
+    Directory(LockDirectoryCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "directory")]
+/// Lock an encrypted directory (remove key)
+struct LockDirectoryCmd {
+    #[argh(positional)]
+    path: PathBuf,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "unlock")]
+/// Unlock a resource
+struct UnlockCmd {
+    #[argh(subcommand)]
+    resource: UnlockResource,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum UnlockResource {
+    Directory(UnlockDirectoryCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "directory")]
+/// Unlock an encrypted directory (add key)
+struct UnlockDirectoryCmd {
+    #[argh(positional)]
+    path: PathBuf,
+
+    #[argh(positional)]
+    key_id: String,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "check")]
+/// Check resource state
+struct CheckCmd {
+    #[argh(subcommand)]
+    resource: CheckResource,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum CheckResource {
+    BlockDevice(CheckBlockDeviceCmd),
+    Directory(CheckDirectoryCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "block-device")]
+/// Check block device state
+struct CheckBlockDeviceCmd {
+    #[argh(positional)]
+    path: PathBuf,
+
+    #[argh(subcommand)]
+    state: CheckBlockDeviceState,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum CheckBlockDeviceState {
+    Encrypted(CheckBlockDeviceEncryptedCmd),
+    Unencrypted(CheckBlockDeviceUnencryptedCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "encrypted")]
+/// Check if encrypted
+struct CheckBlockDeviceEncryptedCmd {}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "unencrypted")]
+/// Check if unencrypted
+struct CheckBlockDeviceUnencryptedCmd {}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "directory")]
+/// Check directory state
+struct CheckDirectoryCmd {
+    #[argh(positional)]
+    path: PathBuf,
+
+    #[argh(subcommand)]
+    state: CheckDirectoryState,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum CheckDirectoryState {
+    Encrypted(CheckDirectoryEncryptedCmd),
+    Unencrypted(CheckDirectoryUnencryptedCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "encrypted")]
+/// Check if encrypted
+struct CheckDirectoryEncryptedCmd {}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "unencrypted")]
+/// Check if unencrypted
+struct CheckDirectoryUnencryptedCmd {}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "measure")]
+/// Measure data into TPM PCR
+struct MeasureCmd {
+    #[argh(subcommand)]
+    resource: MeasureResource,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum MeasureResource {
+    Settings(MeasureSettingsCmd),
+    KernelCommandLine(MeasureKernelCommandLineCmd),
+    Pcrphase(MeasurePcrphaseCmd),
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "settings")]
+/// Measure OS settings into PCR
+struct MeasureSettingsCmd {}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "kernel-command-line")]
+/// Measure kernel command line into PCR
+struct MeasureKernelCommandLineCmd {}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "pcrphase")]
+/// Measure boot phase into PCR
+struct MeasurePcrphaseCmd {
+    #[argh(positional)]
+    phase: Phase,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Phase {
+    Sysinit,
+    Preconfigured,
+    Configured,
+    Ready,
+    Shutdown,
+    Final,
+}
+
+impl std::str::FromStr for Phase {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "sysinit" => Ok(Phase::Sysinit),
+            "preconfigured" => Ok(Phase::Preconfigured),
+            "configured" => Ok(Phase::Configured),
+            "ready" => Ok(Phase::Ready),
+            "shutdown" => Ok(Phase::Shutdown),
+            "final" => Ok(Phase::Final),
+            _ => Err(format!(
+                "invalid phase '{}', must be one of: sysinit, preconfigured, configured, ready, shutdown, final",
+                s
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for Phase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Phase::Sysinit => write!(f, "sysinit"),
+            Phase::Preconfigured => write!(f, "preconfigured"),
+            Phase::Configured => write!(f, "configured"),
+            Phase::Ready => write!(f, "ready"),
+            Phase::Shutdown => write!(f, "shutdown"),
+            Phase::Final => write!(f, "final"),
+        }
+    }
+}

--- a/sources/rottweiler/src/measure.rs
+++ b/sources/rottweiler/src/measure.rs
@@ -1,0 +1,45 @@
+use sha2::{Digest, Sha256, Sha384, Sha512};
+use snafu::prelude::*;
+use std::fs;
+
+use crate::system;
+
+type Result<T> = std::result::Result<T, snafu::Whatever>;
+
+/// Path to kernel command line
+const PROC_CMDLINE: &str = "/proc/cmdline";
+
+/// PCR for OS settings measurements
+const PCR_SETTINGS: u32 = 8;
+
+/// PCR for kernel command line measurements
+const PCR_KERNEL_COMMAND_LINE: u32 = 9;
+
+/// PCR for boot phase measurements
+const PCR_PHASE: u32 = 11;
+
+/// Measure OS settings into PCR 8
+pub fn os_settings() -> Result<()> {
+    let data = system::apiclient_get_settings()?;
+    extend_pcr(PCR_SETTINGS, &data)
+}
+
+/// Measure kernel command line into PCR 9
+pub fn kernel_command_line() -> Result<()> {
+    let data = fs::read_to_string(PROC_CMDLINE)
+        .with_whatever_context(|_| format!("failed to read {}", PROC_CMDLINE))?;
+    extend_pcr(PCR_KERNEL_COMMAND_LINE, data.as_bytes())
+}
+
+/// Measure boot phase into PCR 11
+pub fn pcrphase(phase: &str) -> Result<()> {
+    extend_pcr(PCR_PHASE, phase.as_bytes())
+}
+
+/// Compute SHA256/384/512 hashes and extend PCR
+fn extend_pcr(pcr: u32, data: &[u8]) -> Result<()> {
+    let sha256 = hex::encode(Sha256::digest(data));
+    let sha384 = hex::encode(Sha384::digest(data));
+    let sha512 = hex::encode(Sha512::digest(data));
+    system::tpm2_pcrextend(pcr, &sha256, &sha384, &sha512)
+}

--- a/sources/rottweiler/src/mount_point.rs
+++ b/sources/rottweiler/src/mount_point.rs
@@ -1,0 +1,50 @@
+use snafu::prelude::*;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+type Result<T> = std::result::Result<T, snafu::Whatever>;
+
+/// Represents a filesystem mount point with its path
+pub struct MountPoint {
+    pub path: PathBuf,
+}
+
+impl MountPoint {
+    /// Find the mount point for a given path by walking up the directory tree
+    pub fn from_path(path: &Path) -> Result<Self> {
+        let mut current = path.canonicalize().with_whatever_context(|_| {
+            format!("failed to canonicalize path '{}'", path.display())
+        })?;
+
+        let current_stat = std::fs::metadata(&current).with_whatever_context(|_| {
+            format!("failed to get metadata for '{}'", current.display())
+        })?;
+        let current_dev = current_stat.dev();
+
+        loop {
+            let parent = match current.parent() {
+                Some(p) if p != current.as_path() => p,
+                _ => break,
+            };
+
+            let parent_stat = std::fs::metadata(parent).with_whatever_context(|_| {
+                format!("failed to get metadata for '{}'", parent.display())
+            })?;
+
+            if parent_stat.dev() != current_dev {
+                break;
+            }
+
+            current = parent.to_path_buf();
+        }
+
+        Ok(Self { path: current })
+    }
+
+    /// Open the mount point path as a file descriptor
+    pub fn open(&self) -> Result<std::fs::File> {
+        std::fs::File::open(&self.path).with_whatever_context(|_| {
+            format!("failed to open mount point '{}'", self.path.display())
+        })
+    }
+}

--- a/sources/rottweiler/src/system.rs
+++ b/sources/rottweiler/src/system.rs
@@ -1,0 +1,192 @@
+use snafu::prelude::*;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use zeroize::Zeroizing;
+
+type Result<T> = std::result::Result<T, snafu::Whatever>;
+
+const SYSTEMD_CREDS: &str = "/usr/bin/systemd-creds";
+const SYSTEMD_CRYPTSETUP: &str = "/usr/lib/systemd/systemd-cryptsetup";
+const CRYPTSETUP: &str = "/usr/sbin/cryptsetup";
+const APICLIENT: &str = "/usr/bin/apiclient";
+const TPM2_PCREXTEND: &str = "/usr/bin/tpm2_pcrextend";
+
+/// Encrypt data using systemd-creds with TPM2 PCRs
+pub fn systemd_creds_encrypt(name: &str, plaintext: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
+    let pcrs = format!("--tpm2-pcrs={}", get_tpm2_pcrs()?);
+    execute(
+        SYSTEMD_CREDS,
+        &[
+            "encrypt",
+            "-",
+            "-",
+            "--name",
+            name,
+            "--with-key=tpm2",
+            &pcrs,
+        ],
+        Some(plaintext),
+    )
+}
+
+/// Decrypt data using systemd-creds with TPM2
+pub fn systemd_creds_decrypt(name: &str, ciphertext: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
+    execute(
+        SYSTEMD_CREDS,
+        &["decrypt", "-", "-", "--name", name],
+        Some(ciphertext),
+    )
+}
+
+/// Attach a LUKS device using systemd-cryptsetup with the provided key
+pub fn systemd_cryptsetup_attach(
+    volume_name: &str,
+    source_device: &str,
+    key_data: &[u8],
+) -> Result<()> {
+    execute(
+        SYSTEMD_CRYPTSETUP,
+        &[
+            "attach",
+            volume_name,
+            source_device,
+            "/dev/stdin",
+            "luks,headless=yes,tries=1",
+        ],
+        Some(key_data),
+    )?;
+    Ok(())
+}
+
+/// Detach a LUKS device using systemd-cryptsetup
+pub fn systemd_cryptsetup_detach(volume_name: &str) -> Result<()> {
+    execute(SYSTEMD_CRYPTSETUP, &["detach", volume_name], None)?;
+    Ok(())
+}
+
+/// Format a device with LUKS2 using the provided key
+pub fn cryptsetup_luks_format(device: &str, key_data: &[u8]) -> Result<()> {
+    // Use minimal PBKDF2 iterations (1000, per NIST SP 800-132) since we're using a high-entropy
+    // TPM2-sealed key. This matches systemd's behavior and avoids unnecessary key stretching.
+    execute(
+        CRYPTSETUP,
+        &[
+            "luksFormat",
+            "--type",
+            "luks2",
+            "--pbkdf",
+            "pbkdf2",
+            "--pbkdf-force-iterations",
+            "1000",
+            "--batch-mode",
+            device,
+            "-",
+        ],
+        Some(key_data),
+    )?;
+    Ok(())
+}
+
+/// Resize a LUKS device using the provided key
+pub fn cryptsetup_resize(volume_name: &str, key_data: &[u8]) -> Result<()> {
+    execute(
+        CRYPTSETUP,
+        &["resize", "--key-file=-", volume_name],
+        Some(key_data),
+    )?;
+    Ok(())
+}
+
+/// Execute a command with optional stdin input and return stdout
+fn execute(cmd: &str, args: &[&str], input: Option<&[u8]>) -> Result<Zeroizing<Vec<u8>>> {
+    let mut child = Command::new(cmd)
+        .args(args)
+        .stdin(if input.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_whatever_context(|_| format!("failed to spawn {}", cmd))?;
+
+    if let Some(data) = input {
+        let mut stdin = child
+            .stdin
+            .take()
+            .with_whatever_context(|| "failed to open stdin")?;
+
+        stdin
+            .write_all(data)
+            .with_whatever_context(|_| "failed to write to stdin")?;
+
+        drop(stdin);
+    }
+
+    let output = child
+        .wait_with_output()
+        .with_whatever_context(|_| format!("failed to wait for {}", cmd))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        whatever!(
+            "{} failed with exit code {}: {}",
+            cmd,
+            output.status.code().unwrap_or(-1),
+            stderr.trim()
+        );
+    }
+
+    Ok(Zeroizing::new(output.stdout))
+}
+
+/// Get TPM2 PCRs to bind to based on image features
+///
+/// PCR decoder ring:
+/// - PCR 4: hashes of shim, grub, and vmlinuz
+/// - PCR 7: Secure Boot policy
+/// - PCR 9: kernel command line (includes dm-verity root hash of userspace)
+/// - PCR 11: boot phase (sysinit, preconfigured, configured, ready, shutdown, final)
+/// - PCR 14: machine-owner keys
+///
+/// If in-place updates are disabled, then the measurements in PCR 4 (kernel) and
+/// PCR 9 (userspace) shouldn't change.
+fn get_tpm2_pcrs() -> Result<String> {
+    let features = bottlerocket_image_features::parse_image_features()?;
+    Ok(if features.in_place_updates {
+        "7+11+14".to_string()
+    } else {
+        "4+7+9+11+14".to_string()
+    })
+}
+
+/// Get canonicalized settings from apiclient, excluding seed and hostname
+pub fn apiclient_get_settings() -> Result<Zeroizing<Vec<u8>>> {
+    execute(
+        APICLIENT,
+        &[
+            "get",
+            "settings",
+            "--exclude",
+            "settings.updates.seed",
+            "--exclude",
+            "settings.network.hostname",
+            "--canonicalize",
+        ],
+        None,
+    )
+}
+
+/// Extend a TPM PCR with SHA256, SHA384, and SHA512 hashes
+pub fn tpm2_pcrextend(pcr: u32, sha256: &str, sha384: &str, sha512: &str) -> Result<()> {
+    execute(
+        TPM2_PCREXTEND,
+        &[&format!(
+            "{}:sha256={},sha384={},sha512={}",
+            pcr, sha256, sha384, sha512
+        )],
+        None,
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/4680

**Description of changes:**
With Secure Boot enabled and dm-verity enforced, we usually consider the kernel and root filesystem to be trusted. Encrypting BOTTLEROCKET-DATA (`/local`) and BOTTLEROCKET-PRIVATE (`/.bottlerocket`) helps expand that trust boundary to include mutable storage as well, which is useful for remote attestation.

We can encrypt the entire data partition as we usually expect it to be empty and create the filesystem on first boot. However, the private partition cannot be fully encrypted; GRUB needs to read the bootconfig file, and there's potentially also a `net.toml` for network configuration. That means two types of encryption to support - LUKS for full disk encryption, fscrypt for directories.

`systemd` has excellent support for encrypted block devices, but not for directories except when `systemd-homed` is in use. [Managing encrypted filesystems with dirlock](https://lwn.net/Articles/1038859/) provides an overview of some tools in the space, with `dirlock` as an interesting project. However, most of the tools are opinionated (and flexible!) in ways that don't mesh perfectly with our needs. In particular, any sort of automatic fallback to passwords is problematic; if the storage cannot be automatically unlocked, then it can't be trusted and the system should fail closed.

`rottweiler` exists to provide a uniform wrapper around the underlying tools: `systemd-creds`, `cryptsetup`, and the kernel's fscrypt API. It requires a TPM2 device, and uses `systemd-creds` to generate wrapped keys that are sealed to specific PCRs. 


**Testing done:**
Enabled the [encrypted storage](https://github.com/bottlerocket-os/twoliter/pull/589) feature. Booted (and rebooted) images with encrypted block devices and directories.

That exercises these code paths:
```
# /local
rottweiler check block-device ${BOTTLEROCKET_DATA} unencrypted
rottweiler generate-key bottlerocket-data
rottweiler encrypt block-device ${BOTTLEROCKET_DATA} bottlerocket-data
rottweiler attach block-device ${BOTTLEROCKET_DATA} bottlerocket-data
rottweiler detach block-device ${BOTTLEROCKET_DATA}

# /.bottlerocket/datastore
rottweiler check directory ${DATASTORE_DIR} unencrypted
rottweiler generate-key datastore
rottweiler encrypt directory ${DATASTORE_DIR} datastore
```

I've also tested the lock and unlock paths:
```
$ rottweiler lock directory /.bottlerocket/datastore
<succeeds>

# file names are encrypted
$ ls -1 /.bottlerocket/datastore/
8Dpj4eE5GltMa8f00gibrGAoPQGRwM6dpl1KVTJwAHDUs_XVrilBeA
DiPPFeTtYxFN6kBKUkbnRijqId6IlecykRDKSuaFXoT7VOvnX2nswA
UJS1XpONYwoewy4cD9S68nrKCrozqkr33B_G8RnF-Ma6c-GeAbRKKA
eouecYx9ArlXpKsgZrYaDy7bxWrM_AlcXDVmsP0JEGgjjBr-pfgXJw
jM5WLUKW_72Ir3AAqm_Fx9dlekNo4NdO8PVlKhPbukAuu-suNmbaSw
nqDxnwOaczPa3kkYp_14aawGEpszfOYNuidNNRMBNKv25AiuvEcVAA

# files are inaccessible
$ cat /.bottlerocket/datastore/DiPPFeTtYxFN6kBKUkbnRijqId6IlecykRDKSuaFXoT7VOvnX2nswA
cat: /.bottlerocket/datastore/DiPPFeTtYxFN6kBKUkbnRijqId6IlecykRDKSuaFXoT7VOvnX2nswA: Required key not available

# directory can't be unlocked if the PCRs aren't in the expected state
$ rottweiler unlock directory /.bottlerocket/datastore datastore
Error: /usr/bin/systemd-creds failed with exit code 1: Failed to unseal secret using TPM2: Operation not permitted
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
