### PR TITLE
chore: prep core-kit 13.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+# v13.1.0 (2026-02-25)
+
+## OS Changes
+- Suppress IPv6 on interfaces with no IPv6 intent in `net.toml` ([#826])
+- Add support to render `settings.container-registry` into containerd supported `hosts.toml` ([#819])
+- Expand image verifier support with a new helper to render trust policies for all image verifier plugins ([#820])
+- Add `cri-tools`, `erofs-utils`, `perf` packages ([#818])
+- Fix ephemeral storage handling in `apiserver` ([#822])
+- Stop rendering `max_concurrent_downloads` in containerd CRI image plugin config ([#838])
+- Increase `vm.max_map_count` to 1048576 ([#835])
+- Update Rust dependencies for first-party sources ([#837])
+
+### Third Party Package Updates
+- Update `libnvidia-container`, `nvidia-container-toolkit`, `nvidia-k8s-device-plugin` ([#834])
+
+## Build Changes
+- Bump `bottlerocket-settings-models` to 0.21.0 ([#841])
+
+[#819]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/819
+[#818]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/818
+[#826]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/826
+[#820]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/820
+[#822]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/822
+[#834]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/834
+[#835]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/835
+[#837]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/837
+[#838]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/838
+[#841]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/841
+
 # v13.0.0 (2026-02-11)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "13.0.0"
+release-version = "13.1.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "darling",
  "quote",
@@ -1494,8 +1494,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.13.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+version = "0.14.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -1564,8 +1564,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.20.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+version = "0.21.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1630,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "serde",
 ]
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3485,10 +3485,10 @@ name = "image-verifiers"
 version = "0.1.0"
 dependencies = [
  "argh",
- "base64 0.22.1",
+ "base64",
  "generate-readme",
  "log",
- "nix 0.26.4",
+ "nix",
  "serde",
  "serde_json",
  "snafu",
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5376,7 +5376,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5389,7 +5389,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5403,7 +5403,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5416,7 +5416,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5429,7 +5429,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5442,7 +5442,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5455,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5471,7 +5471,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5484,7 +5484,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5497,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5509,8 +5509,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-image-verifier-plugins"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5536,7 +5536,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5549,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.9.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5563,7 +5563,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5576,7 +5576,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -5589,7 +5589,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5615,7 +5615,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5642,7 +5642,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5655,7 +5655,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5668,7 +5668,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.20.0#8a64d422a04e1711777c5a4b44b4f0a009b13fe2"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -6087,7 +6087,7 @@ version = "0.1.0"
 dependencies = [
  "generate-readme",
  "log",
- "nix 0.26.4",
+ "nix",
  "serde",
  "simplelog",
  "snafu",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -232,13 +232,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.20.0"
-version = "0.13.0"
+tag = "bottlerocket-settings-models-v0.21.0"
+version = "0.14.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.20.0"
-version = "0.20.0"
+tag = "bottlerocket-settings-models-v0.21.0"
+version = "0.21.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -247,7 +247,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.20.0"
+tag = "bottlerocket-settings-models-v0.21.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
- Bump the `settings-sdk` and `Twoliter.toml`
- Update the Changelog


**Testing done:**
- Built a core-kit and launched an instance to make sure it booted


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
