### PR TITLE
Add MPS control daemon support to k8s device plugin

### DIFF
--- a/packages/nvidia-k8s-device-plugin/0001-Update-MPS-roots-for-immutable-host-OS.patch
+++ b/packages/nvidia-k8s-device-plugin/0001-Update-MPS-roots-for-immutable-host-OS.patch
@@ -1,0 +1,68 @@
+From efde4273b89c623e036109bfb949926e7fc89b50 Mon Sep 17 00:00:00 2001
+From: Matthew Yeazel <yeazelm@amazon.com>
+Date: Wed, 31 Dec 2025 19:46:25 +0000
+Subject: [PATCH] Update MPS roots for immutable host OS
+
+The code assumes its in the container for the device plugin. The paths
+it creates for tracking state and shared memory won't work on
+Bottlerocket since the root filesystem is immutable. Move these paths to
+/run to allow the files to be created.
+
+Signed-off-by: Matthew Yeazel <yeazelm@amazon.com>
+---
+ cmd/mps-control-daemon/main.go            | 4 ++--
+ cmd/mps-control-daemon/mount/mount-shm.go | 2 +-
+ cmd/mps-control-daemon/mps/root.go        | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/cmd/mps-control-daemon/main.go b/cmd/mps-control-daemon/main.go
+index bb5502f..ec296a4 100644
+--- a/cmd/mps-control-daemon/main.go
++++ b/cmd/mps-control-daemon/main.go
+@@ -214,7 +214,7 @@ func startDaemons(c *cli.Context, cfg *Config) ([]*mps.Daemon, bool, error) {
+ 			return mpsDaemons, true, nil
+ 		}
+ 	}
+-	readyFile, err := os.Create("/mps/.ready")
++	readyFile, err := os.Create("/run/mps/.ready")
+ 	if err != nil {
+ 		return mpsDaemons, true, fmt.Errorf("failed to create .ready file")
+ 	}
+@@ -224,7 +224,7 @@ func startDaemons(c *cli.Context, cfg *Config) ([]*mps.Daemon, bool, error) {
+ }
+ 
+ func stopDaemons(mpsDaemons ...*mps.Daemon) error {
+-	if err := os.Remove("/mps/.ready"); err != nil {
++	if err := os.Remove("/run/mps/.ready"); err != nil {
+ 		klog.Warningf("Failed to remove .ready file: %v", err)
+ 	}
+ 	klog.Info("Stopping MPS daemons.")
+diff --git a/cmd/mps-control-daemon/mount/mount-shm.go b/cmd/mps-control-daemon/mount/mount-shm.go
+index 83825e8..507a1e4 100644
+--- a/cmd/mps-control-daemon/mount/mount-shm.go
++++ b/cmd/mps-control-daemon/mount/mount-shm.go
+@@ -49,7 +49,7 @@ func mountShm(c *cli.Context) error {
+ 	mounter := mount.New(mountExecutable)
+ 
+ 	// TODO: /mps should be configurable.
+-	shmDir := "/mps/shm"
++	shmDir := "/run/mps/shm"
+ 	err = mount.CleanupMountPoint(shmDir, mounter, true)
+ 	if err != nil {
+ 		return fmt.Errorf("error unmounting %v: %w", shmDir, err)
+diff --git a/cmd/mps-control-daemon/mps/root.go b/cmd/mps-control-daemon/mps/root.go
+index 90655d1..805e58d 100644
+--- a/cmd/mps-control-daemon/mps/root.go
++++ b/cmd/mps-control-daemon/mps/root.go
+@@ -23,7 +23,7 @@ import (
+ )
+ 
+ const (
+-	ContainerRoot = Root("/mps")
++	ContainerRoot = Root("/run/mps")
+ )
+ 
+ // Root represents an MPS root.
+-- 
+2.52.0
+

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -16,6 +16,11 @@ flags:
   {{/if}}
   failOnInitError: true
   nvidiaDriverRoot: "/"
+{{#if settings.kubelet-device-plugins.nvidia.device-sharing-strategy}}
+{{#if (eq settings.kubelet-device-plugins.nvidia.device-sharing-strategy "mps")}}
+  mpsRoot: "/run/nvidia/mps"
+{{/if}}
+{{/if}}
   plugin:
     passDeviceSpecs: {{default true settings.kubelet-device-plugins.nvidia.pass-device-specs}}
     {{#if settings.kubelet-device-plugins.nvidia.device-list-strategy}}
@@ -38,5 +43,13 @@ sharing:
     resources:
     - name: "nvidia.com/gpu"
       replicas: {{default 2 settings.kubelet-device-plugins.nvidia.time-slicing.replicas}}
+{{/if}}
+{{#if (eq settings.kubelet-device-plugins.nvidia.device-sharing-strategy "mps")}}
+sharing:
+  mps:
+    renameByDefault: {{default true settings.kubelet-device-plugins.nvidia.mps.rename-by-default}}
+    resources:
+    - name: "nvidia.com/gpu"
+      replicas: {{default 2 settings.kubelet-device-plugins.nvidia.mps.replicas}}
 {{/if}}
 {{/if}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -17,6 +17,10 @@ Source1: nvidia-k8s-device-plugin.service
 Source2: nvidia-k8s-device-plugin-conf
 Source3: nvidia-k8s-device-plugin-exec-start-conf
 Source4: nvidia-k8s-device-plugin-mig-conf
+Source5: nvidia-mps-control-daemon.service
+Source6: nvidia-mps-control-daemon-exec-start-conf
+
+Patch0001: 0001-Update-MPS-roots-for-immutable-host-OS.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{name}(binaries)
@@ -54,34 +58,46 @@ export CGO_LDFLAGS="-Wl,-z,relro -Wl,--export-dynamic"
 export GOLDFLAGS="-compressdwarf=false -linkmode=external -extldflags '${CGO_LDFLAGS}'"
 
 go build -ldflags="${GOLDFLAGS}" -o nvidia-device-plugin ./cmd/nvidia-device-plugin/
+go build -ldflags="${GOLDFLAGS}" -o mps-control-daemon ./cmd/mps-control-daemon/
 gofips build -ldflags="${GOLDFLAGS}" -o fips/nvidia-device-plugin ./cmd/nvidia-device-plugin/
+gofips build -ldflags="${GOLDFLAGS}" -o fips/mps-control-daemon ./cmd/mps-control-daemon/
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 nvidia-device-plugin %{buildroot}%{_cross_bindir}
+install -p -m 0755 mps-control-daemon %{buildroot}%{_cross_bindir}
 
 install -d %{buildroot}%{_cross_fips_bindir}
 install -p -m 0755 fips/nvidia-device-plugin %{buildroot}%{_cross_fips_bindir}
+install -p -m 0755 fips/mps-control-daemon %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:5} %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
+install -d %{buildroot}%{_cross_unitdir}/nvidia-mps-control-daemon.service.d
 install -D -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-conf
 install -D -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-exec-start-conf
 install -D -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-mig-conf
+install -D -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/nvidia-mps-control-daemon-exec-start-conf
 
 
 %files
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_unitdir}/nvidia-k8s-device-plugin.service
+%{_cross_unitdir}/nvidia-mps-control-daemon.service
 %dir %{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
+%dir %{_cross_unitdir}/nvidia-mps-control-daemon.service.d
 %{_cross_templatedir}/nvidia-k8s-device-plugin-conf
 %{_cross_templatedir}/nvidia-k8s-device-plugin-exec-start-conf
 %{_cross_templatedir}/nvidia-k8s-device-plugin-mig-conf
+%{_cross_templatedir}/nvidia-mps-control-daemon-exec-start-conf
 
 %files bin
 %{_cross_bindir}/nvidia-device-plugin
+%{_cross_bindir}/mps-control-daemon
 
 %files fips-bin
 %{_cross_fips_bindir}/nvidia-device-plugin
+%{_cross_fips_bindir}/mps-control-daemon

--- a/packages/nvidia-k8s-device-plugin/nvidia-mps-control-daemon-exec-start-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-mps-control-daemon-exec-start-conf
@@ -1,0 +1,20 @@
+[required-extensions]
+kubelet-device-plugins = "v1"
++++
+[Service]
+ExecStart=
+{{#if (eq settings.kubelet-device-plugins.nvidia.device-sharing-strategy "mps")}}
+{{#if (eq settings.kubelet-device-plugins.nvidia.device-partitioning-strategy "mig")}}
+# MPS and MIG are not supported at the same time
+Type=oneshot
+ExecStart=/bin/echo "MPS and MIG are not supported at the same time"
+{{else}}
+Type=simple
+ExecStart=/usr/bin/mps-control-daemon --config-file /etc/nvidia-k8s-device-plugin/settings.yaml
+RemainAfterExit=no
+{{/if}}
+{{else}}
+Type=oneshot
+ExecStart=/usr/bin/true
+RemainAfterExit=yes
+{{/if}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-mps-control-daemon.service
+++ b/packages/nvidia-k8s-device-plugin/nvidia-mps-control-daemon.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NVIDIA MPS Control Daemon
+Before=nvidia-k8s-device-plugin.service
+
+[Service]
+ExecStart=/usr/bin/true
+Restart=on-failure
+RestartSec=2
+RemainAfterExit=true
+
+[Install]
+RequiredBy=nvidia-k8s-device-plugin.service


### PR DESCRIPTION
**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket/issues/4673

**Description of changes:**
This builds the mps-control-daemon binary from the device plugin that allows MPS support. We have to patch the hardcoded paths for Bottlerocket usage since the device plugin assumes it can write to / which doesn't work with Bottlerocket.

This change also adds a new service to start this binary when settings request it. Otherwise it daemonizes `sleep infinity` to let systemd `try-restart` upon changing the settings for MPS. 

The change should be safe to take without the https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/347 change or the upcoming settings change but the daemon will not work without the kmod update and the settings being properly set.


**Testing done:**
Build images with the kernel change, settings changes, and validated that a node will come up with MPS working if set in user data, and the services are restarted and MPS can be enabled at runtime as well.

#### Setting in userdata for a g6.2xlarge which only has one GPU

<details>

`eksctl` config snippet for setting it at the beginning:
```
    bottlerocket:
      settings:
        kubelet-device-plugins:
          nvidia:
            device-sharing-strategy: "mps"
            mps:
              replicas: 2
```
Results in a node reporting nvidia.com/gpu.shared: 
```
Capacity:
  cpu:                    8
  ephemeral-storage:      81854Mi
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 31619656Ki
  nvidia.com/gpu.shared:  2
  pods:                   58
Allocatable:
  cpu:                    7910m
  ephemeral-storage:      76173383962
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 30602824Ki
  nvidia.com/gpu.shared:  2
  pods:                   58
```

</details>

#### Setting the MPS after boot

<details>

Start with a node with no configuration for MPS:
```
# apiclient get settings.kubelet-device-plugins.nvidia
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "cdi-cri",
        "device-partitioning-strategy": "none",
        "device-sharing-strategy": "none",
        "pass-device-specs": true
      }
    }
  }
}

# systemctl status
● ip-192-168-12-91.us-west-2.compute.internal
    State: running
    Units: 458 loaded (incl. loaded aliases)
     Jobs: 0 queued
   Failed: 0 units
    Since: Wed 2025-12-31 22:32:18 UTC; 5min ago
  systemd: 257.9
  Tainted: unmerged-bin
   CGroup: /
....

# systemctl status nvidia-mps-control-daemon
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-mps-control-daemon.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
             /etc/systemd/system/nvidia-mps-control-daemon.service.d
             └─exec-start.conf
     Active: active (running) since Wed 2025-12-31 22:32:32 UTC; 5min ago
 Invocation: d1565c1130dc4d9e87108f540f1178da
   Main PID: 3111 (/usr/bin/sleep)
      Tasks: 1 (limit: 36988)
     Memory: 308K (peak: 1.2M)
        CPU: 5ms
     CGroup: /system.slice/nvidia-mps-control-daemon.service
             └─3111 /usr/bin/sleep infinity

Dec 31 22:32:32 ip-... systemd[1]: Started NVIDIA MPS Control Daemon.

# systemctl cat nvidia-mps-control-daemon
# /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-mps-control-daemon.service
[Unit]
Description=NVIDIA MPS Control Daemon
After=nvidia-k8s-device-plugin.service
Requires=nvidia-k8s-device-plugin.service

[Service]
Type=simple
ExecStart=/bin/true
Restart=on-failure
RestartSec=5

[Install]
WantedBy=multi-user.target

# /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d/00-aws-config.conf
[Service]
# Set the AWS_SDK_LOAD_CONFIG system-wide instead of at the individual service
# level, to make sure new system services that use the AWS SDK for Go read the
# shared AWS config
Environment=AWS_SDK_LOAD_CONFIG=true

# /etc/systemd/system/nvidia-mps-control-daemon.service.d/exec-start.conf
[Service]
ExecStart=
ExecStart=/usr/bin/sleep infinity
```
The node shows one GPU:
```
Capacity:
  cpu:                8
  ephemeral-storage:  81854Mi
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             31619660Ki
  nvidia.com/gpu:     1
  pods:               58
Allocatable:
  cpu:                7910m
  ephemeral-storage:  76173383962
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             30602828Ki
  nvidia.com/gpu:     1
  pods:               58
```

Then set MPS:
```
apiclient set settings.kubelet-device-plugins.nvidia.device-sharing-strategy=mps settings.kubelet-device-plugins.nvidia.mps.replicas=8


bash-5.1# apiclient get settings.kubelet-device-plugins.nvidia
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "cdi-cri",
        "device-partitioning-strategy": "none",
        "device-sharing-strategy": "mps",
        "mps": {
          "replicas": 8
        },
        "pass-device-specs": true
      }
    }
  }
}
```
Now check the rest of the system:
```
# systemctl status
● ip-192-168-12-91.us-west-2.compute.internal
    State: running
    Units: 458 loaded (incl. loaded aliases)
     Jobs: 0 queued
   Failed: 0 units
    Since: Wed 2025-12-31 22:32:18 UTC; 7min ago
  systemd: 257.9
  Tainted: unmerged-bin
   CGroup: /
           ├─default
...
# systemctl status nvidia-mps-control-daemon
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-mps-control-daemon.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
             /etc/systemd/system/nvidia-mps-control-daemon.service.d
             └─exec-start.conf
     Active: active (running) since Wed 2025-12-31 22:39:41 UTC; 36s ago
 Invocation: 7191c5bc120246709e113d50d3ce3c54
   Main PID: 6994 (mps-control-dae)
      Tasks: 12 (limit: 36988)
     Memory: 49.1M (peak: 62M)
        CPU: 227ms
     CGroup: /system.slice/nvidia-mps-control-daemon.service
             ├─6994 /usr/bin/mps-control-daemon --config-file /etc/nvidia-k8s-device-plugin/settings.yaml
             ├─7015 nvidia-cuda-mps-control -d
             └─7021 tail -n +1 -f /run/mps/nvidia.com/gpu.shared/log/control.log

Dec 31 22:39:41 ip-192-168-12-91.us-west-2.compute.internal mps-control-daemon[7021]: [2025-12-31 22:39:41.892 Control  7015] Accepting connection...
Dec 31 22:39:41 ip-192-168-12-91.us-west-2.compute.internal mps-control-daemon[7021]: [2025-12-31 22:39:41.892 Control  7015] NEW UI
Dec 31 22:39:41 ip-192-168-12-91.us-west-2.compute.internal mps-control-daemon[7021]: [2025-12-31 22:39:41.892 Control  7015] Cmd:set_default_active_thread_percentage 12
Dec 31 22:39:41 ip-192-168-12-91.us-west-2.compute.internal mps-control-daemon[7021]: [2025-12-31 22:39:41.892 Control  7015] 12.0
Dec 31 22:39:41 ip-192-168-12-91.us-west-2.compute.internal mps-control-daemon[7021]: [2025-12-31 22:39:41.892 Control  7015] UI closed
Dec 31 22:40:11 ip-192-168-12-91.us-west-2.compute.internal mps-control-daemon[7021]: [2025-12-31 22:40:11.832 Control  7015] Accepting connection...
Dec 31 22:40:11 ip-192-168-12-91.us-west-2.compute.internal mps-control-daemon[7021]: [2025-12-31 22:40:11.832 Control  7015] NEW UI
Dec 31 22:40:11 ip-192-168-12-91.us-west-2.compute.internal mps-control-daemon[7021]: [2025-12-31 22:40:11.832 Control  7015] Cmd:get_default_active_thread_percentage
Dec 31 22:40:11 ip-192-168-12-91.us-west-2.compute.internal mps-control-daemon[7021]: [2025-12-31 22:40:11.832 Control  7015] 12.0
Dec 31 22:40:11 ip-192-168-12-91.us-west-2.compute.internal mps-control-daemon[7021]: [2025-12-31 22:40:11.832 Control  7015] UI closed

# systemctl cat nvidia-mps-control-daemon
# /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-mps-control-daemon.service
[Unit]
Description=NVIDIA MPS Control Daemon
After=nvidia-k8s-device-plugin.service
Requires=nvidia-k8s-device-plugin.service

[Service]
Type=simple
ExecStart=/bin/true
Restart=on-failure
RestartSec=5

[Install]
WantedBy=multi-user.target

# /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d/00-aws-config.conf
[Service]
# Set the AWS_SDK_LOAD_CONFIG system-wide instead of at the individual service
# level, to make sure new system services that use the AWS SDK for Go read the
# shared AWS config
Environment=AWS_SDK_LOAD_CONFIG=true

# /etc/systemd/system/nvidia-mps-control-daemon.service.d/exec-start.conf
[Service]
ExecStart=
ExecStart=/usr/bin/mps-control-daemon --config-file /etc/nvidia-k8s-device-plugin/settings.yaml

# cat /etc/nvidia-k8s-device-plugin/settings.yaml
version: v1
flags:
  migStrategy: "none"
  failOnInitError: true
  nvidiaDriverRoot: "/"
  mpsRoot: "/run/nvidia/mps"
  plugin:
    passDeviceSpecs: true
    deviceListStrategy: cdi-cri
    deviceIDStrategy: index
    containerDriverRoot: "/"
sharing:
  mps:
    renameByDefault: true
    resources:
    - name: "nvidia.com/gpu"
      replicas: 8
```
And the node shows the empty nvidia.com/gpu offering but now a shared one:
```
Capacity:
  cpu:                    8
  ephemeral-storage:      81854Mi
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 31619660Ki
  nvidia.com/gpu:         1
  nvidia.com/gpu.shared:  8
  pods:                   58
Allocatable:
  cpu:                    7910m
  ephemeral-storage:      76173383962
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 30602828Ki
  nvidia.com/gpu:         0
  nvidia.com/gpu.shared:  8
  pods:                   58
```
This is a known edge case and is similar to how timeslicing works. In order to avoid old resources, you'd need to start with the user-data approach.

Shifting to `rename-by-default=false`(`apiclient set settings.kubelet-device-plugins.nvidia.mps.rename-by-default=false`) will have the original nvidia.com/gpu resource instead:
```
Capacity:
  cpu:                    8
  ephemeral-storage:      81854Mi
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 31619660Ki
  nvidia.com/gpu:         8
  nvidia.com/gpu.shared:  8
  pods:                   58
Allocatable:
  cpu:                    7910m
  ephemeral-storage:      76173383962
  hugepages-1Gi:          0
  hugepages-2Mi:          0
  memory:                 30602828Ki
  nvidia.com/gpu:         8
  nvidia.com/gpu.shared:  0
  pods:                   58
```

And finally, setting sharing to `none` disables MPS:
```
# apiclient set settings.kubelet-device-plugins.nvidia.device-sharing-strategy=none
# systemctl status nvidia-mps-control-daemon
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-mps-control-daemon.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
             /etc/systemd/system/nvidia-mps-control-daemon.service.d
             └─exec-start.conf
     Active: active (running) since Wed 2025-12-31 22:44:41 UTC; 2s ago
 Invocation: 82664a64fd044762a81ecef6d1cc0462
   Main PID: 9436 (/usr/bin/sleep)
      Tasks: 1 (limit: 36988)
     Memory: 308K (peak: 1.2M)
        CPU: 4ms
     CGroup: /system.slice/nvidia-mps-control-daemon.service
             └─9436 /usr/bin/sleep infinity

Dec 31 22:44:41 ip-192-168-12-91.us-west-2.compute.internal systemd[1]: Started NVIDIA MPS Control Daemon.
```
And the resource goes back down to 1.
</details>


With the incompatibility checks in the template. You can see the messages preventing both MIG and MPS from running at the same time:

<details>

```
Jan 15 16:01:19 ip-192-168-23-52.us-west-2.compute.internal systemd[1]: Starting NVIDIA MPS Control Daemon...
Jan 15 16:01:19 ip-192-168-23-52.us-west-2.compute.internal echo[11584]: MPS and MIG are not supported at the same time
Jan 15 16:01:19 ip-192-168-23-52.us-west-2.compute.internal systemd[1]: Finished NVIDIA MPS Control Daemon.
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
