### PR TITLE
Third Party Package Updates - k8s

### DIFF
--- a/packages/aws-iam-authenticator/Cargo.toml
+++ b/packages/aws-iam-authenticator/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.7.8/aws-iam-authenticator-0.7.8.tar.gz"
-sha512 = "63dc40f7ad3f1de4cb4fa3bcda793fe73276fb477f5e001593698cd272fd7d06ff19b3dd73b29b682ef91b25870abae5241e658032d21f647f9b091509e1d5a8"
+url = "https://github.com/kubernetes-sigs/aws-iam-authenticator/archive/v0.7.10/aws-iam-authenticator-0.7.10.tar.gz"
+sha512 = "e6d03ba464464e822ef31f9b7d819fe299ccae3a30f9bb1a9bae941f916dfd50ee4b67efc6ff0597bd404b0e6536ea025375762d83632406ad000bb047980713"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -2,7 +2,7 @@
 %global gorepo aws-iam-authenticator
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.7.8
+%global gover 0.7.10
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.7.1/rolesanywhere-credential-helper-v1.7.1.tar.gz"
-sha512 = "fdbb6cc9a0ec15522edf0ad0c68291de5f6661f371a2bca6fd040d087bda018e9643229235fc59396e0a72229e4ce348f4d24872b63c1a6dde01d1907301c08d"
+url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.7.2/rolesanywhere-credential-helper-v1.7.2.tar.gz"
+sha512 = "33d5673038be8589899207737a084698ce846b738fd8b715261f8cad7ce28d30c773983b269dd98defd8f1321fb2843933838b6b41840bf4aa91544b9111c70a"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo rolesanywhere-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.7.1
+%global gover 1.7.2
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/containerd-1.7/Cargo.toml
+++ b/packages/containerd-1.7/Cargo.toml
@@ -13,8 +13,8 @@ package-name = "containerd-1.7"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.7.29/containerd-1.7.29.tar.gz"
-sha512 = "af2dda3942b15cec69966854818b0d624ff64a68131bb966bc65f2749f5d668d8e515454f9616d5242ec272e9556ab2837dfa74b119ed80598b1d508df21edbd"
+url = "https://github.com/containerd/containerd/archive/v1.7.30/containerd-1.7.30.tar.gz"
+sha512 = "680a24938f5d51568af4734e072496a1926fd8fe0c941991797534e46dcbb3cb63acf72ad6036de6eac6e7bf5d8713b3b4529781d1db581b51c402c487d9cb7b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/containerd-1.7/containerd-1.7.spec
+++ b/packages/containerd-1.7/containerd-1.7.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.7.29
+%global gover 1.7.30
 %global rpmver %{gover}
-%global gitrev 442cb34bda9a6a0fed82a2ca7cade05c5c749582
+%global gitrev 71c1c8666c6a999cc8c319160b6b2ea38c4a2c9e
 
 %global package_priority_epoch 2
 %global _dwz_low_mem_die_limit 0

--- a/packages/containerd-2.1/Cargo.toml
+++ b/packages/containerd-2.1/Cargo.toml
@@ -13,8 +13,8 @@ package-name = "containerd-2.1"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v2.1.5/containerd-2.1.5.tar.gz"
-sha512 = "6376228edf615b1ff3d40287622d4f72793be091d59d5d7e97f7bdc4f265aa4412f4a5dd1937ef795e54aa5ee8a87d785e859d7c6525a25fa86631b878cefc59"
+url = "https://github.com/containerd/containerd/archive/v2.1.6/containerd-2.1.6.tar.gz"
+sha512 = "63bc424a4f3ab56edab89bffe863551286eac224b516fe283ad132cd60e2c2a0d9c6e41fbc2076936ba5a70b467f17229587f8c38d855286f66477147a3490d2"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/containerd-2.1/containerd-2.1.spec
+++ b/packages/containerd-2.1/containerd-2.1.spec
@@ -2,9 +2,9 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 2.1.5
+%global gover 2.1.6
 %global rpmver %{gover}
-%global gitrev fcd43222d6b07379a4be9786bda52438f0dd16a1
+%global gitrev c74fd8780002eb26bd5940ae339d690d891221c2
 
 %global package_priority_epoch 0
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/55/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
-sha512 = "21c30f9002aec10d40e603a3907f4d2673f38da52f969157688fb1deb5eef94dc0f66b415be2b70370f38d559694dfbfbb11c5e1bf106e9baf9312bd1e52c34c"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/56/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
+sha512 = "2ba4a3c617f82b6648699a2257a9f9f36af9cfe52c8aba2ace280a4639de195f882064f876dfb22150d8162978c424c522b4d1607241ddd0aadccf4a73650ade"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 55
+%global releasever 56
 %global gover 1.29.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,8 +14,9 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/48/artifacts/kubernetes/v1.30.14/kubernetes-src.tar.gz"
