### PR TITLE
prairiedog: sort bootconfig keys before writing

### DIFF
--- a/sources/api/prairiedog/src/bootconfig.rs
+++ b/sources/api/prairiedog/src/bootconfig.rs
@@ -64,27 +64,35 @@ fn serialize_boot_settings_to_boot_config(boot_settings: &BootSettings) -> Resul
     // Preallocate string buffer to avoid a bunch of memory allocation calls when we append to
     // the string buffer
     let mut output = String::with_capacity(128);
-    if let Some(kernel_param) = &boot_settings.kernel_parameters {
-        for (key, values) in kernel_param.iter() {
-            output.push_str(&format!("kernel.{key}"));
-            if !values.is_empty() {
-                output.push_str(" =");
-                append_boot_config_value_list(values, &mut output);
-            }
-            output.push('\n')
-        }
-    }
+    // Output init parameters first since "init." comes before "kernel." alphabetically
     if let Some(init_param) = &boot_settings.init_parameters {
-        for (key, values) in init_param.iter() {
-            output.push_str(&format!("init.{key}"));
-            if !values.is_empty() {
-                output.push_str(" =");
-                append_boot_config_value_list(values, &mut output);
-            }
-            output.push('\n')
-        }
+        write_sorted_params(&mut output, init_param, "init");
+    }
+    if let Some(kernel_param) = &boot_settings.kernel_parameters {
+        write_sorted_params(&mut output, kernel_param, "kernel");
     }
     Ok(output)
+}
+
+/// Writes parameters to output in sorted order with the given prefix
+fn write_sorted_params(
+    output: &mut String,
+    params: &HashMap<BootConfigKey, Vec<BootConfigValue>>,
+    prefix: &str,
+) {
+    // Sort keys alphabetically for consistent ordering
+    let mut sorted_keys: Vec<_> = params.keys().collect();
+    sorted_keys.sort_by_cached_key(|k| k.as_ref().to_string());
+
+    for key in sorted_keys {
+        let values = &params[key];
+        output.push_str(&format!("{prefix}.{key}"));
+        if !values.is_empty() {
+            output.push_str(" =");
+            append_boot_config_value_list(values, output);
+        }
+        output.push('\n');
+    }
 }
 
 /// Queries Bottlerocket boot settings and generates initrd image file with boot config as the only data
@@ -570,6 +578,42 @@ mod boot_settings_tests {
                 &boot_config_to_boot_settings_json(DEFAULT_BOOTCONFIG_STR).unwrap()
             )
             .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_bootconfig_output_is_sorted() {
+        // Test with both kernel and init parameters to verify sorting
+        let boot_settings = BootSettings {
+            reboot_to_reconcile: None,
+            kernel_parameters: to_boot_settings_params(hashmap! {
+                "zebra" => vec!["last"],
+                "apple" => vec!["first"],
+                "middle" => vec!["middle"],
+            }),
+            init_parameters: to_boot_settings_params(hashmap! {
+                "zoo" => vec!["last"],
+                "aardvark" => vec!["first"],
+            }),
+        };
+        let output = serialize_boot_settings_to_boot_config(&boot_settings).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+
+        // Verify init parameters come first (init < kernel alphabetically)
+        assert_eq!(lines[0], "init.aardvark = \"first\"");
+        assert_eq!(lines[1], "init.zoo = \"last\"");
+
+        // Verify kernel parameters come after, also sorted
+        assert_eq!(lines[2], "kernel.apple = \"first\"");
+        assert_eq!(lines[3], "kernel.middle = \"middle\"");
+        assert_eq!(lines[4], "kernel.zebra = \"last\"");
+
+        // Verify ALL lines are in sorted order
+        let mut sorted_lines = lines.clone();
+        sorted_lines.sort();
+        assert_eq!(
+            lines, sorted_lines,
+            "All lines should be in alphabetical order"
         );
     }
 


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/4680

**Description of changes:**
Ensure that bootconfig keys are written in a consistent order. While the bootconfig format supports more complex syntax, `prairiedog` only emits simple "key.name = value" lines which can be sorted without changing the semantics.


**Testing done:**
Requires the change in https://github.com/bottlerocket-os/twoliter/pull/596 so that the initial bootconfig file preserves the "sorted lines" invariant.

