### PR TITLE
Fix whippet defaults and wildcard replacements

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -6699,6 +6699,7 @@ dependencies = [
  "serde_repr",
  "simplelog",
  "snafu",
+ "test-case",
  "tokio",
  "toml",
  "zbus",

--- a/sources/whippet/Cargo.toml
+++ b/sources/whippet/Cargo.toml
@@ -24,3 +24,6 @@ zvariant = { workspace = true }
 
 [build-dependencies]
 generate-readme.workspace = true
+
+[dev-dependencies]
+test-case.workspace = true

--- a/sources/whippet/src/dbus_policy.rs
+++ b/sources/whippet/src/dbus_policy.rs
@@ -26,6 +26,8 @@ use serde::Serialize;
 use snafu::ResultExt;
 use zvariant::{Type, Value as ZVariantValue};
 
+const DEFAULT_MAX_FDS: u64 = u64::MAX;
+
 /// Top-level policy structure that matches launcher's Dbus format. It is crucial that
 /// the order of the fields remains like it is, otherwise the broker rejects the policy.
 ///
@@ -72,7 +74,7 @@ pub struct OwnRecord {
 /// https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c#L877
 macro_rules! impl_record {
     ($record_type:ident, $rule_variant:path, [$(($struct_field:ident, $rule_field:ident)),*]) => {
-        #[derive(Debug, Type, Serialize, Clone, ZVariantValue, Default)]
+        #[derive(Debug, Type, Serialize, Clone, ZVariantValue)]
         pub struct $record_type {
             pub verdict: bool,
             pub priority: u64,
@@ -84,6 +86,23 @@ macro_rules! impl_record {
             pub broadcast: u32,
             pub min_fds: u64,
             pub max_fds: u64,
+        }
+
+        impl Default for $record_type {
+            fn default() -> Self {
+                Self {
+                    verdict: Default::default(),
+                    priority: Default::default(),
+                    name: Default::default(),
+                    path: Default::default(),
+                    interface: Default::default(),
+                    member: Default::default(),
+                    record_type: Default::default(),
+                    broadcast: Default::default(),
+                    min_fds: Default::default(),
+                    max_fds: crate::dbus_policy::DEFAULT_MAX_FDS,
+                }
+            }
         }
 
         impl TryFrom<&Rule> for $record_type {
@@ -99,6 +118,10 @@ macro_rules! impl_record {
                     } => Ok(Self {
                         verdict: *allow,
                         priority: *priority,
+                        name: rule.name()?,
+                        interface: rule.interface()?,
+                        member: rule.member()?,
+                        path: rule.path()?,
                         $($struct_field: $rule_field.clone(),)*
                         ..Self::default()
                     }),
@@ -113,23 +136,17 @@ macro_rules! impl_record {
     };
 }
 
-impl_record!(SendRecord, Rule::Send, [
-    (broadcast, send_broadcast),
-    (name, send_destination),
-    (interface, send_interface),
-    (member, send_member),
-    (path, send_path),
-    (record_type, send_type)
-]);
+impl_record!(
+    SendRecord,
+    Rule::Send,
+    [(broadcast, send_broadcast), (record_type, send_type)]
+);
 
-impl_record!(ReceiveRecord, Rule::Receive, [
-    (broadcast, receive_broadcast),
-    (interface, receive_interface),
-    (member, receive_member),
-    (path, receive_path),
-    (name, receive_sender),
-    (record_type, receive_type)
-]);
+impl_record!(
+    ReceiveRecord,
+    Rule::Receive,
+    [(broadcast, receive_broadcast), (record_type, receive_type)]
+);
 
 impl DbusPolicy {
     /// Builds a new DbusPolicy object using "system" as the only supported bus_type
@@ -427,5 +444,43 @@ mod tests {
 
         let dbus_policy: DbusPolicy = policy.try_into().unwrap();
         assert_eq!(dbus_policy.uid_entries[1].1.send_rules.len(), 2);
+    }
+
+    #[test]
+    fn test_wildcards_replaced_with_empty_string() {
+        let config_str = r#"
+            [default]
+            rules = [
+                { allow = true, send_interface = "*", send_destination = "*", send_path = "*", send_member = "*" },
+            ]
+        "#;
+        let mut policy: Policy = toml::from_str(config_str).unwrap();
+        policy.set_rule_priorities(&mut 0u64);
+        policy.prepare().unwrap();
+
+        let dbus_policy: DbusPolicy = policy.try_into().unwrap();
+        assert_eq!(dbus_policy.uid_entries[0].1.send_rules[0].interface, "");
+        assert_eq!(dbus_policy.uid_entries[0].1.send_rules[0].name, "");
+        assert_eq!(dbus_policy.uid_entries[0].1.send_rules[0].member, "");
+        assert_eq!(dbus_policy.uid_entries[0].1.send_rules[0].path, "");
+    }
+
+    #[test]
+    fn test_max_fds_are_always_the_default() {
+        let config_str = r#"
+            [default]
+            rules = [
+                { allow = true, send_interface = "*", send_destination = "*", send_path = "*", send_member = "*" },
+            ]
+        "#;
+        let mut policy: Policy = toml::from_str(config_str).unwrap();
+        policy.set_rule_priorities(&mut 0u64);
+        policy.prepare().unwrap();
+
+        let dbus_policy: DbusPolicy = policy.try_into().unwrap();
+        assert_eq!(
+            dbus_policy.uid_entries[0].1.send_rules[0].max_fds,
+            DEFAULT_MAX_FDS
+        );
     }
 }

--- a/sources/whippet/src/dbus_policy.rs
+++ b/sources/whippet/src/dbus_policy.rs
@@ -21,7 +21,7 @@
 //! expected by dbus-broker, ensuring compatibility with the broker's policy engine.
 
 use crate::error::{self, Result};
-use crate::policy::{Context, MessageType, Policy, Rule};
+use crate::policy::{Context, Policy, Rule};
 use serde::Serialize;
 use snafu::ResultExt;
 use zvariant::{Type, Value as ZVariantValue};
@@ -52,8 +52,8 @@ pub struct PolicyBatch {
     pub(crate) connect_verdict: bool,
     pub(crate) connect_priority: u64,
     pub(crate) own_rules: Vec<OwnRecord>,
-    pub(crate) send_rules: Vec<SendReceiveRecord>,
-    pub(crate) recv_rules: Vec<SendReceiveRecord>,
+    pub(crate) send_rules: Vec<SendRecord>,
+    pub(crate) recv_rules: Vec<ReceiveRecord>,
 }
 
 /// Represents an Own Record in the actual dbus policy
@@ -67,22 +67,69 @@ pub struct OwnRecord {
     pub name: String,
 }
 
-/// Represents a Send Record in the actual dbus policy
+/// Represents a Send/Receive Record in the actual dbus policy
 /// See:
 /// https://github.com/bus1/dbus-broker/blob/b0db0890d1254477cf832e5f9f0a798360c80fd9/src/launch/policy.c#L877
-#[derive(Debug, Type, Serialize, Clone, ZVariantValue, Default)]
-pub struct SendReceiveRecord {
-    pub verdict: bool,
-    pub priority: u64,
-    pub name: String,
-    pub path: String,
-    pub interface: String,
-    pub member: String,
-    pub record_type: MessageType,
-    pub broadcast: u32,
-    pub min_fds: u64,
-    pub max_fds: u64,
+macro_rules! impl_record {
+    ($record_type:ident, $rule_variant:path, [$(($struct_field:ident, $rule_field:ident)),*]) => {
+        #[derive(Debug, Type, Serialize, Clone, ZVariantValue, Default)]
+        pub struct $record_type {
+            pub verdict: bool,
+            pub priority: u64,
+            pub name: String,
+            pub path: String,
+            pub interface: String,
+            pub member: String,
+            pub record_type: crate::policy::MessageType,
+            pub broadcast: u32,
+            pub min_fds: u64,
+            pub max_fds: u64,
+        }
+
+        impl TryFrom<&Rule> for $record_type {
+            type Error = crate::error::Error;
+
+            fn try_from(rule: &Rule) -> Result<Self> {
+                match rule {
+                    $rule_variant {
+                        allow,
+                        priority,
+                        $($rule_field,)*
+                        ..
+                    } => Ok(Self {
+                        verdict: *allow,
+                        priority: *priority,
+                        $($struct_field: $rule_field.clone(),)*
+                        ..Self::default()
+                    }),
+                    _ => error::RuleToRecordSnafu {
+                        rule_type: format!("{rule:?}"),
+                        record_type: stringify!($record_type).to_string(),
+                    }
+                    .fail(),
+                }
+            }
+        }
+    };
 }
+
+impl_record!(SendRecord, Rule::Send, [
+    (broadcast, send_broadcast),
+    (name, send_destination),
+    (interface, send_interface),
+    (member, send_member),
+    (path, send_path),
+    (record_type, send_type)
+]);
+
+impl_record!(ReceiveRecord, Rule::Receive, [
+    (broadcast, receive_broadcast),
+    (interface, receive_interface),
+    (member, receive_member),
+    (path, receive_path),
+    (name, receive_sender),
+    (record_type, receive_type)
+]);
 
 impl DbusPolicy {
     /// Builds a new DbusPolicy object using "system" as the only supported bus_type
@@ -215,63 +262,6 @@ impl TryFrom<&Rule> for OwnRecord {
             _ => error::RuleToRecordSnafu {
                 rule_type: format!("{rule:?}"),
                 record_type: "OwnRecord".to_string(),
-            }
-            .fail(),
-        }
-    }
-}
-
-impl TryFrom<&Rule> for SendReceiveRecord {
-    type Error = crate::error::Error;
-
-    fn try_from(rule: &Rule) -> Result<Self> {
-        match rule {
-            Rule::Send {
-                allow,
-                send_destination,
-                send_path,
-                send_interface,
-                send_member,
-                send_type,
-                send_broadcast,
-                priority,
-                ..
-            } => Ok(SendReceiveRecord {
-                verdict: *allow,
-                name: send_destination.clone(),
-                path: send_path.clone(),
-                interface: send_interface.clone(),
-                member: send_member.clone(),
-                record_type: *send_type,
-                broadcast: *send_broadcast,
-                priority: *priority,
-                ..SendReceiveRecord::default()
-            }),
-
-            Rule::Receive {
-                receive_sender,
-                receive_path,
-                receive_interface,
-                receive_member,
-                receive_type,
-                receive_broadcast,
-                allow,
-                priority,
-                ..
-            } => Ok(SendReceiveRecord {
-                verdict: *allow,
-                name: receive_sender.clone(),
-                path: receive_path.clone(),
-                interface: receive_interface.clone(),
-                member: receive_member.clone(),
-                record_type: *receive_type,
-                broadcast: *receive_broadcast,
-                priority: *priority,
-                ..SendReceiveRecord::default()
-            }),
-            _ => error::RuleToRecordSnafu {
-                rule_type: format!("{rule:?}"),
-                record_type: "SendRecord".to_string(),
             }
             .fail(),
         }

--- a/sources/whippet/src/error.rs
+++ b/sources/whippet/src/error.rs
@@ -133,4 +133,7 @@ pub enum Error {
         uid: String,
         source: std::num::ParseIntError,
     },
+
+    #[snafu(display("Can't get property '{property}' from rule '{rule_type}'"))]
+    InvalidPropertyForRule { property: String, rule_type: String },
 }

--- a/sources/whippet/src/policy.rs
+++ b/sources/whippet/src/policy.rs
@@ -465,6 +465,31 @@ fn find_priority_threshold(rules: &[Rule]) -> u64 {
         .unwrap_or_default()
 }
 
+/// Macro to generate rule methods that extract fields and replace wildcards with empty strings
+/// See: https://github.com/bus1/dbus-broker/blob/e3324b3736fd40d95e7943fca6e485013d15d643/src/launch/policy.c#L97
+macro_rules! impl_wildcard_getter {
+    ($method_name:ident, ($($rule_type:ident => $field:ident),*)) => {
+        pub(crate) fn $method_name(&self) -> Result<String> {
+            match self {
+                $(
+                    Self::$rule_type { $field, .. } => {
+                        if $field == "*" {
+                            Ok("".to_string())
+                        } else {
+                            Ok($field.to_owned())
+                        }
+                    }
+                )*
+                _ => error::InvalidPropertyForRuleSnafu {
+                    property: stringify!($method_name).to_string(),
+                    rule_type: format!("{self:?}"),
+                }
+                .fail(),
+            }
+        }
+    };
+}
+
 impl Rule {
     /// Sets the priority of the rule
     fn set_priority(&mut self, new_priority: u64) {
@@ -489,6 +514,11 @@ impl Rule {
     fn is_connect(&self) -> bool {
         matches!(self, Self::ConnectUser { .. })
     }
+
+    impl_wildcard_getter!(interface, (Send => send_interface, Receive => receive_interface));
+    impl_wildcard_getter!(name, (Send => send_destination, Receive => receive_sender));
+    impl_wildcard_getter!(member, (Send => send_member, Receive => receive_member));
+    impl_wildcard_getter!(path, (Send => send_path, Receive => receive_path));
 }
 
 impl Context {
@@ -551,6 +581,7 @@ impl UsernameResolver for PasswdUsernameResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
     const ALICE_USER: u32 = 1;
     const BOB_USER: u32 = 2;
@@ -919,5 +950,59 @@ mod tests {
 
         clean_connect_rules(4, &mut rules);
         assert!(rules.is_empty());
+    }
+
+    #[test_case(Rule::Send {
+            allow: false,
+            priority: u64::default(),
+            send_broadcast: u32::default(),
+            send_destination: "*".to_string(),
+            send_interface: "*".to_string(),
+            send_member: "*".to_string(),
+            send_path: "*".to_string(),
+            send_type: MessageType::default(),
+        }; "with a send rule wildcards are replaced with empty strings")]
+    #[test_case(Rule::Receive {
+            allow: false,
+            priority: u64::default(),
+            receive_broadcast: u32::default(),
+            receive_interface: "*".to_string(),
+            receive_member: "*".to_string(),
+            receive_path: "*".to_string(),
+            receive_sender: "*".to_string(),
+            receive_type: MessageType::default(),
+        }; "with a receive rule wildcards are replaced with empty strings")]
+    fn rules_with_wildcards(rule: Rule) {
+        assert_eq!(rule.name().unwrap(), "");
+        assert_eq!(rule.interface().unwrap(), "");
+        assert_eq!(rule.member().unwrap(), "");
+        assert_eq!(rule.path().unwrap(), "");
+    }
+
+    #[test_case(Rule::Send {
+            allow: false,
+            priority: u64::default(),
+            send_broadcast: u32::default(),
+            send_destination: "name".to_string(),
+            send_interface: "interface".to_string(),
+            send_member: "member".to_string(),
+            send_path: "path".to_string(),
+            send_type: MessageType::default(),
+        }; "with a send rule the original value is returned")]
+    #[test_case(Rule::Receive {
+            allow: false,
+            priority: u64::default(),
+            receive_broadcast: u32::default(),
+            receive_interface: "interface".to_string(),
+            receive_member: "member".to_string(),
+            receive_path: "path".to_string(),
+            receive_sender: "name".to_string(),
+            receive_type: MessageType::default(),
+        }; "with a receive rule the original value is returned")]
+    fn rules_without_wildcards(rule: Rule) {
+        assert_eq!(rule.name().unwrap(), "name");
+        assert_eq!(rule.interface().unwrap(), "interface");
+        assert_eq!(rule.member().unwrap(), "member");
+        assert_eq!(rule.path().unwrap(), "path");
     }
 }


