### PR TITLE
fix: reserve EKS add-on ports in kubelet-sysctl.conf

### DIFF
--- a/packages/kubernetes-1.29/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.29/kubelet-sysctl.conf
@@ -1,2 +1,8 @@
 # Overcommit handling mode - 1: Always overcommit
 vm.overcommit_memory = 1
+
+# Reserve well-known EKS add-on ports to prevent containerd's CRI streaming
+# server from grabbing them via ephemeral port assignment (stream_server_port=0).
+# This is a guardrail for environments where ip_local_port_range has been widened.
+# Explicit binds by add-on pods are unaffected.
+net.ipv4.ip_local_reserved_ports = 2703,9808,9809,10249,10250,10256,61678,61679

--- a/packages/kubernetes-1.30/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.30/kubelet-sysctl.conf
@@ -1,2 +1,8 @@
 # Overcommit handling mode - 1: Always overcommit
 vm.overcommit_memory = 1
+
+# Reserve well-known EKS add-on ports to prevent containerd's CRI streaming
+# server from grabbing them via ephemeral port assignment (stream_server_port=0).
+# This is a guardrail for environments where ip_local_port_range has been widened.
+# Explicit binds by add-on pods are unaffected.
+net.ipv4.ip_local_reserved_ports = 2703,9808,9809,10249,10250,10256,61678,61679

--- a/packages/kubernetes-1.31/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.31/kubelet-sysctl.conf
@@ -1,2 +1,8 @@
 # Overcommit handling mode - 1: Always overcommit
 vm.overcommit_memory = 1
+
+# Reserve well-known EKS add-on ports to prevent containerd's CRI streaming
+# server from grabbing them via ephemeral port assignment (stream_server_port=0).
+# This is a guardrail for environments where ip_local_port_range has been widened.
+# Explicit binds by add-on pods are unaffected.
+net.ipv4.ip_local_reserved_ports = 2703,9808,9809,10249,10250,10256,61678,61679

--- a/packages/kubernetes-1.32/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.32/kubelet-sysctl.conf
@@ -1,2 +1,8 @@
 # Overcommit handling mode - 1: Always overcommit
 vm.overcommit_memory = 1
+
+# Reserve well-known EKS add-on ports to prevent containerd's CRI streaming
+# server from grabbing them via ephemeral port assignment (stream_server_port=0).
+# This is a guardrail for environments where ip_local_port_range has been widened.
+# Explicit binds by add-on pods are unaffected.
+net.ipv4.ip_local_reserved_ports = 2703,9808,9809,10249,10250,10256,61678,61679

--- a/packages/kubernetes-1.33/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.33/kubelet-sysctl.conf
@@ -1,2 +1,8 @@
 # Overcommit handling mode - 1: Always overcommit
 vm.overcommit_memory = 1
+
+# Reserve well-known EKS add-on ports to prevent containerd's CRI streaming
+# server from grabbing them via ephemeral port assignment (stream_server_port=0).
+# This is a guardrail for environments where ip_local_port_range has been widened.
+# Explicit binds by add-on pods are unaffected.
+net.ipv4.ip_local_reserved_ports = 2703,9808,9809,10249,10250,10256,61678,61679

--- a/packages/kubernetes-1.34/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.34/kubelet-sysctl.conf
@@ -1,2 +1,8 @@
 # Overcommit handling mode - 1: Always overcommit
 vm.overcommit_memory = 1
+
+# Reserve well-known EKS add-on ports to prevent containerd's CRI streaming
+# server from grabbing them via ephemeral port assignment (stream_server_port=0).
+# This is a guardrail for environments where ip_local_port_range has been widened.
+# Explicit binds by add-on pods are unaffected.
+net.ipv4.ip_local_reserved_ports = 2703,9808,9809,10249,10250,10256,61678,61679

--- a/packages/kubernetes-1.35/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.35/kubelet-sysctl.conf
@@ -1,2 +1,8 @@
 # Overcommit handling mode - 1: Always overcommit
 vm.overcommit_memory = 1
+
+# Reserve well-known EKS add-on ports to prevent containerd's CRI streaming
+# server from grabbing them via ephemeral port assignment (stream_server_port=0).
+# This is a guardrail for environments where ip_local_port_range has been widened.
+# Explicit binds by add-on pods are unaffected.
+net.ipv4.ip_local_reserved_ports = 2703,9808,9809,10249,10250,10256,61678,61679


### PR DESCRIPTION
### Issue number

Fixes bottlerocket-os/bottlerocket#4783

### Description of changes

Add `net.ipv4.ip_local_reserved_ports` to `kubelet-sysctl.conf` across all supported Kubernetes versions (**1.29–1.35**) to prevent containerd's CRI streaming server from grabbing well-known EKS add-on ports via ephemeral port assignment (`stream_server_port=0`).

This setting installs as `90-kubelet.conf` in `sysctl.d` and is applied by `systemd-sysctl` at boot, after `80-release.conf` sets `ip_local_port_range`. Explicit binds by add-on pods are unaffected — `ip_local_reserved_ports` only blocks ephemeral assignment.

Bottlerocket's default range (**32768–60999**) does not overlap with these ports, so this is a **guardrail** for environments where `ip_local_port_range` has been **widened beyond** the default. This change was discussed in bottlerocket-os/bottlerocket#4786.

### Ports reserved

| Port | Component |
|------|-----------|
| 2703 | EKS Pod Identity Agent (health/liveness probe) |
| 9808 | Amazon EBS CSI Driver node plugin (health check) |
| 9809 | Amazon EFS CSI Driver node plugin (health check) |
| 10249 | kube-proxy (metrics) |
| 10250 | kubelet (API server) |
| 10256 | kube-proxy (health check) |
| 61678 | Amazon VPC CNI / aws-node (Prometheus metrics) |
| 61679 | Amazon VPC CNI / aws-node (introspection endpoint) |

### Testing done

- Verified all **7 `kubelet-sysctl.conf` files** (`kubernetes-1.29` through `1.35`) are updated consistently.
- Confirmed port list against **official EKS add-on manifests** — only add-ons confirmed to use `hostNetwork: true` are included.
- Verified **`90-kubelet.conf` load order** is correct relative to **`80-release.conf`**.

### Terms of contribution

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the **Apache License, version 2.0**, and the **MIT license**.