### PR TITLE
fixes for the latest SDK

### DIFF
--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -71,7 +71,7 @@ Requires: %{name}
 %autosetup -Sgit -n glibc-%{version} -p1
 
 %global glibc_configure %{shrink: \
-BUILDFLAGS="-O2 -g -Wp,-D_GLIBCXX_ASSERTIONS -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" \
+BUILDFLAGS="-O2 -g1 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-clash-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" \
 CFLAGS="${BUILDFLAGS}" CPPFLAGS="" CXXFLAGS="${BUILDFLAGS}" \
 ../configure \
   --prefix="%{_cross_prefix}" \

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -558,6 +558,13 @@ exec 1>&3 2>&4
 # Run non-static builds in the foreground.
 echo "** Output from non-static builds:"
 %cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
+    -p logdog \
+    -p metricdog \
+    -p migrator \
+    -p updog \
+    %{nil}
+
+%cargo_build --manifest-path %{_builddir}/sources/Cargo.toml \
     -p apiserver \
     -p sundog \
     -p schnauzer \
@@ -568,11 +575,7 @@ echo "** Output from non-static builds:"
     -p host-containers \
     -p storewolf \
     -p settings-committer \
-    -p migrator \
     -p signpost \
-    -p updog \
-    -p logdog \
-    -p metricdog \
     -p ghostdog \
     -p corndog \
     -p bootstrap-commands \
@@ -661,8 +664,10 @@ ln -s brush %{buildroot}%{_cross_bindir}/sh
 install -d %{buildroot}%{_cross_libexecdir}/brush/allowed-programs
 
 for p in \
-  logdog migrator metricdog \
-  shibaken updog \
+  logdog \
+  migrator \
+  metricdog \
+  updog \
 ; do
   install -p -m 0755 %{__cargo_outdir_fips}/${p} %{buildroot}%{_cross_fips_bindir}
 done

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -346,24 +346,7 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}pluto-bin)
 
 %package -n %{_cross_os}shibaken
 Summary: IMDS client and settings generator
-Requires: %{_cross_os}shibaken(binaries)
 %description -n %{_cross_os}shibaken
-%{summary}.
-
-%package -n %{_cross_os}shibaken-bin
-Summary: IMDS client and settings generator binaries
-Provides: %{_cross_os}shibaken(binaries)
-Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}shibaken)
-Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}shibaken-fips-bin)
-%description -n %{_cross_os}shibaken-bin
-%{summary}.
-
-%package -n %{_cross_os}shibaken-fips-bin
-Summary: IMDS client and settings generator binaries, FIPS edition
-Provides: %{_cross_os}shibaken(binaries)
-Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}shibaken)
-Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}shibaken-bin)
-%description -n %{_cross_os}shibaken-fips-bin
 %{summary}.
 
 %package -n %{_cross_os}warm-pool-wait
@@ -567,7 +550,6 @@ exec 1>"${fips_output}" 2>&1
     -p metricdog \
     -p migrator \
     -p updog \
-    -p shibaken \
     &
 # Save the PID so we can wait for it later.
 fips_pid="$!"
@@ -929,13 +911,8 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %{_cross_fips_bindir}/logdog
 
 %files -n %{_cross_os}shibaken
-%dir %{_cross_templatedir}
-
-%files -n %{_cross_os}shibaken-bin
 %{_cross_bindir}/shibaken
-
-%files -n %{_cross_os}shibaken-fips-bin
-%{_cross_fips_bindir}/shibaken
+%dir %{_cross_templatedir}
 
 %files -n %{_cross_os}warm-pool-wait
 %{_cross_templatedir}/warm-pool-wait-toml

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -5721,12 +5721,10 @@ name = "shibaken"
 version = "0.1.0"
 dependencies = [
  "argh",
- "aws-lc-rs",
  "base64",
  "generate-readme",
  "imdsclient",
  "log",
- "rustls 0.23.31",
  "serde",
  "serde_json",
  "simplelog",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -251,4 +251,4 @@ tag = "bottlerocket-settings-models-v0.21.0"
 version = "0.1.0"
 
 [profile.release]
-debug = true
+debug = "line-tables-only"

--- a/sources/api/shibaken/Cargo.toml
+++ b/sources/api/shibaken/Cargo.toml
@@ -9,16 +9,11 @@ build = "build.rs"
 # Don't rebuild crate just because of changes to README.
 exclude = ["README.md"]
 
-[features]
-fips = ["rustls/fips", "aws-lc-rs/fips"]
-
 [dependencies]
 argh.workspace = true
-aws-lc-rs = { workspace = true, features = ["bindgen"] }
 base64.workspace = true
 imdsclient.workspace = true
 log.workspace = true
-rustls.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 simplelog.workspace = true

--- a/sources/api/shibaken/src/main.rs
+++ b/sources/api/shibaken/src/main.rs
@@ -53,8 +53,6 @@ enum Commands {
 async fn run() -> Result<()> {
     let args: Args = argh::from_env();
 
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
     // TerminalMode::Stderr will send all logs to stderr, as sundog only expects the json output of
     // the setting on stdout.
     TermLogger::init(


### PR DESCRIPTION
**Issue number:**
Related: bottlerocket-os/bottlerocket-sdk/pull/334, https://github.com/bottlerocket-os/bottlerocket-sdk/pull/332

**Description of changes:**
Enable minimal debuginfo for Rust crates and glibc.

~~Upgrade the minimum kernel version for glibc to 6.1, to match the new SDK requirement.~~

With symbols included, more binaries run afoul of the FIPS check. Remove the TLS feature from `shibaken`, which doesn't need to make TLS calls. Add a separate build job for crates that use `aws-lc-rs`, to avoid feature unification that would cause it to be used for more binaries.


**Testing done:**
Verified that the build succeeds with the newer SDK.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
