### PR TITLE
Third Party Package Updates - ecs

### DIFF
--- a/packages/docker-cli-29/Cargo.toml
+++ b/packages/docker-cli-29/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/docker/cli/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/docker/cli/archive/v29.0.0/cli-29.0.0.tar.gz"
-sha512 = "06f62a961a221c506a232f7f2b951e7259a607b23caaac1bdc7a4e2396890e8f73863a68056ff02f50ed3c68f0ad50aa0fb48f930da4e5ed0b0988a7f9e7637e"
+url = "https://github.com/docker/cli/archive/v29.0.4/cli-29.0.4.tar.gz"
+sha512 = "f91423b233416d75c46580bebe64843f76d7f09a0aa388b2c1fdaa03b9b754f0d0c2225f8567e7b8f55b3f6d1cebe331f5c2c3780031f6d66b8a190c88592f24"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-cli-29/docker-cli-29.spec
+++ b/packages/docker-cli-29/docker-cli-29.spec
@@ -2,9 +2,9 @@
 %global gorepo cli
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 29.0.0
+%global gover 29.0.4
 %global rpmver %{gover}
-%global gitrev 3d4129b9ea4fa263e57984428ad908f6a7d4b94f
+%global gitrev 3247a5aae3791c8306f5b2e215c314267c31c570
 
 %global source_date_epoch 1492525740
 

--- a/packages/docker-engine-29/Cargo.toml
+++ b/packages/docker-engine-29/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/docker-v29.0.0/moby-docker-v29.0.0.tar.gz"
-sha512 = "e05c96fc30c5ffc74aa23bb1425e47c74c1ee2beda64a55115394d619cb493ffbce3222108025d007c5eea6805efe35dadcb84edfd8daa98f1a4f215a84e0f7d"
+url = "https://github.com/moby/moby/archive/docker-v29.0.4/moby-docker-v29.0.4.tar.gz"
+sha512 = "475770b282bdfd0f9f9343fb9818384253d3e17b9976599ad1de52f64e67a1f88a18a40d8b296f37299485fe2e6eabfee6ae6be6547c0fc936053872aa4ef1f7"
 
 [[package.metadata.build-package.external-files]]
 url = "https://cache.bottlerocket.aws/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch/293883e478e87baac370342346a17281cab62e31abdbb03aa9b38efd0e1d8afeb883e81d1274445a25220f6b09dfe7f2b32727b585f01305517e126596751f6f/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch"

--- a/packages/docker-engine-29/docker-engine-29.spec
+++ b/packages/docker-engine-29/docker-engine-29.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/moby
 %global goimport %{goorg}/moby
 
-%global gover 29.0.0
+%global gover 29.0.4
 %global rpmver %{gover}
-%global gitrev d105562beff448ae44d6e3a2f7738b235fd197b5
+%global gitrev 4612690e23f7c4200af175e12cae206b2ee00c7b
 
 %global source_date_epoch 1363394400
 
@@ -143,3 +143,4 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/docker-daemon-nvidia
 %{_cross_fips_bindir}/docker-proxy
 
 %changelog
+


### PR DESCRIPTION
**Description of changes:**
- docker-cli-29 update to v29.0.4
- docker-engine-29 update to v29.0.4


**Testing done:**
- Ran nvidia-smoke-test on ecs-3 variant


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
