### PR TITLE
netdog: Suppress IPv6 on interfaces with no IPv6 intent in net.toml

### DIFF
--- a/sources/netdog/src/cli/generate_net_config.rs
+++ b/sources/netdog/src/cli/generate_net_config.rs
@@ -79,7 +79,7 @@ fn write_network_config_files(net_config: Box<dyn Interfaces>, from_cmd_line: bo
         // be added to a single interface
         if from_cmd_line {
             if let NetworkDConfigFile::Network(ref mut n) = config {
-                n.accept_ra();
+                n.enable_ipv6();
                 n.disable_dad();
             }
         }

--- a/sources/netdog/src/networkd/config/network.rs
+++ b/sources/netdog/src/networkd/config/network.rs
@@ -247,10 +247,14 @@ impl NetworkConfig {
         }
     }
 
-    /// Add config to accept IPv6 router advertisements
+    /// Enable IPv6 link-local addressing, router advertisements, and DHCPv6
+    /// solicitation.
+    ///
+    /// Acts as the inverse of [`NetworkBuilder::disable_ipv6`].
     // TODO: expose a network config option for this
-    pub(crate) fn accept_ra(&mut self) {
+    pub(crate) fn enable_ipv6(&mut self) {
         self.network_mut().ipv6_accept_ra = Some(true);
+        self.network_mut().link_local_addressing = None;
         self.dhcp6_mut().without_ra = Some(WithoutRa::Solicit);
     }
 
@@ -578,6 +582,14 @@ where
         }
     }
 
