### PR TITLE
Update amazon-ecs-cni-plugins to commit 3302076

### DIFF
--- a/packages/amazon-ecs-cni-plugins/0001-bottlerocket-default-filesystem-locations.patch
+++ b/packages/amazon-ecs-cni-plugins/0001-bottlerocket-default-filesystem-locations.patch
@@ -1,8 +1,9 @@
-From 17d96b85504988622545e08cdf0c3b2563f662d4 Mon Sep 17 00:00:00 2001
+From 26377eed2a145dadce368f6aaa00898cdfb8d341 Mon Sep 17 00:00:00 2001
 From: Samuel Karp <skarp@amazon.com>
 Date: Fri, 26 Mar 2021 16:07:25 -0700
 Subject: [PATCH] bottlerocket: default filesystem locations
 
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 ---
  plugins/ecs-bridge/main.go    | 2 +-
  plugins/eni/main.go           | 2 +-
@@ -37,13 +38,13 @@ index ad81cfc..f483bd9 100644
  
  func init() {
 diff --git a/plugins/ipam/config/config.go b/plugins/ipam/config/config.go
-index 7a4378f..f1b9c93 100644
+index b3704c3..3189d14 100644
 --- a/plugins/ipam/config/config.go
 +++ b/plugins/ipam/config/config.go
-@@ -31,7 +31,7 @@ const (
- 	EnvIpamTimeout           = "IPAM_DB_CONNECTION_TIMEOUT"
- 	LastKnownIPKey           = "lastKnownIP"
+@@ -33,7 +33,7 @@ const (
+ 	LastKnownIPv4Key         = "lastKnownIPv4"
  	GatewayValue             = "GateWay"
+ 	GatewayV6Value           = "GateWayV6"
 -	DefaultDBPath            = "/data/eni-ipam.db"
 +	DefaultDBPath            = "/var/lib/ecs/eni-ipam.db"
  	BucketName               = "IPAM"
@@ -63,5 +64,5 @@ index dadabb0..f0906dd 100644
  
  func main() {
 -- 
-2.31.0
+2.52.0
 

--- a/packages/amazon-ecs-cni-plugins/Cargo.toml
+++ b/packages/amazon-ecs-cni-plugins/Cargo.toml
@@ -16,8 +16,8 @@ releases-url = "https://github.com/aws/amazon-ecs-agent/commits/master/amazon-ec
 # This is locked against the version shipped in ecs-agent
 # Verify that the ecs-agent version shipped in bottlerocket tracks the same one here
 # https://github.com/aws/amazon-ecs-agent/releases
-url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/7b4ec6016ab221469fa3abfc00ea7c05f236c26c/amazon-ecs-cni-plugins.tar.gz"
-sha512 = "234021e1132a8c7101603f26c2b4d18e2a54dd8d6e879ae5138fcafac012f792dc25ab1bad37bde5d4e299b996340de557dbe9ba928eae2a8565adff5bd481a8"
+url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/3302076781563428b69e0856b8fdd59b2ac0658f/amazon-ecs-cni-plugins.tar.gz"
+sha512 = "43efc021c9f095e3664840e2666109e1b40e21af0044a458a3a54faa0bb1672d06d4df9eecb5d0ad4539afd79229ae00f59c11d41cbf3c70fb5366d88e78f9fb"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
+++ b/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
@@ -1,11 +1,11 @@
 %global ecscni_goproject github.com/aws
 %global ecscni_gorepo amazon-ecs-cni-plugins
 %global ecscni_goimport %{ecscni_goproject}/%{ecscni_gorepo}
-%global ecscni_gitrev 7b4ec6016ab221469fa3abfc00ea7c05f236c26c
+%global ecscni_gitrev 3302076781563428b69e0856b8fdd59b2ac0658f
 
 Name: %{_cross_os}amazon-ecs-cni-plugins
-# https://github.com/aws/amazon-ecs-cni-plugins/blob/7b4ec6016ab221469fa3abfc00ea7c05f236c26c/VERSION#L1
-Version: 2024.09.0
+# https://github.com/aws/amazon-ecs-cni-plugins/blob/3302076781563428b69e0856b8fdd59b2ac0658f/VERSION#L1
+Version: 2026.01.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: Networking plugins for ECS task networking


### PR DESCRIPTION
<!--Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Update amazon-ecs-cni-plugins from commit `7b4ec60` to commit `3302076`.

This updates the package version from 2024.09.0 to 2026.01.0.

Changes:
- Updated source URL to point to the new commit (3302076781563428b69e0856b8fdd59b2ac0658f)
- Updated sha512 checksum for the new tarball
- Updated version number in spec file to 2026.01.0
- Updated gitrev reference in spec file

**Testing done:**

- New BR AMIs built using binaries generated locally. 
- Ran internal suite of tests with this change and #816 , all tests passed

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
