### PR TITLE
pluto: add logging

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -4384,11 +4384,13 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 name = "pluto"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "aws-config",
  "aws-lc-rs",
  "aws-sdk-ec2",
  "aws-sdk-eks",
  "aws-smithy-experimental",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
  "base64",
@@ -4398,9 +4400,11 @@ dependencies = [
  "generate-readme",
  "httptest",
  "imdsclient",
+ "log",
  "rustls 0.23.37",
  "serde",
  "serde_json",
+ "simplelog",
  "snafu",
  "tempfile",
  "test-case",

--- a/sources/api/pluto/Cargo.toml
+++ b/sources/api/pluto/Cargo.toml
@@ -13,11 +13,13 @@ exclude = ["README.md"]
 fips = ["aws-lc-rs/fips", "aws-smithy-experimental/crypto-aws-lc-fips", "rustls/fips"]
 
 [dependencies]
+argh.workspace = true
 aws-config.workspace = true
 aws-lc-rs = { workspace = true, features = ["bindgen"] }
 aws-sdk-eks.workspace = true
 aws-sdk-ec2.workspace = true
 aws-smithy-experimental = {workspace = true, features = ["crypto-aws-lc"]}
+aws-smithy-runtime-api.workspace = true
 aws-smithy-types.workspace = true
 aws-types.workspace = true
 base64.workspace = true
@@ -25,9 +27,11 @@ bottlerocket-modeled-types.workspace = true
 bottlerocket-settings-models.workspace = true
 constants.workspace = true
 imdsclient.workspace = true
+log.workspace = true
 rustls.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+simplelog.workspace = true
 snafu.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/sources/api/pluto/README.md
+++ b/sources/api/pluto/README.md
@@ -4,9 +4,10 @@ Current version: 0.1.0
 
 ## Introduction
 
-pluto is called by sundog to generate settings required by Kubernetes.
-This is done dynamically because we require access to dynamic networking
-and cluster setup information.
+pluto is a special settings generator that runs only on Bottlerocket EKS nodes and is
+responsible for generating settings required by Kubernetes. It is invoked through a
+systemd service `pluto.service` after sundog generates rest of the settings but before
+`settings-applier.service` commits them.
 
 It uses IMDS to get information such as:
 
@@ -21,17 +22,6 @@ It uses the Bottlerocket API to get information such as:
 
 - Kubernetes Cluster Name
 - AWS Region
-
-## Interface
-
-Pluto takes the name of the setting that it is to generate as its first
-argument.
-It returns the generated setting to stdout as a JSON document.
-Any other output is returned to stderr.
-
-Pluto returns a special exit code of 2 to inform `sundog` that a setting should be skipped. For
-example, if `max-pods` cannot be generated, we want `sundog` to skip it without failing since a
-reasonable default is available.
 
 ## Colophon
 

--- a/sources/api/pluto/src/ec2.rs
+++ b/sources/api/pluto/src/ec2.rs
@@ -2,6 +2,7 @@ use crate::aws::sdk_config;
 use crate::PROVIDER;
 use aws_smithy_experimental::hyper_1_0::HyperClientBuilder;
 use aws_smithy_types::error::display::DisplayErrorContext;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::time::Duration;
 use tokio_retry::{
@@ -59,12 +60,21 @@ where
         Retry::spawn(
             FibonacciBackoff::from_millis(FIBONACCI_BACKOFF_BASE_DURATION_MILLIS).map(jitter),
             || async {
-                client
+                log::info!("EC2 DescribeInstances attempt for {instance_id}");
+                let response = client
                     .describe_instances()
                     .instance_ids(instance_id.to_owned())
                     .send()
                     .await
-                    .context(DescribeInstancesSnafu { instance_id })?
+                    .context(DescribeInstancesSnafu { instance_id });
+                if let Err(Error::DescribeInstances { source, .. }) = &response {
+                    log::error!(
+                        "EC2 DescribeInstances attempt failed, will retry: code={} message={}",
+                        source.code().unwrap_or_default(),
+                        source.message().unwrap_or_default(),
+                    );
+                }
+                response?
                     .reservations
                     .and_then(|reservations| {
                         reservations.first().and_then(|r| {
@@ -78,6 +88,12 @@ where
                     .filter(|private_dns_name| !private_dns_name.is_empty())
                     .context(MissingSnafu {
                         field: "Reservation.Instance.PrivateDNSName",
+                    })
+                    .inspect_err(|e| {
+                        log::error!(
+                            "EC2 DescribeInstances attempt parsed to missing field, will retry: {}",
+                            e
+                        );
                     })
             },
         ),

--- a/sources/api/pluto/src/eks.rs
+++ b/sources/api/pluto/src/eks.rs
@@ -2,6 +2,8 @@ use crate::aws::sdk_config;
 use crate::PROVIDER;
 use aws_sdk_eks::types::KubernetesNetworkConfigResponse;
 use aws_smithy_experimental::hyper_1_0::HyperClientBuilder;
+use aws_smithy_types::error::display::DisplayErrorContext;
+use aws_smithy_types::error::metadata::ProvideErrorMetadata;
 use snafu::{OptionExt, ResultExt, Snafu};
 use std::time::Duration;
 
@@ -12,8 +14,13 @@ pub(crate) type ClusterNetworkConfig = KubernetesNetworkConfigResponse;
 
 #[derive(Debug, Snafu)]
 pub(super) enum Error {
-    #[snafu(display("Error describing cluster: {}", source))]
+    #[snafu(display(
+        "Error describing EKS cluster '{}': {}",
+        cluster,
+        DisplayErrorContext(source)
+    ))]
     DescribeCluster {
+        cluster: String,
         #[snafu(source(from(aws_sdk_eks::error::SdkError<aws_sdk_eks::operation::describe_cluster::DescribeClusterError>, Box::new)))]
         source: Box<
             aws_sdk_eks::error::SdkError<
@@ -47,19 +54,34 @@ where
 
     let client = build_client(https_proxy, no_proxy, config)?;
 
-    tokio::time::timeout(
-        EKS_DESCRIBE_CLUSTER_TIMEOUT,
-        client.describe_cluster().name(cluster.to_owned()).send(),
-    )
+    tokio::time::timeout(EKS_DESCRIBE_CLUSTER_TIMEOUT, async {
+        log::info!("EKS DescribeCluster for {}", cluster);
+        let response = client
+            .describe_cluster()
+            .name(cluster.to_owned())
+            .send()
+            .await
+            .context(DescribeClusterSnafu { cluster });
+        if let Err(Error::DescribeCluster { source, .. }) = &response {
+            log::error!(
+                "EKS DescribeCluster attempt failed: code={} message={}",
+                source.code().unwrap_or_default(),
+                source.message().unwrap_or_default(),
+            );
+        }
+        response?
+            .cluster
+            .context(MissingSnafu { field: "cluster" })?
+            .kubernetes_network_config
+            .context(MissingSnafu {
+                field: "kubernetes_network_config",
+            })
+            .inspect_err(|e| {
+                log::error!("EKS DescribeCluster response missing expected field: {}", e);
+            })
+    })
     .await
     .context(DescribeClusterTimeoutSnafu)?
-    .context(DescribeClusterSnafu)?
-    .cluster
-    .context(MissingSnafu { field: "cluster" })?
-    .kubernetes_network_config
-    .context(MissingSnafu {
-        field: "kubernetes_network_config",
-    })
 }
 
 fn build_client<H, N>(

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -27,11 +27,13 @@ mod ec2;
 mod eks;
 
 use api::{settings_view_get, settings_view_set, SettingsViewDelta};
+use argh::FromArgs;
 use aws_sdk_eks::types::IpFamily;
 use aws_smithy_experimental::hyper_1_0::CryptoMode;
 use base64::Engine;
 use bottlerocket_modeled_types::{KubernetesClusterDnsIp, KubernetesHostnameOverrideSource};
 use imdsclient::ImdsClient;
+use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
 use snafu::{ensure, OptionExt, ResultExt};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
@@ -153,7 +155,18 @@ mod error {
 
         #[snafu(display("Unable to create tempdir: {}", source))]
         Tempdir { source: std::io::Error },
+
+        #[snafu(display("Failed to initialize logger: {}", source))]
+        Logger { source: log::SetLoggerError },
     }
+}
+
+/// Stores arguments
+#[derive(FromArgs, Debug)]
+struct Args {
+    /// log-level trace|debug|info|warn|error
+    #[argh(option)]
+    log_level: Option<LevelFilter>,
 }
 
 use error::PlutoError;
@@ -512,6 +525,14 @@ fn set_aws_config(aws_k8s_info: &SettingsViewDelta, filepath: &Path) -> Result<(
 }
 
 async fn run() -> Result<()> {
+    let args: Args = argh::from_env();
+
+    // SimpleLogger will send errors to stderr and anything less to stdout.
+    let log_level = args.log_level.unwrap_or(LevelFilter::Info);
+    SimpleLogger::init(log_level, LogConfig::default()).context(error::LoggerSnafu)?;
+
+    log::info!("pluto started");
+
     let mut client = ImdsClient::new();
     let current_settings = api::get_aws_k8s_info().await.context(error::AwsInfoSnafu)?;
     let mut aws_k8s_info = SettingsViewDelta::from_api_response(current_settings);
@@ -538,9 +559,13 @@ async fn run() -> Result<()> {
             constants::API_SETTINGS_URI,
             constants::LAUNCH_TRANSACTION
         );
+
+        log::info!("Committing generated Kubernetes settings via Bottlerocket API");
         api::client_command(&["raw", "-m", "PATCH", "-u", uri, "-d", json_str.as_str()])
             .await
             .context(error::SetFailureSnafu)?;
+    } else {
+        log::info!("No settings generated; nothing to commit");
     }
 
     Ok(())

--- a/sources/api/pluto/src/main.rs
+++ b/sources/api/pluto/src/main.rs
@@ -1,9 +1,10 @@
 /*!
 # Introduction
 
-pluto is called by sundog to generate settings required by Kubernetes.
-This is done dynamically because we require access to dynamic networking
-and cluster setup information.
+pluto is a special settings generator that runs only on Bottlerocket EKS nodes and is
+responsible for generating settings required by Kubernetes. It is invoked through a
+systemd service `pluto.service` after sundog generates rest of the settings but before
+`settings-applier.service` commits them.
 
 It uses IMDS to get information such as:
 
@@ -18,17 +19,6 @@ It uses the Bottlerocket API to get information such as:
 
 - Kubernetes Cluster Name
 - AWS Region
-
-# Interface
-
-Pluto takes the name of the setting that it is to generate as its first
-argument.
-It returns the generated setting to stdout as a JSON document.
-Any other output is returned to stderr.
-
-Pluto returns a special exit code of 2 to inform `sundog` that a setting should be skipped. For
-example, if `max-pods` cannot be generated, we want `sundog` to skip it without failing since a
-reasonable default is available.
 */
 
 mod api;


### PR DESCRIPTION
**Description of changes:**
- update readme.md to explain how pluto works currently
- added logging

**Testing done:**
To simulate an error I updated IAM permissions to `DENY` ec2::DescribeInstances calls. The generated logs are as follows.

```
[   15.211729] settings-committer[1665]: 22:20:04 [INFO] Committing settings.
[   16.224034] pluto[1671]: 22:20:05 [ERROR] EC2 DescribeInstances attempt failed, will retry: code=UnauthorizedOperation message=You are not authorized to perform this operation. User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx//i-abc is not authorized to perform: ec2:DescribeInstances with an explicit deny in an identity-based policy
[   16.316280] pluto[1671]: 22:20:05 [ERROR] EC2 DescribeInstances attempt failed, will retry: code=UnauthorizedOperation message=You are not authorized to perform this operation. User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx//i-abc is not authorized to perform: ec2:DescribeInstances with an explicit deny in an identity-based policy
[   16.384069] pluto[1671]: 22:20:05 [ERROR] EC2 DescribeInstances attempt failed, will retry: code=UnauthorizedOperation message=You are not authorized to perform this operation. User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx//i-abc is not authorized to perform: ec2:DescribeInstances with an explicit deny in an identity-based policy
[   16.645846] pluto[1671]: 22:20:05 [ERROR] EC2 DescribeInstances attempt failed, will retry: code=UnauthorizedOperation message=You are not authorized to perform this operation. User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx//i-abc is not authorized to perform: ec2:DescribeInstances with an explicit deny in an identity-based policy
[   16.674229] pluto[1671]: 22:20:06 [ERROR] EC2 DescribeInstances attempt failed, will retry: code=UnauthorizedOperation message=You are not authorized to perform this operation. User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx/i-abc is not authorized to perform: ec2:DescribeInstances with an explicit deny in an identity-based policy
[   17.536820] pluto[1671]: 22:20:06 [ERROR] EC2 DescribeInstances attempt failed, will retry: code=UnauthorizedOperation message=You are not authorized to perform this operation. User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx/i-abc is not authorized to perform: ec2:DescribeInstances with an explicit deny in an identity-based policy
[   18.422499] pluto[1671]: 22:20:07 [ERROR] EC2 DescribeInstances attempt failed, will retry: code=UnauthorizedOperation message=You are not authorized to perform this operation. User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx//i-abc is not authorized to perform: ec2:DescribeInstances with an explicit deny in an identity-based policy
[   18.687825] pluto[1671]: 22:20:08 [ERROR] EC2 DescribeInstances attempt failed, will retry: code=UnauthorizedOperation message=You are not authorized to perform this operation. User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx//i-abc is not authorized to perform: ec2:DescribeInstances with an explicit deny in an identity-based policy
[   20.003547] pluto[1671]: 22:20:09 [ERROR] EC2 DescribeInstances attempt failed, will retry: code=UnauthorizedOperation message=You are not authorized to perform this operation. User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx//i-abc is not authorized to perform: ec2:DescribeInstances with an explicit deny in an identity-based policy
[   20.034138] pluto[1671]: 22:20:09 [ERROR] EC2 DescribeInstances attempt failed, will retry: code=UnauthorizedOperation message=You are not authorized to perform this operation. User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx//i-abc is not authorized to perform: ec2:DescribeInstances with an explicit deny in an identity-based policy

```
I then attached `DENY` to `eks:DescribeCluster` call as well and this is the serial log
```
[  OK  ] Finished User-specified setting generators.

         Starting Generate additional settings for Kubernetes...

[   11.054063] pluto[1660]: 22:50:03 [ERROR] EKS DescribeCluster attempt failed: code=AccessDeniedException message=User: arn:aws:sts::xyz:assumed-role/eksctl-bottlerocket-cluster-135-no-NodeInstanceRole-xxxx/i-abc is not authorized to perform: eks:DescribeCluster on resource: arn:aws:eks:us-west-2:xyz:cluster/bottlerocket-cluster-135 with an explicit deny in an identity-based policy
[  OK  ] Finished Generate additional settings for Kubernetes.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
