### PR TITLE
kubernetes-1.35: update to v1.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
  "rdma-core",
  "readline",
  "release",
+ "rocm-container-toolkit",
  "rocm-k8s-device-plugin",
  "rottweiler",
  "runc",

--- a/packages/kubernetes-1.35/Cargo.toml
+++ b/packages/kubernetes-1.35/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.35"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-35/releases/1/artifacts/kubernetes/v1.35.0-beta.0/kubernetes-src.tar.gz"
-sha512 = "7cd2aa9569e5a70ff7c5ee6048dda768823d6185eeb6946e00a322766f9ff9a6ad9cb70a56c712ee7486b4dbf9125cee6e08b15ba718e871c416a45a29219108"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-35/releases/3/artifacts/kubernetes/v1.35.0/kubernetes-src.tar.gz"
+sha512 = "0616aed1d47e514904f5d6ead778514d885deefe294f1e7b1526ea33ec8e623704061f3fe010aa4578ed397483714d2010e7d5b4f10fd055f032a588c4768fbd"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.35/kubelet-config
+++ b/packages/kubernetes-1.35/kubelet-config
@@ -209,6 +209,7 @@ reservedMemory:
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}
 failSwapOn: false
+failCgroupV1: false
 {{#if settings.kubernetes.memory-swap-behavior}}
 memorySwap:
   swapBehavior: {{settings.kubernetes.memory-swap-behavior}}

--- a/packages/kubernetes-1.35/kubernetes-1.35.spec
+++ b/packages/kubernetes-1.35/kubernetes-1.35.spec
@@ -10,6 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
+%global releasever 3
 %global gover 1.35.0
 %global rpmver %{gover}
 
@@ -32,12 +33,12 @@
 
 Name: %{_cross_os}%{gorepo}
 Version: %{rpmver}
-Release: 0.beta0%{?dist}
+Release: 1%{?dist}
 Summary: Container cluster management
 # base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
 License: Apache-2.0 AND BSD-3-Clause
 URL: https://%{goimport}
-Source0: kubernetes-src.tar.gz
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-35/releases/%{releasever}/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
 Source1: kubelet.service
 Source2: kubelet-env
 Source3: kubelet-config


### PR DESCRIPTION
**Issue number:**
https://github.com/bottlerocket-os/bottlerocket/issues/4725

**Description of changes:**
This PR updates the kubernetes-1.35 kit:

- Updates kubernetes-1.35 from v1.35.0-beta.0 to v1.35.0
- Kubernetes 1.35 changed `failCgroupV1` default to `true`, we keep it as `false` in kubelet config to maintain cgroup v1 compatibility.

**Testing done:**
- [x] Verified containerd version is `2.1.5`
```bash
containerd --version
containerd github.com/containerd/containerd/v2 2.1.5+bottlerocket fcd43222d6b07379a4be9786bda52438f0dd16a1
```
- [x]  Verified kernel version is `6.12`
```bash
bash-5.1# uname -r
6.12.58
```
- [x] Verified nvidia driver version is 580
```
nvidia-smi
Thu Jan  8 01:22:35 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  Tesla T4                       On  |   00000000:00:1E.0 Off |                    0 |
| N/A   23C    P8              9W /   70W |       0MiB /  15360MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```

- [x] Conformance tests
- - [x] x86-64-aws-k8s-135
- - [x] x86-64-aws-k8s-135-fips
- - [x] x86-64-aws-k8s-135-fips-ipv6
- - [x] x86-64-aws-k8s-135-ipv6
- - [x] x86-64-aws-k8s-135-nvidia
- - [x] aarch64-aws-k8s-135
- - [x] aarch64-aws-k8s-135-fips
- - [x] aarch64-aws-k8s-135-fips-ipv6
- - [x] aarch64-aws-k8s-135-ipv6
- - [x] aarch64-aws-k8s-135-nvidia

- [x] EBS CSI driver testing
```
# x86-64-aws-k8s-135
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
block-claim   Bound    pvc-93347526-b1b5-4938-aaf4-908fb4e5ac4e   4Gi        RWO            ebs-sc         11s

NAME   READY   STATUS    RESTARTS   AGE
app    1/1     Running   0          11s

# x86-64-aws-k8s-135-fips
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
block-claim   Bound    pvc-8a3006a0-856d-4330-a422-93384b7a7743   4Gi        RWO            ebs-sc         16s

NAME   READY   STATUS    RESTARTS   AGE
app    1/1     Running   0          17s

# aarch64-aws-k8s-135
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
block-claim   Bound    pvc-7371fecd-fd42-4a87-9367-4952ea3558d7   4Gi        RWO            ebs-sc         11s

NAME   READY   STATUS    RESTARTS   AGE
app    1/1     Running   0          11s

# aarch64-aws-k8s-135-fips
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
block-claim   Bound    pvc-c58b58f4-550b-4efd-92ed-00ace76ad944   4Gi        RWO            ebs-sc         13s

NAME   READY   STATUS    RESTARTS   AGE
app    1/1     Running   0          13s
```

- [x] ECR credential provider testing:
Create a pod that points to a private ECR that the node does not have credentials for. And the image pull failed as expected.
```
» k get pods
NAME              READY   STATUS         RESTARTS   AGE
credential-test   0/1     ErrImagePull   0          5s
```
After configuring the aws config to the node via apiclient which has the credentials for the account that hosts the private ecr image, the pod is running.
```
» k get pods
NAME              READY   STATUS    RESTARTS   AGE
credential-test   1/1     Running   0          2m32s
```


- [x] NVIDIA smoke tests
x86-64
```
» k get pods
NAME                READY   STATUS      RESTARTS   AGE
nvidia-smoke-test   0/1     Completed   0          97s
```
and for aarch64
```
» k get pods
NAME                 READY   STATUS      RESTARTS   AGE
aarch64-smoker-pod   0/1     Completed   0          4m30s
```
- [x] Hybrid nodes testing for vmware variants
```
export TEST_VARIANT="vmware-k8s-1.35" # Your test variant

src/bottlerocket_release_testing_hybrid_node/test_bottlerocket_release_testing_hybrid_node.py::test_nodes_ready PASSED                      [ 33%]
src/bottlerocket_release_testing_hybrid_node/test_bottlerocket_release_testing_hybrid_node.py::test_pods_deployment PASSED                  [ 66%]
src/bottlerocket_release_testing_hybrid_node/test_bottlerocket_release_testing_hybrid_node.py::test_deregister_hybrid_node PASSED           [100%]
 

export TEST_VARIANT="vmware-k8s-1.35-fips" # Your test variant                                                                                                                    
 
src/bottlerocket_release_testing_hybrid_node/test_bottlerocket_release_testing_hybrid_node.py::test_nodes_ready PASSED                      [ 33%]
src/bottlerocket_release_testing_hybrid_node/test_bottlerocket_release_testing_hybrid_node.py::test_pods_deployment PASSED                  [ 66%]
src/bottlerocket_release_testing_hybrid_node/test_bottlerocket_release_testing_hybrid_node.py::test_deregister_hybrid_node PASSED           [100%]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
