### PR TITLE
Third Party Package Updates - libraries

### DIFF
--- a/packages/libcap/Cargo.toml
+++ b/packages/libcap/Cargo.toml
@@ -13,12 +13,12 @@ releases-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libca
 # Changelog can be found here: https://sites.google.com/site/fullycapable/release-notes-for-libcap
 
 [[package.metadata.build-package.external-files]]
-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.76.tar.gz"
-sha512 = "673ed11d46f0e7033f6094893f82e5a141be31fa23626e968b199baecf8f60b37a84248a826afc45a65851c1ce14ac25973ae982c8a3035823450259df4b4383"
+url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.77.tar.gz"
+sha512 = "e5471afc4f149a8330e6df07effe58cac44d8a773b1fff0686e7039c41888e33402e1942fe5271a142e159a6088abbdbb7a82133389b3a9351749c2bf797b6b8"
 
 [[package.metadata.build-package.external-files]]
-url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.76.tar.sign"
-sha512 = "277d64dc2e76ade6780e49d7fb4b8280cfabb1f4c2e553d97c0b35ae7fee8aafb660d8dd9962427525a2fd8111b019ff642448b4caa598afad736779f5f37520"
+url = "https://cdn.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.77.tar.sign"
+sha512 = "c362eefb80bbc110b7d7c676cc2b37e04bd3dab1b8b4577d62a0774b6300258743156c57102e8dc11c35d2ea876053dc57eae44197137273413b959df33ef0c0"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libcap/libcap.spec
+++ b/packages/libcap/libcap.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libcap
-Version: 2.76
+Version: 2.77
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for getting and setting POSIX.1e capabilities

--- a/packages/liburcu/Cargo.toml
+++ b/packages/liburcu/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://lttng.org/files/urcu"
 
 [[package.metadata.build-package.external-files]]
-url = "https://lttng.org/files/urcu/userspace-rcu-0.15.3.tar.bz2"
-sha512 = "9461f5f1ebfcfdb28bc9548738a030d0a29e754ae5340581d057c405c0fa5c17560a251fa15a20cf14d35f1fcc9aceac80841b37a5f348698da52a71ee4d4fe5"
+url = "https://lttng.org/files/urcu/userspace-rcu-0.15.5.tar.bz2"
+sha512 = "48c7e137b986c1a33d91ecd8e5101ed8783b7c4e15b8324660c72bce9879373b80ffd97aca0c3b8015a47dfe2c11b5f4acf9d4a065185d9ba405d4e50a2b58d8"
 
 [[package.metadata.build-package.external-files]]
-url = "https://lttng.org/files/urcu/userspace-rcu-0.15.3.tar.bz2.asc"
-sha512 = "0e884fa83643520b5ee78bd1ec60d14cb8ca9aa3544e6c6be0cfe16785556160bdefc1a44c33e1740d4b35494616e10bbb92b96aad1ee618e00ebc94d45bb786"
+url = "https://lttng.org/files/urcu/userspace-rcu-0.15.5.tar.bz2.asc"
+sha512 = "401a7c04cf553fa95330ce108e0dac0edac91dca423910dac5da86f465fcf734ac1aad7e333d5f6c606e324e5b50c44861cb514a294b3400155902ed59ea673d"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/liburcu/liburcu.spec
+++ b/packages/liburcu/liburcu.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}liburcu
-Version: 0.15.3
+Version: 0.15.5
 Release: 1%{?dist}
 Epoch: 1
 Summary: Library for userspace RCU

