### PR TITLE
packages: add containerd-2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "conntrack-tools",
  "containerd-1_7",
  "containerd-2_1",
+ "containerd-2_2",
  "coreutils",
  "cri-tools",
  "dbus-broker",
@@ -251,6 +252,13 @@ dependencies = [
 
 [[package]]
 name = "containerd-2_1"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "containerd-2_2"
 version = "0.1.0"
 dependencies = [
  "glibc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "packages/conntrack-tools",
   "packages/containerd-1.7",
   "packages/containerd-2.1",
+  "packages/containerd-2.2",
   "packages/coreutils",
   "packages/cri-tools",
   "packages/libcryptsetup",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -27,6 +27,7 @@ cni-plugins = { path = "../../packages/cni-plugins" }
 conntrack-tools = { path = "../../packages/conntrack-tools" }
 containerd-1_7 = { path = "../../packages/containerd-1.7" }
 containerd-2_1 = { path = "../../packages/containerd-2.1" }
+containerd-2_2 = { path = "../../packages/containerd-2.2" }
 coreutils = { path = "../../packages/coreutils" }
 cri-tools = { path = "../../packages/cri-tools" }
 dbus-broker = { path = "../../packages/dbus-broker" }

--- a/packages/containerd-2.1/containerd-2.1.spec
+++ b/packages/containerd-2.1/containerd-2.1.spec
@@ -6,7 +6,7 @@
 %global rpmver %{gover}
 %global gitrev c74fd8780002eb26bd5940ae339d690d891221c2
 
-%global package_priority_epoch 0
+%global package_priority_epoch 1
 %global _dwz_low_mem_die_limit 0
 
 Name: %{_cross_os}%{gorepo}-2.1

--- a/packages/containerd-2.2/1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
+++ b/packages/containerd-2.2/1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
@@ -1,0 +1,72 @@
+From f6f4f959862cad73cc44d07b088f449ae6c69066 Mon Sep 17 00:00:00 2001
+From: Henry Wang <henwang@amazon.com>
+Date: Thu, 10 Apr 2025 20:50:50 +0000
+Subject: [PATCH] Revert "Don't allow io_uring related syscalls in the
+ RuntimeDefault seccomp profile."
+
+This reverts commit a48ddf4a208b24eadea82f0eac62e236f2acf004.
+---
+ contrib/seccomp/seccomp_default.go      |  3 +++
+ contrib/seccomp/seccomp_default_test.go | 36 -------------------------
+ 2 files changed, 3 insertions(+), 36 deletions(-)
+ delete mode 100644 contrib/seccomp/seccomp_default_test.go
+
+diff --git a/contrib/seccomp/seccomp_default.go b/contrib/seccomp/seccomp_default.go
+index 55d673fcb..1135f2391 100644
+--- a/contrib/seccomp/seccomp_default.go
++++ b/contrib/seccomp/seccomp_default.go
+@@ -188,6 +188,9 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
+ 				"ioprio_set",
+ 				"io_setup",
+ 				"io_submit",
++				"io_uring_enter",
++				"io_uring_register",
++				"io_uring_setup",
+ 				"ipc",
+ 				"kill",
+ 				"landlock_add_rule",
+diff --git a/contrib/seccomp/seccomp_default_test.go b/contrib/seccomp/seccomp_default_test.go
+deleted file mode 100644
+index 53e386809..000000000
+--- a/contrib/seccomp/seccomp_default_test.go
++++ /dev/null
+@@ -1,36 +0,0 @@
+-package seccomp
+-
+-import (
+-	"testing"
+-
+-	"github.com/opencontainers/runtime-spec/specs-go"
+-)
+-
+-func TestIOUringIsNotAllowed(t *testing.T) {
+-
+-	disallowed := map[string]bool{
+-		"io_uring_enter":    true,
+-		"io_uring_register": true,
+-		"io_uring_setup":    true,
+-	}
+-
+-	got := DefaultProfile(&specs.Spec{
+-		Process: &specs.Process{
+-			Capabilities: &specs.LinuxCapabilities{
+-				Bounding: []string{},
+-			},
+-		},
+-	})
+-
+-	for _, config := range got.Syscalls {
+-		if config.Action != specs.ActAllow {
+-			continue
+-		}
+-
+-		for _, name := range config.Names {
+-			if disallowed[name] {
+-				t.Errorf("found disallowed io_uring related syscalls")
+-			}
+-		}
+-	}
+-}
+-- 
+2.45.0
+

--- a/packages/containerd-2.2/1002-transfer-service-fallback-to-credentials.toml-for-re.patch
+++ b/packages/containerd-2.2/1002-transfer-service-fallback-to-credentials.toml-for-re.patch
@@ -1,0 +1,137 @@
+From 98bca202890467862de25819e0a1284e9afcfeeb Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 29 Jan 2026 21:52:41 +0000
+Subject: [PATCH] transfer-service: fallback to credentials.toml for registry
+ auth
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ core/transfer/registry/registry.go | 87 ++++++++++++++++++++++++++++--
+ 1 file changed, 83 insertions(+), 4 deletions(-)
+
+diff --git a/core/transfer/registry/registry.go b/core/transfer/registry/registry.go
+index a903bddfa..0f56c8a46 100644
+--- a/core/transfer/registry/registry.go
++++ b/core/transfer/registry/registry.go
+@@ -18,13 +18,18 @@ package registry
+ 
+ import (
+ 	"context"
++	"encoding/base64"
+ 	"errors"
+ 	"fmt"
+ 	"io"
+ 	"net/http"
++	"os"
++	"path/filepath"
+ 	"strings"
+ 	"sync"
+ 
++	"github.com/pelletier/go-toml/v2"
++
+ 	transfertypes "github.com/containerd/containerd/api/types/transfer"
+ 	"github.com/containerd/containerd/v2/core/remotes"
+ 	"github.com/containerd/containerd/v2/core/remotes/docker"
+@@ -39,6 +44,76 @@ import (
+ 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+ )
+ 
++// hostDirectory converts ":port" to "_port_" in directory names.
++// Matches containerd's config/hosts.go encoding.
++func hostDirectory(host string) string {
++	idx := strings.LastIndex(host, ":")
++	if idx > 0 {
++		return host[:idx] + "_" + host[idx+1:] + "_"
++	}
++	return host
++}
++
++func loadHostCredentials(ctx context.Context, hostDir, host string) (string, string, error) {
++	if hostDir == "" {
++		return "", "", nil
++	}
++	// Try encoded path first (registry_5000_), then literal (registry:5000)
++	paths := []string{filepath.Join(hostDir, hostDirectory(host), "credentials.toml")}
++	if hostDirectory(host) != host {
++		paths = append(paths, filepath.Join(hostDir, host, "credentials.toml"))
++	}
++	var d []byte
++	var err error
++	var credPath string
++	for _, p := range paths {
++		d, err = os.ReadFile(p)
++		if err == nil {
++			credPath = p
++			break
++		}
++		if !os.IsNotExist(err) {
++			return "", "", err
++		}
++	}
++	if d == nil {
++		return "", "", nil
++	}
++	var c struct {
++		Username      string `toml:"username"`
++		Password      string `toml:"password"`
++		IdentityToken string `toml:"identitytoken"`
++		Auth          string `toml:"auth"`
++	}
++	if err := toml.Unmarshal(d, &c); err != nil {
++		log.G(ctx).WithError(err).Warnf("failed to parse credentials from %s", credPath)
++		return "", "", nil
++	}
++	if c.Username != "" || c.Password != "" {
++		log.G(ctx).WithField("path", credPath).Debug("using fallback credentials (username/password)")
++		return c.Username, c.Password, nil
++	}
++	if c.IdentityToken != "" {
++		log.G(ctx).WithField("path", credPath).Debug("using fallback credentials (identity token)")
++		return "", c.IdentityToken, nil
++	}
++	if c.Auth != "" {
++		dec, err := base64.StdEncoding.DecodeString(c.Auth)
++		if err != nil {
++			log.G(ctx).WithError(err).Warnf("failed to decode auth from %s", credPath)
++			return "", "", nil
++		}
++		user, passwd, ok := strings.Cut(string(dec), ":")
++		if !ok {
++			log.G(ctx).Warnf("invalid auth format in %s", credPath)
++			return "", "", nil
++		}
++		log.G(ctx).WithField("path", credPath).Debug("using fallback credentials (auth)")
++		return user, strings.Trim(passwd, "\x00"), nil
++	}
++	return "", "", nil
++}
++
+ func init() {
+ 	// TODO: Move this to separate package?
+ 	plugins.Register(&transfertypes.OCIRegistry{}, &OCIRegistry{})
+@@ -134,8 +209,10 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
+ 			if err != nil {
+ 				return "", "", err
+ 			}
+-
+-			return c.Username, c.Secret, nil
++			if c.Username != "" || c.Secret != "" {
++				return c.Username, c.Secret, nil
++			}
++			return loadHostCredentials(ctx, ropts.hostDir, host)
+ 		}
+ 	}
+ 	if ropts.defaultScheme != "" {
+@@ -376,8 +453,10 @@ func (r *OCIRegistry) UnmarshalAny(ctx context.Context, sm streaming.StreamGette
+ 				if err != nil {
+ 					return "", "", err
+ 				}
+-
+-				return c.Username, c.Secret, nil
++				if c.Username != "" || c.Secret != "" {
++					return c.Username, c.Secret, nil
++				}
++				return loadHostCredentials(ctx, s.Resolver.HostDir, host)
+ 			}
+ 		}
+ 		r.headers = http.Header{}

--- a/packages/containerd-2.2/1003-ctr-default-hosts-dir-to-etc-containerd-certs.d.patch
+++ b/packages/containerd-2.2/1003-ctr-default-hosts-dir-to-etc-containerd-certs.d.patch
@@ -1,0 +1,25 @@
+From 5996f17f4b3287148255c0cd89dee981f83dc0c2 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Fri, 30 Jan 2026 19:08:27 +0000
+Subject: [PATCH] ctr: default hosts-dir to /etc/containerd/certs.d
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ cmd/ctr/commands/commands.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmd/ctr/commands/commands.go b/cmd/ctr/commands/commands.go
+index 946da78ed..d4b7a3a87 100644
+--- a/cmd/ctr/commands/commands.go
++++ b/cmd/ctr/commands/commands.go
+@@ -72,8 +72,8 @@ var (
+ 			Usage: "Refresh token for authorization server",
+ 		},
+ 		&cli.StringFlag{
+-			Name: "hosts-dir",
+-			// compatible with "/etc/docker/certs.d"
++			Name:  "hosts-dir",
++			Value: "/etc/containerd/certs.d",
+ 			Usage: "Custom hosts configuration directory",
+ 		},
+ 		&cli.StringFlag{

--- a/packages/containerd-2.2/1004-fix-overlayfs-whiteouts-during-parallel-unpack.patch
+++ b/packages/containerd-2.2/1004-fix-overlayfs-whiteouts-during-parallel-unpack.patch
@@ -1,0 +1,158 @@
+From 90439f0e1ecaaf452d42b177d1c444061a477e1e Mon Sep 17 00:00:00 2001
+From: Wei Fu <fuweid89@gmail.com>
+Date: Wed, 25 Mar 2026 22:51:58 +0000
+Subject: [PATCH] Tweak mount info for overlayfs in case of parallel unpack
+
+Signed-off-by: Yutong Sun <yutongsu@amazon.com>
+---
+ core/unpack/unpacker.go      | 29 ++++++++++++
+ core/unpack/unpacker_test.go | 86 ++++++++++++++++++++++++++++++++++++
+ 2 files changed, 115 insertions(+)
+
+diff --git a/core/unpack/unpacker.go b/core/unpack/unpacker.go
+index d964580c81..a5763edeb8 100644
+--- a/core/unpack/unpacker.go
++++ b/core/unpack/unpacker.go
+@@ -524,6 +524,15 @@ func (u *Unpacker) unpack(
+ 			case <-fetchC[i-fetchOffset]:
+ 			}
+ 
++			// In case of parallel unpack, the parent snapshot isn't provided to the snapshotter.
++			// The overlayfs will return bind mounts for all layers, we need to convert them
++			// to overlay mounts for the applier to perform whiteout conversion correctly.
++			// TODO: this is a temporary workaround until #13053 lands.
++			// See: https://github.com/containerd/containerd/issues/13030
++			if i > 0 && parallel && unpack.SnapshotterKey == "overlayfs" {
++				mounts = bindToOverlay(mounts)
++			}
++
+ 			diff, err := a.Apply(ctx, desc, mounts, unpack.ApplyOpts...)
+ 			if err != nil {
+ 				cleanup.Do(ctx, abort)
+@@ -747,3 +756,23 @@ func uniquePart() string {
+ 	rand.Read(b[:])
+ 	return fmt.Sprintf("%d-%s", t.Nanosecond(), base64.URLEncoding.EncodeToString(b[:]))
+ }
++
++// TODO: this is a temporary workaround until #13053 lands.
++func bindToOverlay(mounts []mount.Mount) []mount.Mount {
++	if len(mounts) != 1 || mounts[0].Type != "bind" {
++		return mounts
++	}
++
++	m := mount.Mount{
++		Type:   "overlay",
++		Source: "overlay",
++	}
++	for _, o := range mounts[0].Options {
++		if o != "rbind" {
++			m.Options = append(m.Options, o)
++		}
++	}
++	m.Options = append(m.Options, "upperdir="+mounts[0].Source)
++
++	return []mount.Mount{m}
++}
+diff --git a/core/unpack/unpacker_test.go b/core/unpack/unpacker_test.go
+index 32581dbd18..48636d6f9f 100644
+--- a/core/unpack/unpacker_test.go
++++ b/core/unpack/unpacker_test.go
+@@ -19,8 +19,10 @@ package unpack
+ import (
+ 	"crypto/rand"
+ 	"fmt"
++	"reflect"
+ 	"testing"
+ 
++	"github.com/containerd/containerd/v2/core/mount"
+ 	"github.com/opencontainers/go-digest"
+ 	"github.com/opencontainers/image-spec/identity"
+ )
+@@ -91,3 +93,87 @@ func BenchmarkUnpackWithChainIDs(b *testing.B) {
+ 		})
+ 	}
+ }
++
++func TestBindToOverlay(t *testing.T) {
++	testCases := []struct {
++		name   string
++		mounts []mount.Mount
++		expect []mount.Mount
++	}{
++		{
++			name: "single bind mount",
++			mounts: []mount.Mount{
++				{
++					Type:    "bind",
++					Source:  "/path/to/source",
++					Options: []string{"ro", "rbind"},
++				},
++			},
++			expect: []mount.Mount{
++				{
++					Type:   "overlay",
++					Source: "overlay",
++					Options: []string{
++						"ro",
++						"upperdir=/path/to/source",
++					},
++				},
++			},
++		},
++		{
++			name: "overlay mount",
++			mounts: []mount.Mount{
++				{
++					Type:   "overlay",
++					Source: "overlay",
++					Options: []string{
++						"lowerdir=/path/to/lower",
++						"upperdir=/path/to/upper",
++					},
++				},
++			},
++			expect: []mount.Mount{
++				{
++					Type:   "overlay",
++					Source: "overlay",
++					Options: []string{
++						"lowerdir=/path/to/lower",
++						"upperdir=/path/to/upper",
++					},
++				},
++			},
++		},
++		{
++			name: "multiple mounts",
++			mounts: []mount.Mount{
++				{
++					Type:   "bind",
++					Source: "/path/to/source1",
++				},
++				{
++					Type:   "bind",
++					Source: "/path/to/source2",
++				},
++			},
++			expect: []mount.Mount{
++				{
++					Type:   "bind",
++					Source: "/path/to/source1",
++				},
++				{
++					Type:   "bind",
++					Source: "/path/to/source2",
++				},
++			},
++		},
++	}
++
++	for _, tc := range testCases {
++		t.Run(tc.name, func(t *testing.T) {
++			result := bindToOverlay(tc.mounts)
++			if !reflect.DeepEqual(result, tc.expect) {
++				t.Errorf("unexpected result: got %v, want %v", result, tc.expect)
++			}
++		})
++	}
++}

--- a/packages/containerd-2.2/Cargo.toml
+++ b/packages/containerd-2.2/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "containerd-2_2"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+package-name = "containerd-2.2"
+releases-url = "https://github.com/containerd/containerd/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/containerd/containerd/archive/v2.2.2/containerd-2.2.2.tar.gz"
+sha512 = "4471047360cd1430a189829a74d605dbe89abe092f0e0ba53ad5954269f253c7c277b8097c5d12acb9e0592a39e50e1808c92e73596e3d2d97cf945f15063ca0"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/containerd-2.2/clarify.toml
+++ b/packages/containerd-2.2/clarify.toml
@@ -1,0 +1,12 @@
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT"
+license-files = [
+    { path = "LICENSE", hash = 0x617d80bc },
+]
+
+[clarify."github.com/grpc-ecosystem/go-grpc-middleware/v2"]
+expression = "Apache-2.0"
+license-files = [
+    { path = "COPYRIGHT", hash = 0x4bba7b1 },
+    { path = "LICENSE", hash = 0x6a39c900 }
+]

--- a/packages/containerd-2.2/containerd-2.2.spec
+++ b/packages/containerd-2.2/containerd-2.2.spec
@@ -1,0 +1,154 @@
+%global goproject github.com/containerd
+%global gorepo containerd
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 2.2.2
+%global rpmver %{gover}
+%global gitrev 301b2dac98f15c27117da5c8af12118a041a31d9
+
+%global package_priority_epoch 0
+%global _dwz_low_mem_die_limit 0
+
+Name: %{_cross_os}%{gorepo}-2.2
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: An industry-standard container runtime
+License: Apache-2.0
+URL: https://%{goimport}
+Source0: https://%{goimport}/archive/v%{gover}/%{gorepo}-%{gover}.tar.gz
+Source1: containerd.service
+Source2: containerd-config-toml_k8s_containerd_sock
+Source3: containerd-config-toml_basic
+Source4: containerd-config-toml_k8s_nvidia_containerd_sock
+Source5: containerd-tmpfiles.conf
+Source6: containerd-cri-base-json
+Source7: snapshotter-toml
+
+# Mount for writing containerd configuration
+Source100: etc-containerd.mount
+
+# Create container storage mount point.
+Source110: prepare-var-lib-containerd.service
+
+# Drop-ins to disable igzip or pigz if the other implementation is preferred.
+Source200: containerd-disable-igzip.conf
+Source201: containerd-disable-pigz.conf
+
+Source1000: clarify.toml
+
+# Patch to support moving from containerd-1.7 to 2.x
+Patch1001: 1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
+# Patch for transfer service to fall back to file for registry creds.
+Patch1002: 1002-transfer-service-fallback-to-credentials.toml-for-re.patch
+# Patch to make ctr use hosts.toml for registry mirrors by default
+Patch1003: 1003-ctr-default-hosts-dir-to-etc-containerd-certs.d.patch
+
+BuildRequires: git
+BuildRequires: %{_cross_os}glibc-devel
+Requires: %{_cross_os}runc
+Requires: %{name}(optimized-gunzip)
+
+Provides: %{_cross_os}%{gorepo} = %{package_priority_epoch}:
+Conflicts: %{_cross_os}%{gorepo}
+
+%description
+%{summary}.
+
+%package pigz
+Summary: Prefer pigz for gzip decompression
+Requires: %{_cross_os}pigz
+Requires: %{name}
+Provides: %{_cross_os}%{gorepo}-pigz = %{package_priority_epoch}:
+Conflicts: %{name}-igzip
+Provides: %{name}(optimized-gunzip) = 1:
+
+%description pigz
+%{summary}.
+
+%package igzip
+Summary: Prefer igzip for gzip decompression
+Requires: %{_cross_os}igzip
+Requires: %{name}
+Provides: %{_cross_os}%{gorepo}-igzip = %{package_priority_epoch}:
+Conflicts: %{name}-pigz
+%if "%{_cross_arch}" == "x86_64"
+Provides: %{name}(optimized-gunzip) = 2:
+%else
+Provides: %{name}(optimized-gunzip) = 0:
+%endif
+
+%description igzip
+%{summary}.
+
+%prep
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
+
+%build
+%set_cross_go_flags
+
+export BUILDTAGS="no_btrfs selinux"
+export LD_VERSION="-X github.com/containerd/containerd/v2/version.Version=%{gover}+bottlerocket"
+export LD_REVISION="-X github.com/containerd/containerd/v2/version.Revision=%{gitrev}"
+
+declare -a BUILD_ARGS
+BUILD_ARGS=(
+  -tags="${BUILDTAGS}"
+  -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}"
+)
+
+for bin in \
+  containerd \
+  containerd-shim-runc-v2 \
+  ctr ;
+do
+  go build "${BUILD_ARGS[@]}" -o ${bin} ./cmd/${bin}
+done
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+for bin in \
+  containerd \
+  containerd-shim-runc-v2 \
+  ctr ;
+do
+  install -p -m 0755 ${bin} %{buildroot}%{_cross_bindir}
+done
+
+install -d %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:1} %{S:100} %{S:110} %{buildroot}%{_cross_unitdir}
+
+install -d %{buildroot}%{_cross_templatedir}
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/containerd
+install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{S:7} %{buildroot}%{_cross_templatedir}
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
+
+install -d %{buildroot}%{_cross_unitdir}/containerd.service.d
+install -p -m 0644 %{S:200} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
+install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-pigz.conf
+
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
+
+%files
+%license LICENSE NOTICE
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+%{_cross_unitdir}/containerd.service
+%{_cross_unitdir}/etc-containerd.mount
+%{_cross_unitdir}/prepare-var-lib-containerd.service
+%dir %{_cross_factorydir}%{_cross_sysconfdir}/containerd
+%{_cross_templatedir}/containerd-config-toml*
+%{_cross_templatedir}/containerd-cri-base-json
+%{_cross_templatedir}/snapshotter-toml
+%{_cross_tmpfilesdir}/containerd.conf
+%{_cross_bindir}/containerd
+%{_cross_bindir}/containerd-shim-runc-v2
+%{_cross_bindir}/ctr
+%files pigz
+%{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
+
+%files igzip
+%{_cross_unitdir}/containerd.service.d/005-disable-pigz.conf
+
+%changelog

--- a/packages/containerd-2.2/containerd-2.2.spec
+++ b/packages/containerd-2.2/containerd-2.2.spec
@@ -42,6 +42,8 @@ Patch1001: 1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
 Patch1002: 1002-transfer-service-fallback-to-credentials.toml-for-re.patch
 # Patch to make ctr use hosts.toml for registry mirrors by default
 Patch1003: 1003-ctr-default-hosts-dir-to-etc-containerd-certs.d.patch
+# Patch to fix whiteouts ignored during parallel unpack with overlayfs
+Patch1004: 1004-fix-overlayfs-whiteouts-during-parallel-unpack.patch
 
 BuildRequires: git
 BuildRequires: %{_cross_os}glibc-devel

--- a/packages/containerd-2.2/containerd-config-toml_basic
+++ b/packages/containerd-2.2/containerd-config-toml_basic
@@ -1,0 +1,34 @@
++++
+version = 3
+root = "/var/lib/containerd"
+state = "/run/containerd"
+disabled_plugins = [
+    "io.containerd.internal.v1.opt",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.snapshotter.v1.blockfile",
+    "io.containerd.snapshotter.v1.devmapper",
+    "io.containerd.snapshotter.v1.native",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.grpc.v1.cri",
+    "io.containerd.tracing.processor.v1.otlp",
+]
+
+imports = ["/etc/containerd/config.d/*.toml"]
+
+[grpc]
+address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.transfer.v1.local"]
+max_concurrent_downloads = 10
+concurrent_layer_fetch_buffer = 0
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+snapshotter = "overlayfs"
+differ = "walking"
+{{#if (eq os.arch "aarch64")}}
+platform = "linux/arm64"
+{{else}}
+{{#if (eq os.arch "x86_64")}}
+platform = "linux/amd64"
+{{/if}}
+{{/if}}

--- a/packages/containerd-2.2/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.2/containerd-config-toml_k8s_containerd_sock
@@ -1,0 +1,74 @@
+[required-extensions]
+container-registry = "v1"
+container-runtime = "v1"
+kubernetes = "v1"
+std = { version = "v1", helpers = ["join_array", "default"]}
++++
+version = 3
+root = "/var/lib/containerd"
+state = "/run/containerd"
+disabled_plugins = [
+    "io.containerd.internal.v1.opt",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.snapshotter.v1.blockfile",
+    "io.containerd.snapshotter.v1.devmapper",
+    "io.containerd.snapshotter.v1.native",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.tracing.processor.v1.otlp",
+]
+
+imports = ["/etc/containerd/config.d/*.toml"]
+
+[grpc]
+address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.cri.v1.images"]
+use_local_image_pull = false
+
+# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
+[plugins."io.containerd.cri.v1.images".pinned_images]
+sandbox = "localhost/kubernetes/pause:0.1.0"
+
+[plugins."io.containerd.cri.v1.runtime"]
+device_ownership_from_security_context = {{default false settings.kubernetes.device-ownership-from-security-context}}
+enable_selinux = true
+{{#if settings.container-runtime.max-container-log-line-size}}
+max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-ports}}
+enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-icmp}}
+enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp}}
+{{/if}}
+
+[plugins."io.containerd.transfer.v1.local"]
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+snapshotter = "overlayfs"
+differ = "walking"
+{{#if (eq os.arch "aarch64")}}
+platform = "linux/arm64"
+{{else}}
+{{#if (eq os.arch "x86_64")}}
+platform = "linux/amd64"
+{{/if}}
+{{/if}}
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
+SystemdCgroup = true
+
+[plugins."io.containerd.cri.v1.runtime".cni]
+bin_dirs = [ "/opt/cni/bin" ]
+conf_dir = "/etc/cni/net.d"
+
+[plugins."io.containerd.cri.v1.images".registry]
+config_path = "/etc/containerd/certs.d"

--- a/packages/containerd-2.2/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.2/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -1,0 +1,96 @@
+[required-extensions]
+container-registry = "v1"
+container-runtime = "v1"
+kubernetes = "v1"
+std = { version = "v1", helpers = ["join_array", "default"]}
++++
+version = 3
+root = "/var/lib/containerd"
+state = "/run/containerd"
+disabled_plugins = [
+    "io.containerd.internal.v1.opt",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.snapshotter.v1.blockfile",
+    "io.containerd.snapshotter.v1.devmapper",
+    "io.containerd.snapshotter.v1.native",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.tracing.processor.v1.otlp",
+]
+
+imports = ["/etc/containerd/config.d/*.toml"]
+
+[grpc]
+address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.cri.v1.images"]
+use_local_image_pull = false
+
+# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
+[plugins."io.containerd.cri.v1.images".pinned_images]
+sandbox = "localhost/kubernetes/pause:0.1.0"
+
+[plugins."io.containerd.cri.v1.runtime"]
+device_ownership_from_security_context = {{default false settings.kubernetes.device-ownership-from-security-context}}
+enable_selinux = true
+{{#if settings.container-runtime.max-container-log-line-size}}
+max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-ports}}
+enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-icmp}}
+enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp}}
+{{/if}}
+
+[plugins."io.containerd.transfer.v1.local"]
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+snapshotter = "overlayfs"
+differ = "walking"
+{{#if (eq os.arch "aarch64")}}
+platform = "linux/arm64"
+{{else}}
+{{#if (eq os.arch "x86_64")}}
+platform = "linux/amd64"
+{{/if}}
+{{/if}}
+
+[plugins."io.containerd.cri.v1.runtime".containerd]
+default_runtime_name = "nvidia"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+# CDI only nvidia container runtime
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-cdi]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+# legacy only nvidia container runtime
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-legacy]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-cdi.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime.cdi"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-legacy.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime.legacy"
+
+[plugins."io.containerd.cri.v1.runtime".cni]
+bin_dirs = [ "/opt/cni/bin" ]
+conf_dir = "/etc/cni/net.d"
+
+[plugins."io.containerd.cri.v1.images".registry]
+config_path = "/etc/containerd/certs.d"

--- a/packages/containerd-2.2/containerd-cri-base-json
+++ b/packages/containerd-2.2/containerd-cri-base-json
@@ -1,0 +1,164 @@
+[required-extensions]
+oci-defaults = { version = "v1", helpers = ["oci_defaults"] }
++++
+{
+    "ociVersion": "1.2.0",
+    "process": {
+        "user": {
+            "uid": 0,
+            "gid": 0
+        },
+        "cwd": "/",
+        {{~#if settings.oci-defaults.capabilities~}}
+        "capabilities": {
+            {{~oci_defaults "containerd" settings.oci-defaults.capabilities~}}
+        },
+        {{~/if~}}
+        {{~#if settings.oci-defaults.resource-limits~}}
+        "rlimits": [
+            {{~oci_defaults "containerd" settings.oci-defaults.resource-limits~}}
+        ],
+        {{~/if~}}
+        "noNewPrivileges": true
+    },
+    "root": {
+        "path": "rootfs"
+    },
+    "mounts": [
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/dev",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/pts",
+            "type": "devpts",
+            "source": "devpts",
+            "options": [
+                "nosuid",
+                "noexec",
+                "newinstance",
+                "ptmxmode=0666",
+                "mode=0620",
+                "gid=5"
+            ]
+        },
+        {
+            "destination": "/dev/shm",
+            "type": "tmpfs",
+            "source": "shm",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "mode=1777",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/mqueue",
+            "type": "mqueue",
+            "source": "mqueue",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/sys",
+            "type": "sysfs",
+            "source": "sysfs",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "ro"
+            ]
+        },
+        {
+            "destination": "/run",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/usr/local/sbin/modprobe",
+            "source": "/usr/bin/kmod",
+            "options": [
+                "exec",
+                "bind",
+                "ro"
+            ]
+        }
+    ],
+    "linux": {
+        "resources": {
+            "devices": [
+                {
+                    "allow": false,
+                    "access": "rwm"
+                }
+            ]
+        },
+        "cgroupsPath": "/default",
+        "namespaces": [
+            {
+                "type": "pid"
+            },
+            {
+                "type": "ipc"
+            },
+            {
+                "type": "uts"
+            },
+            {
+                "type": "mount"
+            },
+            {
+                "type": "network"
+            }
+        ],
+        "maskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap",
+            "/proc/scsi"
+        ],
+        "readonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+        ]
+    }
+}

--- a/packages/containerd-2.2/containerd-disable-igzip.conf
+++ b/packages/containerd-2.2/containerd-disable-igzip.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=CONTAINERD_DISABLE_IGZIP=1

--- a/packages/containerd-2.2/containerd-disable-pigz.conf
+++ b/packages/containerd-2.2/containerd-disable-pigz.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=CONTAINERD_DISABLE_PIGZ=1

--- a/packages/containerd-2.2/containerd-tmpfiles.conf
+++ b/packages/containerd-2.2/containerd-tmpfiles.conf
@@ -1,0 +1,3 @@
+d /etc/cni/net.d - - - -
+d /etc/containerd/config.d - - - -
+L+ /opt/containerd/image-verifier - - - - ../civ

--- a/packages/containerd-2.2/containerd.service
+++ b/packages/containerd-2.2/containerd.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network-online.target configured.target
+Wants=network-online.target configured.target
+Requires=configure-snapshotter.service
+
+[Service]
+Slice=runtime.slice
+EnvironmentFile=/etc/network/proxy.env
+ExecStart=/usr/bin/containerd
+Type=notify
+Delegate=yes
+KillMode=process
+TimeoutSec=0
+RestartSec=2
+Restart=always
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/containerd-2.2/etc-containerd.mount
+++ b/packages/containerd-2.2/etc-containerd.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Containerd Configuration Directory (/etc/containerd)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/etc/containerd
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,mode=0750,context=system_u:object_r:etc_secret_t:s0
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/containerd-2.2/prepare-var-lib-containerd.service
+++ b/packages/containerd-2.2/prepare-var-lib-containerd.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Prepare Containerd Directory (/var/lib/containerd)
+DefaultDependencies=no
+RequiresMountsFor=/var
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+
+# Remove an existing symlink, if present. Intentionally not recursive!
+ExecStartPre=-/usr/bin/rm -f /var/lib/containerd
+
+# Create /var/lib/containerd so it is available for bind mounts.
+ExecStart=/usr/bin/mkdir -p /var/lib/containerd
+
+# Suppress warning if directory exists.
+StandardError=null
+
+RemainAfterExit=true
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/containerd-2.2/snapshotter-toml
+++ b/packages/containerd-2.2/snapshotter-toml
@@ -1,0 +1,20 @@
+[required-extensions]
+container-runtime = "v1"
+std = { version = "v1" }
++++
+{{#if settings.container-runtime.snapshotter}}
+{{#if (eq settings.container-runtime.snapshotter "soci" )}}
+[plugins."io.containerd.cri.v1.images"]
+snapshotter = "soci"
+disable_snapshot_annotations = false
+# Plug soci snapshotter into containerd
+[proxy_plugins.soci]
+type = "snapshot"
+address = "/run/soci-snapshotter/soci-snapshotter.sock"
+[proxy_plugins.soci.exports]
+root = "/var/lib/soci-snapshotter"
+{{else}}
+[plugins."io.containerd.cri.v1.images"]
+snapshotter = "overlayfs"
+{{/if}}
+{{/if}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

### Issue number:

Closes https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/806

### Description of changes:

Introduces containerd `2.2.2` as a new package, replacing containerd 2.1 for all 34 variants.

Upstream changelogs:
- [containerd 2.2.0](https://github.com/containerd/containerd/releases/tag/v2.2.0)
- [containerd 2.2.1](https://github.com/containerd/containerd/releases/tag/v2.2.1)
- [containerd 2.2.2](https://github.com/containerd/containerd/releases/tag/v2.2.2)

**Patch changes:**
- Dropped `1002-bump-google-golang-org-grpc.patch` — upstream 2.2.2 ships gRPC v1.78.0+ natively
- Renumbered remaining patches:
  - `1001` (io_uring revert) — still needed, io_uring syscalls blocked in seccomp defaults
  - `1002` (credential fallback) — was 1003, transfer service credential fallback
  - `1003` (hosts-dir) — was 1004, ctr default hosts-dir

**Other changes:**
- Updated `clarify.toml` — removed stale `goyaml.v2/*` entries
- Config templates unchanged — already using hosts.toml-based registry config

### Testing done:

**1. Binary versions (verified on running node):**
```
bash-5.2# containerd --version
containerd github.com/containerd/containerd/v2 2.2.2+bottlerocket 301b2dac98f15c27117da5c8af12118a041a31d9
bash-5.2# ctr --version
ctr github.com/containerd/containerd/v2 2.2.2+bottlerocket
```

**2. Conformance testing:** 20/20 unique variant/arch combos passing

| Phase | Arch | Instance | Variants Tested | Result |
|-------|------|----------|-----------------|--------|
| A | x86_64 | m5.large | aws-k8s-1.33, 1.33-fips, 1.34, 1.34-fips, 1.35, 1.35-fips | ✅ All passing |
| B | aarch64 | m6g.large | aws-k8s-1.33, 1.33-fips, 1.34, 1.34-fips, 1.35, 1.35-fips | ✅ All passing |
| C | x86_64 | g5.xlarge | aws-k8s-1.29-nvidia-fips, 1.33-nvidia, 1.34-nvidia, 1.35-nvidia | ✅ All passing |
| D | aarch64 | g5g.2xlarge | aws-k8s-1.29-nvidia-fips, 1.33-nvidia, 1.34-nvidia, 1.35-nvidia | ✅ All passing |

<details><summary>Full conformance results per variant/arch</summary>

| Variant | Arch | K8s Version | Tests | Instance |
|---------|------|-------------|-------|----------|
| aws-k8s-1.33 | x86_64 | 1.33 | 419/419 | m5.large |
| aws-k8s-1.33-fips | x86_64 | 1.33 | 419/419 | m5.large |
| aws-k8s-1.34 | x86_64 | 1.34 | 424/424 | m5.large |
| aws-k8s-1.34-fips | x86_64 | 1.34 | 424/424 | m5.large |
| aws-k8s-1.35 | x86_64 | 1.35 | 441/441 | m5.large |
| aws-k8s-1.35-fips | x86_64 | 1.35 | 441/441 | m5.large |
| aws-k8s-1.33 | aarch64 | 1.33 | 419/419 | m6g.large |
| aws-k8s-1.33-fips | aarch64 | 1.33 | 419/419 | m6g.large |
| aws-k8s-1.34 | aarch64 | 1.34 | 424/424 | m6g.large |
| aws-k8s-1.34-fips | aarch64 | 1.34 | 424/424 | m6g.large |
| aws-k8s-1.35 | aarch64 | 1.35 | 441/441 | m6g.large |
| aws-k8s-1.35-fips | aarch64 | 1.35 | 441/441 | m6g.large |
| aws-k8s-1.29-nvidia-fips | x86_64 | 1.29 | 388/388 | g5.xlarge |
| aws-k8s-1.33-nvidia | x86_64 | 1.33 | 419/419 | g5.xlarge |
| aws-k8s-1.34-nvidia | x86_64 | 1.34 | 424/424 | g5.xlarge |
| aws-k8s-1.35-nvidia | x86_64 | 1.35 | 441/441 | g5.xlarge |
| aws-k8s-1.29-nvidia-fips | aarch64 | 1.29 | 388/388 | g5g.2xlarge |
| aws-k8s-1.33-nvidia | aarch64 | 1.33 | 419/419 | g5g.2xlarge |
| aws-k8s-1.34-nvidia | aarch64 | 1.34 | 424/424 | g5g.2xlarge |
| aws-k8s-1.35-nvidia | aarch64 | 1.35 | 441/441 | g5g.2xlarge |

</details>

**3. SubPath test ([bottlerocket#4755](https://github.com/bottlerocket-os/bottlerocket/issues/4755)):** Kubernetes 1.35 enables OCI image volumes by default, but containerd 2.1 silently ignores the `subPath` field in `volumeMounts` for these volumes — mounting the entire image filesystem regardless of the subPath value. We built a test OCI image with a known directory structure, deployed the same pod manifest on both the GA AMI (containerd 2.1) and our custom build (containerd 2.2), and confirmed that 2.1 mounts the full image while 2.2 correctly scopes the mount to only the specified subdirectory. Verified with containerd 2.2.1; low risk for 2.2.2 (no relevant changes in the image volume path).

<details><summary>Full test steps and output</summary>

Test image pushed to ECR (`<ACCOUNT_ID>.dkr.ecr.us-west-2.amazonaws.com/subpath-test:latest`):

```dockerfile
FROM public.ecr.aws/docker/library/busybox:latest
RUN mkdir -p /data/subdir-a /data/subdir-b && \
    echo "content-from-subdir-a" > /data/subdir-a/file-a.txt && \
    echo "content-from-subdir-b" > /data/subdir-b/file-b.txt && \
    echo "content-from-root" > /root-file.txt
```

Pod manifest (same for both tests), mounting with `subPath: data/subdir-a`:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: subpath-test
spec:
  containers:
  - name: checker
    image: public.ecr.aws/docker/library/busybox:latest
    command: ["sleep", "3600"]
    volumeMounts:
    - name: test-image-vol
      mountPath: /mnt/test
      subPath: data/subdir-a
  volumes:
  - name: test-image-vol
    image:
      reference: <ACCOUNT_ID>.dkr.ecr.us-west-2.amazonaws.com/subpath-test:latest
```

**containerd 2.1 (aws-k8s-1.35 GA AMI) — subPath ignored ❌**

The entire image filesystem is mounted at `/mnt/test`:

```
$ kubectl exec subpath-test -- ls -la /mnt/test/
total 24
drwxr-xr-x    1 root     root             6 Mar 16 21:41 .
drwxr-xr-x    3 root     root            18 Mar 16 21:41 ..
drwxr-xr-x    2 root     root         12288 Sep 26  2024 bin
drwxr-xr-x    4 root     root            38 Mar 11 23:33 data
drwxr-xr-x    2 root     root             6 Sep 26  2024 dev
drwxr-xr-x    3 root     root           100 Sep 26  2024 etc
drwxr-xr-x    2 nobody   nobody           6 Sep 26  2024 home
drwxr-xr-x    2 root     root          4096 Sep 26  2024 lib
lrwxrwxrwx    1 root     root             3 Sep 26  2024 lib64 -> lib
drwxr-xr-x    2 root     root             6 Mar 11 23:33 proc
drwx------    2 root     root             6 Sep 26  2024 root
-rw-r--r--    1 root     root            18 Mar 11 23:33 root-file.txt
drwxr-xr-x    2 root     root             6 Mar 11 23:33 sys
drwxrwxrwt    2 root     root             6 Sep 26  2024 tmp
drwxr-xr-x    4 root     root            29 Sep 26  2024 usr
drwxr-xr-x    4 root     root            30 Sep 26  2024 var

$ kubectl exec subpath-test -- ls -la /mnt/test/data
total 0
drwxr-xr-x    4 root     root            38 Mar 11 23:33 .
drwxr-xr-x    1 root     root             6 Mar 16 21:41 ..
drwxr-xr-x    2 root     root            24 Mar 11 23:33 subdir-a
drwxr-xr-x    2 root     root            24 Mar 11 23:33 subdir-b
```

**containerd 2.2 (custom aws-k8s-1.35 build) — subPath working ✅**

Only the contents of `data/subdir-a` are mounted at `/mnt/test`:

```
$ kubectl exec subpath-test -- ls -la /mnt/test/
total 4
drwxr-xr-x    2 root     root            24 Mar 11 23:33 .
drwxr-xr-x    3 root     root            18 Mar 16 21:22 ..
-rw-r--r--    1 root     root            22 Mar 11 23:33 file-a.txt

$ kubectl exec subpath-test -- cat /mnt/test/file-a.txt
content-from-subdir-a

$ kubectl exec subpath-test -- ls /mnt/test/root-file.txt
ls: /mnt/test/root-file.txt: No such file or directory

$ kubectl exec subpath-test -- ls /mnt/test/subdir-b
ls: /mnt/test/subdir-b: No such file or directory

$ kubectl exec subpath-test -- find /mnt/test -type f
/mnt/test/file-a.txt
```

</details>

**4. Image pull performance:** Tested CRI pull times on m5d.4xlarge with ephemeral NVMe storage, pulling `docker.io/pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel` (8.5GB compressed).

| Configuration | `crictl pull` | `ctr pull` | vs 2.1 baseline |
|---------------|---------------|------------|------------------|
| Containerd 2.1.6 (default) | 1m34.7s | 85.4s | — |
| Containerd 2.2.2 (enable parallel unpack) | 1m8.1s | 66.3s | 28% faster |
| SOCI parallel-pull-unpack (on 2.1.6) | 1m4.3s | 84.7s | 32% faster |

<details><summary>Test environment and configuration</summary>

All tests on m5d.4xlarge (16 vCPU, 64GB RAM, 2x300GB NVMe SSD).
Ephemeral NVMe storage bound via bootstrap command to `/var/lib/containerd`, `/var/lib/kubelet`, `/var/log/pods`.
All three configurations use 20 max concurrent downloads.

**Containerd 2.1.6 (baseline):** Concurrent downloads only, no parallel unpack.
```toml
[plugins.'io.containerd.transfer.v1.local']
max_concurrent_downloads = 20
concurrent_layer_fetch_buffer = 16777216
```

**Containerd 2.2.2:** Concurrent downloads + parallel unpack (5 concurrent unpacks).
```toml
[plugins.'io.containerd.transfer.v1.local']
max_concurrent_downloads = 20
concurrent_layer_fetch_buffer = 16777216
max_concurrent_unpacks = 5
```

**SOCI parallel-pull-unpack (on containerd 2.1.6):** SOCI manages both downloads and unpacks via the CRI path.
Ephemeral storage also bound to `/var/lib/soci-snapshotter` (SOCI's unpack working directory).
```toml
[settings.container-runtime]
snapshotter = "soci"

[settings.container-runtime-plugins.soci-snapshotter]
pull-mode = "parallel-pull-unpack"

[settings.container-runtime-plugins.soci-snapshotter.parallel-pull-unpack]
concurrent-download-chunk-size = "8mb"
discard-unpacked-layers = true
max-concurrent-downloads = 20
max-concurrent-downloads-per-image = 5
max-concurrent-unpacks = 5
max-concurrent-unpacks-per-image = 4
```

</details>

### Terms of contribution:

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
