### PR TITLE
chore: ban BehaviorVersion::latest() via clippy.toml

### DIFF
--- a/sources/clippy.toml
+++ b/sources/clippy.toml
@@ -1,0 +1,7 @@
+[[disallowed-methods]]
+path = "aws_smithy_runtime_api::client::behavior_version::BehaviorVersion::latest"
+reason = "BehaviorVersion::latest() is banned. Pin to an explicit version like BehaviorVersion::v2026_01_12() to ensure consistent behavior across updates."
+
+[[disallowed-methods]]
+path = "aws_config::BehaviorVersion::latest"
+reason = "BehaviorVersion::latest() is banned. Pin to an explicit version like BehaviorVersion::v2026_01_12() to ensure consistent behavior across updates."


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**
No issue number, but it started with discussion from this PR - https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/837#discussion_r2830429732

**Description of changes:**
We want to explicitly forbid the use of `BehaviorVersion::latest()` and make it deterministic when we bump the crates `aws_smithy_runtime_api` and `aws_config`. 

Instead, we want to always use explicit version like `BehaviorVersion::v2026_01_12()` and make the version bump explicit.


**Testing done:**
Update [bottlerocket-core-kit/sources/cfsignal/src/cloudformation.rs](https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/29f1af0b9cb80953b131de63dfff6d8477e6c5fe/sources/cfsignal/src/cloudformation.rs#L25) with
```diff
- let config = aws_config::defaults(BehaviorVersion::v2025_08_07()) 
+ let config = aws_config::defaults(BehaviorVersion::latest()) 
``` 
and ran `make twoliter check-clippy`

And get the expect failure:
```
error: use of a disallowed method `aws_config::BehaviorVersion::latest`
  --> cfsignal/src/cloudformation.rs:25:39
   |
25 |     let config = aws_config::defaults(BehaviorVersion::latest())
   |                                       ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: BehaviorVersion::latest() is banned. Pin to an explicit version like BehaviorVersion::v2026_01_12() to ensure consistent behavior across updates.
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_methods
   = note: `-D clippy::disallowed-methods` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::disallowed_methods)]`
```
And fixed the error by just revert it back to explicit `v2025_08_07()`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