--- a/packages/libxcrypt/Cargo.toml
+++ b/packages/libxcrypt/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://github.com/besser82/libxcrypt/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.38/libxcrypt-4.4.38.tar.xz"
-sha512 = "66c6f7e69d64ec6d9cca5c240bcd056c4f2802aab84325bef5c3aff189a0f81bc0944f473cbde8fdcb12cad8a9d35599afb045a5bc4be577e1c67066555bc116"
+url = "https://github.com/besser82/libxcrypt/releases/download/v4.5.2/libxcrypt-4.5.2.tar.xz"
+sha512 = "87b363e2bdc03ea993a9d154eb59a75ef77edd0490a9b58d443de4e1b4eec5196408a1eb9b739718fd92f565fe5157469c1ea3d336a4a54ac0947750b16c44c1"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/besser82/libxcrypt/releases/download/v4.4.38/libxcrypt-4.4.38.tar.xz.asc"
-sha512 = "4563bddc8581b9abca4ecc02d5d0578ec141a3dedf378f64ffd5838217c48f079bf0840a0d1100a909b471490a4a2a60a2e153fed4491625079f20f754edc443"
+url = "https://github.com/besser82/libxcrypt/releases/download/v4.5.2/libxcrypt-4.5.2.tar.xz.asc"
+sha512 = "bbd40cd8538cdf0762f888b35922907956ced69f0d31866b6d750c1d47aa033e19249a6d45a565c34826430cb1e232f7335fb9018ad68f3e5f417716a8e885fb"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libxcrypt/libxcrypt.spec
+++ b/packages/libxcrypt/libxcrypt.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}libxcrypt
-Version: 4.4.38
+Version: 4.5.2
 Release: 1%{?dist}
 Summary: Extended crypt library for descrypt, md5crypt, bcrypt, and others
 License: LGPL-2.1-or-later

--- a/packages/readline/Cargo.toml
+++ b/packages/readline/Cargo.toml
@@ -19,6 +19,18 @@ sha512 = "513002753dcf5db9213dbbb61d51217245f6a40d33b1dd45238e8062dfa8eef0c890b8
 url = "https://ftp.gnu.org/gnu/readline/readline-8.3.tar.gz.sig"
 sha512 = "8f9d4adeb068016e61f76052fb38552db447fc461c7d48811d8af5f0436abce20277e08c475a1c48c99fa37f2b20ca549a94eb5cee0fe6f0d4c854699cc0988c"
 
+[[package.metadata.build-package.external-files]]
+url = "https://ftp.gnu.org/gnu/readline/readline-8.3-patches/readline83-001"
+sha512 = "ced50af353ed527f6ec0eac5f65261f2ed208825ec72fe2acf5f0217f34f84f33dcbf01b895325f6b33664b5a426bac99506193e2ddb6eea8c79ccad37364b89"
+
+[[package.metadata.build-package.external-files]]
+url = "https://ftp.gnu.org/gnu/readline/readline-8.3-patches/readline83-002"
+sha512 = "e45ad6443bd4e271ec8e8ab883de561b6420aec362b0b7f0256086cb5a023d946df55994ed99c76ceb191e8a25e8059ae9b553ef1d546626d671b80af292f04d"
+
+[[package.metadata.build-package.external-files]]
+url = "https://ftp.gnu.org/gnu/readline/readline-8.3-patches/readline83-003"
+sha512 = "6b3ebffe994d0cd4d3466b15e3aee9a73613109283a4442f3bf10e28edcd1204df824c71356d66d01ac21014a806023a101fedf94526a19f6f590d9ffdc864cd"
+
 [build-dependencies]
 glibc = { path = "../glibc" }
 libncurses = { path = "../libncurses" }

--- a/packages/readline/readline.spec
+++ b/packages/readline/readline.spec
@@ -8,6 +8,11 @@ Source0: https://ftp.gnu.org/gnu/readline/readline-%{version}.tar.gz
 Source1: https://ftp.gnu.org/gnu/readline/readline-%{version}.tar.gz.sig
 Source2: gpgkey-7C0135FB088AAF6C66C650B9BB5869F064EA74AB.asc
 Patch1: readline-8.3-shlib.patch
+
+Patch1001: readline83-001
+Patch1002: readline83-002
+Patch1003: readline83-003
+
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libncurses-devel
 Requires: %{_cross_os}libncurses
@@ -24,7 +29,9 @@ Requires: %{name}
 
 %prep
 %{gpgverify} --data=%{S:0} --signature=%{S:1} --keyring=%{S:2}
-%autosetup -n readline-%{version} -p1
+%autosetup -n readline-%{version} -N
+%autopatch -p1 -m0001 -M1000
+%autopatch -p0 -m1001
 
 %build
 %cross_configure --with-curses --disable-install-examples


### PR DESCRIPTION
**Description of changes:**
- readline: update to 8.3.3
  - In readline's git repo, each commit is a patch. They don't release the patch update everytime. But the patches are available to take in https://ftp.gnu.org/gnu/readline/readline-8.3-patches/ 
- libxcrypt: update to 4.5.2
- liburcu: update to 0.15.5
- libcap: update to 2.77

**Testing done:**
`readline` - ran bash commands and they work
`liburcu` - ran xfsprogs test 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