-sha512 = "56d085c23d4b970b18ffd2501078ba5885be45f23392b6c952da7ce26129d94467fdef5c76ac4520e4ef27e1ab66abf951cc0baf0c326c0c432f21f186c91d74"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/49/artifacts/kubernetes/v1.30.14/kubernetes-src.tar.gz"
+sha512 = "bbb1fe095adbc389a9671e1611174682167913e43338cdef29d91c357a70bccde7a898d02208b828e2e81e986b322342b02480fd177997ce8bd700eea4de0700"
 
 [build-dependencies]
 glibc = { path = "../glibc" }
+

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 48
+%global releasever 49
 %global gover 1.30.14
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/37/artifacts/kubernetes/v1.31.14/kubernetes-src.tar.gz"
-sha512 = "c721443fc04842ba54e0e26f75731ac45a33028d9c74a90dac523ebf783d9976e86847d2b58e0483399d6f4951a09dadcb4a3d2fd1b89194f974dd26df1972ca"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/38/artifacts/kubernetes/v1.31.14/kubernetes-src.tar.gz"
+sha512 = "cfd5afe88d7101549845e83980d38077ab902b5b08e341d1387c7dd3b08aa30e4c2b461ed6168205d431807a98c37df50612915b1dcfeaf0c434a1026f33d23f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 37
+%global releasever 38
 %global gover 1.31.14
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.32/Cargo.toml
+++ b/packages/kubernetes-1.32/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.32"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/30/artifacts/kubernetes/v1.32.9/kubernetes-src.tar.gz"
-sha512 = "79aec1ecc7b97675083dd32d7f9030f2881bd2908ebd2f74ab81dd8a94c90dd847f577c3d8b290e4943825231768c1f1908624945931bbb4e5389e28c1cf37e8"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/31/artifacts/kubernetes/v1.32.11/kubernetes-src.tar.gz"
+sha512 = "22fffa662b5c4f11a3a0db6a55f0e61f27831f3d71668a23995d54823c016f0c05776edee106c389ee841ad3da054058791b80469fcffa806bf3361d5d2faa32"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 30
-%global gover 1.32.9
+%global releasever 31
+%global gover 1.32.11
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.33/Cargo.toml
+++ b/packages/kubernetes-1.33/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.33"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/20/artifacts/kubernetes/v1.33.5/kubernetes-src.tar.gz"
-sha512 = "3c62f1f37204bb414be75cd932443d3b0261327a98f0b562cb331a0b2679882c731b02b4a129c1008a14f8fab10b90f63b5f1704608a7ca9472a4c1968a4176b"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/21/artifacts/kubernetes/v1.33.7/kubernetes-src.tar.gz"
+sha512 = "d99d8686288edb0c9b670fde7ab296ed1673c278eeff592ecca673cdd63c64fa2791aef59424a2d945ab0ff9fe69adce6b3cd1ac240b0e3bb03f07cfe71e581b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 20
-%global gover 1.33.5
+%global releasever 21
+%global gover 1.33.7
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.34/Cargo.toml
+++ b/packages/kubernetes-1.34/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.34"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/11/artifacts/kubernetes/v1.34.2/kubernetes-src.tar.gz"
-sha512 = "df4bbd94313f4b8972bbb59d70aaebba8d858a8f7e47a0dbcb087c0eaa9172e834d1eeb60292c2403002eda19719e5f6ee3f2b79f851eff20900c51461a94d91"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/12/artifacts/kubernetes/v1.34.3/kubernetes-src.tar.gz"
+sha512 = "ce3064258c05541a2994c2ec168d86bb9a80012e102857f155c31bb27da58663ae0a5adf8a39da50f6f3fc2a32b84e4eea86684a5e746eb7d5e381b7e56bae2e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.34/kubernetes-1.34.spec
+++ b/packages/kubernetes-1.34/kubernetes-1.34.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 11
-%global gover 1.34.2
+%global releasever 12
+%global gover 1.34.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
**Description of changes:**
- aws-iam-authenticator: update to 0.7.10
- aws-signing-helper: update to 1.7.2
- containerd-1.7: update to 1.7.30
- containerd-2.1: update to 2.1.6
- k8s-1.29-k8s-1.34: update to latest release


**Testing done:**
1. k8s-1.34 conformance - 424/424 - passed
2. k8s-1.29 conformance - 388/388 - passed
3. k8s-1.30 conformance - 402/402- passed
4. k8s-1.31 conformance - 404/404 - passed
5. k8s-1.32 conformance - 411/411 - passed
6. k8s-1.33 conformance - 419/419 - passed
7. nvidia smoke test - passed
8. nvidia smi test - passed


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