### PR DESCRIPTION
**Description of changes:**

The first patch of the splits `SendReceiveRecord` to their own structures. I did this after discussing with @cbgbt that it will be best to have them separated to have a clear separation of concerns and make it harder for developers to construct the wrong type from a `Rule`.

The second patch of the series fixes the default value used by `SendRecord` and `ReceiveRecord` for the `max_fds`, to match what the `dbus-launcher` uses. As part of this change, I also fixed how `whippet` handles wildcards `*` while translating `Rule` to `Send` and `Receive` records, and replaces those values with empty strings following what the `dbus-launcher` does.

**Testing done:**

Prior to this change, `systemd-nspawn` in systemd 257 failed to create containers as one of the Dbus messages included `max_fds = 1` which failed to match the broker condition `MESSAGE_max_fds <= RULE_max_fds`, since `RULE_max_fds` was set to 0 for all rules.

After this change, `systemd-nspawn` runs successfully:

<details>

```bash
bash-5.1# systemd-analyze --version
systemd 257 (257.7)
-PAM -AUDIT +SELINUX -APPARMOR -IMA +IPE -SMACK +SECCOMP -GCRYPT -GNUTLS -OPENSSL +ACL +BLKID -CURL -ELFUTILS -FIDO2 -IDN2 -IDN -IPTC +KMOD -LIBCRYPTSETUP -LIBCRYPTSETUP_PLUGINS +LIBFDISK -PCRE2 -PWQUALITY -P11KIT -QRENCODE -TPM2 -BZIP2 -LZ4 -XZ -ZLIB -ZSTD -BPF_FRAMEWORK -BTF -XKBCOMMON -UTMP -SYSVINIT -LIBARCHIVE
bash-5.1# systemctl status whippet.service
● whippet.service - D-Bus System Message Bus
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/whippet.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Thu 2025-11-06 04:54:25 UTC; 18h ago
 Invocation: 6278eaaeb65f404c9dc940b2a226692e
TriggeredBy: ● dbus.socket
   Main PID: 1272 (whippet)
      Tasks: 6 (limit: 18596)
     Memory: 5.5M (peak: 21.8M)
        CPU: 4.372s
     CGroup: /system.slice/whippet.service
             ├─1272 /usr/bin/whippet
             └─1277 /usr/bin/dbus-broker --log 12 --controller 11 --machine-id ec2aaf8da556039d3f042c6c3ce12549 --max-bytes 536870912 --max-fds 4096 --max-matches 16384

Nov 06 23:29:05 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: POLICY_NAME_CHECK: RECV name=org.freedesktop.systemd1 subject_id=1 subject_seclabel=system_u:system_r:init_t:s0
Nov 06 23:29:05 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: POLICY_NAME_RESULT: RECV name=org.freedesktop.systemd1 subject_id=1 result=rules_found
Nov 06 23:29:05 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: POLICY_RULE_EVAL: RECV subject_id=1 name=org.freedesktop.systemd1 rule_priority=7905747460161236529 priority_match=YES type_match=YES path_match=YES interface_match=YES member_match=YES broadcast_match=YES f…
Nov 06 23:29:05 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: POLICY_RULE_MATCH: RECV name=org.freedesktop.systemd1 path=/org/freedesktop/systemd1 interface=org.freedesktop.systemd1.Manager member=UnitRemoved type=4 broadcast=true n_fds=0 rule_path…1236529 verdict=ALLOW
Nov 06 23:29:05 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: POLICY_RULE_EVAL: RECV subject_id=1 name=org.freedesktop.systemd1 rule_priority=2635249153387079026 priority_match=NO type_match=YES path_match=YES interface_match=YES member_match=YES broadcast_match=YES fd…
Nov 06 23:29:05 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: POLICY_FINAL_VERDICT: RECV subject_id=1 interface=org.freedesktop.systemd1.Manager method=UnitRemoved path=/org/freedesktop/systemd1 type=4 broadcast=true n_fds=0 priority=7905747460161236529 verdict=ALLOW
Nov 06 23:29:05 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] Driver dispatch result - peer :1.1, result=0
Nov 06 23:29:05 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] No message available - peer :1.1
Nov 06 23:29:05 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] No message available - peer :1.1
Nov 06 23:29:05 ip-172-31-46-10.us-west-2.compute.internal whippet[1277]: [BROKER] No message available - peer :1.2
Hint: Some lines were ellipsized, use -l to show in full.
bash-5.1# systemd-nspawn -D /var/lib/machines/test-container/ --register=no bash
░ Spawning container test-container on /var/lib/machines/test-container.
░ Press Ctrl-] three times within 1s to kill container.
bash-5.2#
```

