### PR TITLE
migrate registry settings to hosts.toml format

### DIFF
--- a/packages/containerd-2.1/1003-transfer-service-fallback-to-credentials.toml-for-re.patch
+++ b/packages/containerd-2.1/1003-transfer-service-fallback-to-credentials.toml-for-re.patch
@@ -1,0 +1,137 @@
+From 98bca202890467862de25819e0a1284e9afcfeeb Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 29 Jan 2026 21:52:41 +0000
+Subject: [PATCH] transfer-service: fallback to credentials.toml for registry
+ auth
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ core/transfer/registry/registry.go | 87 ++++++++++++++++++++++++++++--
+ 1 file changed, 83 insertions(+), 4 deletions(-)
+
+diff --git a/core/transfer/registry/registry.go b/core/transfer/registry/registry.go
+index a903bddfa..0f56c8a46 100644
+--- a/core/transfer/registry/registry.go
++++ b/core/transfer/registry/registry.go
+@@ -18,13 +18,18 @@ package registry
+ 
+ import (
+ 	"context"
++	"encoding/base64"
+ 	"errors"
+ 	"fmt"
+ 	"io"
+ 	"net/http"
++	"os"
++	"path/filepath"
+ 	"strings"
+ 	"sync"
+ 
++	"github.com/pelletier/go-toml/v2"
++
+ 	transfertypes "github.com/containerd/containerd/api/types/transfer"
+ 	"github.com/containerd/containerd/v2/core/remotes"
+ 	"github.com/containerd/containerd/v2/core/remotes/docker"
+@@ -39,6 +44,76 @@ import (
+ 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+ )
+ 
++// hostDirectory converts ":port" to "_port_" in directory names.
++// Matches containerd's config/hosts.go encoding.
++func hostDirectory(host string) string {
++	idx := strings.LastIndex(host, ":")
++	if idx > 0 {
++		return host[:idx] + "_" + host[idx+1:] + "_"
++	}
++	return host
++}
++
++func loadHostCredentials(ctx context.Context, hostDir, host string) (string, string, error) {
++	if hostDir == "" {
++		return "", "", nil
++	}
++	// Try encoded path first (registry_5000_), then literal (registry:5000)
++	paths := []string{filepath.Join(hostDir, hostDirectory(host), "credentials.toml")}
++	if hostDirectory(host) != host {
++		paths = append(paths, filepath.Join(hostDir, host, "credentials.toml"))
++	}
++	var d []byte
++	var err error
++	var credPath string
++	for _, p := range paths {
++		d, err = os.ReadFile(p)
++		if err == nil {
++			credPath = p
++			break
++		}
++		if !os.IsNotExist(err) {
++			return "", "", err
++		}
++	}
++	if d == nil {
++		return "", "", nil
++	}
++	var c struct {
++		Username      string `toml:"username"`
++		Password      string `toml:"password"`
++		IdentityToken string `toml:"identitytoken"`
++		Auth          string `toml:"auth"`
++	}
++	if err := toml.Unmarshal(d, &c); err != nil {
++		log.G(ctx).WithError(err).Warnf("failed to parse credentials from %s", credPath)
++		return "", "", nil
++	}
++	if c.Username != "" || c.Password != "" {
++		log.G(ctx).WithField("path", credPath).Debug("using fallback credentials (username/password)")
++		return c.Username, c.Password, nil
++	}
++	if c.IdentityToken != "" {
++		log.G(ctx).WithField("path", credPath).Debug("using fallback credentials (identity token)")
++		return "", c.IdentityToken, nil
++	}
++	if c.Auth != "" {
++		dec, err := base64.StdEncoding.DecodeString(c.Auth)
++		if err != nil {
++			log.G(ctx).WithError(err).Warnf("failed to decode auth from %s", credPath)
++			return "", "", nil
++		}
++		user, passwd, ok := strings.Cut(string(dec), ":")
++		if !ok {
++			log.G(ctx).Warnf("invalid auth format in %s", credPath)
++			return "", "", nil
++		}
++		log.G(ctx).WithField("path", credPath).Debug("using fallback credentials (auth)")
++		return user, strings.Trim(passwd, "\x00"), nil
++	}
++	return "", "", nil
++}
++
+ func init() {
+ 	// TODO: Move this to separate package?
+ 	plugins.Register(&transfertypes.OCIRegistry{}, &OCIRegistry{})
+@@ -134,8 +209,10 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
+ 			if err != nil {
+ 				return "", "", err
+ 			}
+-
+-			return c.Username, c.Secret, nil
++			if c.Username != "" || c.Secret != "" {
++				return c.Username, c.Secret, nil
++			}
++			return loadHostCredentials(ctx, ropts.hostDir, host)
+ 		}
+ 	}
+ 	if ropts.defaultScheme != "" {
+@@ -376,8 +453,10 @@ func (r *OCIRegistry) UnmarshalAny(ctx context.Context, sm streaming.StreamGette
+ 				if err != nil {
+ 					return "", "", err
+ 				}
+-
+-				return c.Username, c.Secret, nil
++				if c.Username != "" || c.Secret != "" {
++					return c.Username, c.Secret, nil
++				}
++				return loadHostCredentials(ctx, s.Resolver.HostDir, host)
+ 			}
+ 		}
+ 		r.headers = http.Header{}

