### PR TITLE
re-packaging the Go packages

### DIFF
--- a/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
+++ b/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
@@ -18,46 +18,16 @@ Patch0001: 0001-bottlerocket-default-filesystem-locations.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 
-Requires: %{name}(binaries)
-Requires: (%{name}(ecs-agent-extras) if %{_cross_os}variant-family(aws-ecs))
+Requires: (%{name}-ecs-agent-extras if %{_cross_os}variant-family(aws-ecs))
 
 %description
 %{summary}.
 
-%package bin
-Summary: ECS networking plugins binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: ECS networking plugins binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
-%{summary}.
-
 %package ecs-agent-extras
 Summary: Extra files necessary for the ECS agent
-Provides: %{name}(ecs-agent-extras)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name}(binaries))
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-ecs-agent-fips-extras)
+Requires: %{name}
 
 %description ecs-agent-extras
-%{summary}.
-
-%package ecs-agent-fips-extras
-Summary: Extra files necessary for the ECS agent, FIPS edition
-Provides: %{name}(ecs-agent-extras)
-Requires: (%{_cross_os}image-feature(fips) and %{name}(binaries))
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-ecs-agent-extras)
-
-%description ecs-agent-fips-extras
 %{summary}.
 
 %prep
@@ -80,13 +50,10 @@ ECS_CNI_BUILD_ARGS=(
 )
 
 go build "${ECS_CNI_BUILD_ARGS[@]}" -o ecs-eni ./plugins/eni
-gofips build "${ECS_CNI_BUILD_ARGS[@]}" -o fips/ecs-eni ./plugins/eni
 
 go build "${ECS_CNI_BUILD_ARGS[@]}" -o ecs-ipam ./plugins/ipam
-gofips build "${ECS_CNI_BUILD_ARGS[@]}" -o fips/ecs-ipam ./plugins/ipam
 
 go build "${ECS_CNI_BUILD_ARGS[@]}" -o ecs-bridge ./plugins/ecs-bridge
-gofips build "${ECS_CNI_BUILD_ARGS[@]}" -o fips/ecs-bridge ./plugins/ecs-bridge
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}
@@ -94,20 +61,14 @@ install -D -p -m 0755 ecs-bridge %{buildroot}%{_cross_libexecdir}/cni/ecs/ecs-br
 install -D -p -m 0755 ecs-eni %{buildroot}%{_cross_libexecdir}/cni/ecs/ecs-eni
 install -D -p -m 0755 ecs-ipam %{buildroot}%{_cross_libexecdir}/cni/ecs/ecs-ipam
 
-install -d %{buildroot}%{_cross_fips_libexecdir}
-install -D -p -m 0755 fips/ecs-bridge %{buildroot}%{_cross_fips_libexecdir}/cni/ecs/ecs-bridge
-install -D -p -m 0755 fips/ecs-eni %{buildroot}%{_cross_fips_libexecdir}/cni/ecs/ecs-eni
-install -D -p -m 0755 fips/ecs-ipam %{buildroot}%{_cross_fips_libexecdir}/cni/ecs/ecs-ipam
-
 # Create symlinks to ECS CNI plugin binaries for amazon-ecs-agent
-install -d %{buildroot}{%{_cross_libexecdir},%{_cross_fips_libexecdir}}/amazon-ecs-agent
+install -d %{buildroot}%{_cross_libexecdir}/amazon-ecs-agent
 for p in \
   ecs-bridge \
   ecs-eni \
   ecs-ipam \
 ; do
   ln -rs %{buildroot}%{_cross_libexecdir}/cni/ecs/${p} %{buildroot}%{_cross_libexecdir}/amazon-ecs-agent/${p}
-  ln -rs %{buildroot}%{_cross_fips_libexecdir}/cni/ecs/${p} %{buildroot}%{_cross_fips_libexecdir}/amazon-ecs-agent/${p}
 done
 
 %cross_scan_attribution go-vendor vendor
@@ -116,25 +77,13 @@ done
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
 %license LICENSE
-
-%files bin
 %{_cross_libexecdir}/cni/ecs/ecs-bridge
 %{_cross_libexecdir}/cni/ecs/ecs-eni
 %{_cross_libexecdir}/cni/ecs/ecs-ipam
-
-%files fips-bin
-%{_cross_fips_libexecdir}/cni/ecs/ecs-bridge
-%{_cross_fips_libexecdir}/cni/ecs/ecs-eni
-%{_cross_fips_libexecdir}/cni/ecs/ecs-ipam
 
 %files ecs-agent-extras
 %{_cross_libexecdir}/amazon-ecs-agent/ecs-bridge
 %{_cross_libexecdir}/amazon-ecs-agent/ecs-eni
 %{_cross_libexecdir}/amazon-ecs-agent/ecs-ipam
-
-%files ecs-agent-fips-extras
-%{_cross_fips_libexecdir}/amazon-ecs-agent/ecs-bridge
-%{_cross_fips_libexecdir}/amazon-ecs-agent/ecs-eni
-%{_cross_fips_libexecdir}/amazon-ecs-agent/ecs-ipam
 
 %changelog

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -16,52 +16,14 @@ Source1000: clarify.toml
 Patch0001: 0001-agent-Add-config-to-make-shell-optional.patch
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 %description
 %{summary}.
 
-%package bin
-Summary: Remote management agent binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Remote management agent binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
-%{summary}.
-
 %package plugin
 Summary: A statically-linked agent to enable remote management of EC2 instances
-Requires: %{name}-plugin(binaries)
 
 %description plugin
-%{summary}.
-
-%package plugin-bin
-Summary: Statically-linked remote management agent binaries
-Provides: %{name}-plugin(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name}-plugin)
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-plugin-fips-bin)
-
-%description plugin-bin
-%{summary}.
-
-%package plugin-fips-bin
-Summary: Statically-linked remote management agent binaries, FIPS edition
-Provides: %{name}-plugin(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name}-plugin)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-plugin-bin)
-
-%description plugin-fips-bin
 %{summary}.
 
 %prep
@@ -73,19 +35,10 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-plugin-bin)
 go build -ldflags "${GOLDFLAGS}" -o amazon-ssm-agent \
   ./core/agent.go ./core/agent_unix.go ./core/agent_parser.go
 
-gofips build -ldflags "${GOLDFLAGS}" -o fips/amazon-ssm-agent \
-  ./core/agent.go ./core/agent_unix.go ./core/agent_parser.go
-
 go build -ldflags "${GOLDFLAGS}" -o ssm-agent-worker \
   ./agent/agent.go ./agent/agent_unix.go ./agent/agent_parser.go
 
-gofips build -ldflags "${GOLDFLAGS}" -o fips/ssm-agent-worker \
-  ./agent/agent.go ./agent/agent_unix.go ./agent/agent_parser.go
-
 go build -ldflags "${GOLDFLAGS}" -o ssm-session-worker \
-  ./agent/framework/processor/executer/outofproc/sessionworker/main.go
-
-gofips build -ldflags "${GOLDFLAGS}" -o fips/ssm-session-worker \
   ./agent/framework/processor/executer/outofproc/sessionworker/main.go
 
 %set_cross_go_flags_static
@@ -93,19 +46,10 @@ gofips build -ldflags "${GOLDFLAGS}" -o fips/ssm-session-worker \
 go build -ldflags "${GOLDFLAGS}" -o static/amazon-ssm-agent \
   ./core/agent.go ./core/agent_unix.go ./core/agent_parser.go
 
-gofips build -ldflags "${GOLDFLAGS}" -o fips-static/amazon-ssm-agent \
-  ./core/agent.go ./core/agent_unix.go ./core/agent_parser.go
-
 go build -ldflags "${GOLDFLAGS}" -o static/ssm-agent-worker \
   ./agent/agent.go ./agent/agent_unix.go ./agent/agent_parser.go
 
-gofips build -ldflags "${GOLDFLAGS}" -o fips-static/ssm-agent-worker \
-  ./agent/agent.go ./agent/agent_unix.go ./agent/agent_parser.go
-
 go build -ldflags "${GOLDFLAGS}" -o static/ssm-session-worker \
-  ./agent/framework/processor/executer/outofproc/sessionworker/main.go
-
-gofips build -ldflags "${GOLDFLAGS}" -o fips-static/ssm-session-worker \
   ./agent/framework/processor/executer/outofproc/sessionworker/main.go
 
 %install
@@ -114,23 +58,20 @@ install -D -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}/amazon-ssm-agent.serv
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/amazon/ssm
 install -m 0644 %{S:2} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/amazon/ssm/amazon-ssm-agent.json
 
-install -d %{buildroot}{%{_cross_bindir},%{_cross_fips_bindir}}
+install -d %{buildroot}%{_cross_bindir}
 for b in amazon-ssm-agent ssm-agent-worker ssm-session-worker; do
   install -p -m 0755 ${b} %{buildroot}%{_cross_bindir}
-  install -p -m 0755 fips/${b} %{buildroot}%{_cross_fips_bindir}
 done
 
 # Install the statically-linked SSM agent under 'libexecdir', since it is meant to be used by other programs
-install -d %{buildroot}{%{_cross_libexecdir},%{_cross_fips_libexecdir}}/amazon-ssm-agent/bin/%{version}
+install -d %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}
 for b in amazon-ssm-agent ssm-agent-worker ssm-session-worker; do
   install -p -m 0755 static/${b} %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}
-  install -p -m 0755 fips-static/${b} %{buildroot}%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}
 done
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 ln -sf %{version} %{buildroot}%{_cross_libexecdir}/amazon-ssm-agent/bin/latest
-ln -sf %{version} %{buildroot}%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/latest
 
 %files
 %license LICENSE
