### PR TITLE
Send whippet's STDERR to both the journal and the console

### DIFF
--- a/packages/os/whippet.service
+++ b/packages/os/whippet.service
@@ -20,6 +20,7 @@ ProtectSystem=full
 PrivateTmp=no
 PrivateDevices=true
 ExecStart=/usr/bin/whippet
+StandardError=journal+console
 
 [Install]
 Alias=dbus.service


### PR DESCRIPTION
**Description of changes:**

Send whippet's STDERR to both the journal and the console

(This is https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/858 but using my fork instead)

**Testing done:**

I confirmed I can see the logs in the serial console, with an AMI built that doesn't alias `whippet.service` to `dbus.service` which prevents the service from getting the socket FD:


```
❯ aws ec2 get-console-output --instance-id $INSTANCE_ID --output text --latest | rg whippet
See 'systemctl status whippet.service' for details.
[    5.964352] whippet[452]: Error: Failed to retrieve 'LISTEN_PID' environment variable
[    5.965771] whippet[452]: Caused by this error:
[    5.966654] whippet[452]:   1: environment variable not found
```

Instance boots with the change:

<details>

```
[root@admin]# sheltie systemctl status whippet.service
● whippet.service - D-Bus System Message Bus
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/whippet.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (running) since Fri 2026-03-06 21:25:56 UTC; 2min 46s ago
 Invocation: 71e9e6417a0249ed8ab7275467592b4d
TriggeredBy: ● dbus.socket
   Main PID: 1518 (whippet)
      Tasks: 10 (limit: 37593)
     Memory: 6.2M (peak: 6.9M)
        CPU: 148ms
     CGroup: /system.slice/whippet.service
             ├─1518 /usr/bin/whippet
             └─1537 /usr/bin/dbus-broker --log 12 --controller 11 --machine-id ec294d8464c32b55954ee4625e3e7410 --max-bytes 536870912 --max-fds 4096 --max-matches 16384

Mar 06 21:25:56 localhost whippet[1518]: 21:25:56 [INFO] read_commands; n_commands=1
Mar 06 21:25:56 localhost whippet[1518]: 21:25:56 [INFO] Using listener socket FD: 3
Mar 06 21:25:56 localhost whippet[1518]: 21:25:56 [INFO] Setting broker listener socket and policy
Mar 06 21:25:56 localhost whippet[1518]: 21:25:56 [INFO] socket reader;
Mar 06 21:25:56 localhost whippet[1518]: 21:25:56 [INFO] read_socket;
Mar 06 21:25:56 localhost whippet[1518]: 21:25:56 [INFO] read_socket;
Mar 06 21:25:56 localhost whippet[1518]: 21:25:56 [INFO] Done setting broker listener socket and policy
Mar 06 21:25:56 localhost whippet[1518]: 21:25:56 [INFO] Policy applied successfully
Mar 06 21:25:56 localhost whippet[1518]: 21:25:56 [INFO] Notified systemd that service is ready
Mar 06 21:25:56 localhost systemd[1]: Started D-Bus System Message Bus.
[root@admin]# sheltie systemctl cat whippet.service
# /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/whippet.service
[Unit]
Description=D-Bus System Message Bus
DefaultDependencies=false
# Ensure the dbus user is created before starting dbus service
After=dbus.socket systemd-sysusers.service
Wants=dbus.socket systemd-sysusers.service
Before=basic.target shutdown.target
Requires=dbus.socket
Conflicts=shutdown.target

[Service]
User=dbus
Type=notify
Sockets=dbus.socket
OOMScoreAdjust=-900
LimitNOFILE=16384
ProtectSystem=full
# Disable private /tmp to avoid dependency on systemd-tmpfiles and consequently
# local-fs.target, allowing dbus to start earlier in the boot
PrivateTmp=no
PrivateDevices=true
ExecStart=/usr/bin/whippet
StandardError=journal+console

[Install]
Alias=dbus.service
WantedBy=preconfigured.target

# /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d/00-aws-config.conf
[Service]
# Set the AWS_SDK_LOAD_CONFIG system-wide instead of at the individual service
# level, to make sure new system services that use the AWS SDK for Go read the
# shared AWS config
Environment=AWS_SDK_LOAD_CONFIG=true
```

</details>

I tested the places where things could go wrong in `whippet` when it initializes:

Logs when policies directory is missing:

<details>

