### PR TITLE
workflows: remove delete-branch setting from update-eni-max-pods

### DIFF
--- a/.github/workflows/update-eni-max-pods.yaml
+++ b/.github/workflows/update-eni-max-pods.yaml
@@ -47,7 +47,6 @@ jobs:
           branch: update-eni-max-pods
           path: bottlerocket-core-kit/
           base: develop
-          delete-branch: true
           add-paths: |
             packages/os/eni-max-pods
           commit-message: "Update eni-max-pods"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

Follow-up of this PR:
* https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/639

The `update-eni-max-pods` workflow does not have permissions to create/delete branches so removing this setting.

**Testing done:**

N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
