### PR TITLE
Fix systemd user for whippet

### DIFF
--- a/packages/os/whippet.service
+++ b/packages/os/whippet.service
@@ -9,6 +9,7 @@ Requires=dbus.socket
 Conflicts=shutdown.target
 
 [Service]
+User=dbus
 Type=notify
 Sockets=dbus.socket
 OOMScoreAdjust=-900


### PR DESCRIPTION
**Description of changes:**

`whippet` should use the `dbus` user just like the dbus-broker

**Testing done:**

Ran `aws-dev` with `whippet`, and confirmed that the service started:

```bash
bash-5.1# systemctl status dbus.service
● whippet.service - D-Bus System Message Bus
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/whippet.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Thu 2025-11-06 04:54:25 UTC; 18h ago
 Invocation: 6278eaaeb65f404c9dc940b2a226692e
TriggeredBy: ● dbus.socket
   Main PID: 1272 (whippet)
      Tasks: 6 (limit: 18596)
     Memory: 5.2M (peak: 21.8M)
        CPU: 4.332s
     CGroup: /system.slice/whippet.service
             ├─1272 /usr/bin/whippet
             └─1277 /usr/bin/dbus-broker --log 12 --controller 11 --machine-id ec2aaf8da556039d3f042c6c3ce12549 --max-bytes 536870912 --max-fds 4096 --max-matches 16384

Nov 06 22:54:37 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] No message available - peer :1.3
Nov 06 22:54:37 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] No message available - peer :1.3
Nov 06 22:54:37 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] Message dequeued successfully - peer :1.0
Nov 06 22:54:37 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] Received message from peer :1.0 - type=SIGNAL(4), serial=138
Nov 06 22:54:37 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] Message details - destination='(null)', interface='org.freedesktop.DBus.Properties', member='PropertiesChanged', path='/org/freedesktop/resolve1'
Nov 06 22:54:37 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] Dispatching to driver - peer :1.0
Nov 06 22:54:37 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] Driver dispatch - peer :1.0, destination='(null)'
Nov 06 22:54:37 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] Driver dispatch result - peer :1.0, result=0
Nov 06 22:54:37 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] No message available - peer :1.0
Nov 06 22:54:37 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] No message available - peer :1.0
bash-5.1# systemctl cat whippet.service | grep User
User=dbus
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
