### PR TITLE
amazon-ecs-cni-plugins: update to 319a734

### DIFF
--- a/packages/amazon-ecs-cni-plugins/Cargo.toml
+++ b/packages/amazon-ecs-cni-plugins/Cargo.toml
@@ -16,8 +16,8 @@ releases-url = "https://github.com/aws/amazon-ecs-agent/commits/master/amazon-ec
 # This is locked against the version shipped in ecs-agent
 # Verify that the ecs-agent version shipped in bottlerocket tracks the same one here
 # https://github.com/aws/amazon-ecs-agent/releases
-url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/3302076781563428b69e0856b8fdd59b2ac0658f/amazon-ecs-cni-plugins.tar.gz"
-sha512 = "43efc021c9f095e3664840e2666109e1b40e21af0044a458a3a54faa0bb1672d06d4df9eecb5d0ad4539afd79229ae00f59c11d41cbf3c70fb5366d88e78f9fb"
+url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/319a734d9edfeeec9e7b64acf0500c45508aa8d3/amazon-ecs-cni-plugins.tar.gz"
+sha512 = "ef1457e0325a2e43c307ea962bd675cc6df8501ada055f10c8c7b51f83486c96eab6368946b0ca4fe47f9fc91d22f51218adb9c07dc5812a80389eaaf1d83df3"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
+++ b/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
@@ -1,11 +1,11 @@
 %global ecscni_goproject github.com/aws
 %global ecscni_gorepo amazon-ecs-cni-plugins
 %global ecscni_goimport %{ecscni_goproject}/%{ecscni_gorepo}
-%global ecscni_gitrev 3302076781563428b69e0856b8fdd59b2ac0658f
+%global ecscni_gitrev 319a734d9edfeeec9e7b64acf0500c45508aa8d3
 
 Name: %{_cross_os}amazon-ecs-cni-plugins
-# https://github.com/aws/amazon-ecs-cni-plugins/blob/3302076781563428b69e0856b8fdd59b2ac0658f/VERSION#L1
-Version: 2026.01.0
+# https://github.com/aws/amazon-ecs-cni-plugins/blob/319a734d9edfeeec9e7b64acf0500c45508aa8d3/VERSION#L1
+Version: 2026.02.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: Networking plugins for ECS task networking


### PR DESCRIPTION
Updates amazon-ecs-cni-plugins to commit 319a734d9edfeeec9e7b64acf0500c45508aa8d3

This includes:
- Bridge plugin routing updates for daemon-bridge communication
- IMDS blocking support via BlockIMDS configuration
- IPv6 support improvements

Corresponds to amazon-ecs-agent PR: https://github.com/aws/amazon-ecs-cni-plugins/pull/120

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**



**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