@@ -139,29 +80,13 @@ ln -sf %{version} %{buildroot}%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/lat
 %{_cross_unitdir}/amazon-ssm-agent.service
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/amazon/ssm
 %{_cross_factorydir}%{_cross_sysconfdir}/amazon/ssm/amazon-ssm-agent.json
-
-%files bin
 %{_cross_bindir}/amazon-ssm-agent
 %{_cross_bindir}/ssm-agent-worker
 %{_cross_bindir}/ssm-session-worker
 
-%files fips-bin
-%{_cross_fips_bindir}/amazon-ssm-agent
-%{_cross_fips_bindir}/ssm-agent-worker
-%{_cross_fips_bindir}/ssm-session-worker
-
 %files plugin
-
-%files plugin-bin
 %dir %{_cross_libexecdir}/amazon-ssm-agent
 %{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}/amazon-ssm-agent
 %{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-agent-worker
 %{_cross_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-session-worker
 %{_cross_libexecdir}/amazon-ssm-agent/bin/latest
-
-%files plugin-fips-bin
-%dir %{_cross_fips_libexecdir}/amazon-ssm-agent
-%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}/amazon-ssm-agent
-%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-agent-worker
-%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/%{version}/ssm-session-worker
-%{_cross_fips_libexecdir}/amazon-ssm-agent/bin/latest

--- a/packages/amazon-vpc-cni-plugins/amazon-vpc-cni-plugins.spec
+++ b/packages/amazon-vpc-cni-plugins/amazon-vpc-cni-plugins.spec
@@ -15,46 +15,16 @@ Source0: https://%{vpccni_goimport}/archive/%{vpccni_gitrev}/%{vpccni_gorepo}.ta
 
 BuildRequires: %{_cross_os}glibc-devel
 
-Requires: %{name}(binaries)
-Requires: (%{name}(ecs-agent-extras) if %{_cross_os}variant-family(aws-ecs))
+Requires: (%{name}-ecs-agent-extras if %{_cross_os}variant-family(aws-ecs))
 
 %description
 %{summary}.
 
-%package bin
-Summary: VPC networking plugins binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: VPC networking plugins binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
-%{summary}.
-
 %package ecs-agent-extras
 Summary: Extra files necessary for the ECS agent
-Provides: %{name}(ecs-agent-extras)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name}(binaries))
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-ecs-agent-fips-extras)
+Requires: %{name}
 
 %description ecs-agent-extras
-%{summary}.
-
-%package ecs-agent-fips-extras
-Summary: Extra files necessary for the ECS agent, FIPS edition
-Provides: %{name}(ecs-agent-extras)
-Requires: (%{_cross_os}image-feature(fips) and %{name}(binaries))
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-ecs-agent-extras)
-
-%description ecs-agent-fips-extras
 %{summary}.
 
 %prep
@@ -84,7 +54,6 @@ for p in \
   vpc-tunnel \
 ; do
   go build "${VPC_CNI_BUILD_ARGS[@]}" -mod=vendor -o ${p} ./plugins/${p}
-  gofips build "${VPC_CNI_BUILD_ARGS[@]}" -mod=vendor -o fips/${p} ./plugins/${p}
 done
 
 %install
@@ -96,16 +65,8 @@ install -D -p -m 0755 vpc-bridge %{buildroot}%{_cross_libexecdir}/cni/vpc/vpc-br
 install -D -p -m 0755 vpc-eni %{buildroot}%{_cross_libexecdir}/cni/vpc/vpc-eni
 install -D -p -m 0755 vpc-tunnel %{buildroot}%{_cross_libexecdir}/cni/vpc/vpc-tunnel
 
-install -d %{buildroot}%{_cross_fips_libexecdir}
-install -D -p -m 0755 fips/aws-appmesh %{buildroot}%{_cross_fips_libexecdir}/cni/vpc/aws-appmesh
-install -D -p -m 0755 fips/ecs-serviceconnect %{buildroot}%{_cross_fips_libexecdir}/cni/vpc/ecs-serviceconnect
-install -D -p -m 0755 fips/vpc-branch-eni %{buildroot}%{_cross_fips_libexecdir}/cni/vpc/vpc-branch-eni
-install -D -p -m 0755 fips/vpc-bridge %{buildroot}%{_cross_fips_libexecdir}/cni/vpc/vpc-bridge
-install -D -p -m 0755 fips/vpc-eni %{buildroot}%{_cross_fips_libexecdir}/cni/vpc/vpc-eni
-install -D -p -m 0755 fips/vpc-tunnel %{buildroot}%{_cross_fips_libexecdir}/cni/vpc/vpc-tunnel
-
 # Create symlinks to VPC CNI plugin binaries for amazon-ecs-agent
-install -d %{buildroot}{%{_cross_libexecdir},%{_cross_fips_libexecdir}}/amazon-ecs-agent
+install -d %{buildroot}%{_cross_libexecdir}/amazon-ecs-agent
 for p in \
   aws-appmesh \
   ecs-serviceconnect \
@@ -115,7 +76,6 @@ for p in \
   vpc-tunnel \
 ; do
   ln -rs %{buildroot}%{_cross_libexecdir}/cni/vpc/${p} %{buildroot}%{_cross_libexecdir}/amazon-ecs-agent/${p}
-  ln -rs %{buildroot}%{_cross_fips_libexecdir}/cni/vpc/${p} %{buildroot}%{_cross_fips_libexecdir}/amazon-ecs-agent/${p}
 done
 
 %cross_scan_attribution go-vendor vendor
@@ -124,22 +84,12 @@ done
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
 %license LICENSE
-
-%files bin
 %{_cross_libexecdir}/cni/vpc/aws-appmesh
 %{_cross_libexecdir}/cni/vpc/ecs-serviceconnect
 %{_cross_libexecdir}/cni/vpc/vpc-branch-eni
 %{_cross_libexecdir}/cni/vpc/vpc-bridge
 %{_cross_libexecdir}/cni/vpc/vpc-eni
 %{_cross_libexecdir}/cni/vpc/vpc-tunnel
-
-%files fips-bin
-%{_cross_fips_libexecdir}/cni/vpc/aws-appmesh
-%{_cross_fips_libexecdir}/cni/vpc/ecs-serviceconnect
-%{_cross_fips_libexecdir}/cni/vpc/vpc-branch-eni
-%{_cross_fips_libexecdir}/cni/vpc/vpc-bridge
-%{_cross_fips_libexecdir}/cni/vpc/vpc-eni
-%{_cross_fips_libexecdir}/cni/vpc/vpc-tunnel
 
 %files ecs-agent-extras
 %{_cross_libexecdir}/amazon-ecs-agent/aws-appmesh
@@ -148,13 +98,5 @@ done
 %{_cross_libexecdir}/amazon-ecs-agent/vpc-bridge
 %{_cross_libexecdir}/amazon-ecs-agent/vpc-eni
 %{_cross_libexecdir}/amazon-ecs-agent/vpc-tunnel
-
-%files ecs-agent-fips-extras
-%{_cross_fips_libexecdir}/amazon-ecs-agent/aws-appmesh
-%{_cross_fips_libexecdir}/amazon-ecs-agent/ecs-serviceconnect
-%{_cross_fips_libexecdir}/amazon-ecs-agent/vpc-branch-eni
-%{_cross_fips_libexecdir}/amazon-ecs-agent/vpc-bridge
-%{_cross_fips_libexecdir}/amazon-ecs-agent/vpc-eni
-%{_cross_fips_libexecdir}/amazon-ecs-agent/vpc-tunnel
 
 %changelog

--- a/packages/aws-iam-authenticator/aws-iam-authenticator.spec
+++ b/packages/aws-iam-authenticator/aws-iam-authenticator.spec
@@ -20,31 +20,12 @@ Source1000: clarify.toml
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 # For IAM Roles Anywhere, the signing helper might be set as the credential
 # process.
 Requires: %{_cross_os}aws-signing-helper
 
 %description
-%{summary}.
-
-%package bin
-Summary: AWS IAM authenticator binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: AWS IAM authenticator binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -55,14 +36,10 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %set_cross_go_flags
 export GO_MAJOR="1.25"
 go build -ldflags="${GOLDFLAGS}" -o aws-iam-authenticator ./cmd/aws-iam-authenticator
-gofips build -ldflags="${GOLDFLAGS}" -o fips/aws-iam-authenticator ./cmd/aws-iam-authenticator
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 aws-iam-authenticator %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/aws-iam-authenticator %{buildroot}%{_cross_fips_bindir}
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -70,11 +47,5 @@ install -p -m 0755 fips/aws-iam-authenticator %{buildroot}%{_cross_fips_bindir}
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_bindir}/aws-iam-authenticator
-
-%files fips-bin
-%{_cross_fips_bindir}/aws-iam-authenticator
-
 %changelog

--- a/packages/aws-otel-collector/aws-otel-collector.spec
+++ b/packages/aws-otel-collector/aws-otel-collector.spec
@@ -18,27 +18,8 @@ Source3: aws-otel-collector.yaml
 Patch0001: 0001-change-logger-and-extraconfig-file-paths.patch
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binary)
 
 %description
-%{summary}.
-
-%package bin
-Summary: Telemetry collector binary
-Provides: %{name}(binary)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Telemetry collector binary, FIPS edition
-Provides: %{name}(binary)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -48,7 +29,6 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 
 %set_cross_go_flags
 go build -ldflags "${GOLDFLAGS}" -o aws-otel-collector ./cmd/awscollector
-gofips build -ldflags "${GOLDFLAGS}" -o fips/aws-otel-collector ./cmd/awscollector
 
 %install
 install -D -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}/aws-otel-collector.service
