### PR TITLE
fixes for ephemeral storage

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "fs2",
  "generate-readme",
  "http 0.2.12",
+ "indexmap",
  "libc",
  "log",
  "maplit",

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -21,6 +21,7 @@ datastore.workspace = true
 envy.workspace = true
 fs2.workspace = true
 http.workspace = true
+indexmap.workspace = true
 libc.workspace = true
 log.workspace = true
 models.workspace = true

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -17,6 +17,7 @@ static MKFSEXT4: &str = "/usr/sbin/mkfs.ext4";
 static FINDMNT: &str = "/usr/bin/findmnt";
 
 static EPHEMERAL_MNT: &str = "/mnt/.ephemeral";
+static SRV_DIR: &str = "/srv";
 
 /// Name of the device and its path from the MD driver
 static RAID_DEVICE_DIR: &str = "/dev/md/";
@@ -170,7 +171,7 @@ pub fn initialize(
     Ok(())
 }
 
-/// binds the specified directories to the pre-configured array, creating those directories if
+/// Binds the specified directories to the pre-configured array, creating those directories if
 /// they do not exist.
 pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
     let device_name = EPHEMERAL_STORAGE_LINK;
@@ -243,8 +244,9 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
 
     let dirs: Vec<OsString> = dirs.iter().map(OsString::from).collect();
     let mut dirs_to_bind = HashSet::new();
+    let mut dirs_to_mask = HashSet::new();
 
-    // Check which directories need binding
+    // Check which directories need binding and/or masking
     for target_dir in &dirs {
         // Transform the directory path to a unique name
         let source_subdir = transform_dir_name(target_dir);
@@ -256,9 +258,19 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         })?;
         std::fs::create_dir_all(target_dir).context(error::MkdirSnafu { dir: target_dir })?;
 
+        let is_source_masked = is_masked(&source_dir)?;
         let is_target_mounted = is_mounted(target_dir)?;
-        if !is_target_mounted {
-            dirs_to_bind.insert((source_dir.clone(), target_dir.clone()));
+
+        match (is_target_mounted, is_source_masked) {
+            (true, true) => continue,
+            (true, false) => {
+                dirs_to_mask.insert(source_dir.into());
+            }
+            (false, false) => {
+                dirs_to_bind.insert((source_dir.clone(), target_dir.clone()));
+                dirs_to_mask.insert(source_dir.into_os_string());
+            }
+            (false, true) => error::DirectoryAlreadyMaskedSnafu { dir: source_dir }.fail()?,
         }
     }
 
@@ -284,6 +296,29 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
             error::BindDirectoryFailureSnafu {
                 source_dir,
                 target_dir,
+                output,
+            }
+        );
+    }
+
+    // Mask source directories that need it
+    for source_dir in &dirs_to_mask {
+        info!("masking {}", source_dir.display());
+        let output = Command::new(MOUNT)
+            .args([
+                OsStr::new("--bind"),
+                OsStr::new("--options"),
+                OsStr::new("nosuid,nodev,noexec,private"),
+                OsStr::new(SRV_DIR),
+                source_dir,
+            ])
+            .output()
+            .context(error::ExecutionFailureSnafu { command: MOUNT })?;
+
+        ensure!(
+            output.status.success(),
+            error::MaskDirectorySnafu {
+                dir: source_dir,
                 output,
             }
         );
@@ -323,6 +358,24 @@ fn is_mounted(path: impl AsRef<OsStr>) -> Result<bool> {
         .status()
         .context(error::FindMntFailureSnafu {})?;
     Ok(status.success())
+}
+
+/// is_masked returns true if the specified path is already masked
+fn is_masked(path: impl AsRef<OsStr>) -> Result<bool> {
+    let output = Command::new(FINDMNT)
+        .args([OsStr::new("-no"), OsStr::new("SOURCE")])
+        .arg(&path)
+        .output()
+        .context(error::CheckMaskSnafu { dir: &path })?;
+
+    // Check if the command was successful and if the output contains "[/srv]"
+    if output.status.success() {
+        let source = String::from_utf8_lossy(&output.stdout);
+        Ok(source.trim().ends_with(&format!("[{SRV_DIR}]")))
+    } else {
+        // If the command failed, the path is not mounted at all
+        Ok(false)
+    }
 }
 
 /// creates the array with the given name from the specified disks
@@ -625,6 +678,20 @@ pub mod error {
             args: String,
             output: std::process::Output,
         },
+        #[snafu(display("Failed to check if directory '{}' is masked: {}", dir.display(), source))]
+        CheckMask {
+            dir: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to mask directory '{}': {}", dir.display(), String::from_utf8_lossy(output.stderr.as_slice())))]
+        MaskDirectory {
+            dir: PathBuf,
+            output: std::process::Output,
+        },
+
+        #[snafu(display("Cannot bind directory '{}': directory is masked", dir.display()))]
+        DirectoryAlreadyMasked { dir: PathBuf },
     }
 }
 

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -220,7 +220,12 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         std::fs::create_dir_all(EPHEMERAL_MNT).context(error::MkdirSnafu { dir: EPHEMERAL_MNT })?;
         info!("mounting {device_name} as {EPHEMERAL_MNT}");
         let output = Command::new(MOUNT)
