### PR TITLE
Provide rocm-container-toolkit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,13 @@ name = "release"
 version = "0.0.0"
 
 [[package]]
+name = "rocm-container-toolkit"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
 name = "rocm-k8s-device-plugin"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ members = [
   "packages/rdma-core",
   "packages/readline",
   "packages/release",
+  "packages/rocm-container-toolkit",
   "packages/rocm-k8s-device-plugin",
   "packages/runc",
   "packages/selinux-policy",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -130,6 +130,7 @@ rdma-core = { path = "../../packages/rdma-core" }
 readline = { path = "../../packages/readline" }
 release = { path = "../../packages/release" }
 rocm-k8s-device-plugin = { path = "../../packages/rocm-k8s-device-plugin" }
+rocm-container-toolkit = { path = "../../packages/rocm-container-toolkit" }
 rottweiler = { path = "../../packages/rottweiler" }
 runc = { path = "../../packages/runc" }
 selinux-policy = { path = "../../packages/selinux-policy" }

--- a/packages/rocm-container-toolkit/Cargo.toml
+++ b/packages/rocm-container-toolkit/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rocm-container-toolkit"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+releases-url = "https://github.com/ROCm/container-toolkit/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/ROCm/container-toolkit/archive/v1.2.0.tar.gz"
+path = "container-toolkit-1.2.0.tar.gz"
+sha512 = "42b0d4c66ade9a4ea0d58bd7fa21da025727a5ed44d8fc9622e1a77699458b9f8091cc1707197f24b461c5d4d1848b3e7aacf2d020452150411fae89ea76d96c"
+bundle-modules = [ "go" ]
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/rocm-container-toolkit/rocm-container-toolkit.spec
+++ b/packages/rocm-container-toolkit/rocm-container-toolkit.spec
@@ -1,0 +1,45 @@
+%global goproject github.com/ROCm
+%global gorepo container-toolkit
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 1.2.0
+%global rpmver %{gover}
+
+Name: %{_cross_os}rocm-container-toolkit
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: AMD ROCm container toolkit for GPU access
+License: Apache-2.0
+URL: https://github.com/ROCm/container-toolkit
+
+Source: container-toolkit-%{gover}.tar.gz
+Source1: bundled-container-toolkit-%{gover}.tar.gz
+
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
+%setup -T -D -n %{gorepo}-%{gover} -b 1 -q
+
+%build
+%set_cross_go_flags
+
+go build -ldflags="${GOLDFLAGS}" -o amd-container-runtime ./cmd/container-runtime
+go build -ldflags="${GOLDFLAGS}" -o amd-ctk ./cmd/amd-ctk
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+install -p -m 0755 amd-container-runtime %{buildroot}%{_cross_bindir}
+install -p -m 0755 amd-ctk %{buildroot}%{_cross_bindir}
+
+%cross_scan_attribution go-vendor vendor
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+%{_cross_bindir}/amd-container-runtime
+%{_cross_bindir}/amd-ctk


### PR DESCRIPTION
**Description of changes:**

Provide the `rocm-container-toolkit`

**Testing done:**
Showing that the code can see the devices.
```
bash-5.1# amd-ctk gpu-tracker status
------------------------------------------------------------------------------------------------------------------------
GPU Id    UUID                     Accessibility       Container Ids
------------------------------------------------------------------------------------------------------------------------
0         0x667ACCF1422E5FB3       Shared              -
1         0x3472AC83DC445F6E       Shared              -
2         0xDBF5DB13F0EE0C99       Shared              -
3         0xEB8399B86CBB82E2       Shared              -
4         0x461870C23AF186E5       Shared              -
5         0x26DE9EF5F32ABAC5       Shared              -
6         0x6851B35334951A62       Shared              -
7         0x198FB1A115A87278       Shared              -

bash-5.1# amd-ctk cdi list
Found 8 AMD GPU devices
amd.com/gpu=all
amd.com/gpu=0
  /dev/dri/renderD128
amd.com/gpu=1
  /dev/dri/renderD136
amd.com/gpu=2
  /dev/dri/renderD144
amd.com/gpu=3
  /dev/dri/renderD152
amd.com/gpu=4
  /dev/dri/renderD160
amd.com/gpu=5
  /dev/dri/renderD168
amd.com/gpu=6
  /dev/dri/renderD176
amd.com/gpu=7
  /dev/dri/renderD184
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
