### PR TITLE
Create new sub packages for auditing functionality

### DIFF
--- a/packages/libaudit/libaudit.spec
+++ b/packages/libaudit/libaudit.spec
@@ -27,6 +27,13 @@ Requires: %{name}
 %description -n %{_cross_os}audit
 %{summary}.
 
+%package -n %{_cross_os}audit-rules
+Summary: Default audit rules for Bottlerocket
+Requires: %{_cross_os}audit
+
+%description -n %{_cross_os}audit-rules
+%{summary}.
+
 %prep
 %autosetup -n audit-userspace-%{version} -p1
 
@@ -83,10 +90,12 @@ install -p -m 0644 %{S:11} %{buildroot}%{_cross_datadir}/audit
 
 %files -n %{_cross_os}audit
 %{_cross_sbindir}/auditctl
-%{_cross_unitdir}/audit-rules.service
-%{_cross_datadir}/audit/audit.rules
 %exclude %{_cross_sbindir}/auditd
 %exclude %{_cross_sbindir}/aureport
 %exclude %{_cross_sbindir}/ausearch
+
+%files -n %{_cross_os}audit-rules
+%{_cross_unitdir}/audit-rules.service
+%{_cross_datadir}/audit/audit.rules
 
 %changelog

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -141,6 +141,7 @@ Source1651: local-mount-encrypted.conf
 Source1652: repart-local-encrypted.conf
 
 Requires: %{_cross_os}audit
+Requires: %{_cross_os}auditd
 Requires: %{_cross_os}chrony
 Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd

--- a/packages/systemd-252/systemd-252.spec
+++ b/packages/systemd-252/systemd-252.spec
@@ -180,6 +180,16 @@ Provides: %{_cross_os}systemd-resolved = %{package_priority_epoch}:
 %description resolved
 %{summary}.
 
+%package journald-audit
+Summary: Files for journald audit socket
+Requires: %{name}
+Requires: %{_cross_os}audit-rules
+Provides: %{_cross_os}auditd = %{package_priority_epoch}:
+Conflicts: %{_cross_os}auditd
+
+%description journald-audit
+%{summary}.
+
 %prep
 %autosetup -n systemd-stable-%{version} -p1
 
@@ -481,7 +491,6 @@ find %{buildroot} -type f -name README -print -delete
 %{_cross_unitdir}/slices.target
 %{_cross_unitdir}/sockets.target
 %dir %{_cross_unitdir}/sockets.target.wants
-%{_cross_unitdir}/sockets.target.wants/systemd-journald-audit.socket
 %{_cross_unitdir}/sockets.target.wants/systemd-journald-dev-log.socket
 %{_cross_unitdir}/sockets.target.wants/systemd-journald.socket
 %{_cross_unitdir}/sockets.target.wants/systemd-udevd-control.socket
@@ -524,7 +533,6 @@ find %{buildroot} -type f -name README -print -delete
 %{_cross_unitdir}/systemd-halt.service
 %{_cross_unitdir}/systemd-journal-catalog-update.service
 %{_cross_unitdir}/systemd-journal-flush.service
-%{_cross_unitdir}/systemd-journald-audit.socket
 %{_cross_unitdir}/systemd-journald-dev-log.socket
 %{_cross_unitdir}/systemd-journald-varlink@.socket
 %{_cross_unitdir}/systemd-journald.service
@@ -800,3 +808,7 @@ find %{buildroot} -type f -name README -print -delete
 %{_cross_unitdir}/sysinit.target.wants/cryptsetup.target
 %{_cross_unitdir}/sysinit.target.wants/integritysetup.target
 %{_cross_unitdir}/sysinit.target.wants/veritysetup.target
+
+%files journald-audit
+%{_cross_unitdir}/systemd-journald-audit.socket
+%{_cross_unitdir}/sockets.target.wants/systemd-journald-audit.socket

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -165,6 +165,16 @@ Provides: %{_cross_os}systemd-resolved = %{package_priority_epoch}:
 %description resolved
 %{summary}.
 
+%package journald-audit
+Summary: Files for journald audit socket
+Requires: %{name}
+Requires: %{_cross_os}audit-rules
+Provides: %{_cross_os}auditd = %{package_priority_epoch}:
+Conflicts: %{_cross_os}auditd
+
+%description journald-audit
+%{summary}.
+
 %prep
 %autosetup -n systemd-%{version} -p1
 
