### PR TITLE
Third Party Package Updates

### DIFF
--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.7.2/rolesanywhere-credential-helper-v1.7.2.tar.gz"
-sha512 = "33d5673038be8589899207737a084698ce846b738fd8b715261f8cad7ce28d30c773983b269dd98defd8f1321fb2843933838b6b41840bf4aa91544b9111c70a"
+url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.7.3/rolesanywhere-credential-helper-v1.7.3.tar.gz"
+sha512 = "58daf46f6ba3272d8808e8d343fe15a409499a9d059d2eafdcddb7fbfe6aa3030c962a92fc68ba0e90b7afa4338e83cfe59402ccfa256dd8c6e1c3e21b3a505e"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo rolesanywhere-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.7.2
+%global gover 1.7.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.29/Cargo.toml
+++ b/packages/kubernetes-1.29/Cargo.toml
@@ -14,7 +14,7 @@ path = "../packages.rs"
 package-name = "kubernetes-1.29"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/57/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-29/releases/59/artifacts/kubernetes/v1.29.15/kubernetes-src.tar.gz"
 sha512 = "dfc7463e91429c5507cea4d319c7d81499dec71ab4b741ba9fbd0d107b6c279fdece73f8cb5987b48aed675c4742fa1e999cecfae95d869456b0c8b77cd88d56"
 
 [build-dependencies]

--- a/packages/kubernetes-1.29/kubernetes-1.29.spec
+++ b/packages/kubernetes-1.29/kubernetes-1.29.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 57
+%global releasever 59
 %global gover 1.29.15
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/50/artifacts/kubernetes/v1.30.14/kubernetes-src.tar.gz"
-sha512 = "792ccf3696e787cce2f51f32b3932435bfa11a0a036365fcbbe5b9ae9ae1fae121598bfed2f9c40f9a61f19a927d872863443468de73185bc2c8889856cc9d58"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/53/artifacts/kubernetes/v1.30.14/kubernetes-src.tar.gz"
+sha512 = "d00e049674ee2ba3f61e549742f12a504cfd148638e1ca69ab70fabf00e77ffccc486042f32f667c1e917319920a98d15568c9d48e51ae9556e68d6b4b1a0cba"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 50
+%global releasever 53
 %global gover 1.30.14
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/39/artifacts/kubernetes/v1.31.14/kubernetes-src.tar.gz"
-sha512 = "2909906ce41d9a92f21db57f4b77f32e5069fb3569250c840e63b8fb71a1b1f64283846012f2ab80f0c44a33bb248d955e9df3599b9754ea2025e737467adcdb"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/42/artifacts/kubernetes/v1.31.14/kubernetes-src.tar.gz"
+sha512 = "3de5f04a947261835173540b24467ee12292d4264a6b3d478b47459e72d99f8c9099695d603ac00ff962886e743e0fca784d6f346673e80d3a16458d0601d1db"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 39
+%global releasever 42
 %global gover 1.31.14
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.32/Cargo.toml
+++ b/packages/kubernetes-1.32/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.32"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/32/artifacts/kubernetes/v1.32.11/kubernetes-src.tar.gz"
-sha512 = "208e87f8fd0f2c97e58be4cd03ca7064a575e25725e95f5e1568dbf4426874f95029c1879120b39fd8a7ad63b467cb6148edd45bbea9085cb7f7dc5539d5a450"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/35/artifacts/kubernetes/v1.32.12/kubernetes-src.tar.gz"
+sha512 = "ab7e6ef9951a120f8a28cd96eb3fbbf781600bdbd6edcfa3692f6ed3338b049a44c1ca9f696cc443556f8071f93f1722346b21cac4036646a3a6dbeb35ea9629"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 32
-%global gover 1.32.11
+%global releasever 35
+%global gover 1.32.12
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.33/Cargo.toml
+++ b/packages/kubernetes-1.33/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.33"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/22/artifacts/kubernetes/v1.33.7/kubernetes-src.tar.gz"
-sha512 = "a75abcb4cad14b8784c31bcdeab1d3c4d5652040fa8f50f1d35fa787639ec09c7453b7e921b390b461ae31fe2a8877ba71c8c19013ce3408bc9de4370874e3f1"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/25/artifacts/kubernetes/v1.33.8/kubernetes-src.tar.gz"
+sha512 = "903ea52c20b585b0b6c08252ea6c88a0711282808a971ef91e295a6bc974734cf24b3c103c4f8b4fd4e8ac1b80b7fc4779c395321dc2ce50a336f2498876814c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 22
-%global gover 1.33.7
+%global releasever 25
+%global gover 1.33.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.34/Cargo.toml
+++ b/packages/kubernetes-1.34/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.34"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/13/artifacts/kubernetes/v1.34.3/kubernetes-src.tar.gz"
-sha512 = "578e384236942b4ab13776aa5e9d19fd0a8dae3ca8791ed89b4a4db49fabcaa4e9b39efc992207334359decac1207301153ad5c81c5c04411ef4a7c26e6d32a9"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/16/artifacts/kubernetes/v1.34.4/kubernetes-src.tar.gz"
+sha512 = "3b4db2190ede0333f688af63e8f0eba081aa97542cf0d70ced4fb72fddef5b6004d814ea1e513f0c9f91a6d0047828fc48671e25aa16b9003b6ecf82deb7a3bb"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.34/kubernetes-1.34.spec
+++ b/packages/kubernetes-1.34/kubernetes-1.34.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 13
-%global gover 1.34.3
+%global releasever 16
+%global gover 1.34.4
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.35/Cargo.toml
+++ b/packages/kubernetes-1.35/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.35"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-35/releases/3/artifacts/kubernetes/v1.35.0/kubernetes-src.tar.gz"
-sha512 = "0616aed1d47e514904f5d6ead778514d885deefe294f1e7b1526ea33ec8e623704061f3fe010aa4578ed397483714d2010e7d5b4f10fd055f032a588c4768fbd"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-35/releases/7/artifacts/kubernetes/v1.35.2/kubernetes-src.tar.gz"
+sha512 = "b83667356ba18cde610b147f99ad971779d77b409ce89401589fa2ba1df5a48fa477a208d7ae3f7f64ef3a3776b803315dc455a1540cab3b95b065abc62d5ab1"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.35/kubernetes-1.35.spec
+++ b/packages/kubernetes-1.35/kubernetes-1.35.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 3
-%global gover 1.35.0
+%global releasever 7
+%global gover 1.35.2
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/soci-snapshotter/Cargo.toml
+++ b/packages/soci-snapshotter/Cargo.toml
@@ -12,15 +12,15 @@ path = "../packages.rs"
 releases-url = "https://github.com/awslabs/soci-snapshotter/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/v0.12.0/soci-snapshotter-0.12.0.tar.gz"
