### PR TITLE
remove kubelet ipv4 ACCEPT override

### DIFF
--- a/packages/kubernetes-1.29/kubelet.service
+++ b/packages/kubernetes-1.29/kubelet.service
@@ -10,7 +10,6 @@ Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
-ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 

--- a/packages/kubernetes-1.30/kubelet.service
+++ b/packages/kubernetes-1.30/kubelet.service
@@ -10,7 +10,6 @@ Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
-ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 

--- a/packages/kubernetes-1.31/kubelet.service
+++ b/packages/kubernetes-1.31/kubelet.service
@@ -10,7 +10,6 @@ Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
-ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 

--- a/packages/kubernetes-1.32/kubelet.service
+++ b/packages/kubernetes-1.32/kubelet.service
@@ -10,7 +10,6 @@ Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
-ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 

--- a/packages/kubernetes-1.33/kubelet.service
+++ b/packages/kubernetes-1.33/kubelet.service
@@ -10,7 +10,6 @@ Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
-ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 

--- a/packages/kubernetes-1.34/kubelet.service
+++ b/packages/kubernetes-1.34/kubelet.service
@@ -10,7 +10,6 @@ Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
-ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 

--- a/packages/kubernetes-1.35/kubelet.service
+++ b/packages/kubernetes-1.35/kubelet.service
@@ -10,7 +10,6 @@ Slice=runtime.slice
 Type=notify
 EnvironmentFile=/etc/network/proxy.env
 EnvironmentFile=/etc/kubernetes/kubelet/env
-ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 # Must be overridden by a drop-in file or `kubelet` won't start
 ExecStart=/usr/bin/false
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:** #540

**Description of changes:**
Removing `FORWARD ACCEPT` override of iptables for kubernetes variants.


**Testing done:**

Built k8s 1.34 and ran k8s e2e tests on ipv4 cluster




**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
