### PR TITLE
Add patches to docker-engine-29

### DIFF
--- a/packages/containerd-2.1/containerd-config-toml_basic
+++ b/packages/containerd-2.1/containerd-config-toml_basic
@@ -13,5 +13,22 @@ disabled_plugins = [
     "io.containerd.tracing.processor.v1.otlp",
 ]
 
+imports = ["/etc/containerd/config.d/*.toml"]
+
 [grpc]
 address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.transfer.v1.local"]
+max_concurrent_downloads = 10
+concurrent_layer_fetch_buffer = 8388608
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+snapshotter = "overlayfs"
+differ = "walking"
+{{#if (eq os.arch "aarch64")}}
+platform = "linux/arm64"
+{{else}}
+{{#if (eq os.arch "x86_64")}}
+platform = "linux/amd64"
+{{/if}}
+{{/if}}

--- a/packages/docker-engine-29/.gitignore
+++ b/packages/docker-engine-29/.gitignore
@@ -1,0 +1,1 @@
+0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch

--- a/packages/docker-engine-29/Cargo.toml
+++ b/packages/docker-engine-29/Cargo.toml
@@ -15,6 +15,10 @@ releases-url = "https://github.com/moby/moby/releases"
 url = "https://github.com/moby/moby/archive/docker-v29.0.0-rc.2/moby-docker-v29.0.0-rc.2.tar.gz"
 sha512 = "89237d52822608d95327efaded6e27f3b10a5252e4c3065dd5f22cf4614d950bdb67ca9770895ad09847eb7f8f0cacf1062220d2078109e5d21e93890cdb4304"
 
+[[package.metadata.build-package.external-files]]
+url = "https://cache.bottlerocket.aws/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch/b35958b9ec38aa14d52cb0a5fe5c7373d523a0f24287a58fd3961a0f57f0bf59741d06645e0a763dda651e0f6846aabc1c3507085caf08c04ce3c34d887a44eb/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch"
+sha512 = "b35958b9ec38aa14d52cb0a5fe5c7373d523a0f24287a58fd3961a0f57f0bf59741d06645e0a763dda651e0f6846aabc1c3507085caf08c04ce3c34d887a44eb"
+
 [build-dependencies]
 glibc = { path = "../glibc" }
 libseccomp = { path = "../libseccomp" }

--- a/packages/docker-engine-29/daemon-json
+++ b/packages/docker-engine-29/daemon-json
@@ -7,7 +7,7 @@ std = { version = "v1", helpers = ["join_array"] }
   "log-driver": "journald",
   "live-restore": true,
   "max-concurrent-downloads": 10,
-  "storage-driver": "overlay2",
+  "storage-driver": "overlayfs",
   "data-root": "/var/lib/docker",
   {{#if settings.oci-defaults.capabilities}}
   "default-capabilities": {{oci_defaults "docker" settings.oci-defaults.capabilities}},

--- a/packages/docker-engine-29/daemon-nvidia-json
+++ b/packages/docker-engine-29/daemon-nvidia-json
@@ -7,7 +7,7 @@ std = { version = "v1", helpers = ["join_array"] }
   "log-driver": "journald",
   "live-restore": true,
   "max-concurrent-downloads": 10,
-  "storage-driver": "overlay2",
+  "storage-driver": "overlayfs",
   "data-root": "/var/lib/docker",
   "runtimes": { "nvidia": { "path": "nvidia-container-runtime" } },
   {{#if settings.oci-defaults.capabilities}}

--- a/packages/docker-engine-29/docker-engine-29.spec
+++ b/packages/docker-engine-29/docker-engine-29.spec
@@ -33,6 +33,7 @@ Source1000: clarify.toml
 
 Patch0001: 0001-Change-default-capabilities-using-daemon-config.patch
 Patch0002: 0002-oci-inject-kmod-in-all-containers.patch
+Patch0003: 0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.

Note
-->

**Issue number:**

https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/712

**Description of changes:**

- Add patch to `docker-engine` based off [this commit](https://github.com/henry118/moby/commit/bda06fd1b6da77e5e8093bb8a245bf3dab6c3ae1) by @henry118 to always use containerd's transfer service
- Update `containerd-2.1` basic config (used by ECS) to enable use of transfer service + import containerd dropins folder for further modification
- Update `docker-engine-29` daemon jsons to use `overlayfs` instead of `overlay2` for storage-driver so the containerd snapshotter is used instead of the legacy graphdriver. Looking at the docker source code, we found that it defaults to graphdriver if the path `/var/lib/docker/overlay2/` exists, so this change avoids that

**Note**: Unlike [the containerd k8s config file](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/develop/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock), for the basic config, we cannot set values based on `settings.container-runtime` as that doesn't exist in the ECS plugin, so resorting to hardcodes for now

**Testing done:**

- Core-kit builds on both platforms
- **Transfer service patch**
Booted an `aws-ecs-3` x86 ami from [this PR ](https://github.com/bottlerocket-os/bottlerocket/pull/4685) with custom core-kit and ran the following tests on it:
```bash
# PROOF PATCH IS APPLIED
bash-5.1# grep -q "transfer/registry" /usr/bin/dockerd && echo "Transfer service patch is present" || echo "Patch not found"
Transfer service patch is present

# TRANSFER PLUGIN LOADED AND RUNNING
bash-5.1# ctr plugins ls | grep transfer
io.containerd.transfer.v1                 local                    -              ok
io.containerd.grpc.v1                     transfer                 -              ok

# CONFIG VERIFICATION
bash-5.1# cat /etc/containerd/config.toml | grep -A 10 "transfer"
[plugins."io.containerd.transfer.v1.local"]
max_concurrent_downloads = 3
concurrent_layer_fetch_buffer = 8388608

[[plugins."io.containerd.transfer.v1.local".unpack_config]]
snapshotter = "overlayfs"
differ = "walking"
platform = "linux/amd64"

# PULL SUCCEEDS
bash-5.1# docker pull nginx:alpine
alpine: Pulling from library/nginx
2d35ebdb57d9: Pull complete
8f6a6833e95d: Pull complete
194fa24e147d: Pull complete
3eaba6cd10a3: Pull complete
df413d6ebdc8: Pull complete
d9a55dab5954: Pull complete
ff8a36d5502a: Pull complete
bdabb0d44271: Pull complete
Digest: sha256:b3c656d55d7ad751196f21b7fd2e8d4da9cb430e32f646adcf92441b72f82b14
Status: Downloaded newer image for nginx:alpine
docker.io/library/nginx:alpine
```
- **Updated daemon jsons**
Booted an `aws-ecs-3` aarch64 ami from [this PR ](https://github.com/bottlerocket-os/bottlerocket/pull/4685) with custom core-kit and ran the following tests on it:
```bash
# VERIFY OVERLAYFS USED INSTEAD OF OVERLAY2
bash-5.1# docker info | grep -i "storage driver"
 Storage Driver: overlayfs
 
bash-5.1# ls -la /var/lib/docker/overlay2/
ls: cannot access '/var/lib/docker/overlay2/': No such file or directory

# VERIFY CONTAINERD SNAPSHOTTER ENABLED 
bash-5.1# docker info | grep -i snapshotter
  driver-type: io.containerd.snapshotter.v1

bash-5.1# journalctl -u docker | grep -i "snapshotter\|overlayfs"
Nov 09 01:39:53 ip-172-31-33-37.us-west-2.compute.internal dockerd[1815]: time="2025-11-09T01:39:53.773378167Z" level=info msg="Starting daemon with containerd snapshotter integration enabled"
Nov 09 01:39:54 ip-172-31-33-37.us-west-2.compute.internal dockerd[1815]: time="2025-11-09T01:39:54.255477883Z" level=info msg="Docker daemon" commit=bb45a3f4a0eaaa3afe8145acc5a901fcad717417 containerd-snapshotter=true storage-driver=overlayfs version=29.0.0-rc.2

# PULL SUCCEEDS
bash-5.1# docker pull nginx:alpine
Digest: sha256:b3c656d55d7ad751196f21b7fd2e8d4da9cb430e32f646adcf92441b72f82b14
Status: Downloaded newer image for nginx:alpine
docker.io/library/nginx:alpine
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
