### PR TITLE
advisories: add end of support BRSAs for containerd-2.0 and libexpat

### DIFF
--- a/advisories/13.0.0/BRSA-ct8ctqeshufb.toml
+++ b/advisories/13.0.0/BRSA-ct8ctqeshufb.toml
@@ -14,4 +14,4 @@ patched-epoch = "2"
 author = "jepiyush"
 issue-date = 2026-02-10T22:00:20Z
 arches = ["x86_64", "aarch64"]
-version = "staging"
+version = "13.0.0"

--- a/advisories/13.0.0/BRSA-x5k4wcrdywzh.toml
+++ b/advisories/13.0.0/BRSA-x5k4wcrdywzh.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-x5k4wcrdywzh"
+title = "libexpat support ended"
+severity = "low"
+end-of-life = true
+description = "libexpat is no longer included in Bottlerocket. All users must upgrade to a version of the OS that does not include this package."
+
+[[advisory.products]]
+package-name = "libexpat"
+patched-version = "2.7.3"
+patched-epoch = "2"
+
+[updateinfo]
+author = "jepiyush"
+issue-date = 2026-02-10T22:49:04Z
+arches = ["x86_64", "aarch64"]
+version = "13.0.0"

--- a/advisories/staging/BRSA-ct8ctqeshufb.toml
+++ b/advisories/staging/BRSA-ct8ctqeshufb.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-ct8ctqeshufb"
+title = "containerd-2.0 support ended"
+severity = "low"
+end-of-life = true
+description = "containerd-2.0 is no longer included in Bottlerocket. All users must upgrade to a version of the OS that does not include this package."
+
+[[advisory.products]]
+package-name = "containerd-2.0"
+patched-version = "2.0.7"
+patched-epoch = "2"
+
+[updateinfo]
+author = "jepiyush"
+issue-date = 2026-02-10T22:00:20Z
+arches = ["x86_64", "aarch64"]
+version = "staging"


### PR DESCRIPTION
**Description of changes:**
add end of support BRSAs for containerd-2.0 and libexpat
- both have epochs bumped from 1 to 2
- both have an additional `end-of-life` field

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
