### PR TITLE
advisories: move from staging to 12.0.0

### DIFF
--- a/advisories/12.0.0/BRSA-h3op2bshbahi.toml
+++ b/advisories/12.0.0/BRSA-h3op2bshbahi.toml
@@ -12,6 +12,6 @@ patched-epoch = "0"
 
 [updateinfo]
 author = "vighmah"
-issue-date = 2025-12-08T23:10:57Z
+issue-date = 2025-12-11T01:14:22Z
 arches = ["aarch64", "x86_64"]
-version = "staging"
+version = "12.0.0"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

N/A

**Description of changes:**
We released core-kit 12.0.0, moving the advisories from staging to 12.0.0




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
