### PR TITLE
release: core-kit v13.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v13.1.2 (2026-03-06)
+
+## OS Changes
+### Third Party Package Updates
+- Update `amazon-ecs-cni-plugins` ([#855])
+
+[#855]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/855
+
 # v13.1.1 (2026-02-26)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "13.1.1"
+release-version = "13.1.2"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/packages/amazon-ecs-cni-plugins/Cargo.toml
+++ b/packages/amazon-ecs-cni-plugins/Cargo.toml
@@ -16,8 +16,8 @@ releases-url = "https://github.com/aws/amazon-ecs-agent/commits/master/amazon-ec
 # This is locked against the version shipped in ecs-agent
 # Verify that the ecs-agent version shipped in bottlerocket tracks the same one here
 # https://github.com/aws/amazon-ecs-agent/releases
-url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/319a734d9edfeeec9e7b64acf0500c45508aa8d3/amazon-ecs-cni-plugins.tar.gz"
-sha512 = "ef1457e0325a2e43c307ea962bd675cc6df8501ada055f10c8c7b51f83486c96eab6368946b0ca4fe47f9fc91d22f51218adb9c07dc5812a80389eaaf1d83df3"
+url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/f26629faf64028796b76154d55c1bc7e3bff13c8/amazon-ecs-cni-plugins.tar.gz"
+sha512 = "9d5eb384e4bed620b2ed40d6afdd4c08167ac489cd6cc1c8edb1bde4b46aa492b35bf98d8b707375ee68deabbc6d0fdf1f1c600bd487933ac75cc0778bafff5f"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
+++ b/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
@@ -1,11 +1,11 @@
 %global ecscni_goproject github.com/aws
 %global ecscni_gorepo amazon-ecs-cni-plugins
 %global ecscni_goimport %{ecscni_goproject}/%{ecscni_gorepo}
-%global ecscni_gitrev 319a734d9edfeeec9e7b64acf0500c45508aa8d3
+%global ecscni_gitrev f26629faf64028796b76154d55c1bc7e3bff13c8
 
 Name: %{_cross_os}amazon-ecs-cni-plugins
-# https://github.com/aws/amazon-ecs-cni-plugins/blob/319a734d9edfeeec9e7b64acf0500c45508aa8d3/VERSION#L1
-Version: 2026.02.0
+# https://github.com/aws/amazon-ecs-cni-plugins/blob/f26629faf64028796b76154d55c1bc7e3bff13c8/VERSION#L1
+Version: 2026.03.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: Networking plugins for ECS task networking


### PR DESCRIPTION
**Description of changes:**
- Update amazon-ecs-cni-plugins from commit 319a734 to f26629f, bumping the version from 2026.02.0 to 2026.03.0.
- Bump Twoliter.toml version and prep the Changelog for the release

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
