### PR TITLE
kubernetes-1.35: add kubelet-env-nvidia template

### DIFF
--- a/packages/kubernetes-1.35/kubelet-env-nvidia
+++ b/packages/kubernetes-1.35/kubelet-env-nvidia
@@ -1,0 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["join_node_taints"] }
+std = { version = "v1", helpers = ["join_map"] }
++++
+NODE_IP={{settings.kubernetes.node-ip}}
+NODE_LABELS=nvidia.com/gpu.present=true,{{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
+NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}

--- a/packages/kubernetes-1.35/kubernetes-1.35.spec
+++ b/packages/kubernetes-1.35/kubernetes-1.35.spec
@@ -55,6 +55,7 @@ Source13: etc-kubernetes-pki-private.mount
 Source14: credential-provider-config-yaml
 Source15: logdog.kubelet.conf
 Source16: multi-user-uphold-kubelet.conf
+Source17: kubelet-env-nvidia
 
 # ExecStartPre drop-ins
 Source20: prestart-load-pause-ctr.conf
@@ -200,6 +201,7 @@ install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet
 
 mkdir -p %{buildroot}%{_cross_templatedir}
 install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
+install -m 0644 %{S:17} %{buildroot}%{_cross_templatedir}/kubelet-env-nvidia
 install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
 install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
 install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
@@ -244,6 +246,7 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_unitdir}/multi-user.target.d/10-kubelet-service.conf
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/kubelet-env
+%{_cross_templatedir}/kubelet-env-nvidia
 %{_cross_templatedir}/kubelet-config
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_templatedir}/kubelet-kubeconfig


### PR DESCRIPTION
**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket/issues/4756

**Description of changes:**

Add a kubelet-env-nvidia template that hardcodes the `nvidia.com/gpu.present=true` node label. NVIDIA components such as the
DRA driver use this label in their deployment `nodeAffinity`. Without it, they refuse to schedule on NVIDIA GPU hosts.

**Testing done:**

In combination with: https://github.com/bottlerocket-os/bottlerocket/pull/4784

Launched a Kubernetes 1.35 NVIDIA variant and confirmed the label is registered:

```fish
❯ if k get nodes --show-labels | rg -q nvidia.com;
   echo "Label present"
end

Label present
```

Confirmed that the only new label is what `nvidia.com/gpu.present`:

<details>

```bash
=== Label Diff ===
  Node A: ip-192-168-58-243.us-west-2.compute.internal
  Node B: ip-192-168-67-54.us-west-2.compute.internal
  Total labels: 16 (identical: 11, different: 4, only-A: 0, only-B: 1)

≠  Different values:
     LABEL                                     NODE A                                        NODE B
  ---------------------------------------------------------------------------------------------------------------------------------------
   ≠ failure-domain.beta.kubernetes.io/zone    us-west-2c                                    us-west-2a
   ≠ kubernetes.io/hostname                    ip-192-168-58-243.us-west-2.compute.internal  ip-192-168-67-54.us-west-2.compute.internal
   ≠ topology.k8s.aws/zone-id                  usw2-az3                                      usw2-az2
   ≠ topology.kubernetes.io/zone               us-west-2c                                    us-west-2a

→  Only on Node B:
     LABEL                                     NODE A                                        NODE B
  ---------------------------------------------------------------------------------------------------------------------------------------
   → nvidia.com/gpu.present                                                                  true

=  Identical:
     LABEL                                     NODE A                                        NODE B
  ---------------------------------------------------------------------------------------------------------------------------------------
     alpha.eksctl.io/cluster-name              bottlerocket-test-k8s-1-34                    bottlerocket-test-k8s-1-34
     alpha.eksctl.io/nodegroup-name            aws-k8s-1-34-x86-64                           aws-k8s-1-34-x86-64
     beta.kubernetes.io/arch                   amd64                                         amd64
     beta.kubernetes.io/instance-type          g4dn.2xlarge                                  g4dn.2xlarge
     beta.kubernetes.io/os                     linux                                         linux
     failure-domain.beta.kubernetes.io/region  us-west-2                                     us-west-2
     k8s.io/cloud-provider-aws                 f03e107b1cf397a788e2ef10f07cdab3              f03e107b1cf397a788e2ef10f07cdab3
     kubernetes.io/arch                        amd64                                         amd64
     kubernetes.io/os                          linux                                         linux
     node.kubernetes.io/instance-type          g4dn.2xlarge                                  g4dn.2xlarge
     topology.kubernetes.io/region             us-west-2                                     us-west-2
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
