### PR TITLE
release: increase vm.max_map_count to 1048576

### DIFF
--- a/packages/release/release-sysctl.conf
+++ b/packages/release/release-sysctl.conf
@@ -64,4 +64,4 @@ fs.inotify.max_user_instances = 8192
 fs.inotify.max_user_watches = 524288
 
 # Increase virtual memory to allow for larger workloads
-vm.max_map_count = 524288
+vm.max_map_count = 1048576


### PR DESCRIPTION
**Description of changes:**

Increase the vm.max_map_count to match what other major Linux distributions do:

- [Fedora]
- [Ubuntu]

[Fedora]: https://fedoraproject.org/wiki/Changes/IncreaseVmMaxMapCount
[Ubuntu]: https://bugs.launchpad.net/ubuntu/+source/procps/+bug/2057792

I couldn't find a public reference for RHEL 10, but I got this from a running instance:

```bash
[ec2-user@ip-172-31-19-71 ~]$ grep PRETTY_NAME /etc/os-release
PRETTY_NAME="Red Hat Enterprise Linux 10.1 (Coughlan)"
[ec2-user@ip-172-31-19-71 ~]$ cat /proc/sys/vm/max_map_count
1048576
[ec2-user@ip-172-31-19-71 ~]$
```

**Testing done:**

- Verified the setting changed for the host:

```bash
[ssm-user@control]$ apiclient exec admin sheltie cat /proc/sys/vm/max_map_count
1048576
[ssm-user@control]$
```

- Verified the setting is reflected in the container:
 
```bash
sh-5.3# grep PRETTY_NAME /etc/os-release
PRETTY_NAME="Fedora Linux 43 (Container Image)"
sh-5.3# cat /proc/sys/vm/max_map_count
1048576
sh-5.3#
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