+    /// Disable IPv6 link-local addressing and router advertisements.
+    ///
+    /// Acts as the inverse of [`NetworkConfig::enable_ipv6`].
+    pub(crate) fn disable_ipv6(&mut self) {
+        self.network.network_mut().link_local_addressing = Some(DhcpBool::Ipv4);
+        self.network.network_mut().ipv6_accept_ra = Some(false);
+    }
+
     /// Add a single static route
     pub(crate) fn with_route(&mut self, route: RouteV1) {
         let destination = match route.to {
@@ -652,7 +664,7 @@ where
 mod tests {
     use super::*;
     use crate::networkd::config::tests::{test_data, TestDevices, BUILDER_DATA};
-    use crate::networkd::devices::{NetworkDBond, NetworkDInterface, NetworkDVlan};
+    use crate::networkd::devices::{self, NetworkDBond, NetworkDInterface, NetworkDVlan};
 
     const FAKE_TEST_DIR: &str = "testdir";
 
@@ -661,6 +673,8 @@ mod tests {
     }
 
     fn network_from_interface(iface: NetworkDInterface) -> NetworkConfig {
+        // Absence of IPv6 config means disable IPv6 (see devices/interface.rs)
+        let disable_v6 = !devices::has_ipv6(&iface.dhcp6, &iface.static6);
         let mut network = NetworkBuilder::new_interface(iface.name);
         network.with_dhcp(iface.dhcp4, iface.dhcp6);
         if let Some(s) = iface.static4 {
@@ -672,10 +686,15 @@ mod tests {
         if let Some(r) = iface.routes {
             network.with_routes(r)
         }
+        if disable_v6 {
+            network.disable_ipv6();
+        }
         network.build()
     }
 
     fn network_from_vlan(vlan: NetworkDVlan) -> NetworkConfig {
+        // Absence of IPv6 config means disable IPv6 (see devices/vlan.rs)
+        let disable_v6 = !devices::has_ipv6(&vlan.dhcp6, &vlan.static6);
         let mut network = NetworkBuilder::new_vlan(vlan.name);
         network.with_dhcp(vlan.dhcp4, vlan.dhcp6);
         if let Some(s) = vlan.static4 {
@@ -687,10 +706,15 @@ mod tests {
         if let Some(r) = vlan.routes {
             network.with_routes(r)
         }
+        if disable_v6 {
+            network.disable_ipv6();
+        }
         network.build()
     }
 
     fn network_from_bond(bond: NetworkDBond) -> NetworkConfig {
+        // Absence of IPv6 config means disable IPv6 (see devices/bond.rs)
+        let disable_v6 = !devices::has_ipv6(&bond.dhcp6, &bond.static6);
         let mut network = NetworkBuilder::new_bond(bond.name.clone());
         network.with_dhcp(bond.dhcp4, bond.dhcp6);
         if let Some(s) = bond.static4 {
@@ -703,6 +727,9 @@ mod tests {
             network.with_routes(r)
         }
         network.with_bind_carrier(bond.interfaces);
+        if disable_v6 {
+            network.disable_ipv6();
+        }
         network.build()
     }
 

--- a/sources/netdog/src/networkd/devices/bond.rs
+++ b/sources/netdog/src/networkd/devices/bond.rs
@@ -89,6 +89,9 @@ impl NetworkFileCreator for NetworkDBond {
         if let Some(vlans) = vlans.get(name) {
             network.with_vlans(vlans.to_vec())
         }
+        if !super::has_ipv6(&self.dhcp6, &self.static6) {
+            network.disable_ipv6();
+        }
 
         configs.push(network.build());
 

--- a/sources/netdog/src/networkd/devices/interface.rs
+++ b/sources/netdog/src/networkd/devices/interface.rs
@@ -80,6 +80,9 @@ impl NetworkFileCreator for NetworkDInterface {
             if let Some(vlans) = attached_vlans {
                 network.with_vlans(vlans.to_vec())
             }
+            if !super::has_ipv6(&self.dhcp6, &self.static6) {
+                network.disable_ipv6();
+            }
 
             vec![network.build()]
         }

--- a/sources/netdog/src/networkd/devices/mod.rs
+++ b/sources/netdog/src/networkd/devices/mod.rs
@@ -11,6 +11,19 @@ pub(crate) use bond::NetworkDBond;
 pub(crate) use interface::NetworkDInterface;
 pub(crate) use vlan::NetworkDVlan;
 
+use crate::addressing::{Dhcp6ConfigV1, StaticConfigV1};
+
+/// Returns `true` if the device has any IPv6 configuration enabled
+/// (dhcp6 with enabled=true, or static6 addresses present).
+pub(crate) fn has_ipv6(dhcp6: &Option<Dhcp6ConfigV1>, static6: &Option<StaticConfigV1>) -> bool {
+    let dhcp6_enabled = match dhcp6 {
+        None => false,
+        Some(Dhcp6ConfigV1::DhcpEnabled(enabled)) => *enabled,
+        Some(Dhcp6ConfigV1::WithOptions(opts)) => opts.enabled,
+    };
+    dhcp6_enabled || static6.is_some()
+}
+
 pub(crate) enum NetworkDDevice {
     Interface(NetworkDInterface),
     Bond(NetworkDBond),

--- a/sources/netdog/src/networkd/devices/vlan.rs
+++ b/sources/netdog/src/networkd/devices/vlan.rs
@@ -70,6 +70,9 @@ impl NetworkFileCreator for NetworkDVlan {
         maybe_add_some!(network, with_static_config, static4);
         maybe_add_some!(network, with_static_config, static6);
         maybe_add_some!(network, with_routes, routes);
+        if !super::has_ipv6(&self.dhcp6, &self.static6) {
+            network.disable_ipv6();
+        }
 
         vec![network.build()]
     }

--- a/sources/netdog/src/networkd/mod.rs
+++ b/sources/netdog/src/networkd/mod.rs
@@ -191,10 +191,10 @@ mod tests {
                         path.display()
                     );
 
-                    // Add IPv6 `accept-ra` config to the interface, regenerate it, and ensure the
+                    // Add IPv6 config to the interface, regenerate it, and ensure the
                     // generated config contains the added IPv6 option
                     if let NetworkDConfigFile::Network(ref mut n) = config {
-                        n.accept_ra();
+                        n.enable_ipv6();
                     }
                     let generated = config.to_string();
                     let mut path = networkd_data()

--- a/sources/netdog/test_data/networkd/builder.toml
+++ b/sources/netdog/test_data/networkd/builder.toml
@@ -153,6 +153,13 @@ to = "3001:dead:beef::2/64"
 from = "2001:dead:beef::2"
 via = "2001:beef:beef::1"
 
+[[interface]]
+name = "eno22"
+dhcp4 = true
+[interface.dhcp6]
+enabled = false
+optional = true
+
 # Bonds and vlans
 [[vlan]]
 name = "myvlan"

--- a/sources/netdog/test_data/networkd/network/bond0.network
+++ b/sources/netdog/test_data/networkd/network/bond0.network
@@ -5,6 +5,8 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 BindCarrier=eno51
 BindCarrier=eno52

--- a/sources/netdog/test_data/networkd/network/bond1.network
+++ b/sources/netdog/test_data/networkd/network/bond1.network
@@ -5,6 +5,8 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 BindCarrier=eno53
 BindCarrier=eno54

--- a/sources/netdog/test_data/networkd/network/c874a4d53265.network
+++ b/sources/netdog/test_data/networkd/network/c874a4d53265.network
@@ -2,6 +2,8 @@
 PermanentMACAddress=c8:74:a4:d5:32:65
 [Network]
 Address=192.168.14.5/24
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 [Route]
 Destination=10.10.10.0/24
 Gateway=192.168.14.25

--- a/sources/netdog/test_data/networkd/network/eno1.network
+++ b/sources/netdog/test_data/networkd/network/eno1.network
@@ -4,6 +4,8 @@ Name=eno1
 RequiredForOnline=true
 [Network]
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/netdog/test_data/networkd/network/eno1001.network
+++ b/sources/netdog/test_data/networkd/network/eno1001.network
@@ -4,6 +4,8 @@ Name=eno1001
 RequiredForOnline=true
 [Network]
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 VLAN=vlancfgdev
 KeepConfiguration=dhcp
 [DHCPv4]

--- a/sources/netdog/test_data/networkd/network/eno11.network
+++ b/sources/netdog/test_data/networkd/network/eno11.network
@@ -2,3 +2,5 @@
 Name=eno11
 [Network]
 Address=192.168.14.2/24
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4

--- a/sources/netdog/test_data/networkd/network/eno12.network
+++ b/sources/netdog/test_data/networkd/network/eno12.network
@@ -2,6 +2,8 @@
 Name=eno12
 [Network]
 Address=10.0.0.9/24
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 [Route]
 Destination=10.10.10.0/24
 Gateway=10.0.0.1

--- a/sources/netdog/test_data/networkd/network/eno13.network
+++ b/sources/netdog/test_data/networkd/network/eno13.network
@@ -2,6 +2,8 @@
 Name=eno13
 [Network]
 Address=192.168.14.2/24
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 [Route]
 Destination=9.9.0.0/16
 Gateway=192.168.1.1

--- a/sources/netdog/test_data/networkd/network/eno14.network
+++ b/sources/netdog/test_data/networkd/network/eno14.network
@@ -3,6 +3,8 @@ Name=eno14
 [Network]
 Address=10.0.0.10/24
 Address=11.0.0.11/24
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 [Route]
 Destination=0.0.0.0/0
 Gateway=10.0.0.1

--- a/sources/netdog/test_data/networkd/network/eno18.network
+++ b/sources/netdog/test_data/networkd/network/eno18.network
@@ -6,6 +6,8 @@ RequiredForOnline=true
 Address=10.0.0.10/24
 Address=11.0.0.11/24
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/netdog/test_data/networkd/network/eno20.network
+++ b/sources/netdog/test_data/networkd/network/eno20.network
@@ -2,6 +2,8 @@
 Name=eno20
 [Network]
 Address=192.168.14.5/24
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 [Route]
 Destination=10.10.10.0/24
 Gateway=192.168.14.25

--- a/sources/netdog/test_data/networkd/network/eno22.network
+++ b/sources/netdog/test_data/networkd/network/eno22.network
@@ -1,5 +1,5 @@
 [Match]
-Name=eno3
+Name=eno22
 [Link]
 RequiredForOnline=true
 RequiredFamilyForOnline=ipv4

--- a/sources/netdog/test_data/networkd/network/eno6.network
+++ b/sources/netdog/test_data/networkd/network/eno6.network
@@ -5,6 +5,8 @@ RequiredForOnline=true
 RequiredFamilyForOnline=ipv4
 [Network]
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 [DHCPv4]
 RouteMetric=100

--- a/sources/netdog/test_data/networkd/network/eno9.network
+++ b/sources/netdog/test_data/networkd/network/eno9.network
@@ -4,6 +4,8 @@ Name=eno9
 RequiredForOnline=false
 [Network]
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/netdog/test_data/networkd/network/f874a4d53264.network
+++ b/sources/netdog/test_data/networkd/network/f874a4d53264.network
@@ -4,6 +4,8 @@ PermanentMACAddress=f8:74:a4:d5:32:64
 RequiredForOnline=true
 [Network]
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/netdog/test_data/networkd/network/f874a4d53265.network
+++ b/sources/netdog/test_data/networkd/network/f874a4d53265.network
@@ -4,6 +4,8 @@ PermanentMACAddress=f8:74:a4:d5:32:65
 RequiredForOnline=true
 [Network]
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/netdog/test_data/networkd/network/f874a4d53266.network
+++ b/sources/netdog/test_data/networkd/network/f874a4d53266.network
@@ -4,6 +4,8 @@ PermanentMACAddress=f8:74:a4:d5:32:66
 RequiredForOnline=true
 [Network]
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/netdog/test_data/networkd/network/mystaticvlan.network
+++ b/sources/netdog/test_data/networkd/network/mystaticvlan.network
@@ -3,3 +3,5 @@ Name=mystaticvlan
 [Network]
 Address=192.168.1.100/24
 ConfigureWithoutCarrier=true
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4

--- a/sources/netdog/test_data/networkd/network/myvlan.network
+++ b/sources/netdog/test_data/networkd/network/myvlan.network
@@ -5,6 +5,8 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true

--- a/sources/netdog/test_data/networkd/network/vlancfgdev.network
+++ b/sources/netdog/test_data/networkd/network/vlancfgdev.network
@@ -5,6 +5,8 @@ RequiredForOnline=true
 [Network]
 ConfigureWithoutCarrier=true
 DHCP=ipv4
+IPv6AcceptRA=false
+LinkLocalAddressing=ipv4
 KeepConfiguration=dhcp
 [DHCPv4]
 UseMTU=true


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

### Issue number:

https://github.com/bottlerocket-os/bottlerocket/issues/4752

### Description of changes:

When an interface has no IPv6 configuration (no `dhcp6` enabled, no `static6` addresses), netdog now emits `IPv6AcceptRA=false` and `LinkLocalAddressing=ipv4` in the generated systemd-networkd `.network` file. This prevents systemd-networkd from re-enabling IPv6 on interfaces where users intend IPv4-only operation.

Previously, even when users set `net.ipv6.conf.<iface>.disable_ipv6=1` via sysctl, systemd-networkd would reset it to `0` on reconfiguration because the generated `.network` files didn't express any IPv6 intent.

Rather than adding a new setting, this infers IPv6 intent from existing `net.toml` fields. If an interface has no `dhcp6` enabled and no `static6` addresses, we treat that as intent to disable IPv6. Users who want IPv6 must opt in via `dhcp6` or `static6`. This keeps the change entirely within netdog's networkd config generation — no new settings, no settings-sdk changes, no migration needed.

**Note:** this change only affects interfaces configured via `net.toml`. Interfaces configured via the kernel command line (`netdog.default-interface=`) are not affected — they continue to get `enable_ipv6()` and `disable_dad()` applied unconditionally as a post-build fixup in `generate_net_config.rs`, preserving legacy behavior. The kernel command line is too limited to express IPv6 intent, so IPv6 remains enabled by default on that path.

**Changes:**
- Add `disable_ipv6()` method on `NetworkBuilder` that sets `LinkLocalAddressing=ipv4` and `IPv6AcceptRA=false`
- Rename `accept_ra()` to `enable_ipv6()` on `NetworkConfig` and make it the inverse of `disable_ipv6()`
- Extract shared `has_ipv6()` helper in the `networkd::devices` module
- Apply IPv6 suppression for interfaces, bonds, and VLANs
- Update 18 golden `.network` test files; add `eno22` test case covering `Dhcp6ConfigV1::WithOptions { enabled: false }`

### Testing done:

Manually verified on `aws-k8s-1.34` (us-west-2) using `apiclient network configure`.

IPv6 disabled (no IPv6 config):

| Config | Result |
|---|---|
| `dhcp4=true` only | ✅ No IPv6 addrs, `IPv6AcceptRA=false`, `LinkLocalAddressing=ipv4` |
| `dhcp4=true, dhcp6=false` | ✅ Same |
| `dhcp4=true, dhcp6.enabled=false` | ✅ Same |

IPv6 enabled (explicit IPv6 config):

| Config | Result |
|---|---|
| `dhcp4=true, dhcp6=true` | ✅ IPv6 link-local present, `DHCP=yes` |
| `dhcp4=true, dhcp6.enabled=true` | ✅ Same |
| `dhcp4=true, static6` (v2 schema) | ✅ Static IPv6 + link-local present |
| `dhcp4=true, dhcp6=true, static6` | ✅ Both static and DHCP IPv6 |

Verified at each step: generated `.network` file, runtime `ip -6 addr`, sysctl `accept_ra`, and `networkctl status`.

<details>
<summary>Sample test output: dhcp4=true only (IPv6 disabled)</summary>

**net.toml:**
```toml
version = 1

[eth0]
dhcp4 = true
```

**Apply config:**
```bash
apiclient network configure base64:dmVyc2lvbiA9IDEKCltldGgwXQpkaGNwNCA9IHRydWUK
```

**Generated .network file:**
```bash
$ cat /etc/systemd/network/10-eth0.network
```
```ini
[Match]
Name=eth0
[Link]
RequiredForOnline=true
[Network]
DHCP=ipv4
IPv6AcceptRA=false
LinkLocalAddressing=ipv4
KeepConfiguration=dhcp
[DHCPv4]
UseMTU=true
```

**IPv6 addresses (empty — none assigned):**
```bash
$ ip -6 addr show eth0
```

**Full interface state (IPv4 only):**
```bash
$ ip addr show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP group default qlen 1000
    link/ether 0a:2f:76:28:03:79 brd ff:ff:ff:ff:ff:ff
    altname enp0s5
    altname ens5
    inet 192.168.28.230/19 metric 1024 brd 192.168.31.255 scope global eth0
       valid_lft forever preferred_lft forever
```

**accept_ra sysctl:**
```bash
$ cat /proc/sys/net/ipv6/conf/eth0/accept_ra
0
```

**networkctl status:**
```bash
$ networkctl status eth0
● 2: eth0
                   Link File: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/network/80-release.link
                Network File: /etc/systemd/network/10-eth0.network
                              └─/etc/systemd/network/10-eth0.network.d/10-dns.conf
                       State: routable (configured)
                Online state: online
                        Type: ether
                        Path: pci-0000:00:05.0
                      Driver: ena
           Alternative Names: enp0s5
                              ens5
            Hardware Address: 0a:2f:76:28:03:79
                         MTU: 9001 (min: 128, max: 9216)
                       QDisc: mq
IPv6 Address Generation Mode: none
    Number of Queues (Tx/Rx): 2/2
                     Address: 192.168.28.230 (DHCPv4 via 192.168.0.1)
                     Gateway: 192.168.0.1
                         DNS: 192.168.0.2
              Search Domains: us-west-2.compute.internal
           Activation Policy: up
         Required For Online: yes
            DHCPv4 Client ID: IAID:0xed10bdb8/DUID
```

Key observations:
- No `inet6` addresses on the interface
- `IPv6 Address Generation Mode: none` confirms no IPv6 link-local
- `accept_ra = 0` confirms router advertisements are suppressed

</details>

<details>
<summary>Sample test output: dhcp4+dhcp6+static6 (IPv6 enabled)</summary>

**net.toml:**
```toml
version = 2

[eth0]
dhcp4 = true
dhcp6 = true

[eth0.static6]
addresses = ["fd00::1/128"]
```

**Apply config:**
```bash
apiclient network configure base64:dmVyc2lvbiA9IDIKCltldGgwXQpkaGNwNCA9IHRydWUKZGhjcDYgPSB0cnVlCgpbZXRoMC5zdGF0aWM2XQphZGRyZXNzZXMgPSBbImZkMDA6OjEvMTI4Il0K
```

**Generated .network file:**
```bash
$ cat /etc/systemd/network/10-eth0.network
```
```ini
[Match]
Name=eth0
[Link]
RequiredForOnline=true
RequiredFamilyForOnline=both
[Network]
Address=fd00::1/128
DHCP=yes
KeepConfiguration=dhcp
[DHCPv4]
UseMTU=true
[IPv6AcceptRA]
UseMTU=true
```

**IPv6 addresses (static + link-local present):**
```bash
$ ip -6 addr show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP group default qlen 1000
    altname enp0s5
    altname ens5
    inet6 fd00::1/128 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::c63:9eff:fef9:bacb/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
```

**Full interface state:**
```bash
$ ip addr show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP group default qlen 1000
    link/ether 0e:63:9e:f9:ba:cb brd ff:ff:ff:ff:ff:ff
    altname enp0s5
    altname ens5
    inet 192.168.18.204/19 metric 1024 brd 192.168.31.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fd00::1/128 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::c63:9eff:fef9:bacb/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
```

**accept_ra sysctl:**
```bash
$ cat /proc/sys/net/ipv6/conf/eth0/accept_ra
0
```

**networkctl status:**
```bash
$ networkctl status eth0
Failed to query link bit rates: Access denied
Failed to query link DHCP leases: Transport endpoint is not connected
● 2: eth0
                   Link File: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/network/80-release.link
                Network File: /etc/systemd/network/10-eth0.network
                              └─/etc/systemd/network/10-eth0.network.d/10-dns.conf
                       State: routable (configured)
                Online state: online                                                                         
                        Type: ether
                        Path: pci-0000:00:05.0
                      Driver: ena
           Alternative Names: enp0s5
                              ens5
            Hardware Address: 0e:63:9e:f9:ba:cb
                         MTU: 9001 (min: 128, max: 9216)
                       QDisc: mq
IPv6 Address Generation Mode: eui64
    Number of Queues (Tx/Rx): 2/2
                     Address: 192.168.18.204 (DHCPv4 via 192.168.0.1)
                              fd00::1
                              fe80::c63:9eff:fef9:bacb
                     Gateway: 192.168.0.1
                         DNS: 192.168.0.2
              Search Domains: us-west-2.compute.internal
           Activation Policy: up
         Required For Online: yes
            DHCPv4 Client ID: IAID:0xed10bdb8/DUID
          DHCPv6 Client DUID: DUID-EN/Vendor:0000ab1160befd2bedd82ffd

Feb 24 23:08:29 localhost systemd-networkd[1329]: eth0: Found matching .network file, based on potentially unpredictable interface name: /etc/systemd/network/10-eth0.network
Feb 24 23:08:29 localhost systemd-networkd[1329]: eth0: Configuring with /etc/systemd/network/10-eth0.network.
Feb 24 23:08:29 localhost systemd-networkd[1329]: eth0: Link UP
Feb 24 23:08:29 localhost systemd-networkd[1329]: eth0: Gained carrier
Feb 24 23:08:29 localhost systemd-networkd[1329]: eth0: Found matching .network file, based on potentially unpredictable interface name: /etc/systemd/network/10-eth0.network
Feb 24 23:08:29 localhost systemd-networkd[1329]: eth0: DHCPv4 address 192.168.18.204/19, gateway 192.168.0.1 acquired from 192.168.0.1
Feb 24 23:08:31 localhost systemd-networkd[1329]: eth0: Gained IPv6LL
Feb 24 23:08:32 localhost systemd-networkd[1329]: eth0: Found matching .network file, based on potentially unpredictable interface name: /etc/systemd/network/10-eth0.network
Feb 24 23:08:32 localhost systemd-networkd[1329]: eth0: Reconfiguring with /etc/systemd/network/10-eth0.network (dropins: /etc/systemd/network/10-eth0.network.d/10-dns.conf).
Feb 24 23:08:32 ip-192-168-18-204.us-west-2.compute.internal systemd-networkd[1329]: eth0: DHCPv4 address 192.168.18.204/19, gateway 192.168.0.1 acquired from 192.168.0.1
```

Key observations:
- `DHCP=yes` enables both DHCPv4 and DHCPv6
- `Address=fd00::1/128` static IPv6 configured
- `[IPv6AcceptRA]` section present (IPv6 RA enabled with MTU)
- Both `fd00::1` (static) and `fe80::` (link-local) addresses present
- No `IPv6AcceptRA=false` or `LinkLocalAddressing=ipv4` — IPv6 is fully enabled

</details>

<details>
<summary>Sample test output: original scenario in bottlerocket-os/bottlerocket/issues/4752 — sysctl disable_ipv6 + net.toml (IPv6 disabled)</summary>

This reproduces the original issue: customer sets `disable_ipv6=1` via sysctl, and previously systemd-networkd would reset it to `0` on reconfiguration.

**User data (relevant sections):**
```toml
[settings.kernel.sysctl]
"net.ipv6.conf.all.disable_ipv6" = "1"
"net.ipv6.conf.default.disable_ipv6" = "1"

[settings.bootstrap-commands.configure-network]
commands = [["apiclient", "network", "configure", "base64:dmVyc2lvbiA9IDEKCltldGgwXQpkaGNwNCA9IHRydWUK"], ["apiclient", "reboot"]]
mode = "once"
essential = true
```

**net.toml:**
```toml
version = 1

[eth0]
dhcp4 = true
```

**Generated .network file:**
```bash
$ cat /etc/systemd/network/10-eth0.network
```
```ini
[Match]
Name=eth0
[Link]
RequiredForOnline=true
[Network]
DHCP=ipv4
IPv6AcceptRA=false
LinkLocalAddressing=ipv4
KeepConfiguration=dhcp
[DHCPv4]
UseMTU=true
```

**sysctl values (all remain `1` — not reset by networkd):**
```bash
$ cat /proc/sys/net/ipv6/conf/all/disable_ipv6
1
$ cat /proc/sys/net/ipv6/conf/default/disable_ipv6
1
$ cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6
1
```

**IPv6 addresses (empty — none assigned):**
```bash
$ ip -6 addr show eth0
```

**Full interface state (IPv4 only):**
```bash
$ ip addr show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP group default qlen 1000
    link/ether 0e:7e:5b:9d:dd:e9 brd ff:ff:ff:ff:ff:ff
    altname enp0s5
    altname ens5
    inet 192.168.12.78/19 metric 1024 brd 192.168.31.255 scope global eth0
       valid_lft forever preferred_lft forever
```

**accept_ra sysctl:**
```bash
$ cat /proc/sys/net/ipv6/conf/eth0/accept_ra
0
```

**Verified: `netdog write-resolv-conf` does not override sysctl:**
```bash
$ netdog write-resolv-conf
$ cat /proc/sys/net/ipv6/conf/eth0/disable_ipv6
1
$ ip -6 addr show eth0
```

Key observations:
- `disable_ipv6=1` persists across networkd reconfiguration — the original bug is fixed
- `netdog write-resolv-conf` (which triggers networkd resolved reload) does not reset the sysctl
- Node joins EKS cluster successfully with IPv4 only

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.