I tested creating a container with its own ENI, and confirmed that all the plumbing to set that up works:

```bash
bash-5.1# systemd-nspawn -D /var/lib/machines/test-container/ --register=no --network-interface=eth1 --resolv-conf=off --boot
░ Spawning container test-container on /var/lib/machines/test-container.
░ Press Ctrl-] three times within 1s to kill container.
systemd 252.23-8.amzn2023 running in system mode (+PAM +AUDIT +SELINUX -APPARMOR +IMA +SMACK +SECCOMP -GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN -IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 +PWQUALITY +P11KIT +QRENCODE +TPM2 -BZIP2 -LZ4 +XZ +ZLIB -ZSTD +BPF_FRAMEWORK +XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified)
Detected virtualization systemd-nspawn.
Detected architecture x86-64.

Welcome to Amazon Linux 2023.9.20251105!

bpf-lsm: BPF LSM hook not enabled in the kernel, BPF LSM not supported
Queued start job for default target graphical.target.
[  OK  ] Created slice system-getty.slice - Slice /system/getty.
[  OK  ] Created slice system-modprobe.slice - Slice /system/modprobe.
[  OK  ] Created slice user.slice - User and Session Slice.
[  OK  ] Started systemd-ask-password-console.path - Dispatch Password Requests to Console Directory Watch.
[  OK  ] Started systemd-ask-password-wall.path - Forward Password Requests to Wall Directory Watch.
[  OK  ] Reached target local-fs.target - Local File Systems.
[  OK  ] Reached target paths.target - Path Units.
[  OK  ] Reached target remote-fs.target - Remote File Systems.
[  OK  ] Reached target slices.target - Slice Units.
[  OK  ] Reached target swap.target - Swaps.
[  OK  ] Listening on systemd-initctl.socket - initctl Compatibility Named Pipe.
[  OK  ] Listening on systemd-journald-dev-log.socket - Journal Socket (/dev/log).
[  OK  ] Listening on systemd-journald.socket - Journal Socket.
[  OK  ] Listening on systemd-networkd.socket - Network Service Netlink Socket.
[  OK  ] Listening on systemd-userdbd.socket - User Database Manager Socket.
         Mounting dev-hugepages.mount - Huge Pages File System...
         Starting systemd-journald.service - Journal Service...
         Starting systemd-network-generator.service - Generate network units from Kernel command line...
[  OK  ] Mounted dev-hugepages.mount - Huge Pages File System.
[  OK  ] Finished systemd-network-generator.service - Generate network units from Kernel command line.
[  OK  ] Reached target network-pre.target - Preparation for Network.
         Starting systemd-networkd.service - Network Configuration...
[  OK  ] Started systemd-journald.service - Journal Service.
         Starting systemd-journal-flush.service - Flush Journal to Persistent Storage...
[  OK  ] Finished systemd-journal-flush.service - Flush Journal to Persistent Storage.
         Starting systemd-tmpfiles-setup.service - Create Volatile Files and Directories...
[  OK  ] Started systemd-networkd.service - Network Configuration.
[  OK  ] Finished systemd-tmpfiles-setup.service - Create Volatile Files and Directories.
         Starting systemd-resolved.service - Network Name Resolution...
         Starting systemd-update-utmp.service - Record System Boot/Shutdown in UTMP...
[  OK  ] Finished systemd-update-utmp.service - Record System Boot/Shutdown in UTMP.
[  OK  ] Started systemd-resolved.service - Network Name Resolution.
[  OK  ] Reached target network.target - Network.
[  OK  ] Reached target nss-lookup.target - Host and Network Name Lookups.
[  OK  ] Reached target sysinit.target - System Initialization.
[  OK  ] Started systemd-tmpfiles-clean.timer - Daily Cleanup of Temporary Directories.
[  OK  ] Reached target timers.target - Timer Units.
[  OK  ] Listening on dbus.socket - D-Bus System Message Bus Socket.
[  OK  ] Reached target sockets.target - Socket Units.
[  OK  ] Reached target basic.target - Basic System.
         Starting systemd-logind.service - User Login Management...
         Starting systemd-user-sessions.service - Permit User Sessions...
         Starting dbus-broker.service - D-Bus System Message Bus...
[  OK  ] Finished systemd-user-sessions.service - Permit User Sessions.
[  OK  ] Started console-getty.service - Console Getty.
[  OK  ] Reached target getty.target - Login Prompts.
[  OK  ] Started dbus-broker.service - D-Bus System Message Bus.
[  OK  ] Started systemd-logind.service - User Login Management.
[  OK  ] Reached target multi-user.target - Multi-User System.
[  OK  ] Reached target graphical.target - Graphical Interface.
         Starting systemd-update-utmp-runlevel.service - Record Runlevel Change in UTMP...
[  OK  ] Finished systemd-update-utmp-runlevel.service - Record Runlevel Change in UTMP.

Amazon Linux 2023.9.20251105
Kernel 6.1.156 on an x86_64 (-)

test-container login:
```

