### PR TITLE
Add trn3 device ids

### DIFF
--- a/sources/pciclient/src/private.rs
+++ b/sources/pciclient/src/private.rs
@@ -31,6 +31,8 @@ lazy_static! {
         "7164", // trn1 device id 0
         "7264", // inf2 device id 0
         "7364", // trn2 device id 0
+        "7564", // trn3 device id 0
+        "7565", // trn3 device id 1
     };
 }
 


### PR DESCRIPTION
**Description of changes:**
This adds to the list of Neuron devices for trn3.

From the 2.25 Neuron driver in `neuron_device.h`:

```
 /* Vendor / Device ID for all devices supported by the driver */
#define AMZN_VENDOR_ID  0x1D0F
#define INF2_DEVICE_ID0 0x7264
#define TRN1_DEVICE_ID0 0x7164
#define TRN2_DEVICE_ID0 0x7364
#define TRN3_DEVICE_ID0 0x7564
#define TRN3_DEVICE_ID1 0x7565
```


**Testing done:**
Built the kit and ran `cargo fmt` and `cargo test` for pciclient.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
