### PR TITLE
selinux-policy: limit interactions between container runtimes and containers

### DIFF
--- a/packages/selinux-policy/base.cil
+++ b/packages/selinux-policy/base.cil
@@ -9,11 +9,21 @@
 (sensitivityorder (s0))
 (sensitivitycategory s0 (range c0 c1023))
 
+; A "range" of one: one sensitivity, no categories. Used for contexts
+; where categories don't matter.
 (level s0 (s0))
 (levelrange s0 (s0 s0))
 
+; A range from one sensitivity with no categories, through one
+; sensitivity with all categories. Used for statements that need to
+; cover the entire range of possibilities.
 (level s0-s0 (s0 (range c0 c1023)))
 (levelrange s0-s0 (s0 s0-s0))
+
+; A "range" of one: one sensitivity with all categories. Used for
+; contexts where categories matter, and so the same sensitivity with
+; no categories cannot be included in the range.
+(levelrange s0-c0-c1023 (s0-s0 s0-s0))
 
 ; The system_r role is used for processes.
 (role system_r)

--- a/packages/selinux-policy/base.cil
+++ b/packages/selinux-policy/base.cil
@@ -38,12 +38,26 @@
 (userlevel system_u s0-s0)
 (userrange system_u s0-s0)
 
-; Take the context from the target file rather than the source
-; process when computing the level for new file objects. We can
-; expect the directory where files are created to have the right
-; range of categories applied, but the process creating the file
-; may be privileged and have the full range or no range at all.
-(defaultrange files target low-high)
+; Take the intersection of the source and target ranges when
+; computing the level for new file objects, using the "glblub"
+; algorithm.
+;
+; Most directories have s0 as the level, except for those used
+; for container root filesystems, which have s0:cX,cY - a pair
+; of categories unique to that container.
+;
+; Most system processes have s0 as the level, while container
+; processes have either s0:cX,cY or s0:c0.c1023 - either a pair
+; of categories for unprivileged containers, or all categories
+; for privileged containers.
+;
+; The advantage of "glblub" is that it produces the correct result
+; if the target has more categories, where "target low_high" would
+; simply take the target's range.
+;
+; The disadvantage is that if the source has fewer categories than
+; the target, then the result may not have the expected categories.
+(defaultrange files glblub)
 
 ; Enable policy to use consolidated network peer controls. This
 ; avoids a function call to the compatibility mode helper, and

--- a/packages/selinux-policy/base.cil
+++ b/packages/selinux-policy/base.cil
@@ -59,6 +59,12 @@
 ; the target, then the result may not have the expected categories.
 (defaultrange files glblub)
 
+; For pipes, take the context from the source instead, to match the
+; common case where pipes to child processes should have the same
+; level as the parent process.
+(defaultrole fifo_file source)
+(defaulttype fifo_file source)
+
 ; Enable policy to use consolidated network peer controls. This
 ; avoids a function call to the compatibility mode helper, and
 ; will be faster when no network labeling rules are defined.

--- a/packages/selinux-policy/files.cil
+++ b/packages/selinux-policy/files.cil
@@ -1,5 +1,5 @@
 ; Permission groups for files.
-(classmap files (relabel mount relax enter describe load execute mutate block))
+(classmap files (relabel mount relax enter describe load execute mutate block receive ioctl))
 
 ; Permission group for relabeling files.
 (classmapping files relabel relabel_file)
@@ -55,7 +55,6 @@
 (classmapping files load load_sock_file)
 (classmapping files load load_fifo_file)
 (classmapping files load load_filesystem)
-(classmapping files load load_fd)
 (classmapping files load load_anon_inode)
 (classmapping files load load_io_uring)
 
@@ -77,6 +76,19 @@
 (classmapping files block block_sock_file)
 (classmapping files block block_fifo_file)
 (classmapping files block block_anon_inode)
