### PR TITLE
sources(migrator): add logic to remove orphaned datastores

### DIFF
--- a/sources/api/migration/migrator/src/main.rs
+++ b/sources/api/migration/migrator/src/main.rs
@@ -39,7 +39,7 @@ use std::os::unix::fs::symlink;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process;
-use tokio::fs;
+use tokio::fs::{self, DirEntry};
 use tokio::runtime::Handle;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tokio_util::io::SyncIoBridge;
@@ -137,7 +137,8 @@ pub(crate) async fn run(args: &Args) -> Result<()> {
     let datastore =
         remove_transient_datastore_entries(migrated_datastore, &args.migrate_to_version).await?;
 
-    flip_to_new_version(&args.migrate_to_version, datastore).await?;
+    let datastore = flip_to_new_version(&args.migrate_to_version, datastore).await?;
+    cleanup_orphaned_datastores(&datastore).await;
 
     Ok(())
 }
@@ -380,7 +381,7 @@ where
     // The most recent, "good", datastore. We keep it around for debugging purposes in case we
     // encounter an error before reaching the final one. Once we reach final we delete the last
     // intermediate_datastore.
-    let mut intermediate_datastore = Option::default();
+    let mut intermediate_datastore: Option<PathBuf> = Option::default();
 
     for migration in migrations {
         let migration = migration.as_ref();
@@ -464,7 +465,7 @@ where
 
         // If an intermediate datastore exists from a previous loop, delete it.
         if let Some(path) = &intermediate_datastore {
-            delete_intermediate_datastore(path).await;
+            delete_datastore_entry(path.as_path()).await;
         }
 
         // Remember the location of the target_datastore to delete it in the next loop iteration
@@ -476,17 +477,78 @@ where
     Ok(target_datastore)
 }
 
-// Try to delete an intermediate datastore if it exists. If it fails to delete, print an error.
-async fn delete_intermediate_datastore(path: &PathBuf) {
-    // Even if we fail to remove an intermediate data store, we don't want to fail the upgrade -
+// Try to delete a datastore if it exists. If it fails to delete, print an error.
+async fn delete_datastore_entry(path: &Path) {
+    // Even if we fail to remove a data store, we don't want to fail the upgrade -
     // just let someone know for later cleanup.
-    trace!("Removing intermediate data store at {}", path.display());
+    trace!("Removing data store at {}", path.display());
     if let Err(e) = fs::remove_dir_all(path).await {
-        error!(
-            "Failed to remove intermediate data store at '{}': {}",
-            path.display(),
-            e
-        );
+        error!("Failed to remove data store at '{}': {}", path.display(), e);
+    }
+}
+
+// Traverse all files under top_dir and return those that do not resolve to the target_datastore
+// Return an empty HashSet on failure without breaking the boot
+async fn find_orphaned_entries(top_dir: &Path, target_datastore: PathBuf) -> HashSet<PathBuf> {
+    let mut active_entries: HashSet<PathBuf> = HashSet::new();
+    let mut orphaned_entries: HashSet<PathBuf> = HashSet::new();
+    let Ok(mut dir_entries) = fs::read_dir(top_dir).await else {
+        return orphaned_entries;
+    };
+    'outer: loop {
+        let entry: DirEntry = match dir_entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) => {
+                warn!("Failed to read directory entry: {}", e);
+                break;
+            }
+        };
+        let path = entry.path();
+        if active_entries.contains(&path) || orphaned_entries.contains(&path) {
+            continue;
+        }
+        let mut seen: HashSet<PathBuf> = HashSet::from([path.clone()]);
+        let mut current = path;
+        // Traverse all symlinks till the end to see if they point to target_datastore
+        while let Ok(next) = fs::read_link(&current).await {
+            let next = top_dir.join(&next);
+            if seen.contains(&next) {
+                // If a loop is detected, mark the files for deletion. Since the migration
+                // is complete when this code runs, the loop should not be a part of the
+                // datastore path
+                warn!("Detected a symlink loop containing {:#?}", seen);
+                orphaned_entries.extend(seen);
+                continue 'outer;
+            }
+            if active_entries.contains(&next) {
+                active_entries.extend(seen);
+                continue 'outer;
+            }
+            seen.insert(next.clone());
+            current = next;
+        }
+        if current == target_datastore {
+            active_entries.extend(seen);
+        } else {
+            orphaned_entries.extend(seen);
+        }
+    } // outer
+    orphaned_entries
+}
+
+// Clean up any datastore folders that do not point to the target_datastore
+async fn cleanup_orphaned_datastores(target_datastore: &Path) {
+    let datastore_dir = match target_datastore.parent() {
+        Some(p) => p.to_owned(),
+        None => return,
+    };
+
+    let orphaned_entries: HashSet<PathBuf> =
+        find_orphaned_entries(&datastore_dir, target_datastore.to_path_buf()).await;
+
+    for entry in orphaned_entries {
+        delete_datastore_entry(&entry).await;
     }
 }
 
