### PR TITLE
ecr-credential-provider: patch to support AWS EUSC

### DIFF
--- a/packages/ecr-credential-provider-1.28/0001-support-new-aws-partition-in-credential-provider.patch
+++ b/packages/ecr-credential-provider-1.28/0001-support-new-aws-partition-in-credential-provider.patch
@@ -1,0 +1,55 @@
+From 9a0819d0782d06da30e4942f207c61f6a5cecf81 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Sat, 25 Oct 2025 01:19:05 +0000
+Subject: [PATCH] support new aws partition in credential provider
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go      |  2 +-
+ cmd/ecr-credential-provider/main_test.go | 10 ++++++++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index 0d78e046..b61bd789 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -42,7 +42,7 @@ import (
+ const ecrPublicRegion string = "us-east-1"
+ const ecrPublicHost string = "public.ecr.aws"
+ 
+-var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
++var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
+ 
+ // ECR abstracts the calls we make to aws-sdk for testing purposes
+ type ECR interface {
+diff --git a/cmd/ecr-credential-provider/main_test.go b/cmd/ecr-credential-provider/main_test.go
+index 296506fb..d047e343 100644
+--- a/cmd/ecr-credential-provider/main_test.go
++++ b/cmd/ecr-credential-provider/main_test.go
+@@ -352,6 +352,12 @@ func Test_parseRegionFromECRPrivateHost(t *testing.T) {
+ 			host:   "123456789123.dkr.ecr.us-iso-east-1.c2s.ic.gov",
+ 			region: "us-iso-east-1",
+ 		},
++		// EUSC
++		{
++			name:   "success",
++			host:   "123456789123.dkr.ecr.eusc-de-east-1.amazonaws.eu",
++			region: "eusc-de-east-1",
++		},
+ 		// Dual-Stack
+ 		{
+ 			name:   "success",
+@@ -411,6 +417,10 @@ func TestRegistryPatternMatch(t *testing.T) {
+ 		{"123456789012.dkr.ecr-fips.lala-land-1.amazonaws.com", true},
+ 		// .cn
+ 		{"123456789012.dkr.ecr.lala-land-1.amazonaws.com.cn", true},
++		// .eu
++		{"123456789012.dkr.ecr.eusc-de-east-1.amazonaws.eu", true},
++		// .eu with fips
++		{"123456789012.dkr.ecr-fips.eusc-de-east-1.amazonaws.eu", true},
+ 		// registry ID too long
+ 		{"1234567890123.dkr.ecr.lala-land-1.amazonaws.com", false},
+ 		// registry ID too short
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.28/0002-ecr-credential-provider-hardcode-ecr-endpoint-for-eu.patch
+++ b/packages/ecr-credential-provider-1.28/0002-ecr-credential-provider-hardcode-ecr-endpoint-for-eu.patch
@@ -1,0 +1,32 @@
+From f718bd08a9d9c8a12471680b12da931a910b61a8 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Sat, 8 Nov 2025 00:20:30 +0000
+Subject: [PATCH] ecr-credential-provider: hardcode ecr endpoint for
+ eusc-de-east-1
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index 5b7d3f6d..ac01797f 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -60,8 +60,12 @@ type ecrPlugin struct {
+ }
+ 
+ func defaultECRProvider(region string) (*ecr.ECR, error) {
++	cfg := aws.Config{Region: aws.String(region)};
++	if region == "eusc-de-east-1" {
++		cfg.Endpoint = aws.String("https://api.ecr.eusc-de-east-1.amazonaws.eu")
++	}
+ 	sess, err := session.NewSessionWithOptions(session.Options{
+-		Config:            aws.Config{Region: aws.String(region)},
++		Config:            cfg,
+ 		SharedConfigState: session.SharedConfigEnable,
+ 	})
+ 	if err != nil {
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.28/ecr-credential-provider-1.28.spec
+++ b/packages/ecr-credential-provider-1.28/ecr-credential-provider-1.28.spec
@@ -19,6 +19,9 @@ Source: cloud-provider-aws-%{gover}.tar.gz
 Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
 Source1000: clarify.toml
 
+Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
+Patch0002: 0002-ecr-credential-provider-hardcode-ecr-endpoint-for-eu.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{name}(binaries)
 
@@ -48,7 +51,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{summary}.
 
 %prep
-%setup -n %{gorepo}-%{gover} -q
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 %setup -T -D -n %{gorepo}-%{gover} -b 1 -q
 
 %build

--- a/packages/ecr-credential-provider-1.29/0001-support-new-aws-partition-in-credential-provider.patch
+++ b/packages/ecr-credential-provider-1.29/0001-support-new-aws-partition-in-credential-provider.patch
@@ -1,0 +1,55 @@
+From 9a0819d0782d06da30e4942f207c61f6a5cecf81 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Sat, 25 Oct 2025 01:19:05 +0000
+Subject: [PATCH] support new aws partition in credential provider
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go      |  2 +-
+ cmd/ecr-credential-provider/main_test.go | 10 ++++++++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index 0d78e046..b61bd789 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -42,7 +42,7 @@ import (
+ const ecrPublicRegion string = "us-east-1"
+ const ecrPublicHost string = "public.ecr.aws"
+ 
+-var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
++var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
+ 
+ // ECR abstracts the calls we make to aws-sdk for testing purposes
+ type ECR interface {
+diff --git a/cmd/ecr-credential-provider/main_test.go b/cmd/ecr-credential-provider/main_test.go
+index 296506fb..d047e343 100644
+--- a/cmd/ecr-credential-provider/main_test.go
++++ b/cmd/ecr-credential-provider/main_test.go
+@@ -352,6 +352,12 @@ func Test_parseRegionFromECRPrivateHost(t *testing.T) {
+ 			host:   "123456789123.dkr.ecr.us-iso-east-1.c2s.ic.gov",
+ 			region: "us-iso-east-1",
+ 		},
++		// EUSC
++		{
++			name:   "success",
++			host:   "123456789123.dkr.ecr.eusc-de-east-1.amazonaws.eu",
++			region: "eusc-de-east-1",
++		},
+ 		// Dual-Stack
+ 		{
+ 			name:   "success",
+@@ -411,6 +417,10 @@ func TestRegistryPatternMatch(t *testing.T) {
+ 		{"123456789012.dkr.ecr-fips.lala-land-1.amazonaws.com", true},
+ 		// .cn
+ 		{"123456789012.dkr.ecr.lala-land-1.amazonaws.com.cn", true},
++		// .eu
++		{"123456789012.dkr.ecr.eusc-de-east-1.amazonaws.eu", true},
++		// .eu with fips
++		{"123456789012.dkr.ecr-fips.eusc-de-east-1.amazonaws.eu", true},
+ 		// registry ID too long
+ 		{"1234567890123.dkr.ecr.lala-land-1.amazonaws.com", false},
+ 		// registry ID too short
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.29/0002-ecr-credential-provider-hardcode-ecr-endpoint-for-eu.patch
+++ b/packages/ecr-credential-provider-1.29/0002-ecr-credential-provider-hardcode-ecr-endpoint-for-eu.patch
@@ -1,0 +1,28 @@
+From f982a493072fd8ca9af7d14e5d33e393f3e9fdfb Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Wed, 29 Oct 2025 20:19:45 +0000
+Subject: [PATCH] ecr-credential-provider: hardcode ecr endpoint for
+ eusc-de-east-1
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index d0033010..a90ffcb5 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -64,6 +64,9 @@ func defaultECRProvider(region string) (*ecr.ECR, error) {
+ 	if region != "" {
+ 		klog.Warningf("No region found in the image reference, the default region will be used. Please refer to AWS SDK documentation for configuration purpose.")
+ 		cfg.Region = aws.String(region)
++		if region == "eusc-de-east-1" {
++			cfg.Endpoint = aws.String("https://api.ecr.eusc-de-east-1.amazonaws.eu")
++		}
+ 	}
+ 	sess, err := session.NewSessionWithOptions(session.Options{
+ 		Config:            cfg,
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.29/ecr-credential-provider-1.29.spec
+++ b/packages/ecr-credential-provider-1.29/ecr-credential-provider-1.29.spec
@@ -19,6 +19,9 @@ Source: cloud-provider-aws-%{gover}.tar.gz
 Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
 Source1000: clarify.toml
 
+Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
+Patch0002: 0002-ecr-credential-provider-hardcode-ecr-endpoint-for-eu.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{name}(binaries)
 
@@ -48,7 +51,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{summary}.
 
 %prep
-%setup -n %{gorepo}-%{gover} -q
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 %setup -T -D -n %{gorepo}-%{gover} -b 1 -q
 
 %build

--- a/packages/ecr-credential-provider-1.30/0001-support-new-aws-partition-in-credential-provider.patch
+++ b/packages/ecr-credential-provider-1.30/0001-support-new-aws-partition-in-credential-provider.patch
@@ -1,0 +1,55 @@
+From 9a0819d0782d06da30e4942f207c61f6a5cecf81 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Sat, 25 Oct 2025 01:19:05 +0000
+Subject: [PATCH] support new aws partition in credential provider
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go      |  2 +-
+ cmd/ecr-credential-provider/main_test.go | 10 ++++++++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index 0d78e046..b61bd789 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -42,7 +42,7 @@ import (
+ const ecrPublicRegion string = "us-east-1"
+ const ecrPublicHost string = "public.ecr.aws"
+ 
+-var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
++var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
+ 
+ // ECR abstracts the calls we make to aws-sdk for testing purposes
+ type ECR interface {
+diff --git a/cmd/ecr-credential-provider/main_test.go b/cmd/ecr-credential-provider/main_test.go
+index 296506fb..d047e343 100644
+--- a/cmd/ecr-credential-provider/main_test.go
++++ b/cmd/ecr-credential-provider/main_test.go
+@@ -352,6 +352,12 @@ func Test_parseRegionFromECRPrivateHost(t *testing.T) {
+ 			host:   "123456789123.dkr.ecr.us-iso-east-1.c2s.ic.gov",
+ 			region: "us-iso-east-1",
+ 		},
++		// EUSC
++		{
++			name:   "success",
++			host:   "123456789123.dkr.ecr.eusc-de-east-1.amazonaws.eu",
++			region: "eusc-de-east-1",
++		},
+ 		// Dual-Stack
+ 		{
+ 			name:   "success",
+@@ -411,6 +417,10 @@ func TestRegistryPatternMatch(t *testing.T) {
+ 		{"123456789012.dkr.ecr-fips.lala-land-1.amazonaws.com", true},
+ 		// .cn
+ 		{"123456789012.dkr.ecr.lala-land-1.amazonaws.com.cn", true},
++		// .eu
++		{"123456789012.dkr.ecr.eusc-de-east-1.amazonaws.eu", true},
++		// .eu with fips
++		{"123456789012.dkr.ecr-fips.eusc-de-east-1.amazonaws.eu", true},
+ 		// registry ID too long
+ 		{"1234567890123.dkr.ecr.lala-land-1.amazonaws.com", false},
+ 		// registry ID too short
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.30/0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+++ b/packages/ecr-credential-provider-1.30/0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
@@ -1,0 +1,31 @@
+From 99df7b5980be2e66d2bbb32b405d24e0d64dbe85 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Fri, 7 Nov 2025 02:21:18 +0000
+Subject: [PATCH] ecr-credential-provider: hardcode ECR endpoint for
+ eusc-de-east-1
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index b61bd789..15642223 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -75,7 +75,11 @@ func defaultECRProvider(ctx context.Context, region string) (ECR, error) {
+ 		return nil, err
+ 	}
+ 
+-	return ecr.NewFromConfig(cfg), nil
++	return ecr.NewFromConfig(cfg, func(o *ecr.Options) {
++		if region == "eusc-de-east-1" {
++			o.BaseEndpoint = aws.String("https://api.ecr.eusc-de-east-1.amazonaws.eu")
++		}
++	}), nil
+ }
+ 
+ func publicECRProvider(ctx context.Context) (ECRPublic, error) {
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
+++ b/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
@@ -19,6 +19,9 @@ Source: cloud-provider-aws-%{gover}.tar.gz
 Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
 Source1000: clarify.toml
 
+Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
+Patch0002: 0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{name}(binaries)
 
@@ -48,7 +51,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{summary}.
 
 %prep
-%setup -n %{gorepo}-%{gover} -q
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 %setup -T -D -n %{gorepo}-%{gover} -b 1 -q
 
 %build

--- a/packages/ecr-credential-provider-1.31/0001-support-new-aws-partition-in-credential-provider.patch
+++ b/packages/ecr-credential-provider-1.31/0001-support-new-aws-partition-in-credential-provider.patch
@@ -1,0 +1,55 @@
+From 9a0819d0782d06da30e4942f207c61f6a5cecf81 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Sat, 25 Oct 2025 01:19:05 +0000
+Subject: [PATCH] support new aws partition in credential provider
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go      |  2 +-
+ cmd/ecr-credential-provider/main_test.go | 10 ++++++++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index 0d78e046..b61bd789 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -42,7 +42,7 @@ import (
+ const ecrPublicRegion string = "us-east-1"
+ const ecrPublicHost string = "public.ecr.aws"
+ 
+-var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
++var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
+ 
+ // ECR abstracts the calls we make to aws-sdk for testing purposes
+ type ECR interface {
+diff --git a/cmd/ecr-credential-provider/main_test.go b/cmd/ecr-credential-provider/main_test.go
+index 296506fb..d047e343 100644
+--- a/cmd/ecr-credential-provider/main_test.go
++++ b/cmd/ecr-credential-provider/main_test.go
+@@ -352,6 +352,12 @@ func Test_parseRegionFromECRPrivateHost(t *testing.T) {
+ 			host:   "123456789123.dkr.ecr.us-iso-east-1.c2s.ic.gov",
+ 			region: "us-iso-east-1",
+ 		},
++		// EUSC
++		{
++			name:   "success",
++			host:   "123456789123.dkr.ecr.eusc-de-east-1.amazonaws.eu",
++			region: "eusc-de-east-1",
++		},
+ 		// Dual-Stack
+ 		{
+ 			name:   "success",
+@@ -411,6 +417,10 @@ func TestRegistryPatternMatch(t *testing.T) {
+ 		{"123456789012.dkr.ecr-fips.lala-land-1.amazonaws.com", true},
+ 		// .cn
+ 		{"123456789012.dkr.ecr.lala-land-1.amazonaws.com.cn", true},
++		// .eu
++		{"123456789012.dkr.ecr.eusc-de-east-1.amazonaws.eu", true},
++		// .eu with fips
++		{"123456789012.dkr.ecr-fips.eusc-de-east-1.amazonaws.eu", true},
+ 		// registry ID too long
+ 		{"1234567890123.dkr.ecr.lala-land-1.amazonaws.com", false},
+ 		// registry ID too short
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.31/0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+++ b/packages/ecr-credential-provider-1.31/0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
@@ -1,0 +1,31 @@
+From 99df7b5980be2e66d2bbb32b405d24e0d64dbe85 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Fri, 7 Nov 2025 02:21:18 +0000
+Subject: [PATCH] ecr-credential-provider: hardcode ECR endpoint for
+ eusc-de-east-1
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index b61bd789..15642223 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -75,7 +75,11 @@ func defaultECRProvider(ctx context.Context, region string) (ECR, error) {
+ 		return nil, err
+ 	}
+ 
+-	return ecr.NewFromConfig(cfg), nil
++	return ecr.NewFromConfig(cfg, func(o *ecr.Options) {
++		if region == "eusc-de-east-1" {
++			o.BaseEndpoint = aws.String("https://api.ecr.eusc-de-east-1.amazonaws.eu")
++		}
++	}), nil
+ }
+ 
+ func publicECRProvider(ctx context.Context) (ECRPublic, error) {
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
+++ b/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
@@ -19,6 +19,9 @@ Source: cloud-provider-aws-%{gover}.tar.gz
 Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
 Source1000: clarify.toml
 
+Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
+Patch0002: 0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{name}(binaries)
 
@@ -48,7 +51,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{summary}.
 
 %prep
-%setup -n %{gorepo}-%{gover} -q
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 %setup -T -D -n %{gorepo}-%{gover} -b 1 -q
 
 %build

--- a/packages/ecr-credential-provider-1.32/0001-support-new-aws-partition-in-credential-provider.patch
+++ b/packages/ecr-credential-provider-1.32/0001-support-new-aws-partition-in-credential-provider.patch
@@ -1,0 +1,55 @@
+From 9a0819d0782d06da30e4942f207c61f6a5cecf81 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Sat, 25 Oct 2025 01:19:05 +0000
+Subject: [PATCH] support new aws partition in credential provider
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go      |  2 +-
+ cmd/ecr-credential-provider/main_test.go | 10 ++++++++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index 0d78e046..b61bd789 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -42,7 +42,7 @@ import (
+ const ecrPublicRegion string = "us-east-1"
+ const ecrPublicHost string = "public.ecr.aws"
+ 
+-var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
++var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
+ 
+ // ECR abstracts the calls we make to aws-sdk for testing purposes
+ type ECR interface {
+diff --git a/cmd/ecr-credential-provider/main_test.go b/cmd/ecr-credential-provider/main_test.go
+index 296506fb..d047e343 100644
+--- a/cmd/ecr-credential-provider/main_test.go
++++ b/cmd/ecr-credential-provider/main_test.go
+@@ -352,6 +352,12 @@ func Test_parseRegionFromECRPrivateHost(t *testing.T) {
+ 			host:   "123456789123.dkr.ecr.us-iso-east-1.c2s.ic.gov",
+ 			region: "us-iso-east-1",
+ 		},
++		// EUSC
++		{
++			name:   "success",
++			host:   "123456789123.dkr.ecr.eusc-de-east-1.amazonaws.eu",
++			region: "eusc-de-east-1",
++		},
+ 		// Dual-Stack
+ 		{
+ 			name:   "success",
+@@ -411,6 +417,10 @@ func TestRegistryPatternMatch(t *testing.T) {
+ 		{"123456789012.dkr.ecr-fips.lala-land-1.amazonaws.com", true},
+ 		// .cn
+ 		{"123456789012.dkr.ecr.lala-land-1.amazonaws.com.cn", true},
++		// .eu
++		{"123456789012.dkr.ecr.eusc-de-east-1.amazonaws.eu", true},
++		// .eu with fips
++		{"123456789012.dkr.ecr-fips.eusc-de-east-1.amazonaws.eu", true},
+ 		// registry ID too long
+ 		{"1234567890123.dkr.ecr.lala-land-1.amazonaws.com", false},
+ 		// registry ID too short
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.32/0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+++ b/packages/ecr-credential-provider-1.32/0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
@@ -1,0 +1,31 @@
+From 99df7b5980be2e66d2bbb32b405d24e0d64dbe85 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Fri, 7 Nov 2025 02:21:18 +0000
+Subject: [PATCH] ecr-credential-provider: hardcode ECR endpoint for
+ eusc-de-east-1
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index b61bd789..15642223 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -75,7 +75,11 @@ func defaultECRProvider(ctx context.Context, region string) (ECR, error) {
+ 		return nil, err
+ 	}
+ 
+-	return ecr.NewFromConfig(cfg), nil
++	return ecr.NewFromConfig(cfg, func(o *ecr.Options) {
++		if region == "eusc-de-east-1" {
++			o.BaseEndpoint = aws.String("https://api.ecr.eusc-de-east-1.amazonaws.eu")
++		}
++	}), nil
+ }
+ 
+ func publicECRProvider(ctx context.Context) (ECRPublic, error) {
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
+++ b/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
@@ -18,6 +18,9 @@ Source: cloud-provider-aws-%{gover}.tar.gz
 Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
 Source1000: clarify.toml
 
+Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
+Patch0002: 0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{name}(binaries)
 
@@ -47,7 +50,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{summary}.
 
 %prep
-%setup -n %{gorepo}-%{gover} -q
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 %setup -T -D -n %{gorepo}-%{gover} -b 1 -q
 
 %build

--- a/packages/ecr-credential-provider-1.33/0001-support-new-aws-partition-in-credential-provider.patch
+++ b/packages/ecr-credential-provider-1.33/0001-support-new-aws-partition-in-credential-provider.patch
@@ -1,0 +1,55 @@
+From 9a0819d0782d06da30e4942f207c61f6a5cecf81 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Sat, 25 Oct 2025 01:19:05 +0000
+Subject: [PATCH] support new aws partition in credential provider
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go      |  2 +-
+ cmd/ecr-credential-provider/main_test.go | 10 ++++++++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index 0d78e046..b61bd789 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -42,7 +42,7 @@ import (
+ const ecrPublicRegion string = "us-east-1"
+ const ecrPublicHost string = "public.ecr.aws"
+ 
+-var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
++var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
+ 
+ // ECR abstracts the calls we make to aws-sdk for testing purposes
+ type ECR interface {
+diff --git a/cmd/ecr-credential-provider/main_test.go b/cmd/ecr-credential-provider/main_test.go
+index 296506fb..d047e343 100644
+--- a/cmd/ecr-credential-provider/main_test.go
++++ b/cmd/ecr-credential-provider/main_test.go
+@@ -352,6 +352,12 @@ func Test_parseRegionFromECRPrivateHost(t *testing.T) {
+ 			host:   "123456789123.dkr.ecr.us-iso-east-1.c2s.ic.gov",
+ 			region: "us-iso-east-1",
+ 		},
++		// EUSC
++		{
++			name:   "success",
++			host:   "123456789123.dkr.ecr.eusc-de-east-1.amazonaws.eu",
++			region: "eusc-de-east-1",
++		},
+ 		// Dual-Stack
+ 		{
+ 			name:   "success",
+@@ -411,6 +417,10 @@ func TestRegistryPatternMatch(t *testing.T) {
+ 		{"123456789012.dkr.ecr-fips.lala-land-1.amazonaws.com", true},
+ 		// .cn
+ 		{"123456789012.dkr.ecr.lala-land-1.amazonaws.com.cn", true},
++		// .eu
++		{"123456789012.dkr.ecr.eusc-de-east-1.amazonaws.eu", true},
++		// .eu with fips
++		{"123456789012.dkr.ecr-fips.eusc-de-east-1.amazonaws.eu", true},
+ 		// registry ID too long
+ 		{"1234567890123.dkr.ecr.lala-land-1.amazonaws.com", false},
+ 		// registry ID too short
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.33/0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+++ b/packages/ecr-credential-provider-1.33/0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
@@ -1,0 +1,31 @@
+From 99df7b5980be2e66d2bbb32b405d24e0d64dbe85 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Fri, 7 Nov 2025 02:21:18 +0000
+Subject: [PATCH] ecr-credential-provider: hardcode ECR endpoint for
+ eusc-de-east-1
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index b61bd789..15642223 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -75,7 +75,11 @@ func defaultECRProvider(ctx context.Context, region string) (ECR, error) {
+ 		return nil, err
+ 	}
+ 
+-	return ecr.NewFromConfig(cfg), nil
++	return ecr.NewFromConfig(cfg, func(o *ecr.Options) {
++		if region == "eusc-de-east-1" {
++			o.BaseEndpoint = aws.String("https://api.ecr.eusc-de-east-1.amazonaws.eu")
++		}
++	}), nil
+ }
+ 
+ func publicECRProvider(ctx context.Context) (ECRPublic, error) {
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
+++ b/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
@@ -18,6 +18,9 @@ Source: cloud-provider-aws-%{gover}.tar.gz
 Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
 Source1000: clarify.toml
 
+Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
+Patch0002: 0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{name}(binaries)
 
@@ -47,7 +50,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{summary}.
 
 %prep
-%setup -n %{gorepo}-%{gover} -q
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 %setup -T -D -n %{gorepo}-%{gover} -b 1 -q
 
 %build

--- a/packages/ecr-credential-provider-1.34/0001-support-new-aws-partition-in-credential-provider.patch
+++ b/packages/ecr-credential-provider-1.34/0001-support-new-aws-partition-in-credential-provider.patch
@@ -1,0 +1,55 @@
+From 9a0819d0782d06da30e4942f207c61f6a5cecf81 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Sat, 25 Oct 2025 01:19:05 +0000
+Subject: [PATCH] support new aws partition in credential provider
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go      |  2 +-
+ cmd/ecr-credential-provider/main_test.go | 10 ++++++++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index 0d78e046..b61bd789 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -42,7 +42,7 @@ import (
+ const ecrPublicRegion string = "us-east-1"
+ const ecrPublicHost string = "public.ecr.aws"
+ 
+-var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.com(?:\.cn)?|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
++var ecrPrivateHostPattern = regexp.MustCompile(`^(\d{12})\.dkr[\.\-]ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.(amazonaws\.(?:com(?:\.cn)?|eu)|on\.(?:aws|amazonwebservices\.com\.cn)|sc2s\.sgov\.gov|c2s\.ic\.gov|cloud\.adc-e\.uk|csp\.hci\.ic\.gov)$`)
+ 
+ // ECR abstracts the calls we make to aws-sdk for testing purposes
+ type ECR interface {
+diff --git a/cmd/ecr-credential-provider/main_test.go b/cmd/ecr-credential-provider/main_test.go
+index 296506fb..d047e343 100644
+--- a/cmd/ecr-credential-provider/main_test.go
++++ b/cmd/ecr-credential-provider/main_test.go
+@@ -352,6 +352,12 @@ func Test_parseRegionFromECRPrivateHost(t *testing.T) {
+ 			host:   "123456789123.dkr.ecr.us-iso-east-1.c2s.ic.gov",
+ 			region: "us-iso-east-1",
+ 		},
++		// EUSC
++		{
++			name:   "success",
++			host:   "123456789123.dkr.ecr.eusc-de-east-1.amazonaws.eu",
++			region: "eusc-de-east-1",
++		},
+ 		// Dual-Stack
+ 		{
+ 			name:   "success",
+@@ -411,6 +417,10 @@ func TestRegistryPatternMatch(t *testing.T) {
+ 		{"123456789012.dkr.ecr-fips.lala-land-1.amazonaws.com", true},
+ 		// .cn
+ 		{"123456789012.dkr.ecr.lala-land-1.amazonaws.com.cn", true},
++		// .eu
++		{"123456789012.dkr.ecr.eusc-de-east-1.amazonaws.eu", true},
++		// .eu with fips
++		{"123456789012.dkr.ecr-fips.eusc-de-east-1.amazonaws.eu", true},
+ 		// registry ID too long
+ 		{"1234567890123.dkr.ecr.lala-land-1.amazonaws.com", false},
+ 		// registry ID too short
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.34/0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+++ b/packages/ecr-credential-provider-1.34/0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
@@ -1,0 +1,31 @@
+From 99df7b5980be2e66d2bbb32b405d24e0d64dbe85 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Fri, 7 Nov 2025 02:21:18 +0000
+Subject: [PATCH] ecr-credential-provider: hardcode ECR endpoint for
+ eusc-de-east-1
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index b61bd789..15642223 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -75,7 +75,11 @@ func defaultECRProvider(ctx context.Context, region string) (ECR, error) {
+ 		return nil, err
+ 	}
+ 
+-	return ecr.NewFromConfig(cfg), nil
++	return ecr.NewFromConfig(cfg, func(o *ecr.Options) {
++		if region == "eusc-de-east-1" {
++			o.BaseEndpoint = aws.String("https://api.ecr.eusc-de-east-1.amazonaws.eu")
++		}
++	}), nil
+ }
+ 
+ func publicECRProvider(ctx context.Context) (ECRPublic, error) {
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.34/ecr-credential-provider-1.34.spec
+++ b/packages/ecr-credential-provider-1.34/ecr-credential-provider-1.34.spec
@@ -18,6 +18,9 @@ Source: cloud-provider-aws-%{gover}.tar.gz
 Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
 Source1000: clarify.toml
 
+Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
+Patch0002: 0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{name}(binaries)
 
@@ -47,7 +50,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %{summary}.
 
 %prep
-%setup -n %{gorepo}-%{gover} -q
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
 %setup -T -D -n %{gorepo}-%{gover} -b 1 -q
 
 %build


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Patches ecr-credential-provider in order to support a new AWS partition.

**Testing done:**

Built ecr-credential-provider with the patches, and confirmed I could get credentials for a registry in the new partition:

```
echo '{"kind":"CredentialProviderRequest","apiVersion":"credentialprovider.kubelet.k8s.io/v1","image":"123456789012.dkr.ecr.eusc-de-east-1.amazonaws.eu"}' | ./ecr-credential-provider
```

Also built the core-kit and an AMI, and confirmed the same worked on the instance.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
