### PR TITLE
Update SELinux policy to allow containers to communicate with the MPS daemon

### DIFF
--- a/packages/nvidia-k8s-device-plugin/0001-Update-MPS-roots-for-immutable-host-OS.patch
+++ b/packages/nvidia-k8s-device-plugin/0001-Update-MPS-roots-for-immutable-host-OS.patch
@@ -24,7 +24,7 @@ index bb5502f..ec296a4 100644
  		}
  	}
 -	readyFile, err := os.Create("/mps/.ready")
-+	readyFile, err := os.Create("/run/mps/.ready")
++	readyFile, err := os.Create("/run/nvidia/mps/.ready")
  	if err != nil {
  		return mpsDaemons, true, fmt.Errorf("failed to create .ready file")
  	}
@@ -33,7 +33,7 @@ index bb5502f..ec296a4 100644
  
  func stopDaemons(mpsDaemons ...*mps.Daemon) error {
 -	if err := os.Remove("/mps/.ready"); err != nil {
-+	if err := os.Remove("/run/mps/.ready"); err != nil {
++	if err := os.Remove("/run/nvidia/mps/.ready"); err != nil {
  		klog.Warningf("Failed to remove .ready file: %v", err)
  	}
  	klog.Info("Stopping MPS daemons.")
@@ -46,7 +46,7 @@ index 83825e8..507a1e4 100644
  
  	// TODO: /mps should be configurable.
 -	shmDir := "/mps/shm"
-+	shmDir := "/run/mps/shm"
++	shmDir := "/run/nvidia/mps/shm"
  	err = mount.CleanupMountPoint(shmDir, mounter, true)
  	if err != nil {
  		return fmt.Errorf("error unmounting %v: %w", shmDir, err)
@@ -59,7 +59,7 @@ index 90655d1..805e58d 100644
  
  const (
 -	ContainerRoot = Root("/mps")
-+	ContainerRoot = Root("/run/mps")
++	ContainerRoot = Root("/run/nvidia/mps")
  )
  
  // Root represents an MPS root.

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -266,6 +266,9 @@
 ; Unprivileged components are not allowed to use the API socket.
 (neverallow unprivileged_s api_socket_t (files (mutate)))
 
+; Allow containers to use MPS pipes for GPU sharing.
+(allow container_s system_t (fifo_file (write)))
+
 ; Only trusted components are allowed to relabel all files, and to
 ; override filesystem labels through "*context=" mount options.
 (allow trusted_s global (files (relabel)))


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket/issues/4673

**Description of changes:**
Fix paths for the patch to the NVIDIA k8s-device-plugin MPS daemon to normalize them all for consistency. Add SELinux permissions for MPS Daemon to communicate with containers via fifo_files.


**Testing done:**
Ran a CUDA workload and ensured the workload is marked as `M + C` instead of just C. No special paths are needed since the device plugin MPS daemon handles the mounts for the container.
``` 
bash-5.2# nvidia-smi
Wed Feb 11 21:23:33 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA A10G                    On  |   00000000:00:1E.0 Off |                    0 |
|  0%   24C    P0             64W /  300W |      89MiB /  23028MiB |      0%   E. Process |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A            4268      C   nvidia-cuda-mps-server                   30MiB |
|    0   N/A  N/A           17009    M+C   /usr/local/bin/mps_test                  10MiB |
|    0   N/A  N/A           17012    M+C   /usr/local/bin/mps_test                  10MiB |
|    0   N/A  N/A           17016    M+C   /usr/local/bin/mps_test                  10MiB |
|    0   N/A  N/A           17032    M+C   /usr/local/bin/mps_test                  10MiB |
+-----------------------------------------------------------------------------------------+
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
