### PR TITLE
packages: override SBOM generation for Rust packages

### DIFF
--- a/packages/early-boot-config/early-boot-config.spec
+++ b/packages/early-boot-config/early-boot-config.spec
@@ -1,5 +1,12 @@
 %global _cross_first_party 1
 %undefine _debugsource_packages
+%global cross_generate_sbom %{shrink: \
+  mkdir -p %{_builddir}/sbom-temp && \
+  sbomtool generate \
+    --name early-boot-config \
+    --out-dir %{_builddir}/sbom-temp \
+    --build-dir %{_builddir}/sources \
+    --spdx --cyclonedx}
 
 Name: %{_cross_os}early-boot-config
 Version: 0.1

--- a/packages/netdog/netdog.spec
+++ b/packages/netdog/netdog.spec
@@ -1,5 +1,12 @@
 %global _cross_first_party 1
 %undefine _debugsource_packages
+%global cross_generate_sbom %{shrink: \
+  mkdir -p %{_builddir}/sbom-temp && \
+  sbomtool generate \
+    --name netdog \
+    --out-dir %{_builddir}/sbom-temp \
+    --build-dir %{_builddir}/sources \
+    --spdx --cyclonedx}
 
 Name: %{_cross_os}netdog
 Version: 0.1.1

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -1,5 +1,12 @@
 %global _cross_first_party 1
 %undefine _debugsource_packages
+%global cross_generate_sbom %{shrink: \
+  mkdir -p %{_builddir}/sbom-temp && \
+  sbomtool generate \
+    --name os \
+    --out-dir %{_builddir}/sbom-temp \
+    --build-dir %{_builddir}/sources \
+    --spdx --cyclonedx}
 
 Name: %{_cross_os}os
 Version: 0.0

--- a/packages/rottweiler/rottweiler.spec
+++ b/packages/rottweiler/rottweiler.spec
@@ -1,5 +1,12 @@
 %global _cross_first_party 1
 %undefine _debugsource_packages
+%global cross_generate_sbom %{shrink: \
+  mkdir -p %{_builddir}/sbom-temp && \
+  sbomtool generate \
+    --name rottweiler \
+    --out-dir %{_builddir}/sbom-temp \
+    --build-dir %{_builddir}/sources \
+    --spdx --cyclonedx}
 
 Name: %{_cross_os}rottweiler
 Version: 0.1.0

--- a/packages/static-pods/static-pods.spec
+++ b/packages/static-pods/static-pods.spec
@@ -1,5 +1,12 @@
 %global _cross_first_party 1
 %undefine _debugsource_packages
+%global cross_generate_sbom %{shrink: \
+  mkdir -p %{_builddir}/sbom-temp && \
+  sbomtool generate \
+    --name static-pods \
+    --out-dir %{_builddir}/sbom-temp \
+    --build-dir %{_builddir}/sources \
+    --spdx --cyclonedx}
 
 Name: %{_cross_os}static-pods
 Version: 0.1


### PR DESCRIPTION
Rust packages using %cargo_build macros build to ${HOME}/.cache rather than %{_builddir}. Override %cross_generate_sbom in these packages to scan the correct directory for SBOM generation.

Affected packages: os, netdog, early-boot-config, static-pods, rottweiler

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #786

**Description of changes:**
Override `cross_generate_sbom` for first party rust packages to point to the correct sources directory.


**Testing done:**
Built Bottlerocket images and inspected SBOM files, ensure that Bottlerocket Dogs showed up.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