-            .args([OsString::from(device_name), OsString::from(EPHEMERAL_MNT)])
+            .args([
+                OsString::from(device_name),
+                OsString::from(EPHEMERAL_MNT),
+                OsString::from("--options"),
+                OsString::from("defaults,nosuid,nodev,noatime,private"),
+            ])
             .output()
             .context(error::ExecutionFailureSnafu { command: MOUNT })?;
 

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -6,7 +6,7 @@ use snafu::{ensure, ResultExt};
 use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
 use std::fs;
-use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 static MOUNT: &str = "/usr/bin/mount";
@@ -16,11 +16,13 @@ static MKFSXFS: &str = "/usr/sbin/mkfs.xfs";
 static MKFSEXT4: &str = "/usr/sbin/mkfs.ext4";
 static FINDMNT: &str = "/usr/bin/findmnt";
 
-/// Name of the array (if created) and filesystem label. Selected to be 12 characters so it
-/// fits within both the xfs and ext4 volume label limit.
-static EPHEMERAL_MNT: &str = ".ephemeral";
+static EPHEMERAL_MNT: &str = "/mnt/.ephemeral";
+
 /// Name of the device and its path from the MD driver
 static RAID_DEVICE_DIR: &str = "/dev/md/";
+
+/// Name of the array (if created) and filesystem label. Selected to be 12 characters so it
+/// fits within both the xfs and ext4 volume label limit.
 static RAID_DEVICE_NAME: &str = "ephemeral";
 /// Intermediate symlink for consistent rottweiler mapper naming
 static EPHEMERAL_DATA_LINK: &str = "/dev/disk/EPHEMERAL-DATA";
@@ -214,12 +216,11 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         )
     }
 
-    let mount_point = format!("/mnt/{EPHEMERAL_MNT}");
-    if !is_mounted(&mount_point)? {
-        std::fs::create_dir_all(&mount_point).context(error::MkdirSnafu { dir: &mount_point })?;
-        info!("mounting {device_name} as {mount_point}");
+    if !is_mounted(EPHEMERAL_MNT)? {
+        std::fs::create_dir_all(EPHEMERAL_MNT).context(error::MkdirSnafu { dir: EPHEMERAL_MNT })?;
+        info!("mounting {device_name} as {EPHEMERAL_MNT}");
         let output = Command::new(MOUNT)
-            .args([OsString::from(device_name), OsString::from(&mount_point)])
+            .args([OsString::from(device_name), OsString::from(EPHEMERAL_MNT)])
             .output()
             .context(error::ExecutionFailureSnafu { command: MOUNT })?;
 
@@ -227,21 +228,20 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
             output.status.success(),
             error::MountArrayFailureSnafu {
                 what: device_name,
-                dest: &mount_point,
+                dest: EPHEMERAL_MNT,
                 output
             }
         );
     } else {
-        info!("device already mounted at {mount_point}, skipping mount");
+        info!("device already mounted at {EPHEMERAL_MNT}, skipping mount");
     }
 
