### PR TITLE
Reformat dbus policy rules

### DIFF
--- a/packages/dbus-broker/dbus-1-system.conf
+++ b/packages/dbus-broker/dbus-1-system.conf
@@ -29,6 +29,26 @@
        systems.) -->
   <listen>unix:path=/run/dbus/system_bus_socket</listen>
 
+  <!-- Only systemd, which runs as root, may report activation failures. -->
+  <policy user="root">
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.systemd1.Activator"/>
+  </policy>
+
+  <!-- root may monitor the system bus. -->
+  <policy user="root">
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Monitoring"/>
+  </policy>
+
+  <!-- If the Stats interface was enabled at compile-time, root may use it.
+       Copy this into system.local.conf or system.d/*.conf if you want to
+       enable other privileged users to view statistics and debug info -->
+  <policy user="root">
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Debug.Stats"/>
+  </policy>
+
   <policy context="default">
     <!-- All users can connect to system bus -->
     <allow user="*"/>
@@ -65,26 +85,6 @@
           send_interface="org.freedesktop.DBus.Debug.Stats"/>
     <deny send_destination="org.freedesktop.DBus"
           send_interface="org.freedesktop.systemd1.Activator"/>
-  </policy>
-
-  <!-- Only systemd, which runs as root, may report activation failures. -->
-  <policy user="root">
-    <allow send_destination="org.freedesktop.DBus"
-           send_interface="org.freedesktop.systemd1.Activator"/>
-  </policy>
-
-  <!-- root may monitor the system bus. -->
-  <policy user="root">
-    <allow send_destination="org.freedesktop.DBus"
-           send_interface="org.freedesktop.DBus.Monitoring"/>
-  </policy>
-
-  <!-- If the Stats interface was enabled at compile-time, root may use it.
-       Copy this into system.local.conf or system.d/*.conf if you want to
-       enable other privileged users to view statistics and debug info -->
-  <policy user="root">
-    <allow send_destination="org.freedesktop.DBus"
-           send_interface="org.freedesktop.DBus.Debug.Stats"/>
   </policy>
 
   <!-- Config files are placed here that among other things, punch

--- a/packages/os/dbus-1-system.toml
+++ b/packages/os/dbus-1-system.toml
@@ -1,22 +1,81 @@
-[user.root]
-rules = [
-    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.systemd1.Activator", allow = true },
-    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus.Monitoring", allow = true },
-    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus.Debug.Stats", allow = true }
-]
+# All users can connect to the system bus
+[[default.rules]]
+user = "*"
+allow = true
 
-[default]
-rules = [
-    { user = "*", allow = true },
-    { own = "*", allow = false },
-    { send_type = "method-call", allow = false },
-    { send_type = "signal", allow = true },
-    { receive_type = "method-call", allow = true },
-    { receive_type = "signal", allow = true },
-    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus", allow = true },
-    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus.Introspectable", allow = true },
-    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus.Properties", allow = true },
-    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus", send_member = "UpdateActivationEnvironment", allow = false },
-    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.DBus.Debug.Stats", allow = false },
-    { send_destination = "org.freedesktop.DBus", send_interface = "org.freedesktop.systemd1.Activator", allow = false }
-]
+# Holes must be punched in service configuration files for name ownership
+# and sending method calls
+[[default.rules]]
+own = "*"
+allow = false
+
+[[default.rules]]
+send_type = "method-call"
+allow = false
+
+# Signals are allowed by default
+[[default.rules]]
+send_type = "signal"
+allow = true
+
+# All messages may be received by default
+[[default.rules]]
+receive_type = "method-call"
+allow = true
+
+[[default.rules]]
+receive_type = "signal"
+allow = true
+
+# Allow anyone to talk to the message bus
+[[default.rules]]
+send_destination = "org.freedesktop.DBus"
+send_interface = "org.freedesktop.DBus"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.DBus"
+send_interface = "org.freedesktop.DBus.Introspectable"
+allow = true
+
+[[default.rules]]
+send_destination = "org.freedesktop.DBus"
+send_interface = "org.freedesktop.DBus.Properties"
+allow = true
+
+# But disallow some specific bus services
+[[default.rules]]
+send_destination = "org.freedesktop.DBus"
+send_interface = "org.freedesktop.DBus"
+send_member = "UpdateActivationEnvironment"
+allow = false
+
+[[default.rules]]
+send_destination = "org.freedesktop.DBus"
+send_interface = "org.freedesktop.DBus.Debug.Stats"
+allow = false
+
+[[default.rules]]
+send_destination = "org.freedesktop.DBus"
+send_interface = "org.freedesktop.systemd1.Activator"
+allow = false
+
+# Only systemd, which runs as root, may report activation failures
+[[user.root.rules]]
+send_destination = "org.freedesktop.DBus"
+send_interface = "org.freedesktop.systemd1.Activator"
+allow = true
+
+# root may monitor the system bus
+[[user.root.rules]]
+send_destination = "org.freedesktop.DBus"
+send_interface = "org.freedesktop.DBus.Monitoring"
+allow = true
+
+# If the Stats interface was enabled at compile-time, root may use it.
+# Copy this rule under policies.d/*.toml if you want to enable other
+# privileged users to view statistics and debug info
+[[user.root.rules]]
+send_destination = "org.freedesktop.DBus"
+send_interface = "org.freedesktop.DBus.Debug.Stats"
+allow = true


### PR DESCRIPTION
**Description of changes:**

The first commit of the series fixes the `dbus-1-system.toml` configuration file to use the same format as the other policies generated for `whippet`.

The second commit of the series re-orders the `dbus-broker` and moves the root user policy at the beginning to match `whippet`'s ordering. This helps while debugging as the priority generated for the rules by either the `dbus-launcher` or `whippet` will be identical.

**Testing done:**

Ran `whippet` and the `dbus-launcher` with a local patch, and confirmed that the priorities generated are identical. Here is an example of the log lines printed with my local patch:

```
--- UID 0 ---
verdict=DENY, priority=2635249153387078809, prefix=true, name=''
verdict=DENY, priority=2635249153387078810, name='', path='', interface='', member='', type=1, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078811, name='', path='', interface='', member='', type=4, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078812, name='', path='', interface='', member='', type=1, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078813, name='', path='', interface='', member='', type=4, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078814, name='org.freedesktop.DBus', path='', interface='org.freedesktop.DBus', member='', type=0, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078815, name='org.freedesktop.DBus', path='', interface='org.freedesktop.DBus.Introspectable', member='', type=0, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078816, name='org.freedesktop.DBus', path='', interface='org.freedesktop.DBus.Properties', member='', type=0, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=DENY, priority=2635249153387078817, name='org.freedesktop.DBus', path='', interface='org.freedesktop.DBus', member='UpdateActivationEnvironment', type=0, broadcast=0, min_fds=0, max_fds=18446744073709551615
┌───────────────────> 🌐 ip-172-31-52-240 in ~
└─> ✦ ❯ bat ~/dbus-brokersorted | head -n 10
--- UID 0 ---
verdict=DENY, priority=2635249153387078809, prefix=true, name=''
verdict=DENY, priority=2635249153387078810, name='', path='', interface='', member='', type=1, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078811, name='', path='', interface='', member='', type=4, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078812, name='', path='', interface='', member='', type=1, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078813, name='', path='', interface='', member='', type=4, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078814, name='org.freedesktop.DBus', path='', interface='org.freedesktop.DBus', member='', type=0, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078815, name='org.freedesktop.DBus', path='', interface='org.freedesktop.DBus.Introspectable', member='', type=0, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=ALLOW, priority=2635249153387078816, name='org.freedesktop.DBus', path='', interface='org.freedesktop.DBus.Properties', member='', type=0, broadcast=0, min_fds=0, max_fds=18446744073709551615
verdict=DENY, priority=2635249153387078817, name='org.freedesktop.DBus', path='', interface='org.freedesktop.DBus', member='UpdateActivationEnvironment', type=0, broadcast=0, min_fds=0, max_fds=18446744073709551615
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