+
+; Permission group for receiving files.
+(classmapping files receive receive_fd)
+
+; Permission group for using ioctl on files.
+(classmapping files ioctl ioctl_file)
+(classmapping files ioctl ioctl_dir)
+(classmapping files ioctl ioctl_lnk_file)
+(classmapping files ioctl ioctl_chr_file)
+(classmapping files ioctl ioctl_blk_file)
+(classmapping files ioctl ioctl_sock_file)
+(classmapping files ioctl ioctl_fifo_file)
+(classmapping files ioctl ioctl_anon_inode)
 
 ; Permission group for mutating files.
 (classmapping files mutate mutate_file)
@@ -213,37 +225,34 @@
 (classpermission load_sock_file)
 (classpermission load_fifo_file)
 (classpermission load_filesystem)
-(classpermission load_fd)
 (classpermission load_anon_inode)
 (classpermission load_io_uring)
 (classpermissionset load_file (
   file (
-    ioctl map open read watch watch_mount watch_mountns watch_reads watch_sb)))
+    map open read watch watch_mount watch_mountns watch_reads watch_sb)))
 (classpermissionset load_dir (
   dir (
-    ioctl map open read search watch watch_mount watch_mountns watch_reads watch_sb)))
+    map open read search watch watch_mount watch_mountns watch_reads watch_sb)))
 (classpermissionset load_lnk_file (
   lnk_file (
-    ioctl map open read watch watch_mount watch_mountns watch_reads watch_sb)))
+    map open read watch watch_mount watch_mountns watch_reads watch_sb)))
 (classpermissionset load_chr_file (
   chr_file (
-    ioctl map open read watch watch_mount watch_mountns watch_reads watch_sb)))
+    map open read watch watch_mount watch_mountns watch_reads watch_sb)))
 (classpermissionset load_blk_file (
   blk_file (
-    ioctl map open read watch watch_mount watch_mountns watch_reads watch_sb)))
+    map open read watch watch_mount watch_mountns watch_reads watch_sb)))
 (classpermissionset load_sock_file (
   sock_file (
-    ioctl map open read watch watch_mount watch_mountns watch_reads watch_sb)))
+    map open read watch watch_mount watch_mountns watch_reads watch_sb)))
 (classpermissionset load_fifo_file (
   fifo_file (
-    ioctl map open read watch watch_mount watch_mountns watch_reads watch_sb)))
+    map open read watch watch_mount watch_mountns watch_reads watch_sb)))
 (classpermissionset load_filesystem (
   filesystem (watch)))
-(classpermissionset load_fd (
-  fd (use)))
 (classpermissionset load_anon_inode (
   anon_inode (
-    execute ioctl map open read
+    execute map open read
     watch watch_mount watch_mountns watch_reads watch_sb)))
 (classpermissionset load_io_uring (
   io_uring (cmd)))
@@ -296,6 +305,37 @@
   fifo_file (watch_with_perm)))
 (classpermissionset block_anon_inode (
   anon_inode (watch_with_perm)))
+
+; Sets of permissions for receiving file objects.
+(classpermission receive_fd)
+(classpermissionset receive_fd (
+  fd (use)))
+
+; Sets of permissions for using ioctl on file objects.
+(classpermission ioctl_file)
+(classpermission ioctl_dir)
+(classpermission ioctl_lnk_file)
+(classpermission ioctl_chr_file)
+(classpermission ioctl_blk_file)
+(classpermission ioctl_sock_file)
+(classpermission ioctl_fifo_file)
+(classpermission ioctl_anon_inode)
+(classpermissionset ioctl_file (
+  file (ioctl)))
+(classpermissionset ioctl_dir (
+  dir (ioctl)))
+(classpermissionset ioctl_lnk_file (
+  lnk_file (ioctl)))
+(classpermissionset ioctl_chr_file (
+  chr_file (ioctl)))
+(classpermissionset ioctl_blk_file (
+  blk_file (ioctl)))
+(classpermissionset ioctl_sock_file (
+  sock_file (ioctl)))
+(classpermissionset ioctl_fifo_file (
+  fifo_file (ioctl)))
+(classpermissionset ioctl_anon_inode (
+  anon_inode (ioctl)))
 
 ; Sets of permissions for mutating file objects, which includes all
 ; actions that are not covered by other policy restrictions.

