### PR TITLE
release: Update ordering for drivers target

### DIFF
--- a/packages/release/drivers.target
+++ b/packages/release/drivers.target
@@ -2,7 +2,7 @@
 Description=Driver units
 AllowIsolate=yes
 After=basic.target
-Before=preconfigured.target
+Before=preconfigured.target settings-applier.service
 Requires=basic.target
 
 [Install]


### PR DESCRIPTION
The drivers target should be before we apply settings so we can enforce lockdown for the kernel after they are loaded.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Related to Issue number:** https://github.com/bottlerocket-os/bottlerocket/issues/4218#issuecomment-3272332222

**Description of changes:**
Updates the drivers.target to be `Before` settings are applied. Related to https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/321


**Testing done:**
Confirmed the target works as expected:
```
bash-5.1# journalctl -u drivers.target
Nov 18 01:10:13 localhost systemd[1]: Reached target Driver units.
bash-5.1# systemctl status drivers.target
● drivers.target - Driver units
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/drivers.target; enabled; preset: enabled)
     Active: active since Tue 2025-11-18 01:10:13 UTC; 2h 26min ago

Nov 18 01:10:13 localhost systemd[1]: Reached target Driver units.
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
