### PR TITLE
Package update libs

### DIFF
--- a/packages/libdevmapper/Cargo.toml
+++ b/packages/libdevmapper/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://sourceware.org/lvm2"
 
 [[package.metadata.build-package.external-files]]
-url = "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.35.tgz"
-sha512 = "e925a7685b1a4d96046187e495627176b7c623418116f01fda6a26e607f9c2d2c3f70fe996a6bbe043d79e0e084a4a7385c853114747e61c2bebc42a16d61f11"
+url = "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.37.tgz"
+sha512 = "c67e9e47c9f117d82b458e43c98e7b2bbf0f176fc86b7fa1a90d04209df14df442f576fd9b1e41be86b161aa744f0db5b6cac9d7b118bc4156354307314c441a"
 
 [[package.metadata.build-package.external-files]]
-url = "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.35.tgz.asc"
-sha512 = "de081006558f8ef998cbfbacc1b887d43702a39bc3dd6dd2a9e59ffd0481889921ef496e8b9133f00699d81877df3c31f5d2ff7091a4de8070836d35576dbebf"
+url = "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.37.tgz.asc"
+sha512 = "98629a6709ba8e145ab3f55fd67d89ad9bcca22e3d9d83d44f58de8afb710ebd48b5841dc790af8a01813d5ca5f84d931e3385c2780b5909b2e6559ca1d77e37"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libdevmapper/libdevmapper.spec
+++ b/packages/libdevmapper/libdevmapper.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libdevmapper
-Version: 2.03.35
+Version: 2.03.37
 Release: 1%{?dist}
 Summary: Library for device mapper
 License: LGPL-2.1-only

--- a/packages/libelf/Cargo.toml
+++ b/packages/libelf/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://sourceware.org/elfutils/ftp/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://sourceware.org/elfutils/ftp/0.193/elfutils-0.193.tar.bz2"
-sha512 = "557e328e3de0d2a69d09c15a9333f705f3233584e2c6a7d3ce855d06a12dc129e69168d6be64082803630397bd64e1660a8b5324d4f162d17922e10ddb367d76"
+url = "https://sourceware.org/elfutils/ftp/0.194/elfutils-0.194.tar.bz2"
+sha512 = "5d00502f61b92643bf61dc61da4ddded36c423466388d992bcd388c5208761b8ed9db1a01492c085cd0984eef30c08f895a8e307e78e0df8df40b56ae35b78a5"
 
 [[package.metadata.build-package.external-files]]
-url = "https://sourceware.org/elfutils/ftp/0.193/elfutils-0.193.tar.bz2.sig"
-sha512 = "75f3935c4a519dc0b23e59e2e6f2bae7926c988aec484f2e1f0759cf7662eca1752f02c16b2f129fee0d7451e961322cf9a315c4ce23e91520f4779ed9fda713"
+url = "https://sourceware.org/elfutils/ftp/0.194/elfutils-0.194.tar.bz2.sig"
+sha512 = "12d90f66dfa37544fb6b368099fac3eae9487188b0ce49409ae5c647c1fa3c68582efc5216a758d830e3775d5686ac2605dba600ad258f27ae99d5ce1094b624"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libelf/libelf.spec
+++ b/packages/libelf/libelf.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libelf
-Version: 0.193
+Version: 0.194
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for ELF files

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -13,8 +13,8 @@ releases-url = "https://download.gnome.org/sources/glib"
 
 # glib uses the "stable releases use even minor numbers" versioning scheme
 [[package.metadata.build-package.external-files]]
-url = "https://download.gnome.org/sources/glib/2.86/glib-2.86.0.tar.xz"
-sha512 = "6ccf5fba13e06012135ec4b5e65c9ad61460f32fc00457081ca799a0518e872589c589b01e1846a23499fa7d4425727b95774851d7a89b15cd71260e0d13bfdd"
+url = "https://download.gnome.org/sources/glib/2.86/glib-2.86.2.tar.xz"
+sha512 = "b9ef7ea7e1eeff142a8ab76fb0552331fd642133a31505e2939f57d7d9c5ec86dcefddc725c715925a42c348d71e2a8bf2eb399150108199b6daeca2761e08d6"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libglib
-Version: 2.86.0
+Version: 2.86.2
 Release: 1%{?dist}
 Epoch: 1
 Summary: The GLib libraries

--- a/packages/libncurses/Cargo.toml
+++ b/packages/libncurses/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://invisible-mirror.net/archives/ncurses/current/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20250927.tgz"
-sha512 = "9877232377f661c32683e226519319ca48d3394e9690888ad1062adda8daecca3bb4be458d3104b57220d1e0364203710a8e38ae9be5e82a331065bf1c62ac2a"
+url = "https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20251129.tgz"
+sha512 = "fffa3f1599bd9aaee293b41305ce2882d8d8f5d07214cdd412dbcf131996e1f1809a7e9e851a13508571be2062f1de5dce47e593c271df9436a88c7764e08c71"
 
 [[package.metadata.build-package.external-files]]
