### PR TITLE
ecr-credential-helper: update to v0.12.0

### DIFF
--- a/packages/ecr-credential-helper/Cargo.toml
+++ b/packages/ecr-credential-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/awslabs/amazon-ecr-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/amazon-ecr-credential-helper/archive/v0.11.0/amazon-ecr-credential-helper-0.11.0.tar.gz"
-sha512 = "c19ec82e826612d439e6f30a18e1948056c7450bfda4ef71d7de7feb73523feb4285c51228560ab2e20450a7341f8fd83d93f7779d70950f0e5d53d1606117d1"
+url = "https://github.com/awslabs/amazon-ecr-credential-helper/archive/v0.12.0/amazon-ecr-credential-helper-0.12.0.tar.gz"
+sha512 = "561d3eca1ba9e2ee7da5b52e135c61a545da6f50ee8e34db34caec1c3bc106b9e1fa4d936288ab0d770c1036b2368bdc38210c409e9eba9445ae036535565e97"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ecr-credential-helper/ecr-credential-helper.spec
+++ b/packages/ecr-credential-helper/ecr-credential-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo amazon-ecr-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.11.0
+%global gover 0.12.0
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

update `ecr-credential-helper` to v0.12.0. This will be needed for turn on `fips140=only` for notation

**Testing done:**
- package build success
- pacakge version
```
bash-5.2# grep -ao '0\.1[0-9]\.[0-9]' /usr/bin/docker-credential-ecr-login | head -5
0.12.0
```
- ecr-credential-helper test in ecs-3 variant
```
bash-5.2# apiclient apply <<EOF
> [settings.image-verifier-plugins]
> enabled = true
> EOF
bash-5.2# find /etc/containerd/image-verifiers/ -name trustpolicy.json
/etc/containerd/image-verifiers/notation/trustpolicy.json
bash-5.2# cat /etc/containerd/image-verifiers/notation/trustpolicy.json
{
   "version":"1.0",
   "trustPolicies":[
      {
         "name":"aws-signer-tp",
         "registryScopes":[
            "*"
         ],
         "signatureVerification":{
            "level":"strict",
                        "override": {
              "revocation": "skip"
                        }
         },
         "trustStores":[
            "signingAuthority:aws-signer-ts",
            "signingAuthority:aws-us-gov-signer-ts"
         ],
         "trustedIdentities":[
            "arn:aws:signer:us-west-2:<account>:/signing-profiles/notation_test",
            "arn:aws-us-gov:signer:us-gov-west-1:<account>:/signing-profiles/notation_test"
         ]
      }
   ]
}
bash-5.2# ctr i pull docker.io/library/hello-world:latest
ctr: image verifier bindir blocked pull of docker.io/library/hello-world:latest with digest sha256:ef54e839ef541993b4e87f25e752f7cf4238fa55f017957c2eb44077083d7a6a for reason: verifier notation-image-verifier rejected image (exit code 1): image verification failed: Error: signature verification failed: no signature is associated with "docker.io/library/hello-world@sha256:ef54e839ef541993b4e87f25e752f7cf4238fa55f017957c2eb44077083d7a6a", make sure the artifact was signed successfully
bash-5.2#
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