```
Mar 09 19:20:19 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: Starting whippet.service - Whippet D-Bus Launcher...
Mar 09 19:20:19 ip-172-31-62-36.us-west-2.compute.internal whippet[682717]: 19:20:19 [INFO] Starting whippet D-Bus launcher
Mar 09 19:20:19 ip-172-31-62-36.us-west-2.compute.internal whippet[682717]: Error: Failed to read path '/tmp/policies'
Mar 09 19:20:19 ip-172-31-62-36.us-west-2.compute.internal whippet[682717]: Caused by this error:
Mar 09 19:20:19 ip-172-31-62-36.us-west-2.compute.internal whippet[682717]:   1: No such file or directory (os error 2)
Mar 09 19:20:19 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: whippet.service: Main process exited, code=exited, status=1/FAILURE
Mar 09 19:20:19 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: whippet.service: Failed with result 'exit-code'.
Mar 09 19:20:19 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: Failed to start whippet.service - Whippet D-Bus Launcher.
```

</details>

Logs when main configuration file is missing:

<details>

```
Mar 09 19:21:51 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: Starting whippet.service - Whippet D-Bus Launcher...
Mar 09 19:21:51 ip-172-31-62-36.us-west-2.compute.internal whippet[688035]: 19:21:51 [INFO] Starting whippet D-Bus launcher
Mar 09 19:21:51 ip-172-31-62-36.us-west-2.compute.internal whippet[688035]: Error: Failed to read path '/home/agarrcia/Code/work/by-feature/whippet/bottlerocket-core-kit/packages/os/dbus-1-system.toml'
Mar 09 19:21:51 ip-172-31-62-36.us-west-2.compute.internal whippet[688035]: Caused by this error:
Mar 09 19:21:51 ip-172-31-62-36.us-west-2.compute.internal whippet[688035]:   1: No such file or directory (os error 2)
Mar 09 19:21:51 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: whippet.service: Main process exited, code=exited, status=1/FAILURE
Mar 09 19:21:51 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: whippet.service: Failed with result 'exit-code'.
Mar 09 19:21:51 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: Failed to start whippet.service - Whippet D-Bus Launcher.
```

</details>

Logs when spawning `dbus-broker` fails:

<details>

```
Mar 09 19:25:18 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: Starting whippet.service - Whippet D-Bus Launcher...
Mar 09 19:25:18 ip-172-31-62-36.us-west-2.compute.internal whippet[694830]: 19:25:18 [INFO] Starting whippet D-Bus launcher
Mar 09 19:25:18 ip-172-31-62-36.us-west-2.compute.internal whippet[694830]: 19:25:18 [INFO] Starting dbus-broker: /home/agarrcia/Code/work/by-feature/whippet/sources/dbus-broker-36/build/src/dbus-broke
Mar 09 19:25:18 ip-172-31-62-36.us-west-2.compute.internal whippet[694830]: Error: Failed to spawn dbus-broker process
Mar 09 19:25:18 ip-172-31-62-36.us-west-2.compute.internal whippet[694830]: Caused by this error:
Mar 09 19:25:18 ip-172-31-62-36.us-west-2.compute.internal whippet[694830]:   1: No such file or directory (os error 2)
Mar 09 19:25:18 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: whippet.service: Main process exited, code=exited, status=1/FAILURE
Mar 09 19:25:18 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: whippet.service: Failed with result 'exit-code'.
Mar 09 19:25:18 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: Failed to start whippet.service - Whippet D-Bus Launcher.
```

</details>

Logs when systemd doesn't pass the expected socket:

<details>

```
Mar 09 19:25:47 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: Starting whippet.service - Whippet D-Bus Launcher...
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: Starting whippet.service - Whippet D-Bus Launcher...
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal whippet[701822]: 19:27:28 [INFO] Starting whippet D-Bus launcher
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal whippet[701822]: 19:27:28 [INFO] Starting dbus-broker: /usr/bin/dbus-broker
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal whippet[701822]: 19:27:28 [INFO] dbus-broker spawned with PID: Some(701952)
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal dbus-broker[701952]: Dispatched 0 messages @ 0(±0)μs / message.
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal whippet[701822]: 19:27:28 [INFO] dbus-broker exited successfully: exit status: 0
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal whippet[701822]: Error: Failed to retrieve 'LISTEN_PID' environment variable
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal whippet[701822]: Caused by this error:
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal whippet[701822]:   1: environment variable not found
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: whippet.service: Main process exited, code=exited, status=1/FAILURE
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: whippet.service: Failed with result 'exit-code'.
Mar 09 19:27:28 ip-172-31-62-36.us-west-2.compute.internal systemd[4108]: Failed to start whippet.service - Whippet D-Bus Launcher.
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
