### PR TITLE
libcrypto: gitignore external patch file

### DIFF
--- a/packages/libcrypto/.gitignore
+++ b/packages/libcrypto/.gitignore
@@ -1,0 +1,1 @@
+1017-Add-CTR-DRBG-derivation-function-2863.patch


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
libcrypto: gitignore external patch file


**Testing done:**
Built fresh and verified it was ignored

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
