### PR TITLE
add lockdown API

### DIFF
--- a/sources/api/apiclient/src/lib.rs
+++ b/sources/api/apiclient/src/lib.rs
@@ -23,6 +23,7 @@ pub mod apply;
 pub mod ephemeral_storage;
 pub mod exec;
 pub mod get;
+pub mod lockdown;
 pub mod reboot;
 pub mod report;
 pub mod set;

--- a/sources/api/apiclient/src/lockdown.rs
+++ b/sources/api/apiclient/src/lockdown.rs
@@ -1,0 +1,36 @@
+use log::info;
+use snafu::ResultExt;
+use std::path::Path;
+
+/// Requests a lockdown through the API.
+pub async fn lockdown<P>(socket_path: P) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    let uri = "/actions/lockdown";
+    let method = "POST";
+    let (_status, _body) = crate::raw_request(&socket_path, uri, method, None)
+        .await
+        .context(error::RequestSnafu { uri, method })?;
+
+    info!("Lockdown completed");
+    Ok(())
+}
+
+mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub enum Error {
+        #[snafu(display("Failed {} request to '{}': {}", method, uri, source))]
+        Request {
+            method: String,
+            uri: String,
+            #[snafu(source(from(crate::Error, Box::new)))]
+            source: Box<crate::Error>,
+        },
+    }
+}
+pub use error::Error;
+pub type Result<T> = std::result::Result<T, error::Error>;

--- a/sources/api/apiclient/src/main.rs
+++ b/sources/api/apiclient/src/main.rs
@@ -6,7 +6,9 @@
 // library calls based on the given flags, etc.)  The library modules contain the code for talking
 // to the API, which is intended to be reusable by other crates.
 
-use apiclient::{apply, ephemeral_storage, exec, get, reboot, report, set, update, SettingsInput};
+use apiclient::{
+    apply, ephemeral_storage, exec, get, lockdown, reboot, report, set, update, SettingsInput,
+};
 use log::{info, log_enabled, trace, warn};
 use model::ephemeral_storage::{Filesystem, Preference};
 use serde::{Deserialize, Serialize};
