### PR TITLE
Update docker 29

### DIFF
--- a/packages/docker-cli-29/Cargo.toml
+++ b/packages/docker-cli-29/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/docker/cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v29.0.0-rc.2/cli-29.0.0-rc.2.tar.gz"
-sha512 = "4194a8916c65873d85af1917873bf642b2d03fa2ea4ec0dced2471e9d93ed7963d7efc786cc44bfeecc0c05233fc55839ed675ba777fa0a73d6964f8a4fa7f92"
+url = "https://github.com/docker/cli/archive/v29.0.0/cli-29.0.0.tar.gz"
+sha512 = "06f62a961a221c506a232f7f2b951e7259a607b23caaac1bdc7a4e2396890e8f73863a68056ff02f50ed3c68f0ad50aa0fb48f930da4e5ed0b0988a7f9e7637e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli-29/docker-cli-29.spec
+++ b/packages/docker-cli-29/docker-cli-29.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 29.0.0-rc.2
-%global rpmver 29.0.0
-%global gitrev b5bac44972112d7486376b5a7e6d3ba258865bf0
+%global gover 29.0.0
+%global rpmver %{gover}
+%global gitrev 3d4129b9ea4fa263e57984428ad908f6a7d4b94f
 
 %global source_date_epoch 1492525740
 
@@ -14,7 +14,7 @@
 
 Name: %{_cross_os}docker-%{gorepo}-29
 Version: %{rpmver}
-Release: 0.rc2%{?dist}
+Release: 1%{?dist}
 Summary: Docker CLI
 License: Apache-2.0
 URL: https://%{goimport}

--- a/packages/docker-engine-29/Cargo.toml
+++ b/packages/docker-engine-29/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/docker-v29.0.0-rc.2/moby-docker-v29.0.0-rc.2.tar.gz"
-sha512 = "89237d52822608d95327efaded6e27f3b10a5252e4c3065dd5f22cf4614d950bdb67ca9770895ad09847eb7f8f0cacf1062220d2078109e5d21e93890cdb4304"
+url = "https://github.com/moby/moby/archive/docker-v29.0.0/moby-docker-v29.0.0.tar.gz"
+sha512 = "e05c96fc30c5ffc74aa23bb1425e47c74c1ee2beda64a55115394d619cb493ffbce3222108025d007c5eea6805efe35dadcb84edfd8daa98f1a4f215a84e0f7d"
 
 [[package.metadata.build-package.external-files]]
-url = "https://cache.bottlerocket.aws/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch/b35958b9ec38aa14d52cb0a5fe5c7373d523a0f24287a58fd3961a0f57f0bf59741d06645e0a763dda651e0f6846aabc1c3507085caf08c04ce3c34d887a44eb/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch"
-sha512 = "b35958b9ec38aa14d52cb0a5fe5c7373d523a0f24287a58fd3961a0f57f0bf59741d06645e0a763dda651e0f6846aabc1c3507085caf08c04ce3c34d887a44eb"
+url = "https://cache.bottlerocket.aws/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch/293883e478e87baac370342346a17281cab62e31abdbb03aa9b38efd0e1d8afeb883e81d1274445a25220f6b09dfe7f2b32727b585f01305517e126596751f6f/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch"
+sha512 = "293883e478e87baac370342346a17281cab62e31abdbb03aa9b38efd0e1d8afeb883e81d1274445a25220f6b09dfe7f2b32727b585f01305517e126596751f6f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-engine-29/docker-engine-29.spec
+++ b/packages/docker-engine-29/docker-engine-29.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/moby
 %global goimport %{goorg}/moby
 
-%global gover 29.0.0-rc.2
-%global rpmver 29.0.0
-%global gitrev bb45a3f4a0eaaa3afe8145acc5a901fcad717417
+%global gover 29.0.0
+%global rpmver %{gover}
+%global gitrev d105562beff448ae44d6e3a2f7738b235fd197b5
 
 %global source_date_epoch 1363394400
 
@@ -15,7 +15,7 @@
 
 Name: %{_cross_os}docker-engine-29
 Version: %{rpmver}
-Release: 0.rc2%{?dist}
+Release: 1%{?dist}
 Summary: Docker engine
 License: Apache-2.0
 URL: https://%{repo}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/712

**Description of changes:**

Update `docker-cli-29` and `docker-engine-29` pkgs to official release v29.0.0.

`0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch` link updated to new patch provided by @henry118.

**Testing done:**
- Core kit builds
- Relevant internal ECS conformance passes
- Nvidia smoke task succeeds
- Manual checks:
```bash
bash-5.1# docker -v
Docker version 29.0.0, build 3d4129b9ea4fa263e57984428ad908f6a7d4b94f

bash-5.1# docker version
Client: Docker Engine - Community
 Version:           29.0.0

bash-5.1# grep -q "transfer/registry" /usr/bin/dockerd && echo "Transfer service patch is present" || echo "Patch not found"
Transfer service patch is present

bash-5.1# ctr plugins ls | grep transfer
io.containerd.transfer.v1                 local                    -              ok
io.containerd.grpc.v1                     transfer                 -              ok

bash-5.1# cat /etc/containerd/config.toml | grep -A 10 "transfer"
[plugins."io.containerd.transfer.v1.local"]
max_concurrent_downloads = 10
concurrent_layer_fetch_buffer = 8388608

[[plugins."io.containerd.transfer.v1.local".unpack_config]]
snapshotter = "overlayfs"
differ = "walking"
platform = "linux/amd64"

bash-5.1# docker pull nginx:alpine
Digest: sha256:b3c656d55d7ad751196f21b7fd2e8d4da9cb430e32f646adcf92441b72f82b14
Status: Downloaded newer image for nginx:alpine
docker.io/library/nginx:alpine

bash-5.1# docker info | grep -i snapshotter
  driver-type: io.containerd.snapshotter.v1

bash-5.1# journalctl -u docker | grep -i "snapshotter\|overlayfs"
Nov 12 23:32:48 ip-172-31-25-77.us-west-2.compute.internal dockerd[1820]: time="2025-11-12T23:32:48.396353746Z" level=info msg="Starting daemon with containerd snapshotter integration enabled"
Nov 12 23:32:49 ip-172-31-25-77.us-west-2.compute.internal dockerd[1820]: time="2025-11-12T23:32:49.461673825Z" level=info msg="Docker daemon" commit=d105562beff448ae44d6e3a2f7738b235fd197b5 containerd-snapshotter=true storage-driver=overlayfs version=29.0.0
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
