### PR TITLE
image-verifiers: override GODEBUG fips140 mode for notation verifier

### DIFF
--- a/sources/image-verifiers/src/bin/notation.rs
+++ b/sources/image-verifiers/src/bin/notation.rs
@@ -9,6 +9,7 @@ If no trust policy is configured, all images are allowed.
 use image_verifiers::{args, logging, policy, reference};
 use log::{debug, error};
 use serde::Deserialize;
+use std::env;
 use std::path::Path;
 use std::process::{self, Command};
 
@@ -60,17 +61,26 @@ fn main() {
         }
     }
 
-    let output = match Command::new("/usr/bin/notation")
-        .args(["verify", &image_ref])
+    let mut cmd = Command::new("/usr/bin/notation");
+    cmd.args(["verify", &image_ref])
         .env(
             "NOTATION_CONFIG",
             "/etc/containerd/image-verifiers/notation",
         )
         .env("NOTATION_CACHE", "/var/cache/notation")
         .env("NOTATION_LIBEXEC", "/usr/libexec/notation-plugins")
-        .env("HOME", "/root")
-        .output()
-    {
+        .env("HOME", "/root");
+
+    // We upgrade to fips140=only for notation to enforce strict FIPS-only
+    // cryptography: all hash functions, TLS ciphers, and signature algorithms
+    // used during image verification must be FIPS-approved with no fallback.
+    if let Ok(godebug) = env::var("GODEBUG") {
+        if godebug == "fips140=on" {
+            cmd.env("GODEBUG", "fips140=only");
+        }
+    }
+
+    let output = match cmd.output() {
         Ok(o) => o,
         Err(e) => {
             error!("image verification failed: {}", e);


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #852

**Description of changes:**
When FIPS mode is enabled, the system-wide GODEBUG=fips140=on setting enables FIPS crypto with fallback. Override this to fips140=only for the notation image verifier to enforce strict FIPS-only cryptography with no fallback to non-FIPS algorithms.


**Testing done:**
testing with #846 
- user data:
```
[settings.ecs]
cluster = "bottlerocket"

[settings.image-verifier-plugins.notation]
trustpolicy = "e....."

[settings.image-verifier-plugins]
enabled = true

# Need below otherwise: ctr: container "admin" in namespace "default": not found
[settings.host-containers.admin]
enabled = true
```
- image verify work
```
bash-5.2# ctr i pull docker.io/library/hello-world:latest
ctr: image verifier bindir blocked pull of docker.io/library/hello-world:latest with digest sha256:ef54e839ef541993b4e87f25e752f7cf4238fa55f017957c2eb44077083d7a6a for reason: verifier notation-image-verifier rejected image (exit code 1): image verification failed: Error: signature verification failed: no signature is associated with "docker.io/library/hello-world@sha256:ef54e839ef541993b4e87f25e752f7cf4238fa55f017957c2eb44077083d7a6a", make sure the artifact was signed successfully
bash-5.2#
```

- source has the newest change

```
bash-5.2# grep -ao 'fips140=only' /opt/civ/bin/notation-image-verifier
fips140=only
```
- env success override

```
bash-5.2# while true; do
>   pid=$(pgrep -f "notation verify" | head -1)
>   if [ -n "$pid" ]; then
>     cat /proc/$pid/environ 2>/dev/null | tr '\0' '\n'
>     break
>   fi
> done
AWS_SDK_LOAD_CONFIG=true
CONTAINERD_DISABLE_PIGZ=1
GODEBUG=fips140=only
HOME=/root
INVOCATION_ID=b36879fb3c6c4f48b3077fb5aefdc863
JOURNAL_STREAM=9:8350
LANG=C.UTF-8
MEMORY_PRESSURE_WATCH=/sys/fs/cgroup/runtime.slice/containerd.service/memory.pressure
MEMORY_PRESSURE_WRITE=c29tZSAyMDAwMDAgMjAwMDAwMAA=
NOTATION_CACHE=/var/cache/notation
NOTATION_CONFIG=/etc/containerd/image-verifiers/notation
NOTATION_LIBEXEC=/usr/libexec/notation-plugins
NOTIFY_SOCKET=/run/systemd/notify
NO_PROXY=localhost,127.0.0.1
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
SYSTEMD_EXEC_PID=2151
TZ=:UTC
USER=root
no_proxy=localhost,127.0.0.1
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
