### PR TITLE
containerd-2.1: stop rendering max_concurrent_downloads in CRI image plugin config

### DIFF
--- a/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
@@ -23,10 +23,6 @@ imports = ["/etc/containerd/config.d/*.toml"]
 address = "/run/containerd/containerd.sock"
 
 [plugins."io.containerd.cri.v1.images"]
-{{#if settings.container-runtime.max-concurrent-downloads}}
-max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
-{{/if}}
-concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
 use_local_image_pull = false
 
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image

--- a/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -23,10 +23,6 @@ imports = ["/etc/containerd/config.d/*.toml"]
 address = "/run/containerd/containerd.sock"
 
 [plugins."io.containerd.cri.v1.images"]
-{{#if settings.container-runtime.max-concurrent-downloads}}
-max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
-{{/if}}
-concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
 use_local_image_pull = false
 
 # Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image


### PR DESCRIPTION
**Description of changes:**
Setting max_concurrent_downloads under [plugins."io.containerd.cri.v1.images"] causes containerd's CheckLocalImagePullConfigs() to detect a non-default value and override use_local_image_pull to true, falling back to legacy client.Pull instead of the transfer service. This setting is already rendered under [plugins."io.containerd.transfer.v1.local"] where it takes effect without triggering the fallback.

Also remove concurrent_layer_fetch_buffer from the CRI section since it is unused when the transfer service is active.

**Testing done:**
* Confirmed that setting max-concurrent-downloads keeps containerd on transfer service. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