--- a/packages/selinux-policy/fs.cil
+++ b/packages/selinux-policy/fs.cil
@@ -6,7 +6,6 @@
 
 ; Label inodes by using the type of the creating task.
 (fsuse task eventpollfs any)
-(fsuse task pipefs any)
 (fsuse task sockfs any)
 
 ; Label inodes by deriving a type from the creating task.
@@ -14,6 +13,7 @@
 (fsuse trans devtmpfs any)
 (fsuse trans hugetlbfs any)
 (fsuse trans mqueue any)
+(fsuse trans pipefs pipe_fs)
 (fsuse trans shm any)
 (fsuse trans tmpfs any)
 

--- a/packages/selinux-policy/mcs.cil
+++ b/packages/selinux-policy/mcs.cil
@@ -21,7 +21,7 @@
 ;
 ; Privileged containers are left alone by the container runtime and
 ; inherit the default level, which covers the range of categories -
-; `s0-s0:c0.1023`. They would also pass the dominance check. However,
+; `s0:c0.1023`. They would also pass the dominance check. However,
 ; since we have privileged subjects that run outside of containers,
 ; we check for that with `(eq t1 privileged_s)`.
 ;

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -74,6 +74,15 @@
 (roletype object_r any_t)
 (context any (system_u object_r any_t s0))
 
+; Pipes created on pipefs, such as between a parent process
+; and its children. The level range must include all categories
+; so that "glblub" preserves the categories from the creating
+; process, since it computes the intersection of source and
+; target categories.
+(type pipe_fs_t)
+(roletype object_r pipe_fs_t)
+(context pipe_fs (system_u object_r pipe_fs_t s0-c0-c1023))
+
 ; Files for system configuration.
 (type etc_t)
 (roletype object_r etc_t)
@@ -218,7 +227,7 @@
   os_t init_exec_t api_exec_t clock_exec_t
   network_exec_t bus_exec_t runtime_exec_t
   mount_exec_t cni_exec_t csi_exec_t civ_exec_t
-  any_t etc_t proc_t binfmt_misc_fs_t
+  any_t etc_t proc_t binfmt_misc_fs_t pipe_fs_t
   local_t data_t private_t secret_t etc_secret_t cache_t
   lease_t measure_t state_t
   api_socket_t))

--- a/packages/selinux-policy/object.cil
+++ b/packages/selinux-policy/object.cil
@@ -156,6 +156,11 @@
 (roletype object_r etc_secret_t)
 (context etc_secret (system_u object_r etc_secret_t s0))
 
+; FIFO pipes created by container runtimes.
+(type runtime_fifo_t)
+(roletype object_r runtime_fifo_t)
+(context runtime_fifo (system_u object_r runtime_fifo_t s0))
+
 ; Dynamic objects are files on temporary storage with special rules.
 (typeattribute dynamic_o)
 (typeattributeset dynamic_o (etc_t binfmt_misc_fs_t))