@@ -498,7 +560,7 @@ async fn delete_intermediate_datastore(path: &PathBuf) {
 /// * pointing the major version to the minor version
 /// * pointing the 'current' link to the major version
 /// * fsyncing the directory to disk
-async fn flip_to_new_version<P>(version: &Version, to_datastore: P) -> Result<()>
+async fn flip_to_new_version<P>(version: &Version, to_datastore: P) -> Result<PathBuf>
 where
     P: AsRef<Path>,
 {
@@ -655,7 +717,7 @@ where
         )
     });
 
-    Ok(())
+    Ok(to_datastore.as_ref().to_path_buf())
 }
 
 async fn load_manifest(repository: tough::Repository) -> Result<Manifest> {

--- a/sources/api/migration/migrator/src/test.rs
+++ b/sources/api/migration/migrator/src/test.rs
@@ -2,7 +2,8 @@
 //! compiled for cfg(test) only.
 use crate::args::Args;
 use crate::{
-    copy_without_transient_entries, flip_to_new_version, perform_migrations, MigrationVersionMeta,
+    cleanup_orphaned_datastores, copy_without_transient_entries, find_orphaned_entries,
+    flip_to_new_version, perform_migrations, MigrationVersionMeta,
 };
 use chrono::{DateTime, Utc};
 use datastore::memory::MemoryDataStore;
@@ -106,6 +107,24 @@ impl TestDatastore {
         let datastore = storewolf::create_new_datastore(tmp.path(), Some(from_version)).unwrap();
         TestDatastore { tmp, datastore }
     }
+
+    /// Adds orphaned directories/symlinks that should be cleaned up.
+    fn add_orphaned_entries(&self) -> Vec<PathBuf> {
+        let base = self.tmp.path();
+        let mut orphaned = Vec::new();
+
+        // Create an orphaned directory (not linked to current)
+        let orphan_dir = base.join("v0.98.0_orphaned");
+        std::fs::create_dir_all(&orphan_dir).unwrap();
+        orphaned.push(orphan_dir.clone());
+
+        // Create a symlink pointing to the orphaned directory
+        let orphan_link = base.join("v0.98");
+        std::os::unix::fs::symlink("v0.98.0_orphaned", &orphan_link).unwrap();
+        orphaned.push(orphan_link);
+
+        orphaned
+    }
 }
 
 /// Represents a TUF repository, which is held in a tempdir.