-url = "https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20250927.tgz.asc"
-sha512 = "f37c9e1327fe087e8501eca8314e90126161e1a887e504bc7f4059b57791d572e48208a57588deedaae6f57e02eaffa7dae6792010f48ff60438fbefa7bb286b"
+url = "https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20251129.tgz.asc"
+sha512 = "f12a0cf9d269e84642d4c1362d22bbc38e0e1e1c5d2bf41de030d57b1f29edb83a976f92bcfe478aeca04d381ca38de65ce2c42e6dd68e9df165bb9d0045373e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libncurses/libncurses.spec
+++ b/packages/libncurses/libncurses.spec
@@ -1,5 +1,5 @@
 %global ncurses_ver 6.5
-%global ncurses_rev 20250927
+%global ncurses_rev 20251129
 
 Name: %{_cross_os}libncurses
 Version: %{ncurses_ver}

--- a/packages/libncurses/ncurses-libs.patch
+++ b/packages/libncurses/ncurses-libs.patch
@@ -3,63 +3,60 @@ index 61e25e6..de73ed7 100644
 --- a/c++/Makefile.in
 +++ b/c++/Makefile.in
 @@ -120,7 +120,7 @@ SHLIB_LIST	= $(SHLIB_DIRS) \
- 		-l@FORM_NAME@@USE_LIB_SUFFIX@ \
- 		-l@MENU_NAME@@USE_LIB_SUFFIX@ \
- 		-l@PANEL_NAME@@USE_LIB_SUFFIX@ \
--		-lncurses@USE_LIB_SUFFIX@ @SHLIB_LIST@
-+		-lncurses@USE_LIB_SUFFIX@ #@SHLIB_LIST@
- 
+ 		-l@FORM_NAME@@ABI_SUFFIX@ \
+ 		-l@MENU_NAME@@ABI_SUFFIX@ \
+ 		-l@PANEL_NAME@@ABI_SUFFIX@ \
+-		-lncurses@ABI_SUFFIX@ @SHLIB_LIST@
++		-lncurses@ABI_SUFFIX@ #@SHLIB_LIST@
+
  LIBROOT		= ncurses++
- 
+
 @@ -159,8 +159,7 @@ LDFLAGS_SHARED	= $(TEST_LDFLAGS) $(CFLAGS_SHARED) @LD_SHARED_OPTS@
  LDFLAGS_DEFAULT	= $(LINK_@DFT_UPR_MODEL@) $(LDFLAGS_@DFT_UPR_MODEL@)
- 
+
  # flags for library built by this makefile
 -LDFLAGS		= $(TEST_ARGS) @LDFLAGS@ \
 -	@LD_MODEL@ $(TEST_LIBS) @LIBS@ $(CXXLIBS)
 +LDFLAGS		= @LDFLAGS@ @LD_MODEL@ @LIBS@ $(CXXLIBS)
- 
+
  AUTO_SRC	= \
  		etip.h
 diff --git a/form/Makefile.in b/form/Makefile.in
 index 2216972..5d648f4 100644
 --- a/form/Makefile.in
 +++ b/form/Makefile.in
-@@ -112,7 +112,7 @@ LINK		= $(LIBTOOL_LINK)
+@@ -115,7 +115,7 @@ LINK		= $(LIBTOOL_LINK)
  LDFLAGS		= @LDFLAGS@ @LD_MODEL@ @LIBS@
- 
+
  SHLIB_DIRS	= -L../lib
--SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@USE_LIB_SUFFIX@ @SHLIB_LIST@
-+SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@USE_LIB_SUFFIX@ #@SHLIB_LIST@
- 
+-SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@ABI_SUFFIX@ @SHLIB_LIST@
++SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@ABI_SUFFIX@ #@SHLIB_LIST@
+
  RPATH_LIST	= @RPATH_LIST@
  RESULTING_SYMS	= @RESULTING_SYMS@
 diff --git a/menu/Makefile.in b/menu/Makefile.in
 index a91eb40..7cec890 100644
 --- a/menu/Makefile.in
 +++ b/menu/Makefile.in
-@@ -112,7 +112,7 @@ LINK		= $(LIBTOOL_LINK)
+@@ -115,7 +115,7 @@ LINK		= $(LIBTOOL_LINK)
  LDFLAGS		= @LDFLAGS@ @LD_MODEL@ @LIBS@
- 
+
  SHLIB_DIRS	= -L../lib
--SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@USE_LIB_SUFFIX@ @SHLIB_LIST@
-+SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@USE_LIB_SUFFIX@ #@SHLIB_LIST@
- 
+-SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@ABI_SUFFIX@ @SHLIB_LIST@
++SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@ABI_SUFFIX@ #@SHLIB_LIST@
+
  RPATH_LIST	= @RPATH_LIST@
  RESULTING_SYMS	= @RESULTING_SYMS@
 diff --git a/panel/Makefile.in b/panel/Makefile.in
 index 8516611..3c9ed7e 100644
 --- a/panel/Makefile.in
 +++ b/panel/Makefile.in
-@@ -114,7 +114,7 @@ LINK		= $(LIBTOOL_LINK)
+@@ -117,7 +117,7 @@ LINK		= $(LIBTOOL_LINK)
  LDFLAGS		= @LDFLAGS@ @LD_MODEL@ @LIBS@
- 
+
  SHLIB_DIRS	= -L../lib
--SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@USE_LIB_SUFFIX@ @SHLIB_LIST@
-+SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@USE_LIB_SUFFIX@ #@SHLIB_LIST@
- 
+-SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@ABI_SUFFIX@ @SHLIB_LIST@
++SHLIB_LIST	= $(SHLIB_DIRS) -lncurses@ABI_SUFFIX@ #@SHLIB_LIST@
+
  RPATH_LIST	= @RPATH_LIST@
  RESULTING_SYMS	= @RESULTING_SYMS@
--- 
-2.47.0
-

--- a/packages/libnftnl/Cargo.toml
+++ b/packages/libnftnl/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://netfilter.org/projects/libnftnl/files"
 
 [[package.metadata.build-package.external-files]]
-url = "http://netfilter.org/projects/libnftnl/files/libnftnl-1.3.0.tar.xz"
-sha512 = "a2220dba97cc9a1bbd0d093a0bd0afd491120a814be6343aef35cbeba0e4781289fa84ced36510b6b9d76e99b3ba35f3964a9a40a21f38e2e0fad90c34fd3916"
+url = "http://netfilter.org/projects/libnftnl/files/libnftnl-1.3.1.tar.xz"
+sha512 = "a4e689b003cc2ae2ecf203335265f337d6de7a50af5410d649a567535c109d08ee9dbae9e8572b1af8c67f09ea27877ca059e04ed3b1c12183ef7b4185bdd10f"
 
 [[package.metadata.build-package.external-files]]
-url = "http://netfilter.org/projects/libnftnl/files/libnftnl-1.3.0.tar.xz.sig"
-sha512 = "251707a6a981e84ec0d723885f033c0d03f83f7f64deab3ba83b11cea728b8ab345d07699120909e58c1c233a0c8401db27bf9054e61913223867ec5eb2a501e"
+url = "http://netfilter.org/projects/libnftnl/files/libnftnl-1.3.1.tar.xz.sig"
+sha512 = "a5df7f034c8a56b49e940542d3551ce171b46580a99ead59d2632a444cfe46ad7161119b95931a5fbcda395252f1cea0ed399070c2b7eaf29b962230f5927ea9"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libnftnl/libnftnl.spec
+++ b/packages/libnftnl/libnftnl.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libnftnl
-Version: 1.3.0
+Version: 1.3.1
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for nftables netlink

--- a/packages/libpcre/Cargo.toml
+++ b/packages/libpcre/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://github.com/PhilipHazel/pcre2/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.46/pcre2-10.46.tar.bz2"
-sha512 = "795b0d74efb898347990c29fefc85f37ac81e7795f9d6a5598d1169a03c547df7ff7eac280f708b1fef68d3e7686e0d4cd55f0c6364e287ff2a983bbd1a3c334"
+url = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.bz2"
+sha512 = "889a6fdc80f8a7285e4a75d189c183b4588df81bdf048302cf0830e11bbf9b9eeb387ba43dfd3aff8ffb3aa693291e8c535845c06e8ce92d1028cefa6b474804"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.46/pcre2-10.46.tar.bz2.sig"
-sha512 = "e755150e291f39222cd09cde046ce72e838a1c16f520fce3f63265126c5c6c5d143dc2f11ad8fabea45ce5e3d3cd482c434da1968354b2470e163ebfc3cc9bba"
+url = "https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.bz2.sig"
+sha512 = "fbea8f001533c700e0adae881d2d13f2a5f32c272cb1323fd6b76530b011fb3e8eafdc6eb762c36d91296f66fe2fe3861887d6f5219045a2dad8de55f3825051"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libpcre/libpcre.spec
+++ b/packages/libpcre/libpcre.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libpcre
-Version: 10.46
+Version: 10.47
 Release: 1%{?dist}
 Summary: Library for regular expressions
 License: BSD-3-Clause

