### PR TITLE
packages: update rocm-k8s-device-plugin to v1.31.0.9

### DIFF
--- a/packages/rocm-k8s-device-plugin/Cargo.toml
+++ b/packages/rocm-k8s-device-plugin/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/ROCm/k8s-device-plugin/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/ROCm/k8s-device-plugin/archive/v1.31.0.8.tar.gz"
-sha512 = "23a127b46ad15cabbdd9abe18a8b75140340dcb10f41c9efdcfd30b38db7142edabaf6a97ed2c621f0414c78c0cb87fdc81a30b5e3fb016d16cbd11210143326"
+url = "https://github.com/ROCm/k8s-device-plugin/archive/v1.31.0.9.tar.gz"
+sha512 = "3bcc09c11afae5d6e20b1af7373b9db78e02e43acd4d451284237d176f36b67fd6a3a67701f872eb2e5093a928e854f13c976bf41cfa994f6704b1c481340269"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/rocm-k8s-device-plugin/rocm-k8s-device-plugin.spec
+++ b/packages/rocm-k8s-device-plugin/rocm-k8s-device-plugin.spec
@@ -2,7 +2,7 @@
 %global gorepo k8s-device-plugin
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.31.0.8
+%global gover 1.31.0.9
 %global rpmver %{gover}
 
 Name: %{_cross_os}rocm-k8s-device-plugin


### PR DESCRIPTION

**Description of changes:**
Update the plugin to include a [bugfix](https://github.com/ROCm/k8s-device-plugin/pull/170) I requested upstream. 


**Testing done:**
Built with core kit and ran with hardware available:
```
I: 7, Runtime: 0x00020c00
Dec 31 01:20:35 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[46752]: I1231 01:20:35.909184   46752 manager.go:42] Starting device plugin manager
Dec 31 01:20:35 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[46752]: I1231 01:20:35.909187   46752 manager.go:46] Registering for system signal notifications
Dec 31 01:20:35 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[46752]: F1231 01:20:35.909538   46752 amdgpu.go:151] amdgpu driver unavailable. exiting with exit code 2. error: stat /sys/module/amdgpu/drivers/: no such file or directory
Dec 31 01:20:35 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[46752]: goroutine 20 [running]:
....
Dec 31 01:20:45 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[48166]: I1231 01:20:45.844847   48166 amdgpu.go:283] Partition counts: map[spx_nps1:8]
Dec 31 01:20:45 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[48166]: I1231 01:20:45.844851   48166 plugin.go:254] Watching GPU with bus ID: 0000:85:00.0 NUMA Node: [1]
Dec 31 01:20:45 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[48166]: I1231 01:20:45.844859   48166 plugin.go:254] Watching GPU with bus ID: 0000:51:00.0 NUMA Node: [0]
Dec 31 01:20:45 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[48166]: I1231 01:20:45.844863   48166 plugin.go:254] Watching GPU with bus ID: 0000:52:00.0 NUMA Node: [0]
Dec 31 01:20:45 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[48166]: I1231 01:20:45.844866   48166 plugin.go:254] Watching GPU with bus ID: 0000:62:00.0 NUMA Node: [0]
Dec 31 01:20:45 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[48166]: I1231 01:20:45.844868   48166 plugin.go:254] Watching GPU with bus ID: 0000:63:00.0 NUMA Node: [0]
Dec 31 01:20:45 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[48166]: I1231 01:20:45.844871   48166 plugin.go:254] Watching GPU with bus ID: 0000:73:00.0 NUMA Node: [1]
Dec 31 01:20:45 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[48166]: I1231 01:20:45.844873   48166 plugin.go:254] Watching GPU with bus ID: 0000:74:00.0 NUMA Node: [1]
Dec 31 01:20:45 ip-172-31-59-18.us-west-2.compute.internal rocm-device-plugin[48166]: I1231 01:20:45.844875   48166 plugin.go:254] Watching GPU with bus ID: 0000:84:00.0 NUMA Node: [1]
```
The device plugin restarted and then came up and offered the devices to the cluster.
```
Capacity:
  amd.com/gpu:        8
....
  pods:               110
Allocatable:
  amd.com/gpu:        8
....
  pods:               110
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