@@ -59,18 +39,13 @@ install -p -m 0644 %{S:2} %{buildroot}%{_cross_tmpfilesdir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 install -p -m 0644 %{S:3} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 
-install -d %{buildroot}{%{_cross_bindir},%{_cross_fips_bindir}}
+install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 aws-otel-collector %{buildroot}%{_cross_bindir}
-install -p -m 0755 fips/aws-otel-collector %{buildroot}%{_cross_fips_bindir}
 
 %files
 %{_cross_attribution_file}
+%{_cross_bindir}/aws-otel-collector
 %{_cross_unitdir}/aws-otel-collector.service
 %{_cross_tmpfilesdir}/aws-otel-collector-tmpfiles.conf
 %{_cross_factorydir}%{_cross_sysconfdir}/aws-otel-collector.yaml
 
-%files bin
-%{_cross_bindir}/aws-otel-collector
-
-%files fips-bin
-%{_cross_fips_bindir}/aws-otel-collector

--- a/packages/aws-signer-notation-plugin/aws-signer-notation-plugin.spec
+++ b/packages/aws-signer-notation-plugin/aws-signer-notation-plugin.spec
@@ -25,29 +25,10 @@ Source102: aws-us-gov-signer-notation-root.crt
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 Requires: %{_cross_os}notation
 Requires: %{_cross_os}ecr-credential-helper
 
 %description
-%{summary}.
-
-%package bin
-Summary: AWS Signer plugin for Notation binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: AWS Signer plugin for Notation binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -58,22 +39,14 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %set_cross_go_flags
 
 go build -ldflags "${GOLDFLAGS}" -o notation-%{plugin_name} ./cmd
-gofips build -ldflags "${GOLDFLAGS}" -o fips/notation-%{plugin_name} ./cmd
 
 %install
-install -d %{buildroot}{%{_cross_libexecdir},%{_cross_fips_libexecdir},%{_cross_templatedir}}
-
 # Place the binaries where notation expects them.
 install -d %{buildroot}%{_cross_libexecdir}/notation-plugins
 install -d %{buildroot}%{_cross_libexecdir}/notation-plugins/plugins
 install -d %{buildroot}%{_cross_libexecdir}/notation-plugins/plugins/%{plugin_name}
 
-install -d %{buildroot}%{_cross_fips_libexecdir}/notation-plugins
-install -d %{buildroot}%{_cross_fips_libexecdir}/notation-plugins/plugins
-install -d %{buildroot}%{_cross_fips_libexecdir}/notation-plugins/plugins/%{plugin_name}
-
 install -p -m 0755 notation-%{plugin_name} %{buildroot}%{_cross_libexecdir}/notation-plugins/plugins/%{plugin_name}/notation-%{plugin_name}
-install -p -m 0755 fips/notation-%{plugin_name} %{buildroot}%{_cross_fips_libexecdir}/notation-plugins/plugins/%{plugin_name}/notation-%{plugin_name}
 
 # Add the notation config truststore directories.
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/%{signing_authority_path}/aws-signer-ts/
@@ -91,11 +64,5 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/%{signing_authority_path}/aws-us-gov-signer-ts/
 %{_cross_factorydir}%{_cross_sysconfdir}/%{signing_authority_path}/aws-signer-ts/aws-signer-notation-root.crt
 %{_cross_factorydir}%{_cross_sysconfdir}/%{signing_authority_path}/aws-us-gov-signer-ts/aws-us-gov-signer-notation-root.crt
-
-%files bin
 %{_cross_libexecdir}/notation-plugins/plugins/%{plugin_name}/notation-%{plugin_name}
-
-%files fips-bin
-%{_cross_fips_libexecdir}/notation-plugins/plugins/%{plugin_name}/notation-%{plugin_name}
-
 %changelog

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -20,31 +20,12 @@ Source1: bundled-rolesanywhere-credential-helper-v%{gover}.tar.gz
 Source2: brush-aws-signing-helper.toml
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 # The AWS SDK for GO needs a program to handle `sh -c` invocations in order to
 # run credential processes.
 Requires: %{_cross_os}package-file(/bin/sh)
 
 %description
-%{summary}.
-
-%package bin
-Summary: AWS signing helper binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: AWS signing helper binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -55,16 +36,11 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %set_cross_go_flags
 
 go build -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o aws-signing-helper main.go
-gofips build -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o fips/aws-signing-helper main.go
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 aws-signing-helper %{buildroot}%{_cross_bindir}/aws_signing_helper
 ln -sf aws_signing_helper %{buildroot}%{_cross_bindir}/aws-signing-helper
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/aws-signing-helper %{buildroot}%{_cross_fips_bindir}/aws_signing_helper
-ln -sf aws_signing_helper %{buildroot}%{_cross_fips_bindir}/aws-signing-helper
 
 install -d %{buildroot}%{_cross_libexecdir}/brush/allowed-programs
 ln -srf \
@@ -84,15 +60,10 @@ ln -sf aws_signing_helper.toml %{buildroot}%{_cross_datadir}/brush/aws-signing-h
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_bindir}/aws_signing_helper
+%{_cross_bindir}/aws-signing-helper
 %{_cross_datadir}/brush/aws_signing_helper.toml
 %{_cross_datadir}/brush/aws-signing-helper.toml
 %{_cross_libexecdir}/brush/allowed-programs/aws_signing_helper
 %{_cross_libexecdir}/brush/allowed-programs/aws-signing-helper
 
-%files bin
-%{_cross_bindir}/aws_signing_helper
-%{_cross_bindir}/aws-signing-helper
-
-%files fips-bin
-%{_cross_fips_bindir}/aws_signing_helper
-%{_cross_fips_bindir}/aws-signing-helper

--- a/packages/cni-plugins/cni-plugins.spec
+++ b/packages/cni-plugins/cni-plugins.spec
@@ -19,27 +19,8 @@ Source1: cni-plugins-tmpfiles.conf
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}iptables
-Requires: %{name}(binaries)
 
 %description
-%{summary}.
-
-%package bin
-Summary: Plugins for container networking binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Plugins for container networking binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -51,15 +32,11 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 
 for d in $(find plugins -mindepth 2 -maxdepth 2 -type d ! -name windows) ; do
   go build -ldflags="${GOLDFLAGS}" -o "bin/${d##*/}" %{goimport}/${d}
