### PR TITLE
thar-be-settings: improve service restart behavior

### DIFF
--- a/sources/api/thar-be-settings/src/error.rs
+++ b/sources/api/thar-be-settings/src/error.rs
@@ -87,4 +87,7 @@ pub enum Error {
         uri: String,
         source: schnauzer::v1::Error,
     },
+
+    #[snafu(display("One or more service restarts failed"))]
+    ServiceRestartsFailed,
 }

--- a/sources/api/thar-be-settings/src/service.rs
+++ b/sources/api/thar-be-settings/src/service.rs
@@ -42,6 +42,98 @@ impl Services {
         }
         Self(output)
     }
+
+    /// Restart all systemd units across all services with a single systemctl call.
+    fn restart_systemd(&self) -> Result<()> {
+        // Collect systemd unit names from all services' restart commands.
+        // e.g. "/bin/systemctl try-restart foo.service" -> "foo.service"
+        let units: Vec<&str> = self
+            .0
+            .values()
+            .flat_map(|s| s.model.restart_commands.iter())
+            .filter(|cmd| cmd.contains("systemctl"))
+            .filter_map(|cmd| cmd.split_whitespace().last())
+            .collect();
+
+        if units.is_empty() {
+            return Ok(());
+        }
+
+        debug!("Restarting systemd units: {:?}", &units);
+        let mut cmd = Command::new("/bin/systemctl");
+        cmd.arg("try-reload-or-restart");
+        cmd.args(&units);
+
+        let result = cmd.output().context(error::CommandExecutionFailureSnafu {
+            command: "systemctl try-reload-or-restart",
+        })?;
+
+        ensure!(
+            result.status.success(),
+            error::FailedRestartCommandSnafu {
+                command: format!("systemctl try-reload-or-restart {}", units.join(" ")),
+                stderr: String::from_utf8_lossy(&result.stderr),
+            }
+        );
+
+        Ok(())
+    }
+}
+
+impl Service {
+    /// Execute non-systemd restart commands for this service.
+    fn restart_non_systemd(&self) -> Result<()> {
+        for restart_command in &self.model.restart_commands {
+            // Skip systemd commands - handled by Services::restart_systemd()
+            if restart_command.contains("systemctl") {
+                continue;
+            }
+
+            // Split on space, assume the first item is the command
+            // and the rest are args.
+            debug!("Restart command: {:?}", &restart_command);
+            let mut command_strings = restart_command.split(' ');
+            let command = command_strings
+                .next()
+                .context(error::InvalidRestartCommandSnafu {
+                    command: restart_command.as_str(),
+                })?;
+            trace!("Command: {}", &command);
+            trace!("Args: {:?}", &command_strings);
+
+            // Go execute the restart command
+            let mut process_command = Command::new(command);
+            process_command.args(command_strings);
+            if let Some(ref changed_settings) = self.changed_settings {
+                if !changed_settings.is_empty() {
+                    process_command.env("CHANGED_SETTINGS", join(changed_settings, " "));
+                }
+            }
+            let result = process_command
+                .output()
+                .context(error::CommandExecutionFailureSnafu {
+                    command: restart_command.as_str(),
+                })?;
+
+            // If the restart command exited nonzero, call it a failure
+            ensure!(
+                result.status.success(),
+                error::FailedRestartCommandSnafu {
+                    command: restart_command.as_str(),
+                    stderr: String::from_utf8_lossy(&result.stderr),
+                }
+            );
+            trace!(
+                "Command stdout: {}",
+                String::from_utf8_lossy(&result.stdout)
+            );
+            trace!(
+                "Command stderr: {}",
+                String::from_utf8_lossy(&result.stderr)
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Returns a `Services` reflecting the set of services affected by the given changed settings in
@@ -133,70 +225,26 @@ where
     Ok(service_map)
 }
 
-/// Call the `restart()` method on each Service in a Services object
+/// Restart services, batching systemd services together and then iterating non-systemd services.
+/// Does not bail early on failure; attempts all restarts and reports any failures at the end.
 pub fn restart_services(services: Services) -> Result<()> {
-    for (name, service) in services.0 {
-        debug!("Checking for restart-commands for {name}");
-        service.restart()?;
+    let mut restart_failed = false;
+
+    if let Err(e) = services.restart_systemd() {
+        error!("systemctl restart failed: {}", e);
+        restart_failed = true;
     }
-    Ok(())
-}
 
-/// This trait is primarily meant to extend the Service model.  It uses the metadata
-/// inside the Service struct to restart the service.
-trait ServiceRestart {
-    /// Restart the service
-    fn restart(&self) -> Result<()>;
-}
-
-impl ServiceRestart for Service {
-    fn restart(&self) -> Result<()> {
-        let restart_commands = &self.model.restart_commands;
-        info!("restart commands {restart_commands:?}");
-        for restart_command in restart_commands {
-            // Split on space, assume the first item is the command
-            // and the rest are args.
-            debug!("Restart command: {:?}", &restart_command);
-            let mut command_strings = restart_command.split(' ');
-            let command = command_strings
-                .next()
-                .context(error::InvalidRestartCommandSnafu {
-                    command: restart_command.as_str(),
-                })?;
-            trace!("Command: {}", &command);
-            trace!("Args: {:?}", &command_strings);
-
-            // Go execute the restart command
-            let mut process_command = Command::new(command);
-            process_command.args(command_strings);
-            if let Some(ref changed_settings) = self.changed_settings {
-                if !changed_settings.is_empty() {
-                    process_command.env("CHANGED_SETTINGS", join(changed_settings, " "));
-                }
-            }
-            let result = process_command
-                .output()
-                .context(error::CommandExecutionFailureSnafu {
-                    command: restart_command.as_str(),
-                })?;
-
-            // If the restart command exited nonzero, call it a failure
-            ensure!(
-                result.status.success(),
-                error::FailedRestartCommandSnafu {
-                    command: restart_command.as_str(),
-                    stderr: String::from_utf8_lossy(&result.stderr),
-                }
-            );
-            trace!(
-                "Command stdout: {}",
-                String::from_utf8_lossy(&result.stdout)
-            );
-            trace!(
-                "Command stderr: {}",
-                String::from_utf8_lossy(&result.stderr)
-            );
+    for (name, service) in &services.0 {
+        if let Err(e) = service.restart_non_systemd() {
+            error!("Failed to restart {}: {}", name, e);
+            restart_failed = true;
         }
+    }
+
+    if restart_failed {
+        error::ServiceRestartsFailedSnafu.fail()
+    } else {
         Ok(())
     }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket/issues/4556

**Description of changes:**

Improves `thar-be-settings` service restart behavior with:

1. **Batch systemd restarts**: All systemd units are now restarted with a single `systemctl try-reload-or-restart` call, making the restart atomic from systemd's perspective.

2. **No early bail**: All service restarts are attempted regardless of individual failures so the system is not left in a partially-configured state. Failures are logged as they occur, and a summary error is returned at the end.

There are various ways to implement this, but I focused on keeping `restart_services` as simple as possible. This meant making symmetrical "flows" for systemd and non-systemd services so the restart process is simply:
```
Restart systemd -> Restart non-systemd -> Report any failures
```

Since systemd services are batched, `restart_systemd` method needs to be part of the `Services impl`. I removed the `ServiceRestart` trait since it was not used for abstraction (only one implementor) and moved the individual service restart logic to `restart_non_systemd` under `Service impl`.

**Testing done:**

Launched an `aws-dev` ami with `thar-be-settings` debug logs enabled and a forced failure in `corndog` to demonstrate the no-bail behavior. Instance failed boot as expected since settings failed to apply, but journal logs show:

1. Systemd batch ✅ 
```
Jan 16 02:54:09 localhost thar-be-settings[1779]: 02:54:09 [DEBUG] (1) thar_be_settings::service: Restarting systemd units: ["containerd.service", "host-containerd.service", "metricdog.service", "cfsignal.service", "chronyd.service", "docker.service", "deprecation-warning@log4j-hotpatch-enabled.timer", "systemd-modules-load", "set-hostname.service"]
```
2. All service restarts attempted despite failures ✅
```
Jan 16 02:54:09 localhost thar-be-settings[1779]: 02:54:09 [DEBUG] (1) thar_be_settings::service: Restart command: "/usr/bin/bootstrap-containers create-containers"
Jan 16 02:54:09 localhost thar-be-settings[1779]: 02:54:09 [DEBUG] (1) thar_be_settings::service: Restart command: "/usr/bin/corndog lockdown"
Jan 16 02:54:09 localhost thar-be-settings[1779]: 02:54:09 [ERROR] Failed to restart lockdown: Restart command failed - '/usr/bin/corndog lockdown':
Jan 16 02:54:09 localhost thar-be-settings[1779]: 02:54:09 [DEBUG] (1) thar_be_settings::service: Restart command: "/usr/bin/certdog"
Jan 16 02:54:09 localhost thar-be-settings[1779]: 02:54:09 [DEBUG] (1) thar_be_settings::service: Restart command: "/usr/bin/prairiedog generate-boot-config"
Jan 16 02:54:09 localhost thar-be-settings[1779]: 02:54:09 [DEBUG] (1) thar_be_settings::service: Restart command: "/usr/bin/corndog sysctl"
Jan 16 02:54:09 localhost thar-be-settings[1779]: 02:54:09 [ERROR] Failed to restart sysctl: Restart command failed - '/usr/bin/corndog sysctl':
Jan 16 02:54:09 localhost thar-be-settings[1779]: 02:54:09 [DEBUG] (1) thar_be_settings::service: Restart command: "/usr/bin/host-containers"
Jan 16 02:54:09 localhost thar-be-settings[1779]: 02:54:09 [DEBUG] (1) thar_be_settings::service: Restart command: "netdog write-resolv-conf"
Jan 16 02:54:09 localhost thar-be-settings[1779]: One or more service restarts failed
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
