### PR TITLE
docker-engine-29: set label for containerd overlayfs mounts

### DIFF
--- a/packages/docker-engine-29/0004-Set-label-for-containerd-overlayfs-mounts.patch
+++ b/packages/docker-engine-29/0004-Set-label-for-containerd-overlayfs-mounts.patch
@@ -1,0 +1,39 @@
+From 3c241eeee132271e665bb29f2d1cb480a308c921 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 13 Nov 2025 03:43:25 +0000
+Subject: [PATCH] Set label for containerd overlayfs mounts
+
+---
+ daemon/containerd/image_snapshot.go | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/daemon/containerd/image_snapshot.go b/daemon/containerd/image_snapshot.go
+index 3c61d98..f8154a1 100644
+--- a/daemon/containerd/image_snapshot.go
++++ b/daemon/containerd/image_snapshot.go
+@@ -151,13 +151,20 @@ func (l *rwLayer) mounts(ctx context.Context) ([]mount.Mount, error) {
+ func (l *rwLayer) Mount(mountLabel string) (string, error) {
+ 	ctx := context.TODO()
+ 
+-	// TODO: Investigate how we can handle mountLabel
+-	_ = mountLabel
+ 	mounts, err := l.mounts(ctx)
+ 	if err != nil {
+ 		return "", err
+ 	}
+ 
++	// Apply SELinux mount label to overlay mounts (rootfs) only
++	if mountLabel != "" {
++		for i := range mounts {
++			if mounts[i].Type == "overlay" {
++				mounts[i].Options = append(mounts[i].Options, "context=\""+mountLabel+"\"")
++			}
++		}
++	}
++
+ 	var root string
+ 	if root, err = l.refCountMounter.Mount(mounts, l.id); err != nil {
+ 		return "", fmt.Errorf("failed to mount %s: %w", root, err)
+-- 
+2.51.0
+

--- a/packages/docker-engine-29/docker-engine-29.spec
+++ b/packages/docker-engine-29/docker-engine-29.spec
@@ -34,6 +34,7 @@ Source1000: clarify.toml
 Patch0001: 0001-Change-default-capabilities-using-daemon-config.patch
 Patch0002: 0002-oci-inject-kmod-in-all-containers.patch
 Patch0003: 0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch
+Patch0004: 0004-Set-label-for-containerd-overlayfs-mounts.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
When mounting a snapshot that uses the overlayfs type, pass `mountLabel` as an additional `context=` mount option.


**Testing done:**
Before, the container's rootfs did not have a `context` option and could not be written to:
```
sh-4.2# findmnt -o OPTIONS /|more
OPTIONS
rw,relatime,seclabel,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/33/fs:/var/lib/containerd/io.containerd.sn
apshotter.v1.overlayfs/snapshots/24/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/23/fs:/var/lib/containerd/io.cont
ainerd.snapshotter.v1.overlayfs/snapshots/22/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/21/fs,upperdir=/var/lib/
containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/34/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshot
s/34/work

sh-4.2# touch /foo
touch: cannot touch '/foo': Permission denied
```

After, the `context` option is correctly set:
```
sh-4.2# findmnt -o OPTIONS /|more
OPTIONS
rw,relatime,context="system_u:object_r:data_t:s0:c58,c649",lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/9/fs
:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapsho
ts/3/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/2/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/
snapshots/1/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/10/fs,workdir=/var/lib/containerd/io.containerd.
snapshotter.v1.overlayfs/snapshots/10/work

sh-4.2# touch /bar
<success>
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