@@ -46,6 +48,7 @@ enum Subcommand {
     Apply(ApplyArgs),
     Exec(ExecArgs),
     Get(GetArgs),
+    Lockdown(LockdownArgs),
     Raw(RawArgs),
     Reboot(RebootArgs),
     Set(SetArgs),
@@ -86,6 +89,10 @@ struct RawArgs {
     uri: String,
     data: Option<String>,
 }
+
+/// Stores user-supplied arguments for the 'lockdown' subcommand.
+#[derive(Debug)]
+struct LockdownArgs {}
 
 /// Stores user-supplied arguments for the 'reboot' subcommand.
 #[derive(Debug)]
@@ -199,6 +206,7 @@ fn usage() -> ! {
             update check               Prints information about available updates.
             update apply               Applies available updates.
             update cancel              Deactivates an applied update.
+            lockdown                   Locks down the host.
             reboot                     Reboots the host.
             exec                       Execute a command in a host container.
             report cis                 Retrieve a Bottlerocket CIS benchmark compliance report.
@@ -222,6 +230,9 @@ fn usage() -> ! {
             [ URI ...]                 The list of URIs to TOML or JSON settings files that you
                                        want to apply to the system.  If no URI is specified, or
                                        if "-" is given, reads from stdin.
+
+        lockdown options:
+            None.
 
         reboot options:
             None.
@@ -365,8 +376,8 @@ fn parse_args(args: impl Iterator<Item = String>) -> (Args, Subcommand) {
             }
 
             // Subcommands
-            "raw" | "apply" | "exec" | "get" | "reboot" | "report" | "set" | "update"
-            | "ephemeral-storage"
+            "raw" | "apply" | "exec" | "get" | "lockdown" | "reboot" | "report" | "set"
+            | "update" | "ephemeral-storage"
                 if subcommand.is_none() && !arg.starts_with('-') =>
             {
                 subcommand = Some(arg)
@@ -383,6 +394,7 @@ fn parse_args(args: impl Iterator<Item = String>) -> (Args, Subcommand) {
         Some("apply") => (global_args, parse_apply_args(subcommand_args)),
         Some("exec") => (global_args, parse_exec_args(subcommand_args)),
         Some("get") => (global_args, parse_get_args(subcommand_args)),
+        Some("lockdown") => (global_args, parse_lockdown_args(subcommand_args)),
         Some("reboot") => (global_args, parse_reboot_args(subcommand_args)),
         Some("report") => (global_args, parse_report_args(subcommand_args)),
         Some("set") => (global_args, parse_set_args(subcommand_args)),
@@ -543,6 +555,14 @@ fn parse_get_args(args: Vec<String>) -> Subcommand {
             canonicalize,
         })
     }
+}
+
+/// Parses arguments for the 'lockdown' subcommand.
+fn parse_lockdown_args(args: Vec<String>) -> Subcommand {
+    if !args.is_empty() {
+        usage_msg(format!("Unknown arguments: {}", args.join(", ")));
+    }
+    Subcommand::Lockdown(LockdownArgs {})
 }
 
 /// Parses arguments for the 'reboot' subcommand.
@@ -1058,6 +1078,12 @@ async fn run() -> Result<()> {
             }
         }
 
+        Subcommand::Lockdown(_lockdown) => {
+            lockdown::lockdown(&args.socket_path)
+                .await
+                .context(error::LockdownSnafu)?;
+        }
+
         Subcommand::Reboot(_reboot) => {
             reboot::reboot(&args.socket_path)
                 .await
@@ -1226,7 +1252,7 @@ async fn main() {
 }
 
 mod error {
-    use apiclient::{apply, ephemeral_storage, exec, get, reboot, report, set, update};
+    use apiclient::{apply, ephemeral_storage, exec, get, lockdown, reboot, report, set, update};
     use snafu::Snafu;
 
     #[derive(Debug, Snafu)]
@@ -1243,6 +1269,9 @@ mod error {
 
         #[snafu(display("Logger setup error: {}", source))]
         Logger { source: log::SetLoggerError },
+
+        #[snafu(display("Failed to lockdown: {}", source))]
+        Lockdown { source: lockdown::Error },
 
         #[snafu(display("Failed to reboot: {}", source))]
         Reboot { source: reboot::Error },

--- a/sources/api/apiserver/src/bin/apiserver.rs
+++ b/sources/api/apiserver/src/bin/apiserver.rs
@@ -6,9 +6,8 @@ extern crate log;
 use libc::gid_t;
 use nix::unistd::Gid;
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
-use snafu::{ensure, ResultExt};
+use snafu::ResultExt;
 use std::env;
-use std::path::Path;
 use std::process;
 use std::str::FromStr;
 
@@ -28,9 +27,6 @@ mod error {
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(crate)))]
     pub(crate) enum Error {
-        #[snafu(display("Datastore does not exist, did storewolf run?"))]
-        NonexistentDatastore,
-
         #[snafu(display("{}", source))]
         Server { source: apiserver::server::Error },
 
@@ -145,12 +141,6 @@ async fn run() -> Result<()> {
 
     // SimpleLogger will send errors to stderr and anything less to stdout.
     SimpleLogger::init(args.log_level, LogConfig::default()).context(error::LoggerSnafu)?;
-
-    // Make sure the datastore exists
-    ensure!(
-        Path::new(&args.datastore_path).exists(),
-        error::NonexistentDatastoreSnafu
-    );
 
     // Access to the data store is controlled through a RwLock, allowing many readers, but a
     // writer will block all other access.  We don't expect any real load, though, as the API

--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -179,8 +179,25 @@ pub enum Error {
     #[snafu(display("Unable to send input to config applier: {}", source))]
     ConfigApplierWrite { source: io::Error },
 
+    #[snafu(display("Unable to start lockdown helper '{}': {}", program, source))]
+    LockdownExec { source: io::Error, program: String },
+
     #[snafu(display("Unable to start shutdown: {}", source))]
     Shutdown { source: io::Error },
+
+    #[snafu(display(
+        "Failed to run lockdown helper '{:?}', exit code: {}, stdout: '{}', stderr: '{}'",
+        args,
+        exit_code,
+        stdout,
+        stderr
+    ))]
+    Lockdown {
+        exit_code: i32,
+        stdout: String,
+        stderr: String,
+        args: Vec<&'static str>,
+    },
 
     #[snafu(display("Failed to reboot, exit code: {}, stderr: {}", exit_code, stderr))]
     Reboot { exit_code: i32, stderr: String },

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -131,6 +131,7 @@ where
             )
             .service(
                 web::scope("/actions")
+                    .route("/lockdown", web::post().to(lockdown))
                     .route("/reboot", web::post().to(reboot))
                     .route("/refresh-updates", web::post().to(refresh_updates))
                     .route("/prepare-update", web::post().to(prepare_update))
@@ -634,6 +635,37 @@ async fn deactivate_update() -> Result<HttpResponse> {
     controller::dispatch_update_command(&["deactivate"])
 }
 
+/// Locks down the machine
+async fn lockdown() -> Result<HttpResponse> {
+    debug!("Locking down now");
+    let commands = vec![vec![
+        "rottweiler",
+        "lock",
+        "directory",
+        "/.bottlerocket/datastore",
+    ]];
+
+    for args in commands {
+        let output = Command::new(args[0])
+            .args(&args[1..])
+            .output()
+            .context(error::LockdownExecSnafu { program: args[0] })?;
+        ensure!(
+            output.status.success(),
+            error::LockdownSnafu {
+                exit_code: match output.status.code() {
+                    Some(code) => code,
+                    None => output.status.signal().unwrap_or(1),
+                },
+                stdout: String::from_utf8_lossy(&output.stdout),
+                stderr: String::from_utf8_lossy(&output.stderr),
+                args
+            }
+        );
+    }
+    Ok(HttpResponse::NoContent().finish())
+}
+
 /// Reboots the machine
 async fn reboot() -> Result<HttpResponse> {
     debug!("Rebooting now");
@@ -978,6 +1010,8 @@ impl ResponseError for error::Error {
             SettingsToJson { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ReleaseData { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Shutdown { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Lockdown { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            LockdownExec { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Reboot { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             UpdateDispatcher { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             UpdateError => StatusCode::INTERNAL_SERVER_ERROR,

--- a/sources/api/openapi.yaml
+++ b/sources/api/openapi.yaml
@@ -642,6 +642,16 @@ paths:
         500:
           description: "Server error"
 
+  /actions/lockdown:
+    post:
+      summary: "Lockdown"
+      operationId: "lockdown"
+      responses:
+        204:
+          description: "Lockdown requested"
+        500:
+          description: "Server error"
+
   /actions/reboot:
     post:
       summary: "Reboot"


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/4680

**Description of changes:**
Add a new API to lock down the OS, preventing changes to persistent settings.


**Testing done:**
```
# initiate lockdown
bash-5.2# apiclient lockdown
18:25:23 [INFO] Lockdown requested

# "os" is still accessible as it doesn't require the datastore
bash-5.2# apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "c667fb85d",
    "pretty_name": "Bottlerocket OS 1.46.0 (aws-dev)",
    "variant_id": "aws-dev",
    "version_id": "1.46.0"
  }
}

# Ugly error when trying to get settings.
bash-5.2# apiclient get settings.motd
Failed to get settings: Failed GET request to '/?prefix=settings.motd': Status 500 when GETing /?prefix=settings.motd: Data store error during get_prefix 'settings.motd' for Live: Data store integrity violation at /var/lib/bottlerocket/datastore/current/live: Live datastore missing

# Ugly error when trying to set settings.
bash-5.2# apiclient set motd=hey
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-pv6lLChRksmB04d3': Status 500 when PATCHing /settings/keypair?tx=apiclient-set-pv6lLChRksmB04d3: Data store error during Failure in setting metadata.: IO error on '/var/lib/bottlerocket/datastore/current/pending/apiclient-set-pv6lLChRksmB04d3/settings': Required key not available (os error 126)

# Reboot still works!
bash-5.2# apiclient reboot
18:26:26 [INFO] Rebooting, goodbye...

# After reboot, settings are available again (otherwise boot would fail).
bash-5.2# apiclient get settings.motd
{
  "settings": {
    "motd": "Welcome to Bottlerocket!"
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