--- a/packages/containerd-2.1/1004-ctr-default-hosts-dir-to-etc-containerd-certs.d.patch
+++ b/packages/containerd-2.1/1004-ctr-default-hosts-dir-to-etc-containerd-certs.d.patch
@@ -1,0 +1,25 @@
+From 5996f17f4b3287148255c0cd89dee981f83dc0c2 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Fri, 30 Jan 2026 19:08:27 +0000
+Subject: [PATCH] ctr: default hosts-dir to /etc/containerd/certs.d
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ cmd/ctr/commands/commands.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmd/ctr/commands/commands.go b/cmd/ctr/commands/commands.go
+index 946da78ed..d4b7a3a87 100644
+--- a/cmd/ctr/commands/commands.go
++++ b/cmd/ctr/commands/commands.go
+@@ -72,8 +72,8 @@ var (
+ 			Usage: "Refresh token for authorization server",
+ 		},
+ 		&cli.StringFlag{
+-			Name: "hosts-dir",
+-			// compatible with "/etc/docker/certs.d"
++			Name:  "hosts-dir",
++			Value: "/etc/containerd/certs.d",
+ 			Usage: "Custom hosts configuration directory",
+ 		},
+ 		&cli.StringFlag{

--- a/packages/containerd-2.1/containerd-2.1.spec
+++ b/packages/containerd-2.1/containerd-2.1.spec
@@ -42,6 +42,8 @@ Patch1001: 1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
 Patch1002: 1002-bump-google-golang-org-grpc.patch
 # Patch for transfer service to fall back to file for registry creds.
 Patch1003: 1003-transfer-service-fallback-to-credentials.toml-for-re.patch
+# Patch to make ctr use hosts.toml for registry mirrors by default
+Patch1004: 1004-ctr-default-hosts-dir-to-etc-containerd-certs.d.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/containerd-2.1/containerd-2.1.spec
+++ b/packages/containerd-2.1/containerd-2.1.spec
@@ -40,6 +40,8 @@ Source1000: clarify.toml
 Patch1001: 1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
 # Patch to update grpc
 Patch1002: 1002-bump-google-golang-org-grpc.patch
+# Patch for transfer service to fall back to file for registry creds.
+Patch1003: 1003-transfer-service-fallback-to-credentials.toml-for-re.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
@@ -71,31 +71,4 @@ bin_dirs = [ "/opt/cni/bin" ]
 conf_dir = "/etc/cni/net.d"
 
 [plugins."io.containerd.cri.v1.images".registry]
-{{#if settings.container-registry.mirrors}}
-{{#each settings.container-registry.mirrors}}
-[plugins."io.containerd.cri.v1.images".registry.mirrors."{{registry}}"]
-endpoint = [{{join_array ", " endpoint }}]
-{{/each}}
-{{/if}}
-
-{{#if settings.container-registry.credentials}}
-{{#each settings.container-registry.credentials}}
-{{#if (eq registry "docker.io") }}
-[plugins."io.containerd.cri.v1.images".registry.configs."registry-1.docker.io".auth]
-{{else}}
-[plugins."io.containerd.cri.v1.images".registry.configs."{{registry}}".auth]
-{{/if}}
-{{#if username}}
-username = "{{{username}}}"
-{{/if}}
-{{#if password}}
-password = "{{{password}}}"
-{{/if}}
-{{#if auth}}
-auth = "{{{auth}}}"
-{{/if}}
-{{#if identitytoken}}
-identitytoken = "{{{identitytoken}}}"
-{{/if}}
-{{/each}}
-{{/if}}
+config_path = "/etc/containerd/certs.d"

--- a/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -93,31 +93,4 @@ bin_dirs = [ "/opt/cni/bin" ]
 conf_dir = "/etc/cni/net.d"
 
 [plugins."io.containerd.cri.v1.images".registry]
-{{#if settings.container-registry.mirrors}}
-{{#each settings.container-registry.mirrors}}
-[plugins."io.containerd.cri.v1.images".registry.mirrors."{{registry}}"]
-endpoint = [{{join_array ", " endpoint }}]
-{{/each}}
-{{/if}}
-
-{{#if settings.container-registry.credentials}}
-{{#each settings.container-registry.credentials}}
-{{#if (eq registry "docker.io") }}
-[plugins."io.containerd.cri.v1.images".registry.configs."registry-1.docker.io".auth]
-{{else}}
-[plugins."io.containerd.cri.v1.images".registry.configs."{{registry}}".auth]
-{{/if}}
-{{#if username}}
-username = "{{{username}}}"
-{{/if}}
-{{#if password}}
-password = "{{{password}}}"
-{{/if}}
-{{#if auth}}
-auth = "{{{auth}}}"
-{{/if}}
-{{#if identitytoken}}
-identitytoken = "{{{identitytoken}}}"
-{{/if}}
-{{/each}}
-{{/if}}
+config_path = "/etc/containerd/certs.d"

--- a/packages/docker-engine-29/Cargo.toml
+++ b/packages/docker-engine-29/Cargo.toml
@@ -16,8 +16,8 @@ url = "https://github.com/moby/moby/archive/docker-v29.0.4/moby-docker-v29.0.4.t
 sha512 = "475770b282bdfd0f9f9343fb9818384253d3e17b9976599ad1de52f64e67a1f88a18a40d8b296f37299485fe2e6eabfee6ae6be6547c0fc936053872aa4ef1f7"
 
 [[package.metadata.build-package.external-files]]
-url = "https://cache.bottlerocket.aws/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch/293883e478e87baac370342346a17281cab62e31abdbb03aa9b38efd0e1d8afeb883e81d1274445a25220f6b09dfe7f2b32727b585f01305517e126596751f6f/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch"
-sha512 = "293883e478e87baac370342346a17281cab62e31abdbb03aa9b38efd0e1d8afeb883e81d1274445a25220f6b09dfe7f2b32727b585f01305517e126596751f6f"
+url = "https://cache.bottlerocket.aws/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch/357030a55a200e76709ded37584419cd035f0f810248c654f2c618467411b28afac5408a600631b429f32e565532e4ebf46f334c6dea09158c84d1366f310be0/0003-Switch-containerd-image-backend-s-image-pull-to-tran.patch"
+sha512 = "357030a55a200e76709ded37584419cd035f0f810248c654f2c618467411b28afac5408a600631b429f32e565532e4ebf46f334c6dea09158c84d1366f310be0"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-engine-29/daemon-json
+++ b/packages/docker-engine-29/daemon-json
@@ -17,12 +17,5 @@ std = { version = "v1", helpers = ["join_array"] }
     {{oci_defaults "docker" settings.oci-defaults.resource-limits}}
   },
   {{/if}}
-  {{#if settings.container-registry.mirrors}}
-  {{#each settings.container-registry.mirrors}}
-  {{#if (eq registry "docker.io" )}}
-  "registry-mirrors": [{{join_array ", " endpoint}}],
-  {{/if}}
-  {{/each}}
-  {{/if}}
   "selinux-enabled": true
 }

--- a/packages/docker-engine-29/docker-engine-29.spec
+++ b/packages/docker-engine-29/docker-engine-29.spec
@@ -25,6 +25,7 @@ Source2: docker.socket
 Source3: docker-sysusers.conf
 Source4: daemon-json
 Source5: daemon-nvidia-json
+Source6: docker-engine-tmpfiles.conf
 
 # Create container storage mount point.
 Source100: prepare-var-lib-docker.service
@@ -96,6 +97,9 @@ install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/docker-daemon-json
 install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/docker-daemon-nvidia-json
 
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/docker-engine.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files
@@ -107,7 +111,9 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/docker-daemon-nvidia
 %{_cross_sysusersdir}/docker.conf
 %{_cross_templatedir}/docker-daemon-json
 %{_cross_templatedir}/docker-daemon-nvidia-json
+%{_cross_tmpfilesdir}/docker-engine.conf
 %{_cross_bindir}/dockerd
 %{_cross_bindir}/docker-proxy
+
 %changelog
 

--- a/packages/docker-engine-29/docker-engine-tmpfiles.conf
+++ b/packages/docker-engine-29/docker-engine-tmpfiles.conf
@@ -1,0 +1,1 @@
+L /etc/docker/certs.d - - - - /etc/containerd/certs.d

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -49,6 +49,7 @@ Source23: br03040101.json
 Source24: k8s04021000.json
 Source25: containerd-image-verifiers-toml
 Source26: thar-be-image-verifiers-toml
+Source27: thar-be-registries-toml
 
 # 1xx sources: systemd units
 Source100: apiserver.service
@@ -107,6 +108,7 @@ Requires: %{_cross_os}signpost
 Requires: %{_cross_os}storewolf
 Requires: %{_cross_os}sundog
 Requires: %{_cross_os}xfscli
+Requires: %{_cross_os}thar-be-registries
 Requires: %{_cross_os}thar-be-settings
 
 Requires: (%{_cross_os}bootstrap-containers or %{_cross_os}image-feature(no-host-containers))
@@ -474,6 +476,11 @@ Requires: %{_cross_os}thar-be-image-verifiers
 %description -n %{_cross_os}digestion-image-verifier
 %{summary}.
 
+%package -n %{_cross_os}thar-be-registries
+Summary: Configure registry mirrors and creds for containerd
+%description -n %{_cross_os}thar-be-registries
+%{summary}.
+
 %prep
 %setup -T -c
 %cargo_prep
@@ -573,6 +580,7 @@ echo "** Output from non-static builds:"
     -p sundog \
     -p schnauzer \
     -p bork \
+    -p thar-be-registries \
     -p thar-be-settings \
     -p thar-be-updates \
     -p host-containers \
@@ -649,6 +657,7 @@ for p in \
   apiserver \
   sundog schnauzer bork \
   corndog thar-be-settings thar-be-updates host-containers \
+  thar-be-registries \
   storewolf settings-committer \
   migrator prairiedog certdog \
   signpost updog metricdog logdog \
@@ -761,7 +770,7 @@ install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 \
   %{S:5} %{S:6} %{S:7} %{S:14} %{S:15} \
   %{S:16} %{S:17} %{S:18} %{S:19} %{S:21} \
-  %{S:25} %{S:26} \
+  %{S:25} %{S:26} %{S:27} \
   %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_unitdir}
@@ -1021,5 +1030,9 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 
 %files -n %{_cross_os}digestion-image-verifier
 %{_cross_libexecdir}/civ/bin/digestion-image-verifier
+
+%files -n %{_cross_os}thar-be-registries
+%{_cross_bindir}/thar-be-registries
+%{_cross_templatedir}/thar-be-registries-toml
 
 %changelog

--- a/packages/os/thar-be-registries-toml
+++ b/packages/os/thar-be-registries-toml
@@ -1,0 +1,29 @@
+[required-extensions]
+container-registry = "v1"
+std = { version = "v1", helpers = ["join_array"]}
++++
+{{#if settings.container-registry.mirrors}}
+{{#each settings.container-registry.mirrors}}
+[[mirrors]]
+registry = "{{registry}}"
+endpoint = [{{{join_array ", " endpoint}}}]
+{{/each}}
+{{/if}}
+{{#if settings.container-registry.credentials}}
+{{#each settings.container-registry.credentials}}
+[[credentials]]
+registry = "{{registry}}"
+{{#if username}}
+username = "{{{username}}}"
+{{/if}}
+{{#if password}}
+password = "{{{password}}}"
+{{/if}}
+{{#if auth}}
+auth = "{{{auth}}}"
+{{/if}}
+{{#if identitytoken}}
+identitytoken = "{{{identitytoken}}}"
+{{/if}}
+{{/each}}
+{{/if}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -6082,6 +6082,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "thar-be-registries"
+version = "0.1.0"
+dependencies = [
+ "generate-readme",
+ "log",
+ "nix 0.26.4",
+ "serde",
+ "simplelog",
+ "snafu",
+ "tempfile",
+ "test-case",
+ "toml",
+ "url",
+ "zeroize",
+]
+
+[[package]]
 name = "thar-be-settings"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "api/storewolf",
     "api/thar-be-settings",
     "api/thar-be-updates",
+    "api/thar-be-registries",
     "api/settings-committer",
     "api/migration/migrator",
     "api/shibaken",

--- a/sources/api/thar-be-registries/Cargo.toml
+++ b/sources/api/thar-be-registries/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "thar-be-registries"
+version = "0.1.0"
+authors = ["Bottlerocket Developers"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+build = "build.rs"
+exclude = ["README.md"]
+
+[dependencies]
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+simplelog.workspace = true
+snafu.workspace = true
+toml.workspace = true
+tempfile.workspace = true
+url.workspace = true
+zeroize = { workspace = true, features = ["derive", "alloc"] }
+nix = { workspace = true, features = ["fs"] }
+
+[dev-dependencies]
+test-case.workspace = true
+
+[build-dependencies]
+generate-readme.workspace = true

--- a/sources/api/thar-be-registries/README.md
+++ b/sources/api/thar-be-registries/README.md
@@ -1,0 +1,25 @@
+# thar-be-registries
+
+Current version: 0.1.0
+
+## Background
+
+thar-be-registries generates containerd registry configuration from Bottlerocket settings.
+
+It reads `/etc/containerd/thar-be-registries.toml` and writes per-registry configuration files to
+`/etc/containerd/certs.d/`.
+
+For each configured registry, it creates:
+* `hosts.toml` - mirror endpoints with pull/resolve capabilities
+* `credentials.toml` - authentication credentials (mode 0600)
+
+### Behavior
+
+* Exits successfully (0) if the input file doesn't exist (graceful no-op)
+* Uses atomic directory replacement to avoid race conditions with containerd
+* containerd reads these files on-demand during image pulls
+
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/api/thar-be-registries/README.tpl
+++ b/sources/api/thar-be-registries/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+Current version: {{version}}
+
+{{readme}}
+
+## Colophon
+
+This text was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and includes the rustdoc from `src/main.rs`.

--- a/sources/api/thar-be-registries/build.rs
+++ b/sources/api/thar-be-registries/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    generate_readme::from_main().ok();
+}

--- a/sources/api/thar-be-registries/src/creds.rs
+++ b/sources/api/thar-be-registries/src/creds.rs
@@ -1,0 +1,90 @@
+//! Containerd registry credentials configuration.
+//!
+//! This module provides types for generating `credentials.toml` files that configure
+//! authentication for containerd registry access.
+
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// Registry credentials (credentials.toml).
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Zeroize, ZeroizeOnDrop)]
+pub struct RegistryCredentials {
+    /// Username for basic authentication.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+
+    /// Password for basic authentication.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+
+    /// Base64-encoded "username:password" for basic authentication.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth: Option<String>,
+
+    /// Identity token for token-based authentication.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identitytoken: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize_username_password() {
+        let creds = RegistryCredentials {
+            username: Some("user".to_string()),
+            password: Some("pass".to_string()),
+            auth: None,
+            identitytoken: None,
+        };
+        let s = toml::to_string(&creds).unwrap();
+        assert!(s.contains(r#"username = "user""#));
+        assert!(s.contains(r#"password = "pass""#));
+    }
+
+    #[test]
+    fn test_serialize_auth_only() {
+        let creds = RegistryCredentials {
+            username: None,
+            password: None,
+            auth: Some("dXNlcjpwYXNz".to_string()),
+            identitytoken: None,
+        };
+        let s = toml::to_string(&creds).unwrap();
+        assert!(s.contains(r#"auth = "dXNlcjpwYXNz""#));
+        assert!(!s.contains("username"));
+    }
+
+    #[test]
+    fn test_serialize_identitytoken_only() {
+        let creds = RegistryCredentials {
+            username: None,
+            password: None,
+            auth: None,
+            identitytoken: Some("token123".to_string()),
+        };
+        let s = toml::to_string(&creds).unwrap();
+        assert!(s.contains(r#"identitytoken = "token123""#));
+    }
+
+    #[test]
+    fn test_empty_serializes_empty() {
+        let creds = RegistryCredentials::default();
+        let s = toml::to_string(&creds).unwrap();
+        assert!(s.is_empty() || s.trim().is_empty());
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let creds = RegistryCredentials {
+            username: Some("u".to_string()),
+            password: Some("p".to_string()),
+            auth: None,
+            identitytoken: None,
+        };
+        let s = toml::to_string(&creds).unwrap();
+        let parsed: RegistryCredentials = toml::from_str(&s).unwrap();
+        assert_eq!(creds, parsed);
+    }
+}

--- a/sources/api/thar-be-registries/src/error.rs
+++ b/sources/api/thar-be-registries/src/error.rs
@@ -1,0 +1,55 @@
+use snafu::Snafu;
+use std::path::PathBuf;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(super)))]
+pub(super) enum Error {
+    #[snafu(display("Failed to read settings from '{}': {}", path, source))]
+    ReadSettings {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to parse settings from '{}': {}", path, source))]
+    ParseSettings {
+        path: String,
+        source: toml::de::Error,
+    },
+
+    #[snafu(display("Failed to create directory '{}': {}", path, source))]
+    CreateDir {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to write file '{}': {}", path, source))]
+    WriteFile {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to serialize TOML: {}", source))]
+    SerializeToml { source: toml::ser::Error },
+
+    #[snafu(display(
+        "Failed to write {} of {} registry configs; see above",
+        failure_count,
+        total_count
+    ))]
+    WriteRegistries {
+        failure_count: usize,
+        total_count: usize,
+    },
+
+    #[snafu(display("Failed to parse registry '{}' as a valid URL", registry))]
+    ParseRegistry { registry: String },
+
+    #[snafu(display("Failed to rename '{}' to '{}': {}", from.display(), to.display(), source))]
+    RenameDir {
+        from: PathBuf,
+        to: PathBuf,
+        source: nix::errno::Errno,
+    },
+}
+
+pub(super) type Result<T> = std::result::Result<T, Error>;

--- a/sources/api/thar-be-registries/src/host_ns.rs
+++ b/sources/api/thar-be-registries/src/host_ns.rs
@@ -1,0 +1,160 @@
+//! Containerd registry host namespace configuration.
+//!
+//! This module provides types for generating `hosts.toml` files that configure
+//! containerd's registry mirrors. See the [containerd documentation] for details.
+//!
+//! [containerd documentation]: https://github.com/containerd/containerd/blob/c4982bffc6dd887a58a189f8a6be99b1b1542953/docs/hosts.md
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use url::Url;
+
+/// A registry mirror endpoint URL.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Endpoint(String);
+
+impl Endpoint {
+    /// Creates a new endpoint from a URL string.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self(url.into())
+    }
+
+    /// Checks if this endpoint has a path component beyond "/".
+    pub fn has_path_component(&self) -> bool {
+        if let Ok(url) = Url::parse(&self.0) {
+            let p = url.path();
+            !p.is_empty() && p != "/"
+        } else {
+            false
+        }
+    }
+}
+
+impl fmt::Display for Endpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Operations a registry host can perform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Capability {
+    Pull,
+    Resolve,
+    Push,
+}
+
+/// Registry host namespace configuration (hosts.toml).
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct HostNamespace {
+    /// Default server URL for this registry namespace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server: Option<String>,
+
+    /// Mirror host configurations, keyed by endpoint URL.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub host: BTreeMap<Endpoint, HostConfig>,
+}
+
+/// Configuration for a single host/mirror endpoint.
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct HostConfig {
+    /// Operations this host can perform.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<BTreeSet<Capability>>,
+
+    /// When true, use the URL path as the API root instead of appending /v2.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub override_path: Option<bool>,
+}
+
+impl HostConfig {
+    /// Creates a new host configuration with the specified capabilities.
+    pub fn new(capabilities: impl IntoIterator<Item = Capability>) -> Self {
+        Self {
+            capabilities: Some(capabilities.into_iter().collect()),
+            override_path: None,
+        }
+    }
+
+    /// Sets the override_path flag and returns self for method chaining.
+    pub fn with_override_path(mut self, override_path: bool) -> Self {
+        self.override_path = Some(override_path);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize_server_only() {
+        let ns = HostNamespace {
+            server: Some("https://registry-1.docker.io".to_string()),
+            host: BTreeMap::new(),
+        };
+        let s = toml::to_string(&ns).unwrap();
+        assert!(s.contains(r#"server = "https://registry-1.docker.io""#));
+        assert!(!s.contains("[host"));
+    }
+
+    #[test]
+    fn test_serialize_server_and_host() {
+        let mut ns = HostNamespace {
+            server: Some("https://registry-1.docker.io".to_string()),
+            host: BTreeMap::new(),
+        };
+        ns.host.insert(
+            Endpoint::new("https://mirror.example.com"),
+            HostConfig::new([Capability::Pull, Capability::Resolve]),
+        );
+        let s = toml::to_string(&ns).unwrap();
+        assert!(s.contains(r#"server = "https://registry-1.docker.io""#));
+        assert!(s.contains(r#"[host."https://mirror.example.com"]"#));
+        assert!(s.contains("pull"));
+    }
+
+    #[test]
+    fn test_serialize_override_path() {
+        let mut ns = HostNamespace::default();
+        ns.host.insert(
+            Endpoint::new("https://ecr.example.com/v2/docker"),
+            HostConfig::new([Capability::Pull]).with_override_path(true),
+        );
+        let s = toml::to_string(&ns).unwrap();
+        assert!(s.contains("override_path = true"));
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let mut ns = HostNamespace {
+            server: Some("https://test.io".to_string()),
+            host: BTreeMap::new(),
+        };
+        ns.host.insert(
+            Endpoint::new("https://mirror.io"),
+            HostConfig::new([Capability::Pull]),
+        );
+        let s = toml::to_string(&ns).unwrap();
+        let parsed: HostNamespace = toml::from_str(&s).unwrap();
+        assert_eq!(ns, parsed);
+    }
+
+    #[test]
+    fn test_empty_serializes_minimal() {
+        let ns = HostNamespace::default();
+        let s = toml::to_string(&ns).unwrap();
+        assert!(s.is_empty() || s.trim().is_empty());
+    }
+
+    #[test]
+    fn test_endpoint_has_path_component() {
+        assert!(!Endpoint::new("https://mirror.example.com").has_path_component());
+        assert!(!Endpoint::new("https://mirror.example.com/").has_path_component());
+        assert!(Endpoint::new("https://mirror.example.com/v2/docker-hub").has_path_component());
+    }
+}

--- a/sources/api/thar-be-registries/src/main.rs
+++ b/sources/api/thar-be-registries/src/main.rs
@@ -1,0 +1,434 @@
+/*!
+# Background
+
+thar-be-registries generates containerd registry configuration from Bottlerocket settings.
+
+It reads `/etc/containerd/thar-be-registries.toml` and writes per-registry configuration files to
+`/etc/containerd/certs.d/`.
+
+For each configured registry, it creates:
+* `hosts.toml` - mirror endpoints with pull/resolve capabilities
+* `credentials.toml` - authentication credentials (mode 0600)
+
+## Behavior
+
+* Exits successfully (0) if the input file doesn't exist (graceful no-op)
+* Uses atomic directory replacement to avoid race conditions with containerd
+* containerd reads these files on-demand during image pulls
+
+*/
+
+use log::{error, info, warn};
+use nix::fcntl::{renameat2, RenameFlags};
+use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
+use snafu::ResultExt;
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+mod creds;
+mod error;
+mod host_ns;
+mod registry;
+mod settings;
+
+use creds::RegistryCredentials;
+use error::{CreateDirSnafu, RenameDirSnafu, Result, SerializeTomlSnafu, WriteFileSnafu};
+use host_ns::{Capability, Endpoint, HostConfig, HostNamespace};
+use registry::{encode_registry_name, parse_registry, DOCKER_HUB_HOST, DOCKER_HUB_REGISTRY};
+use settings::{read_settings, Credential, Mirror};
+
+const CERTS_DIR: &str = "/etc/containerd/certs.d";
+const INPUT_FILE: &str = "/etc/containerd/thar-be-registries.toml";
+
+/// Entry point - generates containerd registry configuration files.
+fn main() {
+    if let Err(e) = run() {
+        error!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+/// Main execution logic
+fn run() -> Result<()> {
+    SimpleLogger::init(LevelFilter::Info, LogConfig::default()).unwrap_or(());
+    info!("Reading registry config from {}", INPUT_FILE);
+
+    if !Path::new(INPUT_FILE).exists() {
+        warn!(
+            "No registry settings file found at '{}', skipping",
+            INPUT_FILE
+        );
+        return Ok(());
+    }
+
+    let settings = read_settings(INPUT_FILE)?;
+
+    let temp_dir = tempfile::tempdir_in("/etc/containerd").context(CreateDirSnafu {
+        path: "/etc/containerd",
+    })?;
+
+    let mirrors = settings.mirrors.unwrap_or_default();
+    let credentials = settings.credentials.unwrap_or_default();
+    let total_count = mirrors.len() + credentials.len();
+    let mut failure_count = 0;
+
+    for mirror in &mirrors {
+        if let Err(e) = write_hosts_toml(temp_dir.path(), mirror) {
+            error!(
+                "Failed to write hosts.toml for '{}': {}",
+                mirror.registry, e
+            );
+            failure_count += 1;
+        }
+    }
+
+    for cred in &credentials {
+        if let Err(e) = write_credentials_toml(temp_dir.path(), cred) {
+            error!(
+                "Failed to write credentials.toml for '{}': {}",
+                cred.registry, e
+            );
+            failure_count += 1;
+        }
+    }
+
+    if failure_count > 0 {
+        return Err(error::Error::WriteRegistries {
+            failure_count,
+            total_count,
+        });
+    }
+
+    // Ensure target exists for atomic swap.
+    fs::create_dir_all(CERTS_DIR).context(CreateDirSnafu { path: CERTS_DIR })?;
+    // After the exchange, the old content is removed when tmp_dir is dropped.
+    rename_exchange_dir(temp_dir.path(), Path::new(CERTS_DIR))?;
+    info!("Successfully wrote registry configs to {}", CERTS_DIR);
+
+    Ok(())
+}
+
+/// Atomically exchange two directories using Linux renameat2.
+/// Both paths must exist. After the call, each path points to what the other contained.
+fn rename_exchange_dir(a: &Path, b: &Path) -> Result<()> {
+    renameat2(None, a, None, b, RenameFlags::RENAME_EXCHANGE)
+        .context(RenameDirSnafu { from: a, to: b })
+}
+
+/// Write hosts.toml for a registry mirror.
+fn write_hosts_toml(base_dir: &Path, mirror: &Mirror) -> Result<()> {
+    let (host, scheme) = parse_registry(&mirror.registry)?;
+    let encoded = encode_registry_name(&host);
+    let dir = base_dir.join(&encoded);
+    fs::create_dir_all(&dir).context(CreateDirSnafu {
+        path: dir.display().to_string(),
+    })?;
+
+    // For the default mirror, indicated by '*' as the registry, there are two options. If only the
+    // mirror should be used, and upstream should never be contacted, then the mirror can be set in
+    // the "server" field. Otherwise, the "server" field should be left unset, so it resolves to
+    // the upstream registry, and the mirror should be listed as a "hosts" entry.
+    //
+    // For consistency with hosts.toml for non-default mirrors, we go with the second option, which
+    // means that there's always a potential fallback to upstream.
+    let server = match host.as_str() {
+        "*" => None,
+        DOCKER_HUB_HOST => Some(format!("https://{}", DOCKER_HUB_REGISTRY)),
+        _ => Some(format!("{}://{}", &scheme, host)),
+    };
+
+    let mut ns = HostNamespace {
+        server,
+        ..Default::default()
+    };
+
+    for endpoint in &mirror.endpoint {
+        let ep = Endpoint::new(endpoint);
+        let mut cfg = HostConfig::new([Capability::Pull, Capability::Resolve]);
+        if ep.has_path_component() {
+            cfg = cfg.with_override_path(true);
+        }
+        ns.host.insert(ep, cfg);
+    }
+
+    let content = toml::to_string(&ns).context(SerializeTomlSnafu)?;
+    let path = dir.join("hosts.toml");
+    fs::write(&path, content).context(WriteFileSnafu {
+        path: path.display().to_string(),
+    })?;
+
+    info!("Wrote hosts.toml for '{}'", mirror.registry);
+    Ok(())
+}
+
+/// Write credentials.toml for a registry.
+/// For docker.io, writes to registry-1.docker.io since containerd's credential
+/// callback receives the actual registry host, not the image reference host.
+fn write_credentials_toml(base_dir: &Path, cred: &Credential) -> Result<()> {
+    let (host, _) = parse_registry(&cred.registry)?;
+    let cred_host = if host == DOCKER_HUB_HOST {
+        DOCKER_HUB_REGISTRY
+    } else {
+        &host
+    };
+    let encoded = encode_registry_name(cred_host);
+    let dir = base_dir.join(&encoded);
+    fs::create_dir_all(&dir).context(CreateDirSnafu {
+        path: dir.display().to_string(),
+    })?;
+
+    let rc = RegistryCredentials {
+        username: cred.username.clone(),
+        password: cred.password.clone(),
+        auth: cred.auth.clone(),
+        identitytoken: cred.identitytoken.clone(),
+    };
+
+    let content = toml::to_string(&rc).context(SerializeTomlSnafu)?;
+    let path = dir.join("credentials.toml");
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&path)
+        .context(WriteFileSnafu {
+            path: path.display().to_string(),
+        })?;
+    file.write_all(content.as_bytes()).context(WriteFileSnafu {
+        path: path.display().to_string(),
+    })?;
+
+    info!("Wrote credentials.toml for '{}'", cred.registry);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use settings::Mirror;
+    use test_case::test_case;
+
+    // Workflow tests - helper to create temp dir and verify file contents
+    fn verify_file(dir: &std::path::Path, rel_path: &str, expected_contents: &[&str]) {
+        let content = fs::read_to_string(dir.join(rel_path)).unwrap();
+        for expected in expected_contents {
+            assert!(
+                content.contains(expected),
+                "Missing '{}' in:\n{}",
+                expected,
+                content
+            );
+        }
+    }
+
+    #[test_case(
+    "docker.io",
+    &["https://mirror.example.com"],
+    "docker.io/hosts.toml",
+    &[r#"server = "https://registry-1.docker.io""#, r#"[host."https://mirror.example.com"]"#]
+    ; "docker.io mirror"
+  )]
+    #[test_case(
+    "registry.example.com:5000",
+    &["https://mirror.local"],
+    "registry.example.com_5000_/hosts.toml",
+    &[r#"server = "https://registry.example.com:5000""#]
+    ; "registry with port"
+  )]
+    #[test_case(
+    "docker.io",
+    &["https://ecr-cache.example.com/v2/docker-hub"],
+    "docker.io/hosts.toml",
+    &["override_path = true"]
+    ; "endpoint with path sets override_path"
+  )]
+    #[test_case(
+    "*",
+    &["https://mirror.global"],
+    "_default/hosts.toml",
+    &[r#"[host."https://mirror.global"]"#]
+    ; "global mirror"
+  )]
+    fn test_write_hosts_toml(
+        registry: &str,
+        endpoints: &[&str],
+        expected_path: &str,
+        expected_contents: &[&str],
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let mirror = Mirror {
+            registry: registry.to_string(),
+            endpoint: endpoints.iter().map(|s| s.to_string()).collect(),
+        };
+        write_hosts_toml(dir.path(), &mirror).unwrap();
+        verify_file(dir.path(), expected_path, expected_contents);
+    }
+
+    #[test_case(
+    "registry.example.com",
+    Some("user"), Some("pass"), None, None,
+    "registry.example.com/credentials.toml",
+    &[r#"username = "user""#, r#"password = "pass""#]
+    ; "username and password"
+  )]
+    #[test_case(
+    "docker.io",
+    Some("user"), Some("pass"), None, None,
+    "registry-1.docker.io/credentials.toml",
+    &[r#"username = "user""#, r#"password = "pass""#]
+    ; "docker.io writes to registry-1.docker.io"
+  )]
+    #[test_case(
+    "registry.example.com",
+    None, None, None, Some("token123"),
+    "registry.example.com/credentials.toml",
+    &[r#"identitytoken = "token123""#]
+    ; "identitytoken only"
+  )]
+    #[test_case(
+    "registry.example.com",
+    None, None, Some("dXNlcjpwYXNz"), None,
+    "registry.example.com/credentials.toml",
+    &[r#"auth = "dXNlcjpwYXNz""#]
+    ; "auth only"
+  )]
+    fn test_write_credentials_toml(
+        registry: &str,
+        username: Option<&str>,
+        password: Option<&str>,
+        auth: Option<&str>,
+        identitytoken: Option<&str>,
+        expected_path: &str,
+        expected_contents: &[&str],
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let cred = Credential {
+            registry: registry.to_string(),
+            username: username.map(String::from),
+            password: password.map(String::from),
+            auth: auth.map(String::from),
+            identitytoken: identitytoken.map(String::from),
+        };
+        write_credentials_toml(dir.path(), &cred).unwrap();
+        verify_file(dir.path(), expected_path, expected_contents);
+    }
+
+    #[test]
+    fn test_workflow_mirror_and_credential_same_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let mirror = Mirror {
+            registry: "registry.example.com".to_string(),
+            endpoint: vec!["https://mirror.example.com".to_string()],
+        };
+        let cred = Credential {
+            registry: "registry.example.com".to_string(),
+            username: Some("user".to_string()),
+            password: Some("pass".to_string()),
+            auth: None,
+            identitytoken: None,
+        };
+        write_hosts_toml(dir.path(), &mirror).unwrap();
+        write_credentials_toml(dir.path(), &cred).unwrap();
+        assert!(dir.path().join("registry.example.com/hosts.toml").exists());
+        assert!(dir
+            .path()
+            .join("registry.example.com/credentials.toml")
+            .exists());
+    }
+
+    #[test]
+    fn test_credentials_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let cred = Credential {
+            registry: "test.io".to_string(),
+            username: Some("u".to_string()),
+            password: Some("p".to_string()),
+            auth: None,
+            identitytoken: None,
+        };
+        write_credentials_toml(dir.path(), &cred).unwrap();
+        let path = dir.path().join("test.io/credentials.toml");
+        let perms = fs::metadata(&path).unwrap().permissions();
+        assert_eq!(
+            perms.mode() & 0o777,
+            0o600,
+            "credentials.toml should be mode 0600"
+        );
+    }
+
+    #[test]
+    fn test_wildcard_no_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let mirror = Mirror {
+            registry: "*".to_string(),
+            endpoint: vec!["https://mirror.example.com".to_string()],
+        };
+        write_hosts_toml(dir.path(), &mirror).unwrap();
+        let content = fs::read_to_string(dir.path().join("_default/hosts.toml")).unwrap();
+        assert!(!content.contains(r#"server = "https://*""#));
+    }
+
+    #[test]
+    fn test_docker_io_special_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let mirror = Mirror {
+            registry: "docker.io".to_string(),
+            endpoint: vec!["https://mirror.example.com".to_string()],
+        };
+        write_hosts_toml(dir.path(), &mirror).unwrap();
+        let content = fs::read_to_string(dir.path().join("docker.io/hosts.toml")).unwrap();
+        assert!(content.contains(r#"server = "https://registry-1.docker.io""#));
+    }
+
+    #[test]
+    fn test_multiple_endpoints() {
+        let dir = tempfile::tempdir().unwrap();
+        let mirror = Mirror {
+            registry: "test.io".to_string(),
+            endpoint: vec![
+                "https://mirror1.example.com".to_string(),
+                "https://mirror2.example.com".to_string(),
+                "https://mirror3.example.com".to_string(),
+            ],
+        };
+        write_hosts_toml(dir.path(), &mirror).unwrap();
+        let content = fs::read_to_string(dir.path().join("test.io/hosts.toml")).unwrap();
+        assert!(content.contains(r#"[host."https://mirror1.example.com"]"#));
+        assert!(content.contains(r#"[host."https://mirror2.example.com"]"#));
+        assert!(content.contains(r#"[host."https://mirror3.example.com"]"#));
+        assert_eq!(content.matches("capabilities").count(), 3);
+    }
+
+    #[test]
+    fn test_empty_endpoints() {
+        let dir = tempfile::tempdir().unwrap();
+        let mirror = Mirror {
+            registry: "test.io".to_string(),
+            endpoint: vec![],
+        };
+        write_hosts_toml(dir.path(), &mirror).unwrap();
+        let content = fs::read_to_string(dir.path().join("test.io/hosts.toml")).unwrap();
+        assert!(content.contains(r#"server = "https://test.io""#));
+        assert!(!content.contains("[host."));
+    }
+
+    #[test]
+    fn test_rename_exchange_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        fs::create_dir(&a).unwrap();
+        fs::create_dir(&b).unwrap();
+        fs::write(a.join("file"), "from_a").unwrap();
+        fs::write(b.join("file"), "from_b").unwrap();
+
+        rename_exchange_dir(&a, &b).unwrap();
+
+        assert_eq!(fs::read_to_string(a.join("file")).unwrap(), "from_b");
+        assert_eq!(fs::read_to_string(b.join("file")).unwrap(), "from_a");
+    }
+}

--- a/sources/api/thar-be-registries/src/registry.rs
+++ b/sources/api/thar-be-registries/src/registry.rs
@@ -1,0 +1,81 @@
+//! Registry parsing and naming logic.
+
+use url::Url;
+
+use crate::error::{ParseRegistrySnafu, Result};
+
+pub(crate) const DOCKER_HUB_HOST: &str = "docker.io";
+pub(crate) const DOCKER_HUB_REGISTRY: &str = "registry-1.docker.io";
+
+/// Parse registry string, extracting host:port and optional scheme.
+/// Works with full URLs (https://docker.io) or bare hostnames (docker.io, registry:5000).
+/// Defaults to https scheme when none is provided.
+pub(crate) fn parse_registry(registry: &str) -> Result<(String, String)> {
+    // Try parsing as-is first (handles URLs with scheme like https://docker.io)
+    // Only accept if it has a host (registry:5000 parses as scheme with no host)
+    if let Ok(url) = Url::parse(registry) {
+        if let Some(host) = url.host_str() {
+            return Ok((format_host_port(host, url.port()), url.scheme().to_string()));
+        }
+    }
+
+    // Parse bare hostname with https:// prefix (handles docker.io or registry:5000)
+    if let Ok(url) = Url::parse(&format!("https://{}", registry)) {
+        if let Some(host) = url.host_str() {
+            return Ok((format_host_port(host, url.port()), "https".to_string()));
+        }
+    }
+
+    ParseRegistrySnafu { registry }.fail()
+}
+
+/// Encode registry name to directory name, replacing `:port` with `_port_`.
+/// The trailing underscore matches containerd's [`hostDirectory()`] encoding,
+/// which uses this format to avoid ambiguity with hostnames containing underscores.
+///
+/// [`hostDirectory()`]: https://github.com/containerd/containerd/blob/b668614b55183acee713ffabdbaa61843d631d0a/core/remotes/docker/config/hosts.go
+pub(crate) fn encode_registry_name(name: &str) -> String {
+    if name == "*" {
+        return "_default".to_string();
+    }
+    if let Some(idx) = name.rfind(':') {
+        format!("{}_{}_", &name[..idx], &name[idx + 1..])
+    } else {
+        name.to_string()
+    }
+}
+
+/// Format host with optional port
+pub(crate) fn format_host_port(host: &str, port: Option<u16>) -> String {
+    match port {
+        Some(p) => format!("{}:{}", host, p),
+        None => host.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    // encode_registry_name tests
+    #[test_case("*", "_default"; "wildcard maps to default")]
+    #[test_case("docker.io", "docker.io"; "no port unchanged")]
+    #[test_case("gcr.io", "gcr.io"; "gcr unchanged")]
+    #[test_case("registry.example.com:5000", "registry.example.com_5000_"; "port encoded")]
+    fn test_encode_registry_name(input: &str, expected: &str) {
+        assert_eq!(encode_registry_name(input), expected);
+    }
+
+    // parse_registry tests
+    #[test_case("*", "*", "https"; "wildcard")]
+    #[test_case("docker.io", "docker.io", "https"; "bare hostname")]
+    #[test_case("registry.example.com:5000", "registry.example.com:5000", "https"; "hostname with port")]
+    #[test_case("https://docker.io", "docker.io", "https"; "https url")]
+    #[test_case("http://registry.local:5000", "registry.local:5000", "http"; "http url with port")]
+    fn test_parse_registry(input: &str, expected_host: &str, expected_scheme: &str) {
+        let (host, scheme) = parse_registry(input).unwrap();
+        assert_eq!(host, expected_host);
+        assert_eq!(scheme, expected_scheme);
+    }
+}

--- a/sources/api/thar-be-registries/src/settings.rs
+++ b/sources/api/thar-be-registries/src/settings.rs
@@ -1,0 +1,73 @@
+//! Input configuration types and deserialization.
+
+use serde::Deserialize;
+use snafu::ResultExt;
+use std::fs;
+
+use crate::error::{ParseSettingsSnafu, ReadSettingsSnafu, Result};
+
+/// Container registry settings
+#[derive(Deserialize)]
+pub(crate) struct Settings {
+    pub(crate) mirrors: Option<Vec<Mirror>>,
+    pub(crate) credentials: Option<Vec<Credential>>,
+}
+
+/// Registry mirror configuration
+#[derive(Deserialize)]
+pub(crate) struct Mirror {
+    pub(crate) registry: String,
+    pub(crate) endpoint: Vec<String>,
+}
+
+/// Registry authentication credentials
+#[derive(Deserialize)]
+pub(crate) struct Credential {
+    pub(crate) registry: String,
+    pub(crate) username: Option<String>,
+    pub(crate) password: Option<String>,
+    pub(crate) auth: Option<String>,
+    pub(crate) identitytoken: Option<String>,
+}
+
+/// Read and parse settings from TOML file
+pub(crate) fn read_settings(path: &str) -> Result<Settings> {
+    let contents = fs::read_to_string(path).context(ReadSettingsSnafu { path })?;
+    toml::from_str(&contents).context(ParseSettingsSnafu { path })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+    use test_case::test_case;
+
+    // Settings schema tests
+    #[test_case(r#"[[mirrors]]
+ registry = "docker.io"
+ endpoint = ["https://mirror.example.com"]"#, true, false; "mirrors only")]
+    #[test_case(r#"[[credentials]]
+ registry = "r.io"
+ username = "u"
+ password = "p""#, false, true; "credentials only")]
+    fn test_settings_schema(toml_str: &str, has_mirrors: bool, has_creds: bool) {
+        let settings: Settings = toml::from_str(toml_str).unwrap();
+        assert_eq!(settings.mirrors.is_some(), has_mirrors);
+        assert_eq!(settings.credentials.is_some(), has_creds);
+    }
+
+    #[test]
+    fn test_read_settings_file_not_found() {
+        let result = read_settings("/nonexistent/path/to/file.toml");
+        assert!(matches!(result, Err(Error::ReadSettings { .. })));
+    }
+
+    #[test]
+    fn test_read_settings_invalid_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("invalid.toml");
+        std::fs::write(&path, "this is not valid toml [[[").unwrap();
+        let result = read_settings(path.to_str().unwrap());
+        assert!(matches!(result, Err(Error::ParseSettings { .. })));
+    }
+}


### PR DESCRIPTION
**Issue number:**
Related: bottlerocket-os/bottlerocket/issues/1963

**Description of changes:**
Add a helper to render `settings.container-registry` into containerd's "new" hosts.toml format.

Since that format doesn't support credentials, write any credentials to our own credentials.toml file, and patch containerd's transfer service to use that as a fallback source.

Remove the container registry settings from the containerd and Docker templates that include them, since we now rely on the transfer service to handle this.


**Testing done:**
<details>

<summary>Credentials used for DockerHub</summary>

```
bash-5.3# apiclient apply <<EOF
> [[settings.container-registry.credentials]]
registry = "docker.io"
auth = "..."
> EOF

bash-5.3# find /etc/containerd/certs.d/
/etc/containerd/certs.d/
/etc/containerd/certs.d/registry-1.docker.io
/etc/containerd/certs.d/registry-1.docker.io/credentials.toml

bash-5.3# docker pull amazonlinux:2023
...
Feb 04 22:50:29 ip-10-0-60-129.us-west-2.compute.internal containerd[1692]: time="2026-02-04T22:50:29.102648887Z" level=debug msg="fetch response received" host=registry-1.docker.io response.header.connection=keep-alive response.header.content-length=162 response.header.content-type=application/json response.header.date="Wed, 04 Feb 2026 22:50:29 GMT" response.header.docker-distribution-api-version=registry/2.0 response.header.docker-ratelimit-source=44.232.127.182 response.header.strict-transport-security="max-age=31536000" response.header.www-authenticate="Bearer realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\",scope=\"repository:library/amazonlinux:pull\"" response.status="401 Unauthorized" url="https://registry-1.docker.io/v2/library/amazonlinux/manifests/2023"
Feb 04 22:50:29 ip-10-0-60-129.us-west-2.compute.internal containerd[1692]: time="2026-02-04T22:50:29.102672128Z" level=debug msg=Unauthorized header="Bearer realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\",scope=\"repository:library/amazonlinux:pull\"" host=registry-1.docker.io
Feb 04 22:50:29 ip-10-0-60-129.us-west-2.compute.internal containerd[1692]: time="2026-02-04T22:50:29.103346427Z" level=debug msg="using fallback credentials (auth)" path=/etc/docker/certs.d/registry-1.docker.io/credentials.toml

```

</details>

<details>
<summary>Mirror used for DockerHub, credentials used for ECR</summary>

```
bash-5.3# apiclient apply <<EOF
[[settings.container-registry.credentials]]
registry = "863599026182.dkr.ecr.us-west-2.amazonaws.com"
username = "AWS"
password = "..."

[[settings.container-registry.mirrors]]
registry = "docker.io"
endpoint = ["https://863599026182.dkr.ecr.us-west-2.amazonaws.com/v2/docker-hub"]
EOF

bash-5.3# find /etc/containerd/certs.d/
/etc/containerd/certs.d/
/etc/containerd/certs.d/863599026182.dkr.ecr.us-west-2.amazonaws.com
/etc/containerd/certs.d/863599026182.dkr.ecr.us-west-2.amazonaws.com/credentials.toml
/etc/containerd/certs.d/docker.io
/etc/containerd/certs.d/docker.io/hosts.toml

bash-5.3# cat /etc/containerd/certs.d/docker.io/hosts.toml
server = "https://registry-1.docker.io"
[host."https://863599026182.dkr.ecr.us-west-2.amazonaws.com/v2/docker-hub"]
capabilities = ["pull", "resolve"]
override_path = true

bash-5.3# docker pull amazonlinux:2
...
Feb 04 22:58:28 ip-10-0-60-129.us-west-2.compute.internal containerd[1692]: time="2026-02-04T22:58:28.405876687Z" level=debug msg="loading host directory" dir=/etc/docker/certs.d/docker.io
Feb 04 22:58:28 ip-10-0-60-129.us-west-2.compute.internal containerd[1692]: time="2026-02-04T22:58:28.405954656Z" level=debug msg=resolving host=863599026182.dkr.ecr.us-west-2.amazonaws.com
Feb 04 22:58:28 ip-10-0-60-129.us-west-2.compute.internal containerd[1692]: time="2026-02-04T22:58:28.405967609Z" level=debug msg="do request" host=863599026182.dkr.ecr.us-west-2.amazonaws.com request.header.accept="application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, */*" request.header.user-agent=containerd/2.1.6+bottlerocket request.method=HEAD url="https://863599026182.dkr.ecr.us-west-2.amazonaws.com/v2/docker-hub/library/amazonlinux/manifests/2?ns=docker.io"
Feb 04 22:58:28 ip-10-0-60-129.us-west-2.compute.internal containerd[1692]: time="2026-02-04T22:58:28.413445017Z" level=debug msg="fetch response received" host=863599026182.dkr.ecr.us-west-2.amazonaws.com response.header.content-length=15 response.header.content-type="text/plain; charset=utf-8" response.header.date="Wed, 04 Feb 2026 22:58:28 GMT" response.header.docker-distribution-api-version=registry/2.0 response.header.sizes= response.header.www-authenticate="Basic realm=\"https://863599026182.dkr.ecr.us-west-2.amazonaws.com/\",service=\"ecr.amazonaws.com\"" response.status="401 Unauthorized" url="https://863599026182.dkr.ecr.us-west-2.amazonaws.com/v2/docker-hub/library/amazonlinux/manifests/2?ns=docker.io"
Feb 04 22:58:28 ip-10-0-60-129.us-west-2.compute.internal containerd[1692]: time="2026-02-04T22:58:28.413464901Z" level=debug msg=Unauthorized header="Basic realm=\"https://863599026182.dkr.ecr.us-west-2.amazonaws.com/\",service=\"ecr.amazonaws.com\"" host=863599026182.dkr.ecr.us-west-2.amazonaws.com
Feb 04 22:58:28 ip-10-0-60-129.us-west-2.compute.internal containerd[1692]: time="2026-02-04T22:58:28.413790893Z" level=debug msg="using fallback credentials (username/password)" path=/etc/docker/certs.d/863599026182.dkr.ecr.us-west-2.amazonaws.com/credentials.toml
```

</details>



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