-  gofips build -ldflags="${GOLDFLAGS}" -o "fips/bin/${d##*/}" %{goimport}/${d}
 done
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/cni/bin
 install -p -m 0755 bin/* %{buildroot}%{_cross_libexecdir}/cni/bin
-
-install -d %{buildroot}%{_cross_fips_libexecdir}/cni/bin
-install -p -m 0755 fips/bin/* %{buildroot}%{_cross_fips_libexecdir}/cni/bin
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/cni-plugins.conf
@@ -71,8 +48,6 @@ install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/cni-plugins.conf
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
 %{_cross_tmpfilesdir}/cni-plugins.conf
-
-%files bin
 %{_cross_libexecdir}/cni/bin/loopback
 %{_cross_libexecdir}/cni/bin/bandwidth
 %{_cross_libexecdir}/cni/bin/bridge
@@ -91,25 +66,4 @@ install -p -m 0644 %{S:1} %{buildroot}%{_cross_tmpfilesdir}/cni-plugins.conf
 %{_cross_libexecdir}/cni/bin/tuning
 %{_cross_libexecdir}/cni/bin/vlan
 %{_cross_libexecdir}/cni/bin/vrf
-
-%files fips-bin
-%{_cross_fips_libexecdir}/cni/bin/loopback
-%{_cross_fips_libexecdir}/cni/bin/bandwidth
-%{_cross_fips_libexecdir}/cni/bin/bridge
-%{_cross_fips_libexecdir}/cni/bin/dhcp
-%{_cross_fips_libexecdir}/cni/bin/dummy
-%{_cross_fips_libexecdir}/cni/bin/firewall
-%{_cross_fips_libexecdir}/cni/bin/host-device
-%{_cross_fips_libexecdir}/cni/bin/host-local
-%{_cross_fips_libexecdir}/cni/bin/ipvlan
-%{_cross_fips_libexecdir}/cni/bin/macvlan
-%{_cross_fips_libexecdir}/cni/bin/portmap
-%{_cross_fips_libexecdir}/cni/bin/ptp
-%{_cross_fips_libexecdir}/cni/bin/sbr
-%{_cross_fips_libexecdir}/cni/bin/static
-%{_cross_fips_libexecdir}/cni/bin/tap
-%{_cross_fips_libexecdir}/cni/bin/tuning
-%{_cross_fips_libexecdir}/cni/bin/vlan
-%{_cross_fips_libexecdir}/cni/bin/vrf
-
 %changelog

--- a/packages/containerd-1.7/containerd-1.7.spec
+++ b/packages/containerd-1.7/containerd-1.7.spec
@@ -49,30 +49,11 @@ BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}runc
 Requires: %{name}(optimized-gunzip)
-Requires: %{name}(binaries)
 
 Provides: %{_cross_os}%{gorepo} = %{package_priority_epoch}:
 Conflicts: %{_cross_os}%{gorepo}
 
 %description
-%{summary}.
-
-%package bin
-Summary: An industry-standard container runtime's binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: An industry-standard container runtime's binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %package pigz
@@ -125,11 +106,10 @@ for bin in \
   ctr ;
 do
   go build "${BUILD_ARGS[@]}" -o ${bin} %{goimport}/cmd/${bin}
-  gofips build "${BUILD_ARGS[@]}" -o fips/${bin} %{goimport}/cmd/${bin}
 done
 
 %install
-install -d %{buildroot}{%{_cross_bindir},%{_cross_fips_bindir}}
+install -d %{buildroot}%{_cross_bindir}
 for bin in \
   containerd \
   containerd-shim \
@@ -138,7 +118,6 @@ for bin in \
   ctr ;
 do
   install -p -m 0755 ${bin} %{buildroot}%{_cross_bindir}
-  install -p -m 0755 fips/${bin} %{buildroot}%{_cross_fips_bindir}
 done
 
 install -d %{buildroot}%{_cross_unitdir}
@@ -169,21 +148,11 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/0
 %{_cross_templatedir}/containerd-cri-base-json
 %{_cross_templatedir}/snapshotter-toml
 %{_cross_tmpfilesdir}/containerd.conf
-
-%files bin
 %{_cross_bindir}/containerd
 %{_cross_bindir}/containerd-shim
 %{_cross_bindir}/containerd-shim-runc-v1
 %{_cross_bindir}/containerd-shim-runc-v2
 %{_cross_bindir}/ctr
-
-%files fips-bin
-%{_cross_fips_bindir}/containerd
-%{_cross_fips_bindir}/containerd-shim
-%{_cross_fips_bindir}/containerd-shim-runc-v1
-%{_cross_fips_bindir}/containerd-shim-runc-v2
-%{_cross_fips_bindir}/ctr
-
 %files pigz
 %{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
 

--- a/packages/containerd-2.1/containerd-2.1.spec
+++ b/packages/containerd-2.1/containerd-2.1.spec
@@ -45,30 +45,11 @@ BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}runc
 Requires: %{name}(optimized-gunzip)
-Requires: %{name}(binaries)
 
 Provides: %{_cross_os}%{gorepo} = %{package_priority_epoch}:
 Conflicts: %{_cross_os}%{gorepo}
 
 %description
-%{summary}.
-
-%package bin
-Summary: An industry-standard container runtime's binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: An industry-standard container runtime's binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %package pigz
@@ -119,18 +100,16 @@ for bin in \
   ctr ;
 do
   go build "${BUILD_ARGS[@]}" -o ${bin} ./cmd/${bin}
-  gofips build "${BUILD_ARGS[@]}" -o fips/${bin} ./cmd/${bin}
 done
 
 %install
-install -d %{buildroot}{%{_cross_bindir},%{_cross_fips_bindir}}
+install -d %{buildroot}%{_cross_bindir}
 for bin in \
   containerd \
   containerd-shim-runc-v2 \
   ctr ;
 do
   install -p -m 0755 ${bin} %{buildroot}%{_cross_bindir}
-  install -p -m 0755 fips/${bin} %{buildroot}%{_cross_fips_bindir}
 done
 
 install -d %{buildroot}%{_cross_unitdir}
@@ -161,17 +140,9 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/0
 %{_cross_templatedir}/containerd-cri-base-json
 %{_cross_templatedir}/snapshotter-toml
 %{_cross_tmpfilesdir}/containerd.conf
-
-%files bin
 %{_cross_bindir}/containerd
 %{_cross_bindir}/containerd-shim-runc-v2
 %{_cross_bindir}/ctr
-
-%files fips-bin
-%{_cross_fips_bindir}/containerd
-%{_cross_fips_bindir}/containerd-shim-runc-v2
-%{_cross_fips_bindir}/ctr
-
 %files pigz
 %{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
 

--- a/packages/docker-cli-25/docker-cli-25.spec
+++ b/packages/docker-cli-25/docker-cli-25.spec
@@ -23,30 +23,11 @@ Source1000: clarify.toml
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 Provides: %{_cross_os}docker-%{gorepo} = %{package_priority_epoch}:
 Conflicts: %{_cross_os}docker-%{gorepo}
 
 %description
-%{summary}.
-
-%package bin
-Summary: Docker CLI binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Docker CLI binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -67,14 +48,10 @@ BUILD_ARGS=(
 )
 
 go build "${BUILD_ARGS[@]}" -o docker %{goimport}/cmd/docker
-gofips build "${BUILD_ARGS[@]}" -o fips/docker %{goimport}/cmd/docker
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 docker %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/docker %{buildroot}%{_cross_fips_bindir}
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -82,11 +59,5 @@ install -p -m 0755 fips/docker %{buildroot}%{_cross_fips_bindir}
 %license LICENSE NOTICE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_bindir}/docker
-
-%files fips-bin
-%{_cross_fips_bindir}/docker
-
 %changelog

--- a/packages/docker-cli-29/docker-cli-29.spec
+++ b/packages/docker-cli-29/docker-cli-29.spec
@@ -23,30 +23,11 @@ Source1000: clarify.toml
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 Provides: %{_cross_os}docker-%{gorepo} = %{package_priority_epoch}:
 Conflicts: %{_cross_os}docker-%{gorepo}
 
 %description
-%{summary}.
-
-%package bin
-Summary: Docker CLI binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Docker CLI binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -67,14 +48,10 @@ BUILD_ARGS=(
 )
 
 go build "${BUILD_ARGS[@]}" -o docker %{goimport}/cmd/docker
-gofips build "${BUILD_ARGS[@]}" -o fips/docker %{goimport}/cmd/docker
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 docker %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/docker %{buildroot}%{_cross_fips_bindir}
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -82,11 +59,5 @@ install -p -m 0755 fips/docker %{buildroot}%{_cross_fips_bindir}
 %license LICENSE NOTICE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_bindir}/docker
-
-%files fips-bin
-%{_cross_fips_bindir}/docker
-
 %changelog

--- a/packages/docker-engine-25/docker-engine-25.spec
+++ b/packages/docker-engine-25/docker-engine-25.spec
@@ -43,29 +43,10 @@ Requires: %{_cross_os}libseccomp
 Requires: %{_cross_os}iptables
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}procps
-Requires: %{name}(binaries)
 Provides: %{_cross_os}docker-engine = %{package_priority_epoch}:
 Conflicts: %{_cross_os}docker-engine
 
 %description
-%{summary}.
-
-%package bin
-Summary: Docker engine binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Docker engine binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -95,17 +76,10 @@ BUILD_ARGS=(
 go build "${BUILD_ARGS[@]}" -o dockerd %{goimport}/cmd/dockerd
 go build "${BUILD_ARGS[@]}" -o docker-proxy %{goimport}/cmd/docker-proxy
 
-gofips build "${BUILD_ARGS[@]}" -o fips/dockerd %{goimport}/cmd/dockerd
-gofips build "${BUILD_ARGS[@]}" -o fips/docker-proxy %{goimport}/cmd/docker-proxy
-
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 dockerd %{buildroot}%{_cross_bindir}
 install -p -m 0755 docker-proxy %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/dockerd %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/docker-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:100} %{buildroot}%{_cross_unitdir}
@@ -129,13 +103,6 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/docker-daemon-nvidia
 %{_cross_sysusersdir}/docker.conf
 %{_cross_templatedir}/docker-daemon-json
 %{_cross_templatedir}/docker-daemon-nvidia-json
-
-%files bin
 %{_cross_bindir}/dockerd
 %{_cross_bindir}/docker-proxy
-
-%files fips-bin
-%{_cross_fips_bindir}/dockerd
-%{_cross_fips_bindir}/docker-proxy
-
 %changelog

--- a/packages/docker-engine-29/docker-engine-29.spec
+++ b/packages/docker-engine-29/docker-engine-29.spec
@@ -46,30 +46,11 @@ Requires: %{_cross_os}libseccomp
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}procps
 Requires: %{_cross_os}nftables
-Requires: %{name}(binaries)
 
 Provides: %{_cross_os}docker-engine = %{package_priority_epoch}:
 Conflicts: %{_cross_os}docker-engine
 
 %description
-%{summary}.
-
-%package bin
-Summary: Docker engine binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Docker engine binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -99,17 +80,10 @@ BUILD_ARGS=(
 go build "${BUILD_ARGS[@]}" -o dockerd %{goimport}/v2/cmd/dockerd
 go build "${BUILD_ARGS[@]}" -o docker-proxy %{goimport}/v2/cmd/docker-proxy
 
-gofips build "${BUILD_ARGS[@]}" -o fips/dockerd %{goimport}/v2/cmd/dockerd
-gofips build "${BUILD_ARGS[@]}" -o fips/docker-proxy %{goimport}/v2/cmd/docker-proxy
-
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 dockerd %{buildroot}%{_cross_bindir}
 install -p -m 0755 docker-proxy %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/dockerd %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/docker-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:100} %{buildroot}%{_cross_unitdir}
@@ -133,14 +107,7 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/docker-daemon-nvidia
 %{_cross_sysusersdir}/docker.conf
 %{_cross_templatedir}/docker-daemon-json
 %{_cross_templatedir}/docker-daemon-nvidia-json
-
-%files bin
 %{_cross_bindir}/dockerd
 %{_cross_bindir}/docker-proxy
-
-%files fips-bin
-%{_cross_fips_bindir}/dockerd
-%{_cross_fips_bindir}/docker-proxy
-
 %changelog
 

--- a/packages/ecr-credential-helper/ecr-credential-helper.spec
+++ b/packages/ecr-credential-helper/ecr-credential-helper.spec
@@ -22,27 +22,8 @@ Source12: root-.ecr.mount
 Source13: docker-root-config.json
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 %description
-%{summary}.
-
-%package bin
-Summary: Amazon ECR credential helper binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Amazon ECR credential helper binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -54,14 +35,10 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %cross_go_configure %{goimport}
 
 go build -ldflags="${GOLDFLAGS}" -o=docker-credential-ecr-login ./ecr-login/cli/docker-credential-ecr-login
-gofips build -ldflags="${GOLDFLAGS}" -o=fips/docker-credential-ecr-login ./ecr-login/cli/docker-credential-ecr-login
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 docker-credential-ecr-login %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/docker-credential-ecr-login %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m0644 %{S:10} %{buildroot}%{_cross_tmpfilesdir}/ecr-credential-helper.conf
@@ -78,13 +55,9 @@ install -p -m0600 %{S:13} %{buildroot}%{_cross_factorydir}/root/.docker/config.j
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
+%{_cross_bindir}/docker-credential-ecr-login
 %{_cross_factorydir}/root/.docker/config.json
 %{_cross_tmpfilesdir}/ecr-credential-helper.conf
 %{_cross_unitdir}/root-.docker.mount
 %{_cross_unitdir}/root-.ecr.mount
 
-%files bin
-%{_cross_bindir}/docker-credential-ecr-login
-
-%files fips-bin
-%{_cross_fips_bindir}/docker-credential-ecr-login

--- a/packages/ecr-credential-provider-1.29/ecr-credential-provider-1.29.spec
+++ b/packages/ecr-credential-provider-1.29/ecr-credential-provider-1.29.spec
@@ -23,31 +23,12 @@ Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
 Patch0002: 0002-ecr-credential-provider-hardcode-ecr-endpoint-for-eu.patch
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 # For IAM Roles Anywhere, the signing helper might be set as the credential
 # process.
 Requires: %{_cross_os}aws-signing-helper
 
 %description
-%{summary}.
-
-%package bin
-Summary: Amazon ECR credential provider binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Amazon ECR credential provider binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -58,14 +39,10 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %set_cross_go_flags
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
-gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
-
-install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
-install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -73,9 +50,4 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
-
-%files fips-bin
-%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
+++ b/packages/ecr-credential-provider-1.30/ecr-credential-provider-1.30.spec
@@ -22,31 +22,12 @@ Source1000: clarify.toml
 Patch0001: 0001-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 # For IAM Roles Anywhere, the signing helper might be set as the credential
 # process.
 Requires: %{_cross_os}aws-signing-helper
 
 %description
-%{summary}.
-
-%package bin
-Summary: Amazon ECR credential provider binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Amazon ECR credential provider binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -57,14 +38,10 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %set_cross_go_flags
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
-gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
-
-install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
-install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -72,9 +49,4 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
-
-%files fips-bin
-%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
+++ b/packages/ecr-credential-provider-1.31/ecr-credential-provider-1.31.spec
@@ -22,31 +22,12 @@ Source1000: clarify.toml
 Patch0001: 0001-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 # For IAM Roles Anywhere, the signing helper might be set as the credential
 # process.
 Requires: %{_cross_os}aws-signing-helper
 
 %description
-%{summary}.
-
-%package bin
-Summary: Amazon ECR credential provider binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Amazon ECR credential provider binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -60,14 +41,10 @@ export GOTOOLCHAIN=local
 export GO_MAJOR="1.24"
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
-gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
-
-install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
-install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -75,9 +52,4 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
-
-%files fips-bin
-%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
+++ b/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
@@ -22,31 +22,12 @@ Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
 Patch0002: 0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 # For IAM Roles Anywhere, the signing helper might be set as the credential
 # process.
 Requires: %{_cross_os}aws-signing-helper
 
 %description
-%{summary}.
-
-%package bin
-Summary: Amazon ECR credential provider binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Amazon ECR credential provider binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -60,14 +41,10 @@ export GOTOOLCHAIN=local
 export GO_MAJOR="1.24"
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
-gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
-
-install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
-install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -75,9 +52,4 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
-
-%files fips-bin
-%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
+++ b/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
@@ -22,31 +22,12 @@ Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
 Patch0002: 0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 # For IAM Roles Anywhere, the signing helper might be set as the credential
 # process.
 Requires: %{_cross_os}aws-signing-helper
 
 %description
-%{summary}.
-
-%package bin
-Summary: Amazon ECR credential provider binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Amazon ECR credential provider binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -60,14 +41,10 @@ export GOTOOLCHAIN=local
 export GO_MAJOR="1.24"
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
-gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
-
-install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
-install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -75,9 +52,4 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
-
-%files fips-bin
-%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.34/ecr-credential-provider-1.34.spec
+++ b/packages/ecr-credential-provider-1.34/ecr-credential-provider-1.34.spec
@@ -22,31 +22,12 @@ Patch0001: 0001-support-new-aws-partition-in-credential-provider.patch
 Patch0002: 0002-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 # For IAM Roles Anywhere, the signing helper might be set as the credential
 # process.
 Requires: %{_cross_os}aws-signing-helper
 
 %description
-%{summary}.
-
-%package bin
-Summary: Amazon ECR credential provider binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Amazon ECR credential provider binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -60,14 +41,10 @@ export GOTOOLCHAIN=local
 export GO_MAJOR="1.24"
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
-gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
-
-install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
-install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -75,9 +52,4 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
-
-%files fips-bin
-%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecr-credential-provider-1.35/ecr-credential-provider-1.35.spec
+++ b/packages/ecr-credential-provider-1.35/ecr-credential-provider-1.35.spec
@@ -21,31 +21,12 @@ Source1000: clarify.toml
 Patch0001: 0001-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 # For IAM Roles Anywhere, the signing helper might be set as the credential
 # process.
 Requires: %{_cross_os}aws-signing-helper
 
 %description
-%{summary}.
-
-%package bin
-Summary: Amazon ECR credential provider binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Amazon ECR credential provider binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -59,14 +40,10 @@ export GOTOOLCHAIN=local
 export GO_MAJOR="1.25"
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
-gofips build -ldflags="${GOLDFLAGS}" -o=fips/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
 install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
-
-install -d %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
-install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins
 
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
@@ -74,9 +51,4 @@ install -p -m 0755 fips/ecr-credential-provider %{buildroot}%{_cross_fips_libexe
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider
-
-%files fips-bin
-%{_cross_fips_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -68,27 +68,8 @@ Requires: %{_cross_os}iptables
 Requires: %{_cross_os}amazon-ssm-agent-plugin
 Requires: %{_cross_os}amazon-ecs-cni-plugins
 Requires: %{_cross_os}amazon-vpc-cni-plugins
-Requires: %{name}(binaries)
 
 %description
-%{summary}.
-
-%package bin
-Summary: Amazon Elastic Container Service agent binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Amazon Elastic Container Service agent binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %package config
@@ -132,7 +113,6 @@ ECS_AGENT_BUILD_ARGS=(
 )
 
 go build "${ECS_AGENT_BUILD_ARGS[@]}" -o amazon-ecs-agent ./agent
-gofips build "${ECS_AGENT_BUILD_ARGS[@]}" -o fips/amazon-ecs-agent ./agent
 
 # Build the pause container
 (
@@ -159,9 +139,6 @@ gofips build "${ECS_AGENT_BUILD_ARGS[@]}" -o fips/amazon-ecs-agent ./agent
 install -d %{buildroot}%{_cross_bindir}
 install -D -p -m 0755 amazon-ecs-agent %{buildroot}%{_cross_bindir}/amazon-ecs-agent
 install -D -p -m 0644 amazon-ecs-pause.tar %{buildroot}%{_cross_libdir}/amazon-ecs-agent/amazon-ecs-pause.tar
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -D -p -m 0755 fips/amazon-ecs-agent %{buildroot}%{_cross_fips_bindir}/amazon-ecs-agent
 
 install -d %{buildroot}%{_cross_unitdir}
 install -D -p -m 0644 %{S:101} %{S:200} %{buildroot}%{_cross_unitdir}
@@ -213,12 +190,7 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_datadir}/logdog.d
 %{_cross_sysctldir}/90-ecs.conf
 %{_cross_libdir}/amazon-ecs-agent/amazon-ecs-pause.tar
 %{_cross_datadir}/logdog.d/logdog.ecs.conf
-
-%files bin
 %{_cross_bindir}/amazon-ecs-agent
-
-%files fips-bin
-%{_cross_fips_bindir}/amazon-ecs-agent
 
 %files config
 %{_cross_templatedir}/ecs-base-conf

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -10,7 +10,6 @@ License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}containerd
-Requires: %{name}(binaries)
 
 Source10: host-containerd.service
 Source11: host-containerd-tmpfiles.conf
@@ -22,24 +21,6 @@ Source100: etc-host-containers.mount.in
 %description
 %{summary}.
 
-%package bin
-Summary: Bottlerocket host container runner binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Bottlerocket host container runner binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
-%{summary}.
-
 %prep
 %setup -T -c
 cp -r %{_builddir}/sources/%{workspace_name}/* .
@@ -49,14 +30,10 @@ export GO_MAJOR="1.24"
 
 %set_cross_go_flags
 go build -ldflags="${GOLDFLAGS}" -o host-ctr ./cmd/host-ctr
-gofips build -ldflags="${GOLDFLAGS}" -o fips/host-ctr ./cmd/host-ctr
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 host-ctr %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/host-ctr %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:10} %{buildroot}%{_cross_unitdir}
@@ -77,11 +54,6 @@ install -p -m 0644 %{S:12} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/
 %{_cross_unitdir}/*.mount
 %{_cross_tmpfilesdir}/host-containerd.conf
 %{_cross_factorydir}%{_cross_sysconfdir}/host-containerd/config.toml
-
-%files bin
 %{_cross_bindir}/host-ctr
-
-%files fips-bin
-%{_cross_fips_bindir}/host-ctr
 
 %changelog

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -84,53 +84,15 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider-1.29
 Requires: %{_cross_os}aws-iam-authenticator
 Requires: %{_cross_os}static-pods
-Requires: %{_cross_os}kubelet-1.29(binaries)
 
 %description -n %{_cross_os}kubelet-1.29
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.29-bin
-Summary: Container cluster node agent binaries
-Provides: %{_cross_os}kubelet-1.29(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.29)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.29-fips-bin)
-
-%description -n %{_cross_os}kubelet-1.29-bin
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.29-fips-bin
-Summary: Container cluster node agent binaries, FIPS edition
-Provides: %{_cross_os}kubelet-1.29(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.29)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.29-bin)
-
-%description -n %{_cross_os}kubelet-1.29-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}kube-proxy-1.29
 Summary: Container cluster node proxy
 Requires: %{_cross_os}kubelet-1.29
-Requires: %{_cross_os}kube-proxy-1.29(binaries)
 
 %description -n %{_cross_os}kube-proxy-1.29
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.29-bin
-Summary: Container cluster node proxy binaries
-Provides: %{_cross_os}kube-proxy-1.29(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.29)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.29-fips-bin)
-
-%description -n %{_cross_os}kube-proxy-1.29-bin
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.29-fips-bin
-Summary: Container cluster node proxy binaries, FIPS edition
-Provides: %{_cross_os}kube-proxy-1.29(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.29)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.29-bin)
-
-%description -n %{_cross_os}kube-proxy-1.29-fips-bin
 %{summary}.
 
 %prep
@@ -182,10 +144,6 @@ output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -257,19 +215,9 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
-
-%files -n %{_cross_os}kubelet-1.29-bin
 %{_cross_bindir}/kubelet
 
-%files -n %{_cross_os}kubelet-1.29-fips-bin
-%{_cross_fips_bindir}/kubelet
-
 %files -n %{_cross_os}kube-proxy-1.29
-
-%files -n %{_cross_os}kube-proxy-1.29-bin
 %{_cross_bindir}/kube-proxy
-
-%files -n %{_cross_os}kube-proxy-1.29-fips-bin
-%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -84,53 +84,15 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider-1.30
 Requires: %{_cross_os}aws-iam-authenticator
 Requires: %{_cross_os}static-pods
-Requires: %{_cross_os}kubelet-1.30(binaries)
 
 %description -n %{_cross_os}kubelet-1.30
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.30-bin
-Summary: Container cluster node agent binaries
-Provides: %{_cross_os}kubelet-1.30(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.30)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.30-fips-bin)
-
-%description -n %{_cross_os}kubelet-1.30-bin
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.30-fips-bin
-Summary: Container cluster node agent binaries, FIPS edition
-Provides: %{_cross_os}kubelet-1.30(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.30)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.30-bin)
-
-%description -n %{_cross_os}kubelet-1.30-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}kube-proxy-1.30
 Summary: Container cluster node proxy
 Requires: %{_cross_os}kubelet-1.30
-Requires: %{_cross_os}kube-proxy-1.30(binaries)
 
 %description -n %{_cross_os}kube-proxy-1.30
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.30-bin
-Summary: Container cluster node proxy binaries
-Provides: %{_cross_os}kube-proxy-1.30(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.30)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.30-fips-bin)
-
-%description -n %{_cross_os}kube-proxy-1.30-bin
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.30-fips-bin
-Summary: Container cluster node proxy binaries, FIPS edition
-Provides: %{_cross_os}kube-proxy-1.30(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.30)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.30-bin)
-
-%description -n %{_cross_os}kube-proxy-1.30-fips-bin
 %{summary}.
 
 %prep
@@ -183,10 +145,6 @@ output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -258,19 +216,9 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
-
-%files -n %{_cross_os}kubelet-1.30-bin
 %{_cross_bindir}/kubelet
 
-%files -n %{_cross_os}kubelet-1.30-fips-bin
-%{_cross_fips_bindir}/kubelet
-
 %files -n %{_cross_os}kube-proxy-1.30
-
-%files -n %{_cross_os}kube-proxy-1.30-bin
 %{_cross_bindir}/kube-proxy
-
-%files -n %{_cross_os}kube-proxy-1.30-fips-bin
-%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -84,53 +84,15 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider-1.31
 Requires: %{_cross_os}aws-iam-authenticator
 Requires: %{_cross_os}static-pods
-Requires: %{_cross_os}kubelet-1.31(binaries)
 
 %description -n %{_cross_os}kubelet-1.31
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.31-bin
-Summary: Container cluster node agent binaries
-Provides: %{_cross_os}kubelet-1.31(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.31)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.31-fips-bin)
-
-%description -n %{_cross_os}kubelet-1.31-bin
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.31-fips-bin
-Summary: Container cluster node agent binaries, FIPS edition
-Provides: %{_cross_os}kubelet-1.31(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.31)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.31-bin)
-
-%description -n %{_cross_os}kubelet-1.31-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}kube-proxy-1.31
 Summary: Container cluster node proxy
 Requires: %{_cross_os}kubelet-1.31
-Requires: %{_cross_os}kube-proxy-1.31(binaries)
 
 %description -n %{_cross_os}kube-proxy-1.31
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.31-bin
-Summary: Container cluster node proxy binaries
-Provides: %{_cross_os}kube-proxy-1.31(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.31)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.31-fips-bin)
-
-%description -n %{_cross_os}kube-proxy-1.31-bin
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.31-fips-bin
-Summary: Container cluster node proxy binaries, FIPS edition
-Provides: %{_cross_os}kube-proxy-1.31(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.31)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.31-bin)
-
-%description -n %{_cross_os}kube-proxy-1.31-fips-bin
 %{summary}.
 
 %prep
@@ -183,10 +145,6 @@ output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -258,19 +216,9 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
-
-%files -n %{_cross_os}kubelet-1.31-bin
 %{_cross_bindir}/kubelet
 
-%files -n %{_cross_os}kubelet-1.31-fips-bin
-%{_cross_fips_bindir}/kubelet
-
 %files -n %{_cross_os}kube-proxy-1.31
-
-%files -n %{_cross_os}kube-proxy-1.31-bin
 %{_cross_bindir}/kube-proxy
-
-%files -n %{_cross_os}kube-proxy-1.31-fips-bin
-%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -83,53 +83,15 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider-1.32
 Requires: %{_cross_os}aws-iam-authenticator
 Requires: %{_cross_os}static-pods
-Requires: %{_cross_os}kubelet-1.32(binaries)
 
 %description -n %{_cross_os}kubelet-1.32
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.32-bin
-Summary: Container cluster node agent binaries
-Provides: %{_cross_os}kubelet-1.32(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.32)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.32-fips-bin)
-
-%description -n %{_cross_os}kubelet-1.32-bin
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.32-fips-bin
-Summary: Container cluster node agent binaries, FIPS edition
-Provides: %{_cross_os}kubelet-1.32(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.32)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.32-bin)
-
-%description -n %{_cross_os}kubelet-1.32-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}kube-proxy-1.32
 Summary: Container cluster node proxy
 Requires: %{_cross_os}kubelet-1.32
-Requires: %{_cross_os}kube-proxy-1.32(binaries)
 
 %description -n %{_cross_os}kube-proxy-1.32
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.32-bin
-Summary: Container cluster node proxy binaries
-Provides: %{_cross_os}kube-proxy-1.32(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.32)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.32-fips-bin)
-
-%description -n %{_cross_os}kube-proxy-1.32-bin
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.32-fips-bin
-Summary: Container cluster node proxy binaries, FIPS edition
-Provides: %{_cross_os}kube-proxy-1.32(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.32)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.32-bin)
-
-%description -n %{_cross_os}kube-proxy-1.32-fips-bin
 %{summary}.
 
 %prep
@@ -182,10 +144,6 @@ output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -257,19 +215,9 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
-
-%files -n %{_cross_os}kubelet-1.32-bin
 %{_cross_bindir}/kubelet
 
-%files -n %{_cross_os}kubelet-1.32-fips-bin
-%{_cross_fips_bindir}/kubelet
-
 %files -n %{_cross_os}kube-proxy-1.32
-
-%files -n %{_cross_os}kube-proxy-1.32-bin
 %{_cross_bindir}/kube-proxy
-
-%files -n %{_cross_os}kube-proxy-1.32-fips-bin
-%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -83,53 +83,15 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider-1.33
 Requires: %{_cross_os}aws-iam-authenticator
 Requires: %{_cross_os}static-pods
-Requires: %{_cross_os}kubelet-1.33(binaries)
 
 %description -n %{_cross_os}kubelet-1.33
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.33-bin
-Summary: Container cluster node agent binaries
-Provides: %{_cross_os}kubelet-1.33(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.33)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.33-fips-bin)
-
-%description -n %{_cross_os}kubelet-1.33-bin
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.33-fips-bin
-Summary: Container cluster node agent binaries, FIPS edition
-Provides: %{_cross_os}kubelet-1.33(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.33)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.33-bin)
-
-%description -n %{_cross_os}kubelet-1.33-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}kube-proxy-1.33
 Summary: Container cluster node proxy
 Requires: %{_cross_os}kubelet-1.33
-Requires: %{_cross_os}kube-proxy-1.33(binaries)
 
 %description -n %{_cross_os}kube-proxy-1.33
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.33-bin
-Summary: Container cluster node proxy binaries
-Provides: %{_cross_os}kube-proxy-1.33(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.33)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.33-fips-bin)
-
-%description -n %{_cross_os}kube-proxy-1.33-bin
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.33-fips-bin
-Summary: Container cluster node proxy binaries, FIPS edition
-Provides: %{_cross_os}kube-proxy-1.33(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.33)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.33-bin)
-
-%description -n %{_cross_os}kube-proxy-1.33-fips-bin
 %{summary}.
 
 %prep
@@ -184,10 +146,6 @@ output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -259,19 +217,9 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
-
-%files -n %{_cross_os}kubelet-1.33-bin
 %{_cross_bindir}/kubelet
 
-%files -n %{_cross_os}kubelet-1.33-fips-bin
-%{_cross_fips_bindir}/kubelet
-
 %files -n %{_cross_os}kube-proxy-1.33
-
-%files -n %{_cross_os}kube-proxy-1.33-bin
 %{_cross_bindir}/kube-proxy
-
-%files -n %{_cross_os}kube-proxy-1.33-fips-bin
-%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.34/kubernetes-1.34.spec
+++ b/packages/kubernetes-1.34/kubernetes-1.34.spec
@@ -83,53 +83,15 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider-1.34
 Requires: %{_cross_os}aws-iam-authenticator
 Requires: %{_cross_os}static-pods
-Requires: %{_cross_os}kubelet-1.34(binaries)
 
 %description -n %{_cross_os}kubelet-1.34
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.34-bin
-Summary: Container cluster node agent binaries
-Provides: %{_cross_os}kubelet-1.34(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.34)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.34-fips-bin)
-
-%description -n %{_cross_os}kubelet-1.34-bin
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.34-fips-bin
-Summary: Container cluster node agent binaries, FIPS edition
-Provides: %{_cross_os}kubelet-1.34(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.34)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.34-bin)
-
-%description -n %{_cross_os}kubelet-1.34-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}kube-proxy-1.34
 Summary: Container cluster node proxy
 Requires: %{_cross_os}kubelet-1.34
-Requires: %{_cross_os}kube-proxy-1.34(binaries)
 
 %description -n %{_cross_os}kube-proxy-1.34
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.34-bin
-Summary: Container cluster node proxy binaries
-Provides: %{_cross_os}kube-proxy-1.34(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.34)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.34-fips-bin)
-
-%description -n %{_cross_os}kube-proxy-1.34-bin
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.34-fips-bin
-Summary: Container cluster node proxy binaries, FIPS edition
-Provides: %{_cross_os}kube-proxy-1.34(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.34)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.34-bin)
-
-%description -n %{_cross_os}kube-proxy-1.34-fips-bin
 %{summary}.
 
 %prep
@@ -184,10 +146,6 @@ output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -259,19 +217,9 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
-
-%files -n %{_cross_os}kubelet-1.34-bin
 %{_cross_bindir}/kubelet
 
-%files -n %{_cross_os}kubelet-1.34-fips-bin
-%{_cross_fips_bindir}/kubelet
-
 %files -n %{_cross_os}kube-proxy-1.34
-
-%files -n %{_cross_os}kube-proxy-1.34-bin
 %{_cross_bindir}/kube-proxy
-
-%files -n %{_cross_os}kube-proxy-1.34-fips-bin
-%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/kubernetes-1.35/kubernetes-1.35.spec
+++ b/packages/kubernetes-1.35/kubernetes-1.35.spec
@@ -83,53 +83,15 @@ Requires: %{_cross_os}findutils
 Requires: %{_cross_os}ecr-credential-provider-1.35
 Requires: %{_cross_os}aws-iam-authenticator
 Requires: %{_cross_os}static-pods
-Requires: %{_cross_os}kubelet-1.35(binaries)
 
 %description -n %{_cross_os}kubelet-1.35
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.35-bin
-Summary: Container cluster node agent binaries
-Provides: %{_cross_os}kubelet-1.35(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kubelet-1.35)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kubelet-1.35-fips-bin)
-
-%description -n %{_cross_os}kubelet-1.35-bin
-%{summary}.
-
-%package -n %{_cross_os}kubelet-1.35-fips-bin
-Summary: Container cluster node agent binaries, FIPS edition
-Provides: %{_cross_os}kubelet-1.35(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kubelet-1.35)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kubelet-1.35-bin)
-
-%description -n %{_cross_os}kubelet-1.35-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}kube-proxy-1.35
 Summary: Container cluster node proxy
 Requires: %{_cross_os}kubelet-1.35
-Requires: %{_cross_os}kube-proxy-1.35(binaries)
 
 %description -n %{_cross_os}kube-proxy-1.35
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.35-bin
-Summary: Container cluster node proxy binaries
-Provides: %{_cross_os}kube-proxy-1.35(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}kube-proxy-1.35)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}kube-proxy-1.35-fips-bin)
-
-%description -n %{_cross_os}kube-proxy-1.35-bin
-%{summary}.
-
-%package -n %{_cross_os}kube-proxy-1.35-fips-bin
-Summary: Container cluster node proxy binaries, FIPS edition
-Provides: %{_cross_os}kube-proxy-1.35(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}kube-proxy-1.35)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}kube-proxy-1.35-bin)
-
-%description -n %{_cross_os}kube-proxy-1.35-fips-bin
 %{summary}.
 
 %prep
@@ -184,10 +146,6 @@ output="./_output/local/bin/linux/%{_cross_go_arch}"
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
 install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
@@ -259,19 +217,9 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
-
-%files -n %{_cross_os}kubelet-1.35-bin
 %{_cross_bindir}/kubelet
 
-%files -n %{_cross_os}kubelet-1.35-fips-bin
-%{_cross_fips_bindir}/kubelet
-
 %files -n %{_cross_os}kube-proxy-1.35
-
-%files -n %{_cross_os}kube-proxy-1.35-bin
 %{_cross_bindir}/kube-proxy
-
-%files -n %{_cross_os}kube-proxy-1.35-fips-bin
-%{_cross_fips_bindir}/kube-proxy
 
 %changelog

--- a/packages/notation-image-verifier/notation-image-verifier.spec
+++ b/packages/notation-image-verifier/notation-image-verifier.spec
@@ -10,29 +10,10 @@ URL: https://github.com/bottlerocket-os/bottlerocket
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}notation
 Requires: %{_cross_os}aws-signer-notation-plugin
-Requires: %{name}(binaries)
 
 Source1: containerd-image-verifiers-toml
 
 %description
-%{summary}.
-
-%package bin
-Summary: A notation-based containerd image verification plugin binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: A notation-based containerd image verification plugin binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -42,27 +23,17 @@ cp -r %{_builddir}/sources/%{workspace_name}/* .
 %build
 %set_cross_go_flags
 go build -ldflags="${GOLDFLAGS}" -o notation-image-verifier .
-gofips build -ldflags="${GOLDFLAGS}" -o fips/notation-image-verifier .
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/image-verifiers/bin
 install -p -m 0755 notation-image-verifier %{buildroot}%{_cross_libexecdir}/image-verifiers/bin
-
-install -d %{buildroot}%{_cross_fips_libexecdir}/image-verifiers/bin
-install -p -m 0755 fips/notation-image-verifier %{buildroot}%{_cross_fips_libexecdir}/image-verifiers/bin
 
 install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_templatedir}
 
 %files
 %dir %{_cross_libexecdir}/image-verifiers/bin
-%dir %{_cross_fips_libexecdir}/image-verifiers/bin
 %{_cross_templatedir}/containerd-image-verifiers-toml
-
-%files bin
 %{_cross_libexecdir}/image-verifiers/bin/notation-image-verifier
-
-%files fips-bin
-%{_cross_fips_libexecdir}/image-verifiers/bin/notation-image-verifier
 
 %changelog

--- a/packages/notation/notation.spec
+++ b/packages/notation/notation.spec
@@ -20,28 +20,9 @@ Source2: notation-trust-policy-json
 Source3: notation-tmpfiles.conf
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 Requires: %{_cross_os}ecr-credential-helper
 
 %description
-%{summary}.
-
-%package bin
-Summary: A CLI tool to sign and verify artifacts' binaries.
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: A CLI tool to sign and verify artifacts' binaries, FIPS edition.
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -52,13 +33,12 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %set_cross_go_flags
 
 go build -ldflags "${GOLDFLAGS}" -o notation ./cmd/notation
-gofips build -ldflags "${GOLDFLAGS}" -o fips/notation ./cmd/notation
 
 %install
-install -d %{buildroot}{%{_cross_bindir},%{_cross_fips_bindir},%{_cross_templatedir}}
+install -d %{buildroot}%{_cross_bindir}
+install -d %{buildroot}%{_cross_templatedir}
 
 install -p -m 0755 notation %{buildroot}%{_cross_bindir}
-install -p -m 0755 fips/notation %{buildroot}%{_cross_fips_bindir}
 install -p -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/notation-trust-policy-json
 
 # Add the notation config and cache directories
@@ -79,11 +59,6 @@ install -p -m 0644 %{S:3} %{buildroot}%{_cross_tmpfilesdir}/notation.conf
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/notation
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/notation/plugins
 %dir %{_cross_factorydir}%{_cross_sysconfdir}/notation/truststore/x509/signingAuthority
-
-%files bin
 %{_cross_bindir}/notation
-
-%files fips-bin
-%{_cross_fips_bindir}/notation
 
 %changelog

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -23,27 +23,8 @@ Source6: nvidia-mps-control-daemon-exec-start-conf
 Patch0001: 0001-Update-MPS-roots-for-immutable-host-OS.patch
 
 BuildRequires: %{_cross_os}glibc-devel
-Requires: %{name}(binaries)
 
 %description
-%{summary}.
-
-%package bin
-Summary: Kubernetes device plugin for NVIDIA GPUs binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Kubernetes device plugin for NVIDIA GPUs binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -59,17 +40,11 @@ export GOLDFLAGS="-compressdwarf=false -linkmode=external -extldflags '${CGO_LDF
 
 go build -ldflags="${GOLDFLAGS}" -o nvidia-device-plugin ./cmd/nvidia-device-plugin/
 go build -ldflags="${GOLDFLAGS}" -o mps-control-daemon ./cmd/mps-control-daemon/
-gofips build -ldflags="${GOLDFLAGS}" -o fips/nvidia-device-plugin ./cmd/nvidia-device-plugin/
-gofips build -ldflags="${GOLDFLAGS}" -o fips/mps-control-daemon ./cmd/mps-control-daemon/
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 nvidia-device-plugin %{buildroot}%{_cross_bindir}
 install -p -m 0755 mps-control-daemon %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/nvidia-device-plugin %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/mps-control-daemon %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}
@@ -81,10 +56,11 @@ install -D -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-pl
 install -D -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-mig-conf
 install -D -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/nvidia-mps-control-daemon-exec-start-conf
 
-
 %files
 %license LICENSE
 %{_cross_attribution_file}
+%{_cross_bindir}/nvidia-device-plugin
+%{_cross_bindir}/mps-control-daemon
 %{_cross_unitdir}/nvidia-k8s-device-plugin.service
 %{_cross_unitdir}/nvidia-mps-control-daemon.service
 %dir %{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
@@ -94,10 +70,3 @@ install -D -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/nvidia-mps-control-d
 %{_cross_templatedir}/nvidia-k8s-device-plugin-mig-conf
 %{_cross_templatedir}/nvidia-mps-control-daemon-exec-start-conf
 
-%files bin
-%{_cross_bindir}/nvidia-device-plugin
-%{_cross_bindir}/mps-control-daemon
-
-%files fips-bin
-%{_cross_fips_bindir}/nvidia-device-plugin
-%{_cross_fips_bindir}/mps-control-daemon

--- a/packages/rocm-k8s-device-plugin/rocm-k8s-device-plugin.spec
+++ b/packages/rocm-k8s-device-plugin/rocm-k8s-device-plugin.spec
@@ -17,29 +17,10 @@ Source1: rocm-k8s-device-plugin.service
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libdrm-devel
 BuildRequires: %{_cross_os}hwloc-devel
-Requires: %{name}(binaries)
 Requires: %{_cross_os}libdrm
 Requires: %{_cross_os}hwloc
 
 %description
-%{summary}.
-
-%package bin
-Summary: Kubernetes device plugin for AMD GPUs binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: Kubernetes device plugin for AMD GPUs binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -50,14 +31,10 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
 %cross_go_configure %{goimport}
 
 go build -ldflags="${GOLDFLAGS}" -o  rocm-device-plugin ./cmd/k8s-device-plugin/
-gofips build -ldflags="${GOLDFLAGS}" -o fips/rocm-device-plugin ./cmd/k8s-device-plugin/
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 rocm-device-plugin %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/rocm-device-plugin %{buildroot}%{_cross_fips_bindir}
 
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}
@@ -65,10 +42,6 @@ install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}
 %files
 %license LICENSE
 %{_cross_attribution_file}
+%{_cross_bindir}/rocm-device-plugin
 %{_cross_unitdir}/rocm-k8s-device-plugin.service
 
-%files bin
-%{_cross_bindir}/rocm-device-plugin
-
-%files fips-bin
-%{_cross_fips_bindir}/rocm-device-plugin

--- a/packages/runc/runc.spec
+++ b/packages/runc/runc.spec
@@ -26,27 +26,8 @@ BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libseccomp-devel
 Requires: %{_cross_os}libseccomp
-Requires: %{name}(binaries)
 
 %description
-%{summary}.
-
-%package bin
-Summary: CLI for running Open Containers binaries
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: CLI for running Open Containers binaries, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %prep
@@ -67,14 +48,10 @@ BUILD_ARGS=(
 )
 
 go build "${BUILD_ARGS[@]}" -o bin/runc .
-gofips build "${BUILD_ARGS[@]}" -o fips/bin/runc .
 
 %install
 install -d %{buildroot}%{_cross_bindir}
 install -p -m 0755 bin/runc %{buildroot}%{_cross_bindir}
-
-install -d %{buildroot}%{_cross_fips_bindir}
-install -p -m 0755 fips/bin/runc %{buildroot}%{_cross_fips_bindir}
 
 %cross_scan_attribution go-vendor vendor
 
@@ -82,11 +59,6 @@ install -p -m 0755 fips/bin/runc %{buildroot}%{_cross_fips_bindir}
 %license LICENSE NOTICE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-
-%files bin
 %{_cross_bindir}/runc
-
-%files fips-bin
-%{_cross_fips_bindir}/runc
 
 %changelog

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -22,29 +22,10 @@ Source1000: clarify.toml
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libz-devel
-Requires: %{name}(binaries)
 Requires: (%{name}-k8s if %{_cross_os}variant-runtime(k8s))
 Requires: %{name}(optimized-gunzip)
 
 %description
-%{summary}.
-
-%package bin
-Summary: A remote snapshotter for containerd
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(fips) or %{name}-fips-bin)
-
-%description bin
-%{summary}.
-
-%package fips-bin
-Summary: A remote snapshotter for containerd, FIPS edition
-Provides: %{name}(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{name}-bin)
-
-%description fips-bin
 %{summary}.
 
 %package pigz
@@ -91,14 +72,10 @@ export LD_REVISION="-X github.com/awslabs/soci-snapshotter/version.Revision=%{gi
 
 go build -C cmd -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}" -o "../out/soci-snapshotter-grpc" ./soci-snapshotter-grpc
 
-gofips build -C cmd -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}" -o "../out/fips/soci-snapshotter-grpc" ./soci-snapshotter-grpc
-
 %install
 install -d %{buildroot}%{_cross_bindir}
-install -d %{buildroot}%{_cross_fips_bindir}
 install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0755 out/soci-snapshotter-grpc %{buildroot}%{_cross_bindir}
-install -p -m 0755 out/fips/soci-snapshotter-grpc %{buildroot}%{_cross_fips_bindir}
 
 SOCIMOUNTPATH=$(systemd-escape --path /etc/soci-snapshotter)
 install -p -m 0644 %{S:100} %{buildroot}%{_cross_unitdir}/${SOCIMOUNTPATH}.mount
@@ -126,12 +103,7 @@ posix.symlink("%{_cross_bindir}/unpigz", "%{_cross_bindir}/soci-gunzip")
 %{_cross_attribution_vendor_dir}
 %{_cross_attribution_file}
 %{_cross_templatedir}/soci-config-toml
-
-%files bin
 %{_cross_bindir}/soci-snapshotter-grpc
-
-%files fips-bin
-%{_cross_fips_bindir}/soci-snapshotter-grpc
 
 %files pigz
 # No files provided by pigz but required for packaging.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #814 

**Description of changes:**
re-packaging the Go packages to remove the fips binary and `gofips` build


**Testing done:**
- ecs/eks boot test and ecs ec2 running task.
- ecs-2-fips: internal ECS testing passes
- k8s-1.29-fips: Conformance test pass
- k8s-1.29-fips test
- build all the k8s fips/non-fips variants successful
- build `k8s-1.35-nvidia-fips` smoke test pass
```
╰$ ls
x86_64-aws-ecs-2-fips         x86_64-aws-k8s-1.30       x86_64-aws-k8s-1.31-fips  x86_64-aws-k8s-1.33       x86_64-aws-k8s-1.34-fips
x86_64-aws-ecs-2-nvidia-fips  x86_64-aws-k8s-1.30-fips  x86_64-aws-k8s-1.32       x86_64-aws-k8s-1.33-fips  x86_64-aws-k8s-1.35
x86_64-aws-k8s-1.29-fips      x86_64-aws-k8s-1.31       x86_64-aws-k8s-1.32-fips  x86_64-aws-k8s-1.34       x86_64-aws-k8s-1.35-fips
```

```
│127.0.0.1 - - [02/Feb/2026:23:08:47 +0000] "HEAD /v2/test/manifests/latest HTTP/1.1" 400 0 "-" "containerd/1.7.30+bottlerocket"                                                     ││://localhost:5001"]}]}}'                                                                                                                                                            │
│2026/02/02 23:09:59 [info] 30#30: *6 SSL_do_handshake() failed (SSL: error:0A0000C1:SSL routines::no shared cipher) while SSL handshaking, client: 127.0.0.1, server: 0.0.0.0:5001  ││                                                                                                                                                                                    │
│2026/02/02 23:10:10 [info] 30#30: *7 SSL_do_handshake() failed (SSL: error:0A0000C1:SSL routines::no shared cipher) while SSL handshaking, client: 127.0.0.1, server: 0.0.0.0:5001  ││                                                                                                                                                                                    │
│2026/02/02 23:10:36 [info] 30#30: *8 SSL_do_handshake() failed (SSL: error:0A0000C1:SSL routines::no shared cipher) while SSL handshaking, client: 127.0.0.1, server: 0.0.0.0:5001  ││Then recreate the nonfips test pod.                                                                                                                                                 │
│2026/02/02 23:10:47 [info] 30#30: *9 SSL_do_handshake() failed (SSL: error:0A0000C1:SSL routines::no shared cipher) while SSL handshaking, client: 127.0.0.1, server: 0.0.0.0:5001


Events:
  Type    Reason     Age    From               Message
  ----    ------     ----   ----               -------
  Normal  Scheduled  9m14s  default-scheduler  Successfully assigned default/test-pull-fips to ip-192-168-53-98.us-west-2.compute.internal
  Normal  Pulling    9m14s  kubelet            Pulling image "localhost:5000/test:latest"
  Normal  Pulled     9m14s  kubelet            Successfully pulled image "localhost:5000/test:latest" in 31ms (31ms including waiting)
  Normal  Created    9m14s  kubelet            Created container: test
  Normal  Started    9m14s  kubelet            Started container test
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
