### PR TITLE
Prevent race condition between system services and `/tmp`

### DIFF
--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -111,6 +111,7 @@ Source1109: modprobe-no-exit.conf
 Source1110: tmp-mount-noexec.conf
 Source1111: network-pre-target-dbus-dep.conf
 Source1112: fips-go.conf
+Source1113: requires-tmp.conf
 
 # network link rules
 Source1200: 80-release.link
@@ -234,6 +235,7 @@ install -p -m 0644 %{S:1104} %{buildroot}%{_cross_unitdir}/service.d/00-aws-conf
 
 install -d %{buildroot}%{_cross_unitdir}/service.d
 install -p -m 0644 %{S:1112} %{buildroot}%{_cross_unitdir}/service.d/00-fips-go.conf
+install -p -m 0644 %{S:1113} %{buildroot}%{_cross_unitdir}/service.d/10-requires-tmp.conf
 
 install -d %{buildroot}%{_cross_libdir}/systemd/system.conf.d
 install -p -m 0644 %{S:98} %{buildroot}%{_cross_libdir}/systemd/system.conf.d/80-release.conf
@@ -435,6 +437,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/deprecation-warning@.service
 %{_cross_unitdir}/deprecation-warning@.timer
 %{_cross_unitdir}/service.d/00-aws-config.conf
+%{_cross_unitdir}/service.d/10-requires-tmp.conf
 %dir %{_cross_unitdir}/systemd-resolved.service.d
 %{_cross_unitdir}/systemd-resolved.service.d/00-env.conf
 %{_cross_unitdir}/systemd-resolved.service.d/10-private-tmp.conf

--- a/packages/release/requires-tmp.conf
+++ b/packages/release/requires-tmp.conf
@@ -1,0 +1,3 @@
+[Unit]
+Wants=tmp.mount
+After=tmp.mount


### PR DESCRIPTION
**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket/issues/4788

**Description of changes:**

System services with sandboxing options need systemd to create directories under /tmp. If tmp.mount isn't ready when these services start, systemd attempts to create them on the immutable root filesystem, causing startup failures.

Add a global service drop-in that orders all system services after tmp.mount via Wants= and After=, preventing the race.

**Testing done:**

I launched 1000 instances with a custom AMI. Prior this fix, 60% of my launches resulted in failures that hit the race condition with this error:

```
(whippet)[829]: whippet.service: Failed to set up mount namespacing: /run/systemd/unit-root/dev: Read-only file system
```

After this fix, I no longer hit the error.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
