### PR TITLE
containerd-2.1: disable concurrent layer fetch by default

### DIFF
--- a/packages/containerd-2.1/containerd-config-toml_basic
+++ b/packages/containerd-2.1/containerd-config-toml_basic
@@ -20,7 +20,7 @@ address = "/run/containerd/containerd.sock"
 
 [plugins."io.containerd.transfer.v1.local"]
 max_concurrent_downloads = 10
-concurrent_layer_fetch_buffer = 8388608
+concurrent_layer_fetch_buffer = 0
 
 [[plugins."io.containerd.transfer.v1.local".unpack_config]]
 snapshotter = "overlayfs"

--- a/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
@@ -26,7 +26,7 @@ address = "/run/containerd/containerd.sock"
 {{#if settings.container-runtime.max-concurrent-downloads}}
 max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
-concurrent_layer_fetch_buffer = {{default 8388608 settings.container-runtime.concurrent-download-chunk-size}}
+concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
 use_local_image_pull = false
 
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
@@ -50,7 +50,7 @@ enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp
 {{#if settings.container-runtime.max-concurrent-downloads}}
 max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
-concurrent_layer_fetch_buffer = {{default 8388608 settings.container-runtime.concurrent-download-chunk-size}}
+concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
 
 [[plugins."io.containerd.transfer.v1.local".unpack_config]]
 snapshotter = "overlayfs"

--- a/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -26,7 +26,7 @@ address = "/run/containerd/containerd.sock"
 {{#if settings.container-runtime.max-concurrent-downloads}}
 max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
-concurrent_layer_fetch_buffer = {{default 8388608 settings.container-runtime.concurrent-download-chunk-size}}
+concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
 use_local_image_pull = false
 
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
@@ -50,7 +50,7 @@ enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp
 {{#if settings.container-runtime.max-concurrent-downloads}}
 max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
-concurrent_layer_fetch_buffer = {{default 8388608 settings.container-runtime.concurrent-download-chunk-size}}
+concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
 
 [[plugins."io.containerd.transfer.v1.local".unpack_config]]
 snapshotter = "overlayfs"


### PR DESCRIPTION
The ConcurrentLayerFetchBuffer feature was previously set to 8MiB, enabling parallel layer downloads. Rolling out this feature revealed compatibility challenges with certain registry implementations and race conditions in the concurrent fetch logic.

Setting the buffer to 0 disables layer chunking, changing to non-chunked layer downloads. This provides more reliable behavior across different registry implementations while the underlying issues are addressed.


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related issues #https://github.com/bottlerocket-os/bottlerocket/issues/4709

**Description of changes:**

Disabling the 8MiB default. Users can still set it via:

```
apiclient set settings.container-runtime.concurrent-download-chunk-size="8mib"
```


**Testing done:**

Launched AMI and confirmed settings are updated. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