-    let mount_point = Path::new(&mount_point);
     for dir in &dirs {
         // construct a directory name (E.g. /var/lib/kubelet => ._var_lib_kubelet) that will be
         // unique between the binding targets
         let mut directory_name = dir.replace('/', "_");
         directory_name.insert(0, '.');
-        let mount_destination = mount_point.join(&directory_name);
+        let mount_destination: PathBuf = [EPHEMERAL_MNT, &directory_name].iter().collect();
 
         // we may run before the directories we are binding exist, so create them
         std::fs::create_dir_all(dir).context(error::MkdirSnafu { dir })?;
@@ -298,10 +298,10 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-/// is_bound returns true if the specified path is already listed as a mount
-fn is_mounted(path: &String) -> Result<bool> {
+/// is_mounted returns true if the specified path is already listed as a mount
+fn is_mounted(path: impl AsRef<OsStr>) -> Result<bool> {
     let status = Command::new(FINDMNT)
-        .arg(OsString::from(path))
+        .arg(path)
         .status()
         .context(error::FindMntFailureSnafu {})?;
     Ok(status.success())

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -2,6 +2,7 @@
 
 use model::ephemeral_storage::{Filesystem, Preference};
 
+use indexmap::IndexSet;
 use snafu::{ensure, ResultExt};
 use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
@@ -243,7 +244,7 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
     }
 
     let dirs: Vec<OsString> = dirs.iter().map(OsString::from).collect();
-    let mut dirs_to_bind = HashSet::new();
+    let mut dirs_to_bind = IndexSet::new();
     let mut dirs_to_mask = HashSet::new();
 
     // Check which directories need binding and/or masking
@@ -252,11 +253,10 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         let source_subdir = transform_dir_name(target_dir);
         let source_dir: PathBuf = [EPHEMERAL_MNT, &source_subdir].iter().collect();
 
-        // we may run before the directories we are binding exist, so create them
+        // Create the source directory now, since there's no chance of mounting over it.
         std::fs::create_dir_all(&source_dir).context(error::MkdirSnafu {
             dir: source_dir.clone(),
         })?;
-        std::fs::create_dir_all(target_dir).context(error::MkdirSnafu { dir: target_dir })?;
 
         let is_source_masked = is_masked(&source_dir)?;
         let is_target_mounted = is_mounted(target_dir)?;
@@ -274,6 +274,9 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         }
     }
 
