### PR TITLE
Third Party Package Updates

### DIFF
--- a/packages/ecr-credential-helper/Cargo.toml
+++ b/packages/ecr-credential-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/awslabs/amazon-ecr-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/amazon-ecr-credential-helper/archive/v0.10.1/amazon-ecr-credential-helper-0.10.1.tar.gz"
-sha512 = "d4e42300e8c498284fb33a4d1765b311f69f14c0946ea6dcff706aaf8bcea1634db086d7ada28816b4201e694514b4ccf54354fbe9825319c78050d941351df3"
+url = "https://github.com/awslabs/amazon-ecr-credential-helper/archive/v0.11.0/amazon-ecr-credential-helper-0.11.0.tar.gz"
+sha512 = "c19ec82e826612d439e6f30a18e1948056c7450bfda4ef71d7de7feb73523feb4285c51228560ab2e20450a7341f8fd83d93f7779d70950f0e5d53d1606117d1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ecr-credential-helper/ecr-credential-helper.spec
+++ b/packages/ecr-credential-helper/ecr-credential-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo amazon-ecr-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.10.1
+%global gover 0.11.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
**Description of changes:**
- ecr-credential-helper: update to 0.11.0

**Testing done:**
ecr-credential-helper test in ecs-3 variant
```
[ssm-user@control]$ apiclient set settings.image-verifier-plugins.notation.trustpolicy="*******"
[ssm-user@control]$ apiclient set settings.image-verifier-plugins.enabled=true
*********
bash-5.1# ctr i pull docker.io/library/hello-world:latest
ctr: image verifier bindir blocked pull of docker.io/library/hello-world:latest with digest sha256:d4aaab6242e0cace87e2ec17a2ed3d779d18fbfd03042ea58f2995626396a274 for reason: verifier notation-image-verifier rejected image (exit code 1): verifying image: docker.io/library/hello-world@sha256:d4aaab6242e0cace87e2ec17a2ed3d779d18fbfd03042ea58f2995626396a274
image verification failed: Error: signature verification failed: no signature is associated with "docker.io/library/hello-world@sha256:d4aaab6242e0cace87e2ec17a2ed3d779d18fbfd03042ea58f2995626396a274", make sure the artifact was signed successfully
bash-5.1# ctr -n k8s.io image pull *******/test-container-images:signed
public.ecr.aws/s2v1a1q8/test container i        saved
└──manifest (1882fa4569e0)                      complete        |++++++++++++++++++++++++++++++++++++++|
   ├──config (e7b39c54cdec)                     complete        |++++++++++++++++++++++++++++++++++++++|
   └──layer (1074353eec0d)                      complete        |++++++++++++++++++++++++++++++++++++++|
application/vnd.oci.image.manifest.v1+json sha256:1882fa4569e0c591ea092d3766c4893e19b8901a8e649de7067188aba3cc0679
Completed pull from OCI Registry (*******/test-container-images:signed) elapsed: 2.0 s  total:  3.7 Mi  (1.8 MiB/s)
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