Before, I launched an EC2 instance and then rebooted it twice. I ended up with three different PCR 9 measurements.
```
# First boot

module_blacklist=i8042 fips=1 SYSTEMD_DEFAULT_MOUNT_RATE_LIMIT_BURST=25 SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 BOOT_IMAGE=(hd0,gpt3)/vmlinuz console=tty0 console=ttyS0,115200n8 net.ifnames=0 netdog.default-interface=eth0:dhcp4,dhcp6? quiet bootconfig root=/dev/dm-0 rootwait ro raid=noautodetect random.trust_cpu=on selinux=1 enforcing=1 "dm-mod.create=root,,,ro,0 697120 verity 1 PARTUUID=2195dee7-da67-42a2-9b8b-f3bdf3677ae7/PARTNROFF=1 PARTUUID=2195dee7-da67-42a2-9b8b-f3bdf3677ae7/PARTNROFF=2 4096 4096 87140 1 sha256 6f879a90b68bcbbbd025194f766004ac19e95a68b3c7b5224902023ed30256f4 af0533d3e8e1234cde04326bb8c6741921afcaf02b4989c8d9d68d6ed4c40dfd 2 restart_on_corruption ignore_zero_blocks" -- systemd.unit=fipscheck.target systemd.log_target=journal-or-kmsg systemd.log_color=0 systemd.show_status=true

bash-5.1# tpm2_pcrread sha256:9
  sha256:
    9 : 0x8B7E4F531CE42CAE97C7C6B8E9C9EEC611159E933435862A754CFF9D080E2859

# Next boot

module_blacklist=i8042 SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 fips=1 SYSTEMD_DEFAULT_MOUNT_RATE_LIMIT_BURST=25 BOOT_IMAGE=(hd0,gpt3)/vmlinuz console=tty0 console=ttyS0,115200n8 net.ifnames=0 netdog.default-interface=eth0:dhcp4,dhcp6? quiet bootconfig root=/dev/dm-0 rootwait ro raid=noautodetect random.trust_cpu=on selinux=1 enforcing=1 "dm-mod.create=root,,,ro,0 697120 verity 1 PARTUUID=2195dee7-da67-42a2-9b8b-f3bdf3677ae7/PARTNROFF=1 PARTUUID=2195dee7-da67-42a2-9b8b-f3bdf3677ae7/PARTNROFF=2 4096 4096 87140 1 sha256 6f879a90b68bcbbbd025194f766004ac19e95a68b3c7b5224902023ed30256f4 af0533d3e8e1234cde04326bb8c6741921afcaf02b4989c8d9d68d6ed4c40dfd 2 restart_on_corruption ignore_zero_blocks" -- systemd.unit=fipscheck.target systemd.log_target=journal-or-kmsg systemd.log_color=0 systemd.show_status=true

bash-5.1# tpm2_pcrread sha256:9
  sha256:
    9 : 0xC78BE69DD4F2495D380B942EA7A3D860C5C086A50BF8DB3A8D5A20F504151B39

# Third boot

SYSTEMD_DEFAULT_MOUNT_RATE_LIMIT_BURST=25 SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 fips=1 module_blacklist=i8042 BOOT_IMAGE=(hd0,gpt3)/vmlinuz console=tty0 console=ttyS0,115200n8 net.ifnames=0 netdog.default-interface=eth0:dhcp4,dhcp6? quiet bootconfig root=/dev/dm-0 rootwait ro raid=noautodetect random.trust_cpu=on selinux=1 enforcing=1 "dm-mod.create=root,,,ro,0 697120 verity 1 PARTUUID=2195dee7-da67-42a2-9b8b-f3bdf3677ae7/PARTNROFF=1 PARTUUID=2195dee7-da67-42a2-9b8b-f3bdf3677ae7/PARTNROFF=2 4096 4096 87140 1 sha256 6f879a90b68bcbbbd025194f766004ac19e95a68b3c7b5224902023ed30256f4 af0533d3e8e1234cde04326bb8c6741921afcaf02b4989c8d9d68d6ed4c40dfd 2 restart_on_corruption ignore_zero_blocks" -- systemd.unit=fipscheck.target systemd.log_target=journal-or-kmsg systemd.log_color=0 systemd.show_status=true

bash-5.1# tpm2_pcrread sha256:9
  sha256:
    9 : 0x8206A3A69914690083E34BA9F0C9D8774080120F3435EA02BE6F76615218EBDD
```

After, I ended up with the same measurement for all three boots:
```
bash-5.1# cat /proc/cmdline
SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 SYSTEMD_DEFAULT_MOUNT_RATE_LIMIT_BURST=25 fips=1 module_blacklist=i8042 BOOT_IMAGE=(hd0,gpt3)/vmlinuz console=tty0 console=ttyS0,115200n8 net.ifnames=0 netdog.default-interface=eth0:dhcp4,dhcp6? quiet bootconfig root=/dev/dm-0 rootwait ro raid=noautodetect random.trust_cpu=on selinux=1 enforcing=1 "dm-mod.create=root,,,ro,0 697128 verity 1 PARTUUID=89e10074-e8b2-404a-8b52-e45288baf23c/PARTNROFF=1 PARTUUID=89e10074-e8b2-404a-8b52-e45288baf23c/PARTNROFF=2 4096 4096 87141 1 sha256 8490d102ce61d3615d83b1767abe9ea97a9e25433ba7e5a6adeb6413d85bf0d6 b7f30cc5a8de34970b2bafb3c749653affb00b6f42b6ab68a2e9c087ca32f5fb 2 restart_on_corruption ignore_zero_blocks" -- systemd.unit=fipscheck.target systemd.log_target=journal-or-kmsg systemd.log_color=0 systemd.show_status=true
bash-5.1# tpm2_pcrread sha256:9
  sha256:
    9 : 0x47B57ABCBCD2834D150160733070D8EEA38A9B20D39F206CF258A0652689DCBB
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