+    // Sort to ensure parent directories are mounted before children
+    dirs_to_bind.sort();
+
     // Perform bind mounts for directories that need it
     for (source_dir, target_dir) in &dirs_to_bind {
         info!(
@@ -281,6 +284,10 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
             source_dir.display(),
             target_dir.display(),
         );
+
+        // Create the target directory now, in case we mounted one of its parent directories in a
+        // previous iteration.
+        std::fs::create_dir_all(target_dir).context(error::MkdirSnafu { dir: target_dir })?;
 
         let output = Command::new(MOUNT)
             .args([

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -533,6 +533,11 @@ fn should_encrypt() -> Result<bool> {
 fn encrypt_ephemeral_device(device: &str) -> Result<String> {
     info!("encrypting ephemeral device {device:?}");
 
+    // Clear previous link if it exists
+    if std::fs::exists(EPHEMERAL_DATA_LINK).is_ok_and(|x| x) {
+        std::fs::remove_file(EPHEMERAL_DATA_LINK).context(error::DiskUnlinkFailureSnafu {})?;
+    }
+
     // Create intermediate symlink for rottweiler to use
     // This ensures consistent mapper name: /dev/mapper/EPHEMERAL-DATA
     std::os::unix::fs::symlink(device, EPHEMERAL_DATA_LINK)

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -216,7 +216,7 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
 
     let mount_point = format!("/mnt/{EPHEMERAL_MNT}");
     if !is_mounted(&mount_point)? {
-        std::fs::create_dir_all(&mount_point).context(error::MkdirSnafu {})?;
+        std::fs::create_dir_all(&mount_point).context(error::MkdirSnafu { dir: &mount_point })?;
         info!("mounting {device_name} as {mount_point}");
         let output = Command::new(MOUNT)
             .args([OsString::from(device_name), OsString::from(&mount_point)])
@@ -244,8 +244,10 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         let mount_destination = mount_point.join(&directory_name);
 
         // we may run before the directories we are binding exist, so create them
-        std::fs::create_dir_all(dir).context(error::MkdirSnafu {})?;
-        std::fs::create_dir_all(&mount_destination).context(error::MkdirSnafu {})?;
+        std::fs::create_dir_all(dir).context(error::MkdirSnafu { dir })?;
+        std::fs::create_dir_all(&mount_destination).context(error::MkdirSnafu {
+            dir: &mount_destination,
+        })?;
 
         if is_mounted(dir)? {
             info!("skipping bind mount of {dir:?}, already mounted");
@@ -268,7 +270,8 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         ensure!(
             output.status.success(),
             error::BindDirectoryFailureSnafu {
-                dir: String::from_utf8_lossy(source_dir.as_encoded_bytes()),
+                source_dir,
+                target_dir: mount_destination,
                 output,
             }
         );
@@ -286,7 +289,7 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         ensure!(
             output.status.success(),
             error::ShareMountsFailureSnafu {
-                dir: String::from_utf8_lossy(source_dir.as_encoded_bytes()),
+                dir: source_dir,
                 output
             }
         );
@@ -527,6 +530,7 @@ fn run_rottweiler_checked(args: &[&str], device: &str) -> Result<()> {
 
 pub mod error {
     use snafu::Snafu;
+    use std::{ffi::OsString, path::PathBuf};
 
     #[derive(Debug, Snafu)]
     #[snafu(visibility(pub(super)))]
@@ -556,15 +560,16 @@ pub mod error {
         #[snafu(display("Failed to create disk symlink {}", source))]
         DiskSymlinkFailure { source: std::io::Error },
 
-        #[snafu(display("Failed to bind directory {}: {}", dir, String::from_utf8_lossy(output.stderr.as_slice())))]
+        #[snafu(display("Failed to bind directory '{}' to '{}': {}", source_dir.display(), target_dir.display(), String::from_utf8_lossy(output.stderr.as_slice())))]
         BindDirectoryFailure {
-            dir: String,
+            source_dir: OsString,
+            target_dir: OsString,
             output: std::process::Output,
         },
 
-        #[snafu(display("Failed to share mounts for directory {} : {}", dir, String::from_utf8_lossy(output.stderr.as_slice())))]
+        #[snafu(display("Failed to share mounts for directory {} : {}", dir.display(), String::from_utf8_lossy(output.stderr.as_slice())))]
         ShareMountsFailure {
-            dir: String,
+            dir: PathBuf,
             output: std::process::Output,
         },
 
@@ -586,8 +591,11 @@ pub mod error {
         #[snafu(display("Invalid Parameter '{}', {}", parameter, reason))]
         InvalidParameter { parameter: String, reason: String },
 
-        #[snafu(display("Failed to create directory, {}", source))]
-        Mkdir { source: std::io::Error },
+        #[snafu(display("Failed to create directory '{}': {}", dir.display(), source))]
+        Mkdir {
+            source: std::io::Error,
+            dir: PathBuf,
+        },
 
         #[snafu(display("Unable to load image features: {}", message))]
         LoadImageFeatures { message: String },

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -236,33 +236,40 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         info!("device already mounted at {EPHEMERAL_MNT}, skipping mount");
     }
 
-    for dir in &dirs {
-        // construct a directory name (E.g. /var/lib/kubelet => ._var_lib_kubelet) that will be
-        // unique between the binding targets
-        let mut directory_name = dir.replace('/', "_");
-        directory_name.insert(0, '.');
-        let mount_destination: PathBuf = [EPHEMERAL_MNT, &directory_name].iter().collect();
+    let dirs: Vec<OsString> = dirs.iter().map(OsString::from).collect();
+    let mut dirs_to_bind = HashSet::new();
+
+    // Check which directories need binding
+    for target_dir in &dirs {
+        // Transform the directory path to a unique name
+        let source_subdir = transform_dir_name(target_dir);
+        let source_dir: PathBuf = [EPHEMERAL_MNT, &source_subdir].iter().collect();
 
         // we may run before the directories we are binding exist, so create them
-        std::fs::create_dir_all(dir).context(error::MkdirSnafu { dir })?;
-        std::fs::create_dir_all(&mount_destination).context(error::MkdirSnafu {
-            dir: &mount_destination,
+        std::fs::create_dir_all(&source_dir).context(error::MkdirSnafu {
+            dir: source_dir.clone(),
         })?;
+        std::fs::create_dir_all(target_dir).context(error::MkdirSnafu { dir: target_dir })?;
 
-        if is_mounted(dir)? {
-            info!("skipping bind mount of {dir:?}, already mounted");
-            continue;
+        let is_target_mounted = is_mounted(target_dir)?;
+        if !is_target_mounted {
+            dirs_to_bind.insert((source_dir.clone(), target_dir.clone()));
         }
-        // call the equivalent of
-        // mount --rbind /mnt/.ephemeral/._var_lib_kubelet /var/lib/kubelet
-        let source_dir = OsString::from(&dir);
-        info!("binding {source_dir:?} to {mount_destination:?}");
+    }
+
+    // Perform bind mounts for directories that need it
+    for (source_dir, target_dir) in &dirs_to_bind {
+        info!(
+            "binding '{}' to '{}'",
+            source_dir.display(),
+            target_dir.display(),
+        );
 
         let output = Command::new(MOUNT)
             .args([
                 OsStr::new("--rbind"),
-                mount_destination.as_ref(),
-                &source_dir,
+                source_dir.as_ref(),
+                target_dir.as_ref(),
             ])
             .output()
             .context(error::ExecutionFailureSnafu { command: MOUNT })?;
@@ -271,31 +278,37 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
             output.status.success(),
             error::BindDirectoryFailureSnafu {
                 source_dir,
-                target_dir: mount_destination,
+                target_dir,
                 output,
             }
         );
     }
 
-    for dir in dirs {
-        let source_dir = OsString::from(&dir);
-        info!("sharing mounts for {source_dir:?}");
-        // mount --make-rshared /var/lib/kubelet
+    // Make mounts shared
+    for target_dir in &dirs {
+        info!("sharing mounts for {}", target_dir.display());
         let output = Command::new(MOUNT)
-            .args([OsStr::new("--make-rshared"), &source_dir])
+            .args([OsStr::new("--make-rshared"), target_dir])
             .output()
             .context(error::ExecutionFailureSnafu { command: MOUNT })?;
 
         ensure!(
             output.status.success(),
             error::ShareMountsFailureSnafu {
-                dir: source_dir,
+                dir: target_dir,
                 output
             }
         );
     }
 
     Ok(())
+}
+
+/// Transform a directory path into a unique name suitable for use as a mount source
+pub fn transform_dir_name(dir: impl AsRef<OsStr>) -> String {
+    let mut directory_name = dir.as_ref().to_string_lossy().replace('/', "_");
+    directory_name.insert(0, '.');
+    directory_name
 }
 
 /// is_mounted returns true if the specified path is already listed as a mount
@@ -639,5 +652,20 @@ mod tests {
         for dir in ["/var/lib/docker", "/var/lib/containerd", "/var/log/ecs"] {
             assert!(allowed_dirs.allowed_exact.contains(dir));
         }
+    }
+
+    #[test]
+    fn test_transform_dir_name() {
+        // Test basic path transformation
+        assert_eq!(transform_dir_name("/var/lib/kubelet"), "._var_lib_kubelet");
+
+        // Test path with trailing slash
+        assert_eq!(transform_dir_name("/var/lib/docker/"), "._var_lib_docker_");
+
+        // Test root path
+        assert_eq!(transform_dir_name("/"), "._");
+
+        // Test empty string
+        assert_eq!(transform_dir_name(""), ".");
     }
 }


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Refactor the implementation for the ephemeral storage API and fix four problems.

`/mnt/ephemeral` was previously mounted without the "private" option, leading to mount amplification as every directory under `/var/lib/kubelet` would appear twice. Parsing mount information can be a bottleneck for `systemd` on busy systems. 

Mounting `/mnt/ephemeral` without the "private" option leads to another issue, which is that paths like `/mnt/ephemeral/._var_lib_kubelet` would show some of the same content as `/var/lib/kubelet`, but not all, because pod mounts will no longer propagate back to the parent. Rather than accept the inconsistency, we mount over the parent to "mask" it with a read-only mount and prevent it from being used as another way to view the content.

See also the notes in https://github.com/bottlerocket-os/bottlerocket/pull/2240 from when the same change was made for `/local` and `/var`.

#395 included a fix to make the API idempotent, but #721 introduced a regression when initializing encrypted storage. Fix that in the same way, by removing the symlink if it already exists.

Bind mounts might not happen in the correct order - parent directories before children. Sort bind mounts first to ensure this.

**Testing done:**
<details>

<summary>Mounts no longer propagate back to /mnt/ephemeral</summary>

Before:
```
bash-5.2# findmnt -R /mnt -o TARGET,PROPAGATION,OPTIONS
TARGET                                                                                                          PROPAGATION OPTIONS
/mnt                                                                                                            shared      rw,nosuid,nodev,noatime,seclabel,attr2,inod
`-/mnt/.ephemeral                                                                                               shared      rw,relatime,seclabel,attr2,inode64,logbufs=
  |-/mnt/.ephemeral/._var_lib_kubelet/pods/5bf2ab9e-e6c6-4e37-b90f-874cafaafd4c/volumes/kubernetes.io~projected/kube-api-access-46q8s
  |                                                                                                             shared      rw,relatime,seclabel,size=409600k,noswap
  |-/mnt/.ephemeral/._var_lib_kubelet/pods/82eae8b0-5a7a-4b7c-9437-b5961c5cde14/volumes/kubernetes.io~projected/kube-api-access-gtnh9
  |                                                                                                             shared      rw,relatime,seclabel,size=6933428k,noswap
  |-/mnt/.ephemeral/._var_lib_kubelet/pods/0a20da32-a3aa-4617-9f98-bd2057450f51/volumes/kubernetes.io~projected/kube-api-access-j29rg
```

After:
```
bash-5.2#  findmnt -R /mnt -o TARGET,PROPAGATION,OPTIONS
TARGET                                PROPAGATION OPTIONS                                                                                                              /mnt                                  shared      rw,nosuid,nodev,noatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,sunit=8,swidth=8,noquota
`-/mnt/.ephemeral                     private     rw,nosuid,nodev,noatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota
  |-/mnt/.ephemeral/._var_lib_kubelet private     ro,nosuid,nodev,noexec,relatime,seclabel,user_xattr,acl,cache_strategy=readaround                                      `-/mnt/.ephemeral/._var_log_pods    private     ro,nosuid,nodev,noexec,relatime,seclabel,user_xattr,acl,cache_strategy=readaround
```

</details>

<details>

<summary>Mounts have expected options</summary>

Before:
```
bash-5.2# findmnt /var/lib/kubelet/ -o TARGET,OPTIONS
TARGET           OPTIONS
/var/lib/kubelet rw,relatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota
```

After:
```
bash-5.2# findmnt /var/lib/kubelet/ -o TARGET,OPTIONS
TARGET           OPTIONS
/var/lib/kubelet rw,nosuid,nodev,noatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota
```

</details>

<details>

<summary>Init API is idempotent</summary>

Before:
```
bash-5.2# apiclient ephemeral-storage init
Failed to initialize ephemeral storage: Failed POST request to '/actions/ephemeral-storage/init': Status 500 when POSTing /actions/ephemeral-storage/init: Unable to initialize ephemeral storage: Failed to create disk symlink File exists (os error 17)
```

After (later boot phase, expected failure):
```
bash-5.2# apiclient ephemeral-storage init
Failed to initialize ephemeral storage: Failed POST request to '/actions/ephemeral-storage/init': Status 500 when POSTing /actions/ephemeral-storage/init: Unable to initialize ephemeral storage: Failed to run 'rottweiler' with args 'attach block-device /dev/disk/EPHEMERAL-DATA ephemeral-storage' on device '/dev/disk/EPHEMERAL-DATA': stdout: , stderr: Error: /usr/bin/systemd-creds failed with exit code 1: Failed to unseal secret using TPM2: Operation not permitted
```

After (same boot phase, success):
```
bash-5.3# apiclient ephemeral-storage init
bash-5.3# apiclient ephemeral-storage init
```

</details>

<details>

<summary>Parent directories mounted before children</summary>

Before:
```
bash-5.3# apiclient ephemeral-storage bind --dirs /mnt/foo/bar /mnt/foo
Failed to initialize ephemeral storage: Failed POST request to '/actions/ephemeral-storage/bind': Status 500 when POSTing /actions/ephemeral-storage/bind: Unable to bind ephemeral storage: Failed to bind directory '/mnt/.ephemeral/._mnt_foo_bar' to '/mnt/foo/bar': mount: /mnt/foo/bar: mount point does not exist.
```

After:
```
bash-5.3# apiclient ephemeral-storage bind --dirs /mnt/foo/bar/baz /mnt/foo /mnt/bar
bash-5.3# findmnt -R /mnt -o TARGET,SOURCE
TARGET                                SOURCE
/mnt                                  /dev/mapper/BOTTLEROCKET-DATA[/mnt]
├─/mnt/.ephemeral                     /dev/mapper/EPHEMERAL-DATA
│ ├─/mnt/.ephemeral/._mnt_foo         /dev/dm-0[/srv]
│ ├─/mnt/.ephemeral/._mnt_bar         /dev/dm-0[/srv]
│ └─/mnt/.ephemeral/._mnt_foo_bar_baz /dev/dm-0[/srv]
├─/mnt/bar                            /dev/mapper/EPHEMERAL-DATA[/._mnt_bar]
└─/mnt/foo                            /dev/mapper/EPHEMERAL-DATA[/._mnt_foo]
  └─/mnt/foo/bar/baz                  /dev/mapper/EPHEMERAL-DATA[/._mnt_foo_bar_baz]
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
