### PR TITLE
perf: fix parallel build race with header install

### DIFF
--- a/packages/perf/0001-libperf-fix-parallel-build-race-with-header-install.patch
+++ b/packages/perf/0001-libperf-fix-parallel-build-race-with-header-install.patch
@@ -1,0 +1,44 @@
+From 35a24cfee56f4802be928f282c23e13fa886e5d9 Mon Sep 17 00:00:00 2001
+From: Gaurav Sharma <mgsharm@amazon.com>
+Date: Wed, 18 Mar 2026 08:28:42 +0000
+Subject: [PATCH] libperf: fix parallel build race with header install
+
+When perf is built with high parallelism (-j128), there is a race
+condition between the install_headers and libperf.a targets in the
+libperf sub-build. Both are invoked as targets of a single make
+invocation from Makefile.perf:
+
+  $(MAKE) -C $(LIBPERF_DIR) ... $@ install_headers
+
+The perf tool's exported CFLAGS includes -I$(LIBPERF_OUTPUT)/include
+which points to the header install destination. The coreutils install
+command creates the destination file (truncated) before writing content.
+If the compiler runs between file creation and content write, it
+includes an empty header, causing incomplete type and missing prototype
+errors in the libperf source files.
+
+Fix this by making the libperf compilation target depend on
+install_headers, ensuring all headers are fully installed before any
+source files are compiled.
+
+Signed-off-by: Gaurav Sharma <mgsharm@amazon.com>
+---
+ tools/lib/perf/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/lib/perf/Makefile b/tools/lib/perf/Makefile
+index 7fbb50b..69a250b 100644
+--- a/tools/lib/perf/Makefile
++++ b/tools/lib/perf/Makefile
+@@ -109,7 +109,7 @@ uapi-asm-generic:
+ 		$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.asm-headers obj=$(uapi-asm) \
+ 		generic=include/uapi/asm-generic $(syscall-y),)
+ 
+-$(LIBPERF_IN): uapi-asm-generic FORCE
++$(LIBPERF_IN): uapi-asm-generic install_headers FORCE
+ 	$(Q)$(MAKE) $(build)=libperf
+ 
+ $(LIBPERF_A): $(LIBPERF_IN)
+-- 
+2.50.1
+

--- a/packages/perf/perf.spec
+++ b/packages/perf/perf.spec
@@ -8,6 +8,8 @@ Source0: https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{version}.tar.xz
 Source1: https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-%{version}.tar.sign
 Source2: gpgkey-647F28654894E3BD457199BE38DBBDC86092693E.asc
 
+Patch0001: 0001-libperf-fix-parallel-build-race-with-header-install.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libelf-devel
 Requires: %{_cross_os}libelf


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

The perf build has a race condition with high parallelism (-j128). In tools/perf/Makefile.perf, the libperf sub-build runs both libperf.a (compilation) and install_headers (copying headers to the output directory) as targets in a single parallel make invocation. The compiler's search path checks the output directory first, but the install command creates an empty file before writing the actual content. With -j128, the compiler can pick up that empty file before it's fully written, which causes incomplete type and missing prototype errors.

This adds a one-line patch to tools/lib/perf/Makefile that makes compilation depend on install_headers, ensuring all headers are fully installed before source files are compiled.


**Testing done:**
  - Built multiple times to confirm the issue is no longer encountered.
  - make ARCH=aarch64
  - make ARCH=x86_64

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
