### PR TITLE
nvidia-container-toolkit: reduce missing-resource warnings

### DIFF
--- a/packages/nvidia-container-toolkit/0001-discover-reduce-missing-resource-warnings-to-debug-l.patch
+++ b/packages/nvidia-container-toolkit/0001-discover-reduce-missing-resource-warnings-to-debug-l.patch
@@ -1,0 +1,54 @@
+From 723f7a1ceb01d246996c0b398d34f933e9d1709f Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Thu, 19 Feb 2026 22:38:13 +0000
+Subject: [PATCH] discover: reduce missing-resource warnings to debug level
+
+Libraries and binaries discovered via mount lookups may not be present
+on all hosts. Log missing resources at debug level instead of warning
+to avoid noise.
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ internal/discover/mounts-to-container-path.go | 4 ++--
+ internal/discover/mounts.go                   | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/internal/discover/mounts-to-container-path.go b/internal/discover/mounts-to-container-path.go
+index 602f153..2a2927d 100644
+--- a/internal/discover/mounts-to-container-path.go
++++ b/internal/discover/mounts-to-container-path.go
+@@ -46,11 +46,11 @@ func (d *mountsToContainerPath) Mounts() ([]Mount, error) {
+ 		}
+ 		candidates, err := d.locator.Locate(target)
+ 		if err != nil {
+-			d.logger.Warningf("Could not locate %v: %v", target, err)
++			d.logger.Debugf("Could not locate %v: %v", target, err)
+ 			continue
+ 		}
+ 		if len(candidates) == 0 {
+-			d.logger.Warningf("Missing %v", target)
++			d.logger.Debugf("Missing %v", target)
+ 			continue
+ 		}
+ 		hostPath := candidates[0]
+diff --git a/internal/discover/mounts.go b/internal/discover/mounts.go
+index cafa261..eef7b3d 100644
+--- a/internal/discover/mounts.go
++++ b/internal/discover/mounts.go
+@@ -75,11 +75,11 @@ func (d *mounts) Mounts() ([]Mount, error) {
+ 		d.logger.Debugf("Locating %v", candidate)
+ 		located, err := d.lookup.Locate(candidate)
+ 		if err != nil {
+-			d.logger.Warningf("Could not locate %v: %v", candidate, err)
++			d.logger.Debugf("Could not locate %v: %v", candidate, err)
+ 			continue
+ 		}
+ 		if len(located) == 0 {
+-			d.logger.Warningf("Missing %v", candidate)
++			d.logger.Debugf("Missing %v", candidate)
+ 			continue
+ 		}
+ 		d.logger.Debugf("Located %v as %v", candidate, located)
+-- 
+2.52.0
+

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -23,6 +23,7 @@ Source4: nvidia-container-toolkit-tmpfiles-ecs.conf
 Source5: nvidia-container-toolkit-tmpfiles-k8s.conf
 Source6: nvidia-container-toolkit-config-k8s
 Source7: generate-cdi-specs.service
+Patch0001: 0001-discover-reduce-missing-resource-warnings-to-debug-l.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}libnvidia-container


### PR DESCRIPTION
**Issue number:**

Closes #827 

**Description of changes:**

The CDI spec generator logs warnings for missing host libraries/binaries. These warnings are misleading to downstreams, as they suggest initialization failures when none occurred.

The tool offers a --quiet flag, but it suppresses everything below error level, which also hides useful info-level logs needed for debugging.

Instead of using --quiet, downgrade the noisy missing-library warnings to debug level. This preserves info logs for diagnostics while eliminating the misleading warnings.


**Testing done:**

<details>

Before:

```bash
bash-5.2# journalctl -u generate-cdi-specs.service | grep warn
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Failed to evaluate symlink /dev/dri/by-path/pci-0000:00:1e.0-card; ignoring"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Failed to evaluate symlink /dev/dri/by-path/pci-0000:00:1e.0-render; ignoring"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate libnvidia-egl-gbm.so.*.*: pattern libnvidia-egl-gbm.so.*.* not found\nlibnvidia-egl-gbm.so.*.*: not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate libnvidia-egl-wayland.so.*.*: pattern libnvidia-egl-wayland.so.*.* not found\nlibnvidia-egl-wayland.so.*.*: not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate libnvidia-vulkan-producer.so.580.126.09: pattern libnvidia-vulkan-producer.so.580.126.09 not found\nlibnvidia-vulkan-producer.so.580.126.09: not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate nvidia_drv.so: pattern nvidia_
drv.so not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate libglxserver_nvidia.so.580.126.09: pattern libglxserver_nvidia.so.580.126.09 not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate X11/xorg.conf.d/10-nvidia.conf: pattern X11/xorg.conf.d/10-nvidia.conf not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate X11/xorg.conf.d/nvidia-drm-outputclass.conf: pattern X11/xorg.conf.d/nvidia-drm-outputclass.conf not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate /nvidia-fabricmanager/socket:pattern /nvidia-fabricmanager/socket not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate /tmp/nvidia-mps: pattern /tmp/nvidia-mps not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate nvidia-imex: pattern nvidia-imex not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate nvidia-imex-ctl: pattern nvidia-imex-ctl not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate nvidia_drv.so: pattern nvidia_drv.so not found"
Feb 25 02:22:21 ip-172-31-12-237.us-west-2.compute.internal nvidia-ctk[1774]: time="2026-02-25T02:22:21Z" level=warning msg="Could not locate libglxserver_nvidia.so.580.126.09: pattern libglxserver_nvidia.so.580.126.09 not found"
bash-5.2#
```

```bash
bash-5.2# journalctl -u generate-cdi-specs.service | grep warning
Feb 25 02:11:28 ip-192-168-25-16.us-west-2.compute.internal nvidia-ctk[2797]: time="2026-02-25T02:11:28Z" level=warning msg="Failed to evaluate symlink /dev/dri/by-path/pci-0000:31:00.0-card; ignoring"
Feb 25 02:11:28 ip-192-168-25-16.us-west-2.compute.internal nvidia-ctk[2797]: time="2026-02-25T02:11:28Z" level=warning msg="Failed to evaluate symlink /dev/dri/by-path/pci-0000:31:00.0-render; ignoring"
bash-5.2#
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
