### PR TITLE
rdma-core: bump version to 60.0 and enable pci in hwloc

### DIFF
--- a/packages/hwloc/hwloc.spec
+++ b/packages/hwloc/hwloc.spec
@@ -36,7 +36,6 @@ Requires: %{_cross_os}systemd-devel
     --disable-gl \
     --disable-libxml2 \
     --disable-opencl \
-    --disable-pci \
     --disable-plugins \
     --exec-prefix=%{_cross_prefix} \
     --program-prefix=""

--- a/packages/rdma-core/Cargo.toml
+++ b/packages/rdma-core/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/linux-rdma/rdma-core/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/linux-rdma/rdma-core/releases/download/v57.0/rdma-core-57.0.tar.gz"
-sha512 = "4a904d34af6863655545fe720cc25a8800684f63c51cebb67be2058363949217903957dc925c69d41294362ccff75fb0d37f3bc31cd6f6f252a804d6713f62cf"
+url = "https://github.com/linux-rdma/rdma-core/releases/download/v60.0/rdma-core-60.0.tar.gz"
+sha512 = "e1e4d95b42b2374145b5f1e06ff82da39e4f9d4ec7bada3d4e931efad30281d7ceed80f1150b5de506a6d756b6f360ac5eff3ec6bbb79684a17008b551308d50"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/rdma-core/rdma-core.spec
+++ b/packages/rdma-core/rdma-core.spec
@@ -1,7 +1,7 @@
-%global abiver 57
+%global abiver 59
 
 Name: %{_cross_os}rdma-core
-Version: 57.0
+Version: 60.0
 Release: 1%{?dist}
 Summary: RDMA core userspace infrastructure, including core libraries and util programs.
 License: Linux-OpenIB AND MIT


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
* rdma-core: bump version to 60.0
* Also enable pci in hwloc


**Testing done:**
* Performed confirmation tests to ensure EKS compatibility.
* Verified booted AMI


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