@@ -225,7 +230,7 @@
 (typeattribute all_o)
 (typeattributeset all_o (
   os_t init_exec_t api_exec_t clock_exec_t
-  network_exec_t bus_exec_t runtime_exec_t
+  network_exec_t bus_exec_t runtime_exec_t runtime_fifo_t
   mount_exec_t cni_exec_t csi_exec_t civ_exec_t
   any_t etc_t proc_t binfmt_misc_fs_t pipe_fs_t
   local_t data_t private_t secret_t etc_secret_t cache_t

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -63,6 +63,7 @@
 
 ; PID 1 starts container runtimes as "runtime_t".
 (typetransition init_t runtime_exec_t process runtime_t)
+(rangetransition init_t runtime_exec_t process s0-c0-c1023)
 (allow init_t runtime_t (processes (transform)))
 (allow runtime_t runtime_exec_t (file (entrypoint)))
 

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -26,6 +26,20 @@
 ; Unprivileged components cannot interact with privileged processes.
 (neverallow unprivileged_s privileged_s (processes (interact)))
 
+; If a process creates a FIFO in a directory, rather than a pipe in
+; pipefs, it should use the role and type from that target.
+(roletransition system_r all_o fifo_file object_r)
+; ... most ephemeral directories
+(typetransition all_s any_t fifo_file any_t)
+; ... persistent, shared host directories
+(typetransition all_s local_t fifo_file local_t)
+; ... persistent, read-restricted host directories
+(typetransition all_s secret_t fifo_file secret_t)
+; ... persistent, write-restricted host directories
+(typetransition all_s state_t fifo_file state_t)
+; ... container root filesystems
+(typetransition all_s data_t fifo_file data_t)
+
 ; PID 1 starts as "kernel_t" and becomes "init_t".
 (typetransition kernel_t init_exec_t process init_t)
 (allow kernel_t init_t (processes (transform)))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -6,9 +6,13 @@
 (typeattribute global)
 (typeattributeset global ((all_s) (all_o)))
 
-; Define a subset of these types which are considered public.
+; Define a subset of these types which are not considered public.
+(typeattribute non_public)
+(typeattributeset non_public (runtime_s read_restricted_o))
+
+; Define everything else as public types.
 (typeattribute public)
-(typeattributeset public (xor (global) (read_restricted_o)))
+(typeattributeset public (xor (global) (non_public)))
 
 ; All subjects are allowed to describe all processes.
 (allow all_s all_s (processes (describe)))
@@ -158,7 +162,7 @@
 (allow privileged_s global (files (load ioctl)))
 
 ; Unprivileged subjects cannot read or execute restricted objects.
-(neverallow unprivileged_s read_restricted_o (files (load execute)))
+(neverallow unprivileged_s non_public (files (load execute)))
 
 ; Container subjects can execute anything that's public.
 (allow container_s public (files (execute)))

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -118,8 +118,16 @@
 ; is mounted from the root filesystem and used as the init process.
 (allow container_s runtime_exec_t (file (entrypoint)))
 
+; Pipes created by runtimes should receive a special label and range
+; so that other processes can mutate them.
+(typetransition runtime_t pipe_fs_t fifo_file runtime_fifo_t)
+(rangetransition runtime_t pipe_fs_t fifo_file s0)
+
+; Allow runtimes to mutate their own pipes.
+(allow runtime_s runtime_fifo_t (files (mutate)))
+
 ; Allow containers to communicate with runtimes via pipes.
-(allow container_s runtime_t (files (mutate)))
+(allow container_s runtime_fifo_t (files (mutate)))
 
 ; If a runtime process creates a directory for cached container archives
 ; or snapshot layers on local storage, it receives the "cache_t" label.

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -82,7 +82,7 @@
 ; The level range is adjusted to span all categories, since privileged
 ; containers won't get an MCS pair assigned.
 (typetransition runtime_t privileged_container_exec_o process control_t)
-(rangetransition runtime_t privileged_container_exec_o process s0-s0)
+(rangetransition runtime_t privileged_container_exec_o process s0-c0-c1023)
 
 ; Some processes should transition to unprivileged containers by default.
 (typetransition runtime_t unprivileged_container_exec_o process container_t)
@@ -91,7 +91,7 @@
 ; If PID 1 is used to invoke a CSI helper directly, it should also
 ; run as a privileged container.
 (typetransition init_t csi_exec_t process control_t)
-(rangetransition init_t csi_exec_t process s0-s0)
+(rangetransition init_t csi_exec_t process s0-c0-c1023)
 (allow init_t control_t (processes (transform)))
 
 ; Allow transitions to container labels for programs invoked by OCI

--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -140,14 +140,14 @@
 ; The socket for the API server gets the "api_socket_t" label.
 (typetransition api_t any_t sock_file "api.sock" api_socket_t)
 
-; All subjects can describe anything.
-(allow all_s global (files (describe)))
+; All subjects can describe anything and receive any file descriptors.
+(allow all_s global (files (describe receive)))
 
-; All subjects can read from anything that's public.
-(allow all_s public (files (load)))
+; All subjects can read from and use ioctls on anything that's public.
+(allow all_s public (files (load ioctl)))
 
 ; Privileged subjects can read from anything at all.
-(allow privileged_s global (files (load)))
+(allow privileged_s global (files (load ioctl)))
 
 ; Unprivileged subjects cannot read or execute restricted objects.
 (neverallow unprivileged_s read_restricted_o (files (load execute)))

--- a/packages/selinux-policy/selinux-policy.spec
+++ b/packages/selinux-policy/selinux-policy.spec
@@ -2,6 +2,7 @@
 
 %global _cross_first_party 1
 %global policytype fortified
+%global policyvers 32
 
 Name: %{_cross_os}selinux-policy
 Version: 0.0
@@ -50,7 +51,7 @@ cp -p \
 
 %build
 %{_sourcedir}/catgen.sh > category.cil
-secilc --policyvers=31 *.cil
+secilc --policyvers=%{policyvers} *.cil
 
 %install
 poldir="%{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/selinux"
@@ -58,7 +59,7 @@ install -d "${poldir}/%{policytype}/"{contexts/files,policy}
 install -p -m 0644 %{S:100} "${poldir}/config"
 install -p -m 0644 %{S:101} "${poldir}/%{policytype}/contexts"
 install -p -m 0644 file_contexts "${poldir}/%{policytype}/contexts/files"
-install -p -m 0644 policy.31 "${poldir}/%{policytype}/policy"
+install -p -m 0644 policy.%{policyvers} "${poldir}/%{policytype}/policy"
 
 moddir="%{buildroot}%{_cross_factorydir}%{_cross_sharedstatedir}/selinux/%{policytype}/active/modules/100"
 install -d "${moddir}"
@@ -82,7 +83,7 @@ install -p -m 0644 %{S:103} %{buildroot}%{_cross_tmpfilesdir}/selinux-policy.con
 %{_cross_factorydir}%{_cross_sysconfdir}/selinux/config
 %{_cross_factorydir}%{_cross_sysconfdir}/selinux/%{policytype}/contexts/files/file_contexts
 %{_cross_factorydir}%{_cross_sysconfdir}/selinux/%{policytype}/contexts/lxc_contexts
-%{_cross_factorydir}%{_cross_sysconfdir}/selinux/%{policytype}/policy/policy.31
+%{_cross_factorydir}%{_cross_sysconfdir}/selinux/%{policytype}/policy/policy.%{policyvers}
 %{_cross_factorydir}%{_cross_sharedstatedir}/selinux/%{policytype}
 %{_cross_sysconfdir}/selinux
 %{_cross_tmpfilesdir}/selinux-policy.conf

--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -612,7 +612,7 @@ func withSuperpowered() oci.SpecOpts {
 		oci.WithParentCgroupDevices,
 		oci.WithPrivileged,
 		oci.WithNewPrivileges,
-		oci.WithSelinuxLabel("system_u:system_r:super_t:s0-s0:c0.c1023"),
+		oci.WithSelinuxLabel("system_u:system_r:super_t:s0:c0.c1023"),
 		oci.WithAllDevicesAllowed,
 	)
 }
@@ -626,7 +626,7 @@ func withBootstrap() oci.SpecOpts {
 		withRootFsShared(),
 		// host PID namespace is required to configure audit rules
 		oci.WithHostNamespace(runtimespec.PIDNamespace),
-		oci.WithSelinuxLabel("system_u:system_r:control_t:s0-s0:c0.c1023"),
+		oci.WithSelinuxLabel("system_u:system_r:control_t:s0:c0.c1023"),
 		// Bootstrap containers don't require all capabilities. We only add:
 		// - CAP_SYS_ADMIN: for mounting filesystems
 		// - CAP_NET_ADMIN: for managing iptables rules
@@ -651,7 +651,7 @@ func withBootstrap() oci.SpecOpts {
 // withDefault adds container options for non-privileged containers
 func withDefault() oci.SpecOpts {
 	return oci.Compose(
-		oci.WithSelinuxLabel("system_u:system_r:control_t:s0-s0:c0.c1023"),
+		oci.WithSelinuxLabel("system_u:system_r:control_t:s0:c0.c1023"),
 		// Non-privileged containers only have access to a subset of the devices
 		oci.WithDefaultUnixDevices,
 		// No additional capabilities required for non-privileged containers


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
The overall goal is to limit interactions between container runtimes and containers to just the pipes used for logging output, thereby reducing the exposed surface area.

In policy terms, that's accomplished by this change:
```
 ; Allow containers to communicate with runtimes via pipes.
-(allow container_s runtime_t (files (mutate)))
+(allow container_s runtime_fifo_t (files (mutate)))
```

For that to work, it must be possible to give pipes a different label than that of the parent process, which in turn requires other changes.

The first set of changes enables the use of `glblub` ("greatest lower bound, lowest upper bound") as the default range for file types, and adjusts other range transitions so that everything continues to get the intended range.
```
selinux-policy: use single level for containers
host-ctr: use single SELinux level for processes
selinux-policy: adjust level for container runtimes
selinux-policy: update to policy version 32
selinux-policy: use "glblub" for the default range
```

The second logical change is enabling transition rules for `pipefs`, rather than using task-labeling, so that pipes can receive a different label. We also separate out the ability to "use" or receive file descriptors from the broader "load" permission. Permissions for ioctls are split out as well to prepare for future restrictions.
```
selinux-policy: use transition SIDs for pipefs
selinux-policy: split out perms for ioctls and fds
```

Finally, pipes are given a newly created label that both container runtimes and containers can read and write to. Since containers no longer need to read and write to the container runtime type, such access can then be explicitly blocked.
```
selinux-policy: relabel pipes for container runtimes
selinux-policy: restrict reads for container runtimes
```


**Testing done:**
Ran the SELinux test suite to check for process and file labels. The only change there was the expected one; privileged containers now run as `system_u:system_r:control_t:s0:c0.c1023` instead of `system_u:system_r:control_t:s0-s0:c0.c1023`.

Pipe labels before:
```
# find /proc/*/fd -lname 'pipe:*' -exec ls -1LZ {} + 2>/dev/null | grep -oP '^\s*\S+' | tr -d ' ' | sort -u
system_u:system_r:container_t:s0:c560,c574
system_u:system_r:control_t:s0-s0:c0.c1023
system_u:system_r:runtime_t:s0
system_u:system_r:super_t:s0-s0:c0.c1023
system_u:system_r:super_t:s0:c493,c600
```

Pipe labels after:
```
# find /proc/*/fd -lname 'pipe:*' -exec ls -1LZ {} + 2>/dev/null | grep -oP '^\s*\S+' | tr -d ' ' | sort -u
system_u:object_r:container_t:s0:c134,c708
system_u:object_r:control_t:s0:c0.c1023
system_u:object_r:runtime_fifo_t:s0
system_u:object_r:super_t:s0:c0.c1023
system_u:object_r:super_t:s0:c13,c1000
```

FIFO labels before and after:
```
# find / -type p -exec ls -1LZ {} + 2>/dev/null | grep -oP '^\s*\S+' | sort -u
system_u:object_r:any_t:s0
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
