### PR TITLE
Remove hugepages from reservedMemory rendering

### DIFF
--- a/packages/kubernetes-1.29/kubelet-config
+++ b/packages/kubernetes-1.29/kubelet-config
@@ -191,12 +191,6 @@ reservedMemory:
 {{#if this.memory}}
       memory: {{this.memory}}
 {{/if}}
-{{#if this.hugepages-1Gi}}
-      hugepages-1Gi: {{this.hugepages-1Gi}}
-{{/if}}
-{{#if this.hugepages-2Mi}}
-      hugepages-2Mi: {{this.hugepages-2Mi}}
-{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/packages/kubernetes-1.30/kubelet-config
+++ b/packages/kubernetes-1.30/kubelet-config
@@ -197,12 +197,6 @@ reservedMemory:
 {{#if this.memory}}
       memory: {{this.memory}}
 {{/if}}
-{{#if this.hugepages-1Gi}}
-      hugepages-1Gi: {{this.hugepages-1Gi}}
-{{/if}}
-{{#if this.hugepages-2Mi}}
-      hugepages-2Mi: {{this.hugepages-2Mi}}
-{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/packages/kubernetes-1.31/kubelet-config
+++ b/packages/kubernetes-1.31/kubelet-config
@@ -197,12 +197,6 @@ reservedMemory:
 {{#if this.memory}}
       memory: {{this.memory}}
 {{/if}}
-{{#if this.hugepages-1Gi}}
-      hugepages-1Gi: {{this.hugepages-1Gi}}
-{{/if}}
-{{#if this.hugepages-2Mi}}
-      hugepages-2Mi: {{this.hugepages-2Mi}}
-{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -197,12 +197,6 @@ reservedMemory:
 {{#if this.memory}}
       memory: {{this.memory}}
 {{/if}}
-{{#if this.hugepages-1Gi}}
-      hugepages-1Gi: {{this.hugepages-1Gi}}
-{{/if}}
-{{#if this.hugepages-2Mi}}
-      hugepages-2Mi: {{this.hugepages-2Mi}}
-{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -197,12 +197,6 @@ reservedMemory:
 {{#if this.memory}}
       memory: {{this.memory}}
 {{/if}}
-{{#if this.hugepages-1Gi}}
-      hugepages-1Gi: {{this.hugepages-1Gi}}
-{{/if}}
-{{#if this.hugepages-2Mi}}
-      hugepages-2Mi: {{this.hugepages-2Mi}}
-{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/packages/kubernetes-1.34/kubelet-config
+++ b/packages/kubernetes-1.34/kubelet-config
@@ -195,12 +195,6 @@ reservedMemory:
 {{#if this.memory}}
       memory: {{this.memory}}
 {{/if}}
-{{#if this.hugepages-1Gi}}
-      hugepages-1Gi: {{this.hugepages-1Gi}}
-{{/if}}
-{{#if this.hugepages-2Mi}}
-      hugepages-2Mi: {{this.hugepages-2Mi}}
-{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/packages/kubernetes-1.35/kubelet-config
+++ b/packages/kubernetes-1.35/kubelet-config
@@ -195,12 +195,6 @@ reservedMemory:
 {{#if this.memory}}
       memory: {{this.memory}}
 {{/if}}
-{{#if this.hugepages-1Gi}}
-      hugepages-1Gi: {{this.hugepages-1Gi}}
-{{/if}}
-{{#if this.hugepages-2Mi}}
-      hugepages-2Mi: {{this.hugepages-2Mi}}
-{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related https://github.com/bottlerocket-os/bottlerocket/issues/4754

**Description of changes:**

Removes `hugepages-1Gi` and `hugepages-2Mi` from kubelet reservedMemory template rendering.

Kubelet rejects hugepages in reservedMemory - it's not a recognized reservable resource in kubeReserved. Memory Manager requires `reservedMemory = kubeReserved + systemReserved + evictionHard` exactly, so specifying hugepages causes initialization failure:


Failed to initialize memory manager" err="the total amount \"10Mi\" of type \
"hugepages-2Mi\" is not equal to the value \"0\" determined by Node Allocatable
feature

**Testing done:**

Launched instance with userdata
```
[settings.kubernetes.memory-manager-reserved-memory.0]
enabled = true
memory = "674Mi"
"hugepages-2Mi": "10Mi"

[settings.kernel.sysctl]
"vm.nr_hugepages" = "10"

```

There is no longer failure like
```
err="failed to run Kubelet: the total amount \"10Mi\" of type \"hugepages-2Mi\" is not equal to the value \"0\" determined by Node Allocatable feature"
```

kubelet started successfully.

Node joined the cluster with `Ready` status.
```
k get nodes
NAME                                           STATUS   ROLES    AGE    VERSION
ip-192-168-16-31.us-west-2.compute.internal    Ready    <none>   21m    v1.34.3-eks-3c60543
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.