@@ -542,7 +552,6 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %{_cross_unitdir}/systemd-halt.service
 %{_cross_unitdir}/systemd-journal-catalog-update.service
 %{_cross_unitdir}/systemd-journal-flush.service
-%{_cross_unitdir}/systemd-journald-audit.socket
 %{_cross_unitdir}/systemd-journald-dev-log.socket
 %{_cross_unitdir}/systemd-journald-varlink@.socket
 %{_cross_unitdir}/systemd-journald.service
@@ -871,3 +880,6 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_bootconfigdir}/21-cgroup-enable-l
 %{_cross_unitdir}/sysinit.target.wants/integritysetup.target
 %{_cross_unitdir}/sysinit.target.wants/veritysetup.target
 %{_cross_unitdir}/system-systemd\x2dveritysetup.slice
+
+%files journald-audit
+%{_cross_unitdir}/systemd-journald-audit.socket


### PR DESCRIPTION
**Description of changes:**
Bottlerocket provides very basic audit rules out of the box. If a variant wants to change behavior with regards to these audit rules or redirect audit events to something other than the journal, it is currently difficult to do this. By moving the socket activation and rules service to sub packages, now a variant can override this default behavior by providing a different package that provides a higher epoch of `auditd`. 

**Testing done:**
Built `aws-ecs-2` and `aws-ecs-3` variants to confirm both versions of systemd still get the audit rules without any other changes:
```
$ grep audit application-inventory.json
      "Name": "audit",
      "Url": "https://github.com/linux-audit/audit-userspace/",
      "Summary": "Tools for the audit subsystem"
      "Name": "audit-rules",
      "Url": "https://github.com/linux-audit/audit-userspace/",
      "Summary": "Default audit rules for Bottlerocket"
      "Name": "libaudit",
      "Url": "https://github.com/linux-audit/audit-userspace/",
      "Summary": "Library for the audit subsystem"
      "Name": "systemd-252-journald-audit",
      "Summary": "Files for journald audit socket"
```
By providing a conflicting package, it will override the files, here is the  test spec file:
```
Name: %{_cross_os}auditd-test
Epoch: 2
...
# Override auditing from core-kit
Provides: %{_cross_os}audit-rules = 2:
Conflicts: %{_cross_os}audit-rules

# Override systemd journald-audit
Provides: %{_cross_os}auditd = 2:
Conflicts: auditd
....
```
Adding it to the ecs-3 variant:
```
index 970ac339..e011fa5f 100644
--- a/variants/aws-ecs-3/Cargo.toml
+++ b/variants/aws-ecs-3/Cargo.toml
@@ -20,6 +20,7 @@ encrypted-storage = true
 included-packages = [
 # core
     "release",
+    "auditd-test",
     "kernel-6.12",
     "containerd-2.1",
     "systemd-257",
```
Now the application inventory no longer has the other auditd packages:
```
$ grep -B10 -A10 auditd-test build/images/x86_64-aws-ecs-3/latest/application-inventory.json
...
    {
      "Name": "bottlerocket-auditd-test",
      "Publisher": "Bottlerocket",
      "Version": "0.0",
      "Release": "1.1765608064.b7ac6e1a.br1",
      "Epoch": "2",
      "InstalledTime": "2025-12-18T21:54:02Z",
      "ApplicationType": "Unspecified",
      "Architecture": "x86_64",
      "Url": "https://github.com/bottlerocket-os/bottlerocket",
      "Summary": "Test package to override audit components"
    },
...
$ grep audit build/images/x86_64-aws-ecs-3/latest/application-inventory.json
      "Name": "audit",
      "Url": "https://github.com/linux-audit/audit-userspace/",
      "Summary": "Tools for the audit subsystem"
      "Name": "bottlerocket-auditd-test",
      "Summary": "Test package to override audit components"
      "Name": "libaudit",
      "Url": "https://github.com/linux-audit/audit-userspace/",
      "Summary": "Library for the audit subsystem"
```
Checking the filesystem itself, there is only `auditctl` but no service for setting rules or the socket activation:
```
$ find root -name "*audit*"
root/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/tpm2_getcommandauditdigest
root/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/tpm2_getsessionauditdigest
root/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/tpm2_setcommandauditstatus
root/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/libaudit.so.1
root/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/libaudit.so.1.0.0
root/x86_64-bottlerocket-linux-gnu/sys-root/usr/sbin/auditctl
root/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/licenses/libaudit
```




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