--- a/packages/nftables/Cargo.toml
+++ b/packages/nftables/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://netfilter.org/projects/nftables/files/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://netfilter.org/projects/nftables/files/nftables-1.1.3.tar.xz"
-sha512 = "b5c244cb6db73eb232e5c999e07403b60c543efb9c4b9991838cc9c43a1bd08ca7b2926233536cbb0cc66e2a9acc4fbddc4b5565f5665e753c107a8739a86040"
+url = "https://netfilter.org/projects/nftables/files/nftables-1.1.6.tar.xz"
+sha512 = "8d0a833d0ae2b6ac82e0da8bb74ffb69679e49a938b86a75d4ee3d81343400a95fe064cf95d60d22df30370779e524b31497a9c89a516d9bff645f3f83bb6bb1"
 
 [[package.metadata.build-package.external-files]]
-url = "https://netfilter.org/projects/nftables/files/nftables-1.1.3.tar.xz.sig"
-sha512 = "7aa972c146e0dfaacc8faaef9b9ebbe419f7cbc5814d1fb978b35a4972d384aabe2e6e053fefc6d5d042acb9bff5f35e5f97cbee0c4a0152c53ab9c2e5b0335f"
+url = "https://netfilter.org/projects/nftables/files/nftables-1.1.6.tar.xz.sig"
+sha512 = "7a7cc7773c4784f7c5902b3fd33b7efcb808eb846bee4a0fed5f8ef54759a5cf2dd59605d171fe2ffa59416db7e56162f59b7abbd7fdfa2b5e3d417942743585"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nftables/nftables.spec
+++ b/packages/nftables/nftables.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}nftables
-Version: 1.1.3
+Version: 1.1.6
 Release: 1%{?dist}
 Summary: Tools for managing Netfilter tables
 License: GPL-2.0-only


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**

- Update `libnftnl` from 1.3.0 to 1.3.1
- Update `nftables` from 1.1.3 to 1.1.6
- Update `libpcre` from 10.46 to 10.47
- Update `libglib` from 2.86.0 to 2.86.2
- Update `libelf` from 0.193 to 0.194
- Update `libdevmapper` from 2.03.35 to 2.03.37
- Update `libncurses` from 6.5-20250927 to 6.5-20251129

**Testing done:**

- Core-kit builds with new sources
- Built both `aws-dev` and `vmware-dev` variants for testing.

- `libnftnl`, `nftables`
Ran `iptables -L -n` 
```bash
bash-5.1# iptables -L -n
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
KUBE-FIREWALL  all  --  0.0.0.0/0            0.0.0.0/0

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination
KUBE-FIREWALL  all  --  0.0.0.0/0            0.0.0.0/0

Chain KUBE-FIREWALL (2 references)
target     prot opt source               destination
DROP       all  -- !127.0.0.0/8          127.0.0.0/8          /* block incoming localnet connections */ ! ctstate RELATED,ESTABLISHED,DNAT

Chain KUBE-KUBELET-CANARY (0 references)
target     prot opt source               destination
```
ran `nft list tables` 
```bash
bash-5.1# nft list tables
table ip filter
table ip mangle
table ip6 mangle
table ip nat
table ip6 nat
table ip6 filter
table ip kube-proxy
table ip6 kube-proxy
```

Confirmed nftables v1.1.6.
```bash
bash-5.1# nft --version
nftables v1.1.6 (Commodore Bullmoose #7)
```

- `libpcre`
Ran `grep -P '\d+' /etc/os-release`
```bash
bash-5.1# grep -P '\d+' /etc/os-release
VERSION="1.51.0 (aws-k8s-1.34)"
PRETTY_NAME="Bottlerocket OS 1.51.0 (aws-k8s-1.34)"
VARIANT_ID=aws-k8s-1.34
VERSION_ID=1.51.0
BUILD_ID=ab80ed24-dirty
```

- `libelf`
Crashed the kernel with `echo 'c' > /proc/sysrq-trigger` and verified `/var/log/kdump` contains `vmcore.dump`, `dmesg.log`, and `prairiedog.log`

- `libdevmapper`
Manually attached a 100GB EBS volume (`/dev/nvme2n1`) and encrypted it with LUKS using Argon2id key derivation:
```
cryptsetup luksFormat --pbkdf argon2id --batch-mode --key-file /tmp/passphrase /dev/nvme2n1
cryptsetup open --key-file /tmp/passphrase /dev/nvme2n1 crypt
ls -latr /dev/mapper/crypt
lrwxrwxrwx. 1 root root 7 Dec  9 01:51 /dev/mapper/crypt -> ../dm-1

cryptsetup --version
cryptsetup 2.8.1 flags: UDEV BLKID KEYRING FIPS KERNEL_CAPI
```

- `libncurses`
Verified `libncursesw.so.6.5`, `libtinfo.so.6.5`, `libreadline.so.8.3` present in `/usr/lib64/`

- `libglib`
VMware variant power cycle works:
```
govc vm.power -off <vm-name>
Powering off VirtualMachine:<vm-name>... OK
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