@@ -152,6 +171,10 @@ async fn create_test_repo(test_type: TestType) -> TestRepo {
     let migration_names = test_type.migration_names();
     manifest.migrations.insert(
         (Version::new(0, 99, 0), Version::new(0, 99, 1)),
+        migration_names.clone(),
+    );
+    manifest.migrations.insert(
+        (Version::new(0, 99, 1), Version::new(0, 99, 2)),
         migration_names.clone(),
     );
     update_metadata::write_file(tuf_indir.join("manifest.json").as_path(), &manifest).unwrap();
@@ -265,17 +288,15 @@ async fn assert_directory_structure_with_failed_migration(
 
 /// Asserts that the expected directories and files are in the datastore directory after a
 /// successful migration. Returns the absolute path that the `current` symlink is pointing to.
-async fn assert_directory_structure(dir: &Path) -> PathBuf {
+async fn assert_directory_structure(dir: &Path, from: Version, to: Version) -> PathBuf {
     let paths = list_dir_entries(dir).await;
-    assert_eq!(paths.len(), 8);
+    assert_eq!(paths.len(), 6);
     assert_dir_entry_exists(&paths, "current");
     assert_dir_entry_exists(&paths, "result.txt");
-    assert_dir_entry_exists(&paths, "v0");
-    assert_dir_entry_exists(&paths, "v0.99");
-    assert_dir_entry_exists(&paths, "v0.99.0");
-    assert_dir_entry_exists(&paths, "v0.99.1");
-    assert_dir_starting_with_exists(&paths, "v0.99.0_");
-    assert_dir_starting_with_exists(&paths, "v0.99.1_");
+    assert_dir_entry_exists(&paths, format!("v{}", from.major).as_str());
+    assert_dir_entry_exists(&paths, format!("v{}.{}", from.major, from.minor).as_str());
+    assert_dir_entry_exists(&paths, format!("v{}", to).as_str());
+    assert_dir_starting_with_exists(&paths, format!("v{}_", to).as_str());
 
     let symlink = paths
         .iter()
@@ -347,7 +368,7 @@ async fn migrate_forward() {
         datastore_path: test_datastore.datastore.clone(),
         log_level: log::LevelFilter::Info,
         migration_directory: test_repo.targets_path.clone(),
-        migrate_to_version: to_version,
+        migrate_to_version: to_version.clone(),
         root_path: root(),
         metadata_directory: test_repo.metadata_path.clone(),
     };
@@ -370,12 +391,14 @@ async fn migrate_forward() {
     let got: String = third_line.chars().take(want.len()).collect();
     assert_eq!(got, want);
 
-    flip_to_new_version(&args.migrate_to_version, datastore)
+    let datastore = flip_to_new_version(&args.migrate_to_version, datastore)
         .await
         .unwrap();
+    cleanup_orphaned_datastores(&datastore).await;
 
     // Check the directory.
-    let current = assert_directory_structure(test_datastore.tmp.path()).await;
+    let current =
+        assert_directory_structure(test_datastore.tmp.path(), from_version, to_version).await;
 
     // We have successfully migrated so current should be pointing to a directory that starts with
     // v0.99.1.
@@ -400,7 +423,7 @@ async fn migrate_backward() {
         datastore_path: test_datastore.datastore.clone(),
         log_level: log::LevelFilter::Info,
         migration_directory: test_repo.targets_path.clone(),
-        migrate_to_version: to_version,
+        migrate_to_version: to_version.clone(),
         root_path: root(),
         metadata_directory: test_repo.metadata_path.clone(),
     };
@@ -422,12 +445,13 @@ async fn migrate_backward() {
     let got: String = second_line.chars().take(want.len()).collect();
     assert_eq!(got, want);
 
-    flip_to_new_version(&args.migrate_to_version, datastore)
+    let datastore = flip_to_new_version(&args.migrate_to_version, datastore)
         .await
         .unwrap();
-
+    cleanup_orphaned_datastores(&datastore).await;
     // Check the directory.
-    let current = assert_directory_structure(test_datastore.tmp.path()).await;
+    let current =
+        assert_directory_structure(test_datastore.tmp.path(), from_version, to_version).await;
 
     // We have successfully migrated so current should be pointing to a directory that starts with
     // v0.99.0.
@@ -693,4 +717,146 @@ async fn test_services_removed() {
             Key::new(datastore::KeyType::Data, "yet-another-thing.f.g").unwrap() => "\"rules\"".to_string(),
         }
     );
+}
+
+async fn do_migration(
+    from_version: &str,
+    to_version: &str,
+    test_repo: &TestRepo,
+    datastore: &TestDatastore,
+) {
+    let from = Version::parse(from_version).unwrap();
+    let to = Version::parse(to_version).unwrap();
+
+    let version_meta = MigrationVersionMeta::new(from.clone(), to.clone()).unwrap();
+    let args = Args {
+        datastore_path: datastore.datastore.clone(),
+        log_level: log::LevelFilter::Info,
+        migration_directory: test_repo.targets_path.clone(),
+        migrate_to_version: to.clone(),
+        root_path: root(),
+        metadata_directory: test_repo.metadata_path.clone(),
+    };
+    let outstore = perform_migrations(&version_meta, &args).await.unwrap();
+    let outstore = flip_to_new_version(&to, &outstore).await.unwrap();
+    cleanup_orphaned_datastores(&outstore).await;
+}
+
+#[tokio::test]
+async fn test_datastore_cleanup_across_migrations_forward() {
+    let test_repo = create_test_repo(TestType::Success).await;
+    let mut test_datastore = TestDatastore::new(Version::parse("0.99.0").unwrap());
+    // First migration: from source -> intermediate
+    do_migration("0.99.0", "0.99.1", &test_repo, &test_datastore).await;
+
+    let current = assert_directory_structure(
+        test_datastore.tmp.path(),
+        Version::parse("0.99.0").unwrap(),
+        Version::parse("0.99.1").unwrap(),
+    )
+    .await;
+    assert!(current
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("v0.99.1"));
+
+    // We need to "flip" the datastore to point to the new current datastore
+    test_datastore.datastore = current;
+
+    // Second migration: intermediate -> target
+    do_migration("0.99.1", "0.99.2", &test_repo, &test_datastore).await;
+
+    let current = assert_directory_structure(
+        test_datastore.tmp.path(),
+        Version::parse("0.99.1").unwrap(),
+        Version::parse("0.99.2").unwrap(),
+    )
+    .await;
+    assert!(current
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("v0.99.2"));
+}
+
+#[tokio::test]
+async fn test_datastore_cleanup_across_migrations_backward() {
+    let test_repo = create_test_repo(TestType::Success).await;
+    let mut test_datastore = TestDatastore::new(Version::parse("0.99.2").unwrap());
+    // First migration: from source -> intermediate
+    do_migration("0.99.2", "0.99.1", &test_repo, &test_datastore).await;
+
+    let current = assert_directory_structure(
+        test_datastore.tmp.path(),
+        Version::parse("0.99.2").unwrap(),
+        Version::parse("0.99.1").unwrap(),
+    )
+    .await;
+    assert!(current
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("v0.99.1"));
+
+    // We need to "flip" the datastore to point to the new current datastore
+    test_datastore.datastore = current;
+
+    // Second migration: intermediate -> target
+    do_migration("0.99.1", "0.99.0", &test_repo, &test_datastore).await;
+
+    let current = assert_directory_structure(
+        test_datastore.tmp.path(),
+        Version::parse("0.99.1").unwrap(),
+        Version::parse("0.99.0").unwrap(),
+    )
+    .await;
+    assert!(current
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .starts_with("v0.99.0"));
+}
+
+#[tokio::test]
+async fn test_symlink_graph() {
+    let test = TestDatastore::new(Version::parse("0.99.2").unwrap());
+    let expected_orphans = test.add_orphaned_entries();
+    let orphaned = find_orphaned_entries(test.tmp.path(), test.datastore.clone()).await;
+
+    // All entries we added should be detected as orphaned
+    for expected in &expected_orphans {
+        assert!(
+            orphaned.contains(expected),
+            "Expected {:?} to be in orphaned set",
+            expected
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_symlink_loop_handled() {
+    let tmp = TempDir::new().unwrap();
+    let base = tmp.path();
+
+    // Create a symlink loop: a -> b -> c -> a
+    std::os::unix::fs::symlink("b", base.join("a")).unwrap();
+    std::os::unix::fs::symlink("c", base.join("b")).unwrap();
+    std::os::unix::fs::symlink("a", base.join("c")).unwrap();
+
+    // Create the "real" datastore that current points to
+    let real_datastore = base.join("real_datastore");
+    std::fs::create_dir_all(&real_datastore).unwrap();
+    std::os::unix::fs::symlink(&real_datastore, base.join("current")).unwrap();
+
+    let orphaned = find_orphaned_entries(base, real_datastore.clone()).await;
+
+    // The loop entries should be orphaned (cycle detection marks them unreachable)
+    assert!(orphaned.contains(&base.join("a")));
+    assert!(orphaned.contains(&base.join("b")));
+    assert!(orphaned.contains(&base.join("c")));
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

## Issue number:

Related https://github.com/bottlerocket-os/bottlerocket/issues/2589

## Description of changes:
The disk space was filling up because, overtime, repeated updates to the latest released version of Bottlerocket were causing datastore from older versions to be left behind. I was able to reproduce this by setting up Brupop to update an instance from v1.15.0 incrementally using the `settings.updates.version-lock` to point to the next version.

The datastore ends up like below:
<details>

```bash
bash-5.2# ls -la /var/lib/bottlerocket/datastore/
total 88
drwxr-xr-x. 22 root root 4096 Dec 23 19:38 .
drwxr-xr-x.  5 root root 4096 Dec 22 20:55 ..
lrwxrwxrwx.  1 root root    2 Dec 23 19:38 current -> v1
lrwxrwxrwx.  1 root root    5 Dec 23 19:38 v1 -> v1.30
lrwxrwxrwx.  1 root root    7 Dec 22 21:13 v1.15 -> v1.15.1
lrwxrwxrwx.  1 root root   24 Dec 22 20:53 v1.15.0 -> v1.15.0_V4ECmJkMTlSK70CH
drwxr-xr-x.  4 root root 4096 Dec 22 21:34 v1.15.0_V4ECmJkMTlSK70CH
lrwxrwxrwx.  1 root root   24 Dec 22 21:13 v1.15.1 -> v1.15.0_V4ECmJkMTlSK70CH
lrwxrwxrwx.  1 root root    7 Dec 22 21:54 v1.16 -> v1.16.1
lrwxrwxrwx.  1 root root   24 Dec 22 21:34 v1.16.0 -> v1.16.0_driEKIVyUAe0KV5a
drwxr-xr-x.  4 root root 4096 Dec 22 21:54 v1.16.0_driEKIVyUAe0KV5a
lrwxrwxrwx.  1 root root   24 Dec 22 21:54 v1.16.1 -> v1.16.1_6FpEbWIngaUpGEl5
drwxr-xr-x.  4 root root 4096 Dec 22 22:15 v1.16.1_6FpEbWIngaUpGEl5
lrwxrwxrwx.  1 root root    7 Dec 22 22:16 v1.17 -> v1.17.0
lrwxrwxrwx.  1 root root   24 Dec 22 22:16 v1.17.0 -> v1.17.0_BATyRc0OneS2mjK8
drwxr-xr-x.  4 root root 4096 Dec 22 22:20 v1.17.0_BATyRc0OneS2mjK8
lrwxrwxrwx.  1 root root    7 Dec 22 22:21 v1.18 -> v1.18.0
lrwxrwxrwx.  1 root root   24 Dec 22 22:21 v1.18.0 -> v1.18.0_DAlgl2I18QK8D7Eh
drwxr-xr-x.  4 root root 4096 Dec 22 22:47 v1.18.0_DAlgl2I18QK8D7Eh
lrwxrwxrwx.  1 root root    7 Dec 23 15:54 v1.19 -> v1.19.5
lrwxrwxrwx.  1 root root   24 Dec 22 22:47 v1.19.0 -> v1.19.0_2Lmzs158W3o9Fvji
drwxr-xr-x.  4 root root 4096 Dec 23 02:56 v1.19.0_2Lmzs158W3o9Fvji
lrwxrwxrwx.  1 root root   24 Dec 23 02:57 v1.19.1 -> v1.19.1_Mf18meVLGMsWukUH
drwxr-xr-x.  4 root root 4096 Dec 23 02:58 v1.19.1_Mf18meVLGMsWukUH
lrwxrwxrwx.  1 root root   24 Dec 23 02:59 v1.19.2 -> v1.19.2_VxdgM9UemaPgEIti
drwxr-xr-x.  4 root root 4096 Dec 23 15:31 v1.19.2_VxdgM9UemaPgEIti
lrwxrwxrwx.  1 root root   24 Dec 23 15:32 v1.19.3 -> v1.19.3_1cDkZLmqsTyHUMYb
drwxr-xr-x.  4 root root 4096 Dec 23 15:54 v1.19.3_1cDkZLmqsTyHUMYb
lrwxrwxrwx.  1 root root   24 Dec 23 15:41 v1.19.4 -> v1.19.3_1cDkZLmqsTyHUMYb
lrwxrwxrwx.  1 root root   24 Dec 23 15:54 v1.19.5 -> v1.19.5_4TyksvbYrQAUqZgS
drwxr-xr-x.  4 root root 4096 Dec 23 16:00 v1.19.5_4TyksvbYrQAUqZgS
lrwxrwxrwx.  1 root root    7 Dec 23 16:31 v1.20 -> v1.20.5
lrwxrwxrwx.  1 root root   24 Dec 23 16:01 v1.20.0 -> v1.20.0_vpBXewdBz3K2RAIU
drwxr-xr-x.  4 root root 4096 Dec 23 16:31 v1.20.0_vpBXewdBz3K2RAIU
lrwxrwxrwx.  1 root root   24 Dec 23 16:04 v1.20.1 -> v1.20.0_vpBXewdBz3K2RAIU
lrwxrwxrwx.  1 root root   24 Dec 23 16:11 v1.20.2 -> v1.20.0_vpBXewdBz3K2RAIU
lrwxrwxrwx.  1 root root   24 Dec 23 16:15 v1.20.3 -> v1.20.0_vpBXewdBz3K2RAIU
lrwxrwxrwx.  1 root root   24 Dec 23 16:19 v1.20.4 -> v1.20.0_vpBXewdBz3K2RAIU
lrwxrwxrwx.  1 root root   24 Dec 23 16:31 v1.20.5 -> v1.20.5_sJfv8kZyyT4lJNIq
drwxr-xr-x.  4 root root 4096 Dec 23 16:34 v1.20.5_sJfv8kZyyT4lJNIq
lrwxrwxrwx.  1 root root    7 Dec 23 16:35 v1.21 -> v1.21.1
lrwxrwxrwx.  1 root root   24 Dec 23 16:35 v1.21.1 -> v1.21.1_rbbN56FrjNRXgKCc
drwxr-xr-x.  4 root root 4096 Dec 23 16:36 v1.21.1_rbbN56FrjNRXgKCc
lrwxrwxrwx.  1 root root    7 Dec 23 16:36 v1.22 -> v1.22.0
lrwxrwxrwx.  1 root root   24 Dec 23 16:36 v1.22.0 -> v1.22.0_qa0RPN7Vb9WTFmzK
drwxr-xr-x.  4 root root 4096 Dec 23 16:39 v1.22.0_qa0RPN7Vb9WTFmzK
lrwxrwxrwx.  1 root root    7 Dec 23 16:39 v1.23 -> v1.23.0
lrwxrwxrwx.  1 root root   24 Dec 23 16:39 v1.23.0 -> v1.23.0_wsNBTxGFpxyLTQTu
drwxr-xr-x.  4 root root 4096 Dec 23 16:54 v1.23.0_wsNBTxGFpxyLTQTu
lrwxrwxrwx.  1 root root    7 Dec 23 16:54 v1.24 -> v1.24.1
lrwxrwxrwx.  1 root root   24 Dec 23 16:53 v1.24.0 -> v1.23.0_wsNBTxGFpxyLTQTu
lrwxrwxrwx.  1 root root   24 Dec 23 16:54 v1.24.1 -> v1.24.1_iwoTrZKNVKX4h2vD
drwxr-xr-x.  4 root root 4096 Dec 23 16:56 v1.24.1_iwoTrZKNVKX4h2vD
lrwxrwxrwx.  1 root root    7 Dec 23 16:57 v1.25 -> v1.25.0
lrwxrwxrwx.  1 root root   24 Dec 23 16:57 v1.25.0 -> v1.25.0_S6BgjRNa5gejHwOk
drwxr-xr-x.  4 root root 4096 Dec 23 17:19 v1.25.0_S6BgjRNa5gejHwOk
lrwxrwxrwx.  1 root root    7 Dec 23 17:09 v1.26 -> v1.26.2
lrwxrwxrwx.  1 root root   24 Dec 23 17:00 v1.26.1 -> v1.25.0_S6BgjRNa5gejHwOk
lrwxrwxrwx.  1 root root   24 Dec 23 17:09 v1.26.2 -> v1.25.0_S6BgjRNa5gejHwOk
lrwxrwxrwx.  1 root root    7 Dec 23 17:22 v1.27 -> v1.27.1
lrwxrwxrwx.  1 root root   24 Dec 23 17:20 v1.27.0 -> v1.27.0_TsEx3hfSpmgO5XCy
drwxr-xr-x.  4 root root 4096 Dec 23 17:23 v1.27.0_TsEx3hfSpmgO5XCy
lrwxrwxrwx.  1 root root   24 Dec 23 17:22 v1.27.1 -> v1.27.0_TsEx3hfSpmgO5XCy
lrwxrwxrwx.  1 root root    7 Dec 23 17:24 v1.28 -> v1.28.0
lrwxrwxrwx.  1 root root   24 Dec 23 17:24 v1.28.0 -> v1.28.0_Mkh5aT9DmRJ2Yvrb
drwxr-xr-x.  4 root root 4096 Dec 23 19:38 v1.28.0_Mkh5aT9DmRJ2Yvrb
lrwxrwxrwx.  1 root root    7 Dec 23 17:45 v1.29 -> v1.29.0
lrwxrwxrwx.  1 root root   24 Dec 23 17:45 v1.29.0 -> v1.28.0_Mkh5aT9DmRJ2Yvrb
lrwxrwxrwx.  1 root root    7 Dec 23 19:38 v1.30 -> v1.30.0
lrwxrwxrwx.  1 root root   24 Dec 23 19:38 v1.30.0 -> v1.30.0_wmjzliXa0BtfgPOr
drwxr-xr-x.  4 root root 4096 Dec 23 19:38 v1.30.0_wmjzliXa0BtfgPOr
```

</details>

This change adds a new method `cleanup_orphaned_datastores` which locates all datastore symlinks that do not resolve `target` datastore and deletes everything else.

There is a helper function named `find_all_files_to_delete` which does the actual symlink traversal.

I also extended the unit tests to add multi-stage migrations to verify this behaviour.

## Testing done:

### Migrate from 1.53.0 to 1.54.0 (with settings migrations):
<details>

- Initial state
    ```bash
        bash-5.2# ls -la /var/lib/bottlerocket/datastore/
        total 12
        drwxr-xr-x  3 root root 4096 Feb 17 04:59 .
        drwxr-xr-x. 5 root root 4096 Feb 17 04:59 ..
        lrwxrwxrwx  1 root root    2 Feb 17 04:59 current -> v1
        lrwxrwxrwx  1 root root    5 Feb 17 04:59 v1 -> v1.53
        lrwxrwxrwx  1 root root    7 Feb 17 04:59 v1.53 -> v1.53.0
        lrwxrwxrwx  1 root root   24 Feb 17 04:59 v1.53.0 -> v1.53.0_MBb5IUZ2jNtloSZB
        drwxr-xr-x  4 root root 4096 Feb 17 04:59 v1.53.0_MBb5IUZ2jNtloSZB
    ```

- Forward migration
    ```bash
        bash-5.2# ls -la /var/lib/bottlerocket/datastore/
        total 12
        drwxr-xr-x  3 root root 4096 Feb 17 05:09 .
        drwxr-xr-x. 5 root root 4096 Feb 17 04:59 ..
        lrwxrwxrwx  1 root root    2 Feb 17 05:09 current -> v1
        lrwxrwxrwx  1 root root    5 Feb 17 05:09 v1 -> v1.54
        lrwxrwxrwx  1 root root    7 Feb 17 05:09 v1.54 -> v1.54.0
        lrwxrwxrwx  1 root root   24 Feb 17 05:09 v1.54.0 -> v1.54.0_pzujidtVjBccrhUX
        drwxr-xr-x  4 root root 4096 Feb 17 05:09 v1.54.0_pzujidtVjBccrhUX
    ```
- Rollback
    ```bash
        bash-5.2# ls -la /var/lib/bottlerocket/datastore/
        total 12
        drwxr-xr-x  3 root root 4096 Feb 17 17:54 .
        drwxr-xr-x. 5 root root 4096 Feb 17 04:59 ..
        lrwxrwxrwx  1 root root    2 Feb 17 17:54 current -> v1
        lrwxrwxrwx  1 root root    5 Feb 17 17:54 v1 -> v1.53
        lrwxrwxrwx  1 root root    7 Feb 17 17:54 v1.53 -> v1.53.0
        lrwxrwxrwx  1 root root   24 Feb 17 17:54 v1.53.0 -> v1.53.0_9GTssIfOT9f1FkFX
        drwxr-xr-x  4 root root 4096 Feb 17 17:54 v1.53.0_9GTssIfOT9f1FkFX
    ```

</details>

### Migrate 1.53.0 to 1.54.0 then to 1.55.0 then to 1.55.1 
<details>

- Initial State
   ```bash
        bash-5.2# ls -la /var/lib/bottlerocket/datastore/
        total 12
        drwxr-xr-x  3 root root 4096 Feb 17 17:54 .
        drwxr-xr-x. 5 root root 4096 Feb 17 04:59 ..
        lrwxrwxrwx  1 root root    2 Feb 17 17:54 current -> v1
        lrwxrwxrwx  1 root root    5 Feb 17 17:54 v1 -> v1.53
        lrwxrwxrwx  1 root root    7 Feb 17 17:54 v1.53 -> v1.53.0
        lrwxrwxrwx  1 root root   24 Feb 17 17:54 v1.53.0 -> v1.53.0_9GTssIfOT9f1FkFX
        drwxr-xr-x  4 root root 4096 Feb 17 17:54 v1.53.0_9GTssIfOT9f1FkFX
    ```

- Forward migration 
    - 1.53.0 to 1.54.0
        ```bash
        bash-5.2# ls -la /var/lib/bottlerocket/datastore/
        total 12
        drwxr-xr-x  3 root root 4096 Feb 17 17:58 .
        drwxr-xr-x. 5 root root 4096 Feb 17 04:59 ..
        lrwxrwxrwx  1 root root    2 Feb 17 17:58 current -> v1
        lrwxrwxrwx  1 root root    5 Feb 17 17:58 v1 -> v1.54
        lrwxrwxrwx  1 root root    7 Feb 17 17:58 v1.54 -> v1.54.0
        lrwxrwxrwx  1 root root   24 Feb 17 17:58 v1.54.0 -> v1.54.0_6LFpR1IK89zHTT9W
        drwxr-xr-x  4 root root 4096 Feb 17 17:58 v1.54.0_6LFpR1IK89zHTT9W
        ```
    - 1.54.0 to 1.55.0
        ```bash
        bash-5.2# ls -la /var/lib/bottlerocket/datastore/
        total 12
        drwxr-xr-x  3 root root 4096 Feb 17 18:13 .
        drwxr-xr-x. 5 root root 4096 Feb 17 04:59 ..
        lrwxrwxrwx  1 root root    2 Feb 17 18:13 current -> v1
        lrwxrwxrwx  1 root root    5 Feb 17 18:13 v1 -> v1.55
        lrwxrwxrwx  1 root root    7 Feb 17 18:13 v1.55 -> v1.55.0
        lrwxrwxrwx  1 root root   24 Feb 17 18:13 v1.55.0 -> v1.55.0_rqPaOT8EyZhGwsww
        drwxr-xr-x  4 root root 4096 Feb 17 18:13 v1.55.0_rqPaOT8EyZhGwsww
        ```
    - 1.55.0 to 1.55.1
        ```bash
        bash-5.2# ls -la /var/lib/bottlerocket/datastore/
        total 12
        drwxr-xr-x  3 root root 4096 Feb 17 18:23 .
        drwxr-xr-x. 5 root root 4096 Feb 17 04:59 ..
        lrwxrwxrwx  1 root root    2 Feb 17 18:23 current -> v1
        lrwxrwxrwx  1 root root    5 Feb 17 18:23 v1 -> v1.55
        lrwxrwxrwx  1 root root    7 Feb 17 18:23 v1.55 -> v1.55.1
        lrwxrwxrwx  1 root root   24 Feb 17 18:23 v1.55.1 -> v1.55.1_BrdJXy7KR4fOul7J
        drwxr-xr-x  4 root root 4096 Feb 17 18:23 v1.55.1_BrdJXy7KR4fOul7J
        ```
- Rollback
    ```bash
        total 12
        drwxr-xr-x  3 root root 4096 Feb 17 18:27 .
        drwxr-xr-x. 5 root root 4096 Feb 17 04:59 ..
        lrwxrwxrwx  1 root root    2 Feb 17 18:27 current -> v1
        lrwxrwxrwx  1 root root    5 Feb 17 18:27 v1 -> v1.55
        lrwxrwxrwx  1 root root    7 Feb 17 18:27 v1.55 -> v1.55.0
        lrwxrwxrwx  1 root root   24 Feb 17 18:27 v1.55.0 -> v1.55.0_oT7OTfJqxzvd1h2G
        drwxr-xr-x  4 root root 4096 Feb 17 18:27 v1.55.0_oT7OTfJqxzvd1h2G
    ```

### To illustrate how this would have looked without this change:

   
    bash-5.2# ls -la /var/lib/bottlerocket/datastore/
	total 12
	drwxr-xr-x  3 root root 4096 Feb 17 17:54 .
	drwxr-xr-x. 5 root root 4096 Feb 17 04:59 ..
	lrwxrwxrwx  1 root root    2 Feb 17 17:54 current -> v1
	lrwxrwxrwx  1 root root    5 Feb 17 18:27 v1 -> v1.55
	lrwxrwxrwx  1 root root    7 Feb 17 18:27 v1.55 -> v1.55.0
	lrwxrwxrwx  1 root root   24 Feb 17 18:27 v1.55.0 -> v1.55.0_oT7OTfJqxzvd1h2G
	drwxr-xr-x  4 root root 4096 Feb 17 18:27 v1.55.0_oT7OTfJqxzvd1h2G
	lrwxrwxrwx  1 root root   24 Feb 17 18:23 v1.55.1 -> v1.55.1_BrdJXy7KR4fOul7J
	drwxr-xr-x  4 root root 4096 Feb 17 18:23 v1.55.1_BrdJXy7KR4fOul7J
	drwxr-xr-x  4 root root 4096 Feb 17 18:13 v1.55.0_rqPaOT8EyZhGwsww
	lrwxrwxrwx  1 root root    7 Feb 17 17:58 v1.54 -> v1.54.0
	lrwxrwxrwx  1 root root   24 Feb 17 17:58 v1.54.0 -> v1.54.0_6LFpR1IK89zHTT9W
	drwxr-xr-x  4 root root 4096 Feb 17 17:58 v1.54.0_6LFpR1IK89zHTT9W
	lrwxrwxrwx  1 root root    7 Feb 17 17:54 v1.53 -> v1.53.0
	lrwxrwxrwx  1 root root   24 Feb 17 17:54 v1.53.0 -> v1.53.0_9GTssIfOT9f1FkFX
	drwxr-xr-x  4 root root 4096 Feb 17 17:54 v1.53.0_9GTssIfOT9f1FkFX

</details>
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
