### PR TITLE
downgrade apiserver dependencies to Wants

### DIFF
--- a/packages/os/bootstrap-commands.service
+++ b/packages/os/bootstrap-commands.service
@@ -2,7 +2,8 @@
 Description=Bootstrap Commands
 # We depend on systemd-logind.service for running systemd-inhibit.
 After=systemd-logind.service settings-applier.service apiserver.service
-Requires=systemd-logind.service settings-applier.service apiserver.service
+Requires=settings-applier.service
+Wants=systemd-logind.service apiserver.service
 RefuseManualStart=true
 RefuseManualStop=true
 ConditionPathExists=/etc/bootstrap-commands/bootstrap-commands.toml

--- a/packages/release/measure-settings.service
+++ b/packages/release/measure-settings.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Measure Settings into PCR 8
 After=settings-applier.service apiserver.service tpm2.target
-Requires=settings-applier.service apiserver.service
+Requires=settings-applier.service
+Wants=apiserver.service
 Before=bootstrap-commands.service
 ConditionSecurity=tpm2
 RefuseManualStart=true


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
Otherwise, if `apiserver.service` ever restarts, systemd will restart many other services and targets in the boot sequence.

**Testing done:**
Before:
```
bash-5.2# systemctl restart apiserver
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopped target Multi-User System.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopping Multi-User System...
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: License files was skipped because of an unmet condition check (ConditionPathExists=/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/bottlerocket/licenses.squashfs).
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: activate-configured.service: Deactivated successfully.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopped Activate configured.target.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopping Activate configured.target...
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: activate-multi-user.service: Deactivated successfully.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopped Activate multi-user.target.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopping Activate multi-user.target...
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopped target Bottlerocket final configuration complete.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopping Bottlerocket final configuration complete...
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Starting Configure Snapshotter...
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: systemd-pcrphase-preconfigured.service: Deactivated successfully.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopped TPM PCR Barrier (Preconfigured).
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopping TPM PCR Barrier (Preconfigured)...
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopped target Bottlerocket initial configuration complete.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopping Bottlerocket initial configuration complete...
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: bootstrap-commands.service: Deactivated successfully.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopped Bootstrap Commands.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopping Bootstrap Commands...
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Send signal to CloudFormation Stack was skipped because of an unmet condition check (ConditionPathExists=!/var/lib/bottlerocket/cfsignal.ran).
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Disables UDP offload was skipped because of an unmet condition check (ConditionVirtualization=vmware).
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Load crash kernel was skipped because of an unmet condition check (ConditionKernelCommandLine=crashkernel).
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: measure-settings.service: Deactivated successfully.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopped Measure Settings into PCR 8.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopping Measure Settings into PCR 8...
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal apiserver[1610]: 22:21:20 [INFO] SIGTERM received; starting graceful shutdown
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal apiserver[1610]: 22:21:20 [INFO] shutting down idle worker
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopping Bottlerocket API server...
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal apiserver[1610]: 22:21:20 [INFO] accept thread stopped
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal (echo)[2646]: configure-snapshotter.service: Referenced but unset environment variable evaluates to an empty string: SELECTED_SNAPSHOTTER
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: configure-snapshotter.service: Skipped due to 'exec-condition'.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Condition check resulted in Configure Snapshotter being skipped.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: apiserver.service: Deactivated successfully.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Stopped Bottlerocket API server.
Feb 04 22:21:20 i-0e3dd210a318aeb41.us-west-2.compute.internal systemd[1]: Starting Bottlerocket API server..
```

After:
```
bash-5.2# systemctl restart apiserver
Feb 04 22:19:30 i-0860ee1725c5cf472.us-west-2.compute.internal apiserver[1627]: 22:19:30 [INFO] SIGTERM received; starting graceful shutdown
Feb 04 22:19:30 i-0860ee1725c5cf472.us-west-2.compute.internal apiserver[1627]: 22:19:30 [INFO] accept thread stopped
Feb 04 22:19:30 i-0860ee1725c5cf472.us-west-2.compute.internal apiserver[1627]: 22:19:30 [INFO] shutting down idle worker
Feb 04 22:19:30 i-0860ee1725c5cf472.us-west-2.compute.internal systemd[1]: Stopping Bottlerocket API server...
Feb 04 22:19:30 i-0860ee1725c5cf472.us-west-2.compute.internal systemd[1]: apiserver.service: Deactivated successfully.
Feb 04 22:19:30 i-0860ee1725c5cf472.us-west-2.compute.internal systemd[1]: Stopped Bottlerocket API server.
Feb 04 22:19:30 i-0860ee1725c5cf472.us-west-2.compute.internal systemd[1]: Starting Bottlerocket API server...
Feb 04 22:19:31 i-0860ee1725c5cf472.us-west-2.compute.internal apiserver[2938]: 22:19:31 [INFO] Starting server at /run/api.sock with 1 thread and datastore at /var/lib/bottlerocket/datastore/current
Feb 04 22:19:31 i-0860ee1725c5cf472.us-west-2.compute.internal systemd[1]: Started Bottlerocket API server.
Feb 04 22:19:31 i-0860ee1725c5cf472.us-west-2.compute.internal apiserver[2938]: 22:19:31 [INFO] starting 1 workers
Feb 04 22:19:31 i-0860ee1725c5cf472.us-west-2.compute.internal apiserver[2938]: 22:19:31 [INFO] Actix runtime found; starting in Actix runtime
Feb 04 22:19:31 i-0860ee1725c5cf472.us-west-2.compute.internal apiserver[2938]: 22:19:31 [INFO] starting service: "actix-web-service-"/run/api.sock"", workers: 1, listening on: "/run/api.sock" (pathname)
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
