### PR TITLE
Switch to use Go 1.24+ runtime FIPS support.

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -4,7 +4,7 @@ project-vendor = "Bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.66.0"
+version = "0.70.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.66.0"
-digest = "0LNg8ap1LAvV4sVA7/cpCCbLnR3HI5IbZHFr6ugJrC0="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.70.0"
+digest = "8ndrJE5YUkGs4lLbnEwmWeQ69TyLYhf7QEOCvPb2kg4="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,5 +7,5 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.66.0"
+version = "0.70.0"
 vendor = "bottlerocket"

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -160,11 +160,6 @@ export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
 make WHAT="cmd/kube-proxy"
 
-export KUBE_OUTPUT_SUBPATH="_fips_output/local"
-export GOEXPERIMENT="boringcrypto"
-make WHAT="cmd/kubelet"
-make WHAT="cmd/kube-proxy"
-
 # build the pause container
 cd build/pause/linux/
 
@@ -188,10 +183,9 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
-fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -161,11 +161,6 @@ export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
 make WHAT="cmd/kube-proxy"
 
-export KUBE_OUTPUT_SUBPATH="_fips_output/local"
-export GOEXPERIMENT="boringcrypto"
-make WHAT="cmd/kubelet"
-make WHAT="cmd/kube-proxy"
-
 # build the pause container
 cd build/pause/linux/
 
@@ -189,10 +184,9 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
-fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -161,11 +161,6 @@ export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
 make WHAT="cmd/kube-proxy"
 
-export KUBE_OUTPUT_SUBPATH="_fips_output/local"
-export GOEXPERIMENT="boringcrypto"
-make WHAT="cmd/kubelet"
-make WHAT="cmd/kube-proxy"
-
 # build the pause container
 cd build/pause/linux/
 
@@ -189,10 +184,9 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
-fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -160,11 +160,6 @@ export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
 make WHAT="cmd/kube-proxy"
 
-export KUBE_OUTPUT_SUBPATH="_fips_output/local"
-export GOEXPERIMENT="boringcrypto"
-make WHAT="cmd/kubelet"
-make WHAT="cmd/kube-proxy"
-
 # build the pause container
 cd build/pause/linux/
 
@@ -188,10 +183,9 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
-fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -162,11 +162,6 @@ export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
 make WHAT="cmd/kube-proxy"
 
-export KUBE_OUTPUT_SUBPATH="_fips_output/local"
-export GOEXPERIMENT="boringcrypto"
-make WHAT="cmd/kubelet"
-make WHAT="cmd/kube-proxy"
-
 # build the pause container
 cd build/pause/linux/
 
@@ -190,10 +185,9 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
-fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}

--- a/packages/kubernetes-1.34/kubernetes-1.34.spec
+++ b/packages/kubernetes-1.34/kubernetes-1.34.spec
@@ -162,11 +162,6 @@ export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
 make WHAT="cmd/kube-proxy"
 
-export KUBE_OUTPUT_SUBPATH="_fips_output/local"
-export GOEXPERIMENT="boringcrypto"
-make WHAT="cmd/kubelet"
-make WHAT="cmd/kube-proxy"
-
 # build the pause container
 cd build/pause/linux/
 
@@ -190,10 +185,9 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
-fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}

--- a/packages/kubernetes-1.35/kubernetes-1.35.spec
+++ b/packages/kubernetes-1.35/kubernetes-1.35.spec
@@ -162,11 +162,6 @@ export KUBE_CGO_OVERRIDES="kube-proxy"
 make WHAT="cmd/kubelet"
 make WHAT="cmd/kube-proxy"
 
-export KUBE_OUTPUT_SUBPATH="_fips_output/local"
-export GOEXPERIMENT="boringcrypto"
-make WHAT="cmd/kubelet"
-make WHAT="cmd/kube-proxy"
-
 # build the pause container
 cd build/pause/linux/
 
@@ -190,10 +185,9 @@ install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
 
-fips_output="./_fips_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${fips_output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}

--- a/packages/release/fips-go.conf
+++ b/packages/release/fips-go.conf
@@ -1,0 +1,6 @@
+[Service]
+# Enable Go FIPS 140-3 fips140=on mode. When enabled, Go's crypto packages use the
+# NIST DRBG for randomness, crypto/tls only negotiates FIPS-approved
+# algorithms, and mandatory self-tests run on initialization.
+# See: https://go.dev/blog/fips140
+Environment=GODEBUG=fips140=on

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -110,6 +110,7 @@ Source1108: systemd-sysusers-selinux.conf
 Source1109: modprobe-no-exit.conf
 Source1110: tmp-mount-noexec.conf
 Source1111: network-pre-target-dbus-dep.conf
+Source1112: fips-go.conf
 
 # network link rules
 Source1200: 80-release.link
@@ -230,6 +231,9 @@ install -p -m 0644 %{S:81} %{buildroot}%{_cross_sysctldir}/81-release-swap.conf
 
 install -d %{buildroot}%{_cross_unitdir}/service.d
 install -p -m 0644 %{S:1104} %{buildroot}%{_cross_unitdir}/service.d/00-aws-config.conf
+
+install -d %{buildroot}%{_cross_unitdir}/service.d
+install -p -m 0644 %{S:1112} %{buildroot}%{_cross_unitdir}/service.d/00-fips-go.conf
 
 install -d %{buildroot}%{_cross_libdir}/systemd/system.conf.d
 install -p -m 0644 %{S:98} %{buildroot}%{_cross_libdir}/systemd/system.conf.d/80-release.conf
@@ -467,6 +471,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %files fips
 %{_cross_bootconfigdir}/10-fips.conf
 %{_cross_tmpfilesdir}/release-fips.conf
+%{_cross_unitdir}/service.d/00-fips-go.conf
 %{_cross_unitdir}/*-bin.mount
 %{_cross_unitdir}/*-libexec.mount
 %{_cross_unitdir}/fipscheck.target


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #799

**Description of changes:**

Switch Kubernetes to use Go 1.24+ runtime FIPS support.
Packaging the `GODEBUG=fips140=on` config file in fips variants

Note: these are the minimal changes for switching Go 1.24+ runtime FIPS support. 
The rest of the changes need to be clean up will go to a separate release with the SDK clean up release


**Testing done:**
Testing with non fips cypher image registry
```
Events:
  Type     Reason     Age                     From               Message
  ----     ------     ----                    ----               -------
  Normal   Scheduled  7m35s                   default-scheduler  Successfully assigned default/test-pull-nonfips to ip-192-168-31-220.us-west-2.compute.internal
  Normal   Pulling    4m38s (x5 over 7m35s)   kubelet            Pulling image "localhost:5001/test:latest"
  Warning  Failed     4m38s (x5 over 7m35s)   kubelet            Failed to pull image "localhost:5001/test:latest": failed to pull and unpack image "localhost:5001/test:latest": failed to resolve image: failed to do request: Head "https://localhost:5001/v2/test/manifests/latest": remote error: tls: handshake failure
  Warning  Failed     4m38s (x5 over 7m35s)   kubelet            Error: ErrImagePull
  Warning  Failed     2m24s (x20 over 7m34s)  kubelet            Error: ImagePullBackOff
  Normal   BackOff    2m11s (x21 over 7m34s)  kubelet            Back-off pulling image "localhost:5001/test:latest"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
