### PR TITLE
bump sdk to latest version

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -4,7 +4,7 @@ project-vendor = "Bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.70.0"
+version = "0.71.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.70.0"
-digest = "8ndrJE5YUkGs4lLbnEwmWeQ69TyLYhf7QEOCvPb2kg4="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.71.0"
+digest = "iMa7LTTLC/m0Uka2sdg3C/uqLfE6Tj7wHzTG8PJy/5U="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,5 +7,5 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.70.0"
+version = "0.71.0"
 vendor = "bottlerocket"

--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -37,11 +37,6 @@ Requires: %{_cross_os}e2fsprogs-libs
 %autosetup -n e2fsprogs-%{version} -p1
 
 %build
-# e2fsprogs enables some fsverity functionality, which uses an ioctl()
-# that was introduced only in kernel 5.12. We set this to no to skip it
-# since bottlerocket-sdk currently uses kernel 5.10.
-export ac_cv_header_linux_fsverity_h=no
-
 %cross_configure \
   CFLAGS="${CFLAGS} -fno-strict-aliasing" \
   --enable-elf-shlibs \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
- Update core-kit to use the latest bottlerocket-sdk
- Fixes: https://github.com/bottlerocket-os/bottlerocket-sdk/issues/313
- With the new bottlerocket-sdk, we can remove the change in `e2fsprogs` and allow it to build kernel `fs_verity` headers

**Testing done:**
- Built and launched instances with AMD64 and ARM64 AMIs


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