I had internet access from within the container:

```bash
[root@test-container /]# cat /etc/os-release
NAME="Amazon Linux"
VERSION="2023"
ID="amzn"
ID_LIKE="fedora"
VERSION_ID="2023"
PLATFORM_ID="platform:al2023"
PRETTY_NAME="Amazon Linux 2023.9.20251105"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2023"
HOME_URL="https://aws.amazon.com/linux/amazon-linux-2023/"
DOCUMENTATION_URL="https://docs.aws.amazon.com/linux/"
SUPPORT_URL="https://aws.amazon.com/premiumsupport/"
BUG_REPORT_URL="https://github.com/amazonlinux/amazon-linux-2023"
VENDOR_NAME="AWS"
VENDOR_URL="https://aws.amazon.com/"
SUPPORT_END="2029-06-30"
[root@test-container /]# ping 8.8.8.8
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
64 bytes from 8.8.8.8: icmp_seq=1 ttl=117 time=5.89 ms
64 bytes from 8.8.8.8: icmp_seq=2 ttl=117 time=5.88 ms
^C
--- 8.8.8.8 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1002ms
rtt min/avg/max/mdev = 5.875/5.883/5.891/0.008 ms
[root@test-container /]#
```

I tested `networkctl` can configure the extra ENI in my host:

```bash
bash-5.1# networkctl list
IDX LINK    TYPE     OPERATIONAL SETUP
  1 lo      loopback carrier     unmanaged
  2 eth0    ether    routable    configured
  3 docker0 bridge   no-carrier  unmanaged
  6 eth1    ether    routable    configured

4 links listed.
bash-5.1# ping -I eth1 8.8.8.8
PING 8.8.8.8 (8.8.8.8) from 172.31.40.46 eth1: 56(84) bytes of data.
64 bytes from 8.8.8.8: icmp_seq=1 ttl=117 time=5.97 ms
^C
--- 8.8.8.8 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 5.974/5.974/5.974/0.000 ms
bash-5.1#  resolvectl status eth1
Link 6 (eth1)
    Current Scopes: DNS
         Protocols: +DefaultRoute -LLMNR -mDNS -DNSOverTLS DNSSEC=no/unsupported
Current DNS Server: 8.8.8.8
       DNS Servers: 8.8.8.8 172.31.0.2
     Default Route: yes
bash-5.1#
```

</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