-sha512 = "6e0c236b985526fc551c44e1b8b580cafa776f277ab29751a22fbe9e53c7308a953b90572eef40239091da9daab0c0b577ba404ff332e13b6bbd15b3200a4242"
-bundle-root-path = "soci-snapshotter-0.12.0/cmd"
+url = "https://github.com/awslabs/soci-snapshotter/archive/v0.12.1/soci-snapshotter-0.12.1.tar.gz"
+sha512 = "cf67566bbbe2e93f692cec835d8add0d40729fc463cfcd4a3f164a0514b38289721bac5cce55b5220a2e834116e871a83601ee3df668000eceecd3d150939de6"
+bundle-root-path = "soci-snapshotter-0.12.1/cmd"
 bundle-output-path = "bundled-cmd.tar.gz"
 bundle-modules = [ "go" ]
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/v0.12.0/soci-snapshotter-0.12.0.tar.gz"
-sha512 = "6e0c236b985526fc551c44e1b8b580cafa776f277ab29751a22fbe9e53c7308a953b90572eef40239091da9daab0c0b577ba404ff332e13b6bbd15b3200a4242"
+url = "https://github.com/awslabs/soci-snapshotter/archive/v0.12.1/soci-snapshotter-0.12.1.tar.gz"
+sha512 = "cf67566bbbe2e93f692cec835d8add0d40729fc463cfcd4a3f164a0514b38289721bac5cce55b5220a2e834116e871a83601ee3df668000eceecd3d150939de6"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -1,7 +1,7 @@
 %global gorepo soci-snapshotter
-%global gover 0.12.0
+%global gover 0.12.1
 %global rpmver %{gover}
-%global gitrev eef118c6072dc125f0e030089833c4230540929f
+%global gitrev c140af2f22fffade79af74ddcc1c29388d763051
 
 Name: %{_cross_os}soci-snapshotter
 Version: %{gover}


### PR DESCRIPTION
**Description of changes:**
- Update kubernetes packages to latest release
- Update aws-signing-helper to v1.7.3
- Update soci-snapshotter to v0.12.1

**Testing done:**
- conformance passed for k8s-1.29-1.35
- enabled soci and tested image pull


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
