### PR TITLE
source: add ecr-credential-helper-shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "e2fsprogs",
  "early-boot-config",
  "ecr-credential-helper",
+ "ecr-credential-helper-shim",
  "ecr-credential-provider-1_29",
  "ecr-credential-provider-1_30",
  "ecr-credential-provider-1_31",
@@ -332,6 +333,13 @@ dependencies = [
 
 [[package]]
 name = "ecr-credential-helper"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "ecr-credential-helper-shim"
 version = "0.1.0"
 dependencies = [
  "glibc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "packages/e2fsprogs",
   "packages/early-boot-config",
   "packages/ecr-credential-helper",
+  "packages/ecr-credential-helper-shim",
   "packages/ecr-credential-provider-1.29",
   "packages/ecr-credential-provider-1.30",
   "packages/ecr-credential-provider-1.31",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -37,6 +37,7 @@ docker-init = { path = "../../packages/docker-init" }
 e2fsprogs = { path = "../../packages/e2fsprogs" }
 early-boot-config = { path = "../../packages/early-boot-config" }
 ecr-credential-helper = { path = "../../packages/ecr-credential-helper" }
+ecr-credential-helper-shim = { path = "../../packages/ecr-credential-helper-shim" }
 ecr-credential-provider-1_29 = { path = "../../packages/ecr-credential-provider-1.29" }
 ecr-credential-provider-1_30 = { path = "../../packages/ecr-credential-provider-1.30" }
 ecr-credential-provider-1_31 = { path = "../../packages/ecr-credential-provider-1.31" }

--- a/packages/ecr-credential-helper-shim/Cargo.toml
+++ b/packages/ecr-credential-helper-shim/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ecr-credential-helper-shim"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[package.metadata.build-package]
+source-groups = [ "ecr-credential-helper-shim" ]
+
+[lib]
+path = "../packages.rs"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/ecr-credential-helper-shim/ecr-credential-helper-shim.spec
+++ b/packages/ecr-credential-helper-shim/ecr-credential-helper-shim.spec
@@ -1,0 +1,29 @@
+%global _cross_first_party 1
+%undefine _debugsource_packages
+
+Name: %{_cross_os}ecr-credential-helper-shim
+Version: 0.1.0
+Release: 1%{?dist}
+Summary: FIPS shim for ECR credential helper
+License: Apache-2.0 OR MIT
+URL: https://github.com/bottlerocket-os/bottlerocket
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%prep
+%setup -T -c
+%cargo_prep
+
+%build
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p ecr-credential-helper-shim \
+    --target-dir=${HOME}/.cache/ecr-credential-helper-shim
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${HOME}/.cache/ecr-credential-helper-shim/%{__cargo_target}/release/ecr-credential-helper-shim %{buildroot}%{_cross_bindir}/docker-credential-ecr-login
+
+%files
+%{_cross_bindir}/docker-credential-ecr-login

--- a/packages/ecr-credential-helper/ecr-credential-helper.spec
+++ b/packages/ecr-credential-helper/ecr-credential-helper.spec
@@ -8,6 +8,7 @@
 %global _dwz_low_mem_die_limit 0
 
 Name: %{_cross_os}ecr-credential-helper
+Requires: %{_cross_os}ecr-credential-helper-shim
 Version: %{rpmver}
 Release: 1%{?dist}
 Summary: Amazon ECR credential helper
@@ -31,14 +32,12 @@ BuildRequires: %{_cross_os}glibc-devel
 %cross_go_setup %{gorepo}-%{gover} %{goproject} %{goimport}
 
 %build
-# cross_go_configure cd's to the correct GOPATH location
 %cross_go_configure %{goimport}
-
 go build -ldflags="${GOLDFLAGS}" -o=docker-credential-ecr-login ./ecr-login/cli/docker-credential-ecr-login
 
 %install
-install -d %{buildroot}%{_cross_bindir}
-install -p -m 0755 docker-credential-ecr-login %{buildroot}%{_cross_bindir}
+install -d %{buildroot}%{_cross_libexecdir}
+install -p -m 0755 docker-credential-ecr-login %{buildroot}%{_cross_libexecdir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m0644 %{S:10} %{buildroot}%{_cross_tmpfilesdir}/ecr-credential-helper.conf
@@ -55,9 +54,8 @@ install -p -m0600 %{S:13} %{buildroot}%{_cross_factorydir}/root/.docker/config.j
 %license LICENSE
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
-%{_cross_bindir}/docker-credential-ecr-login
+%{_cross_libexecdir}/docker-credential-ecr-login
 %{_cross_factorydir}/root/.docker/config.json
 %{_cross_tmpfilesdir}/ecr-credential-helper.conf
 %{_cross_unitdir}/root-.docker.mount
 %{_cross_unitdir}/root-.ecr.mount
-

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2516,6 +2516,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecr-credential-helper-shim"
+version = "0.1.0"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -83,6 +83,8 @@ members = [
     "xfscli",
 
     "whippet",
+
+    "ecr-credential-helper-shim",
 ]
 
 [workspace.dependencies]

--- a/sources/ecr-credential-helper-shim/Cargo.toml
+++ b/sources/ecr-credential-helper-shim/Cargo.toml
@@ -1,0 +1,11 @@
+
+[package]
+name = "ecr-credential-helper-shim"
+version = "0.1.0"
+authors = ["Jingwei Wang <jweiw@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+

--- a/sources/ecr-credential-helper-shim/src/main.rs
+++ b/sources/ecr-credential-helper-shim/src/main.rs
@@ -1,0 +1,21 @@
+use std::env;
+use std::process::{self, Command};
+
+fn main() {
+    let godebug = env::var("GODEBUG")
+        .unwrap_or_default()
+        .replace("fips140=only", "fips140=on");
+
+    let status = Command::new("/usr/libexec/docker-credential-ecr-login")
+        .args(env::args().skip(1))
+        .env("GODEBUG", &godebug)
+        .status();
+
+    match status {
+        Ok(s) => process::exit(s.code().unwrap_or(1)),
+        Err(err) => {
+            eprintln!("Failed to exec /usr/libexec/docker-credential-ecr-login: {err}");
+            process::exit(1);
+        }
+    }
+}

--- a/sources/notation-image-verifier/main.go
+++ b/sources/notation-image-verifier/main.go
@@ -64,6 +64,7 @@ func main() {
 	// Bottlerocket does not have a $HOME set by default and notation expect to find
 	// credentials from the ecr-credential-helper here.
 	os.Setenv("HOME", "/root")
+	os.Setenv("GODEBUG", "fips140=on")
 
 	cmd := exec.Command("notation", "verify", imageRef)
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
This is part of the changes to enable `notation` in `fips140=only` mode.
Introduce ecr-credential-helper-shim, a Rust binary that downgrades GODEBUG from fips140=only to fips140=on before exec'ing the Go-based ecr-credential-helper, since the Go ECR credential helper does not support fips140=only mode.


**Testing done:**
- build ecs-3-fips and ecs-3 variants imaging signing test pass.
```
== when pulling public.ecr.aws/o7o0w6s5/public-alpine-clone:latest ==
Digest: sha256:85f2b723e106c34644cd5851d7e81ee87da98ac54672b29947c052a45d31dc2f
Status: Downloaded newer image for public.ecr.aws/o7o0w6s5/public-alpine-clone:latest
public.ecr.aws/o7o0w6s5/public-alpine-clone:latest
=======================

Waiter CommandExecuted failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "Failed"
== when pulling hello-world ==
Using default tag: latest
Error response from daemon: image verifier bindir blocked pull of docker.io/library/hello-world:latest with digest sha256:ef54e839ef541993b4e87f25e752f7cf4238fa55f017957c2eb44077083d7a6a for reason: verifier notation-image-verifier rejected image (exit code 1): verifying image: docker.io/library/hello-world@sha256:ef54e839ef541993b4e87f25e752f7cf4238fa55f017957c2eb44077083d7a6a
image verification failed: Error: signature verification failed: no signature is associated with "docker.io/library/hello-world@sha256:ef54e839ef541993b4e87f25e752f7cf4238fa55f017957c2eb44077083d7a6a", make sure the artifact was signed successfully
=======================

Waiter CommandExecuted failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "Failed"
== when pulling public.ecr.aws/o7o0w6s5/public-nginx-clone:latest ==
Error response from daemon: image verifier bindir blocked pull of public.ecr.aws/o7o0w6s5/public-nginx-clone:latest with digest sha256:bd1578eec775d0b28fd7f664b182b7e1fb75f1dd09f92d865dababe8525dfe8b for reason: verifier notation-image-verifier rejected image (exit code 1): verifying image: public.ecr.aws/o7o0w6s5/public-nginx-clone@sha256:bd1578eec775d0b28fd7f664b182b7e1fb75f1dd09f92d865dababe8525dfe8b
image verification failed: Error: signature verification failed for all the signatures associated with public.ecr.aws/o7o0w6s5/public-nginx-clone@sha256:bd1578eec775d0b28fd7f664b182b7e1fb75f1dd09f92d865dababe8525dfe8b
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
