### PR TITLE
host-ctr: add CDI support for superpowered containers

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 const (
@@ -343,6 +344,7 @@ func runCtr(containerdSocket string, namespace string, containerID string, sourc
 		switch {
 		case superpowered:
 			specOpts = append(specOpts, withSuperpowered())
+			specOpts = append(specOpts, withCDIDevices("nvidia.com/gpu=all"))
 		case cType == bootstrap:
 			specOpts = append(specOpts, withBootstrap())
 		default:
@@ -615,6 +617,36 @@ func withSuperpowered() oci.SpecOpts {
 		oci.WithSelinuxLabel("system_u:system_r:super_t:s0-s0:c0.c1023"),
 		oci.WithAllDevicesAllowed,
 	)
+}
+
+// withCDIDevices injects CDI devices into the container spec.
+// Enables GPU tools like nvidia-smi in superpowered containers.
+// Fails gracefully if CDI specs don't exist (non-GPU instances).
+func withCDIDevices(devices ...string) oci.SpecOpts {
+	return func(ctx context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
+		if len(devices) == 0 {
+			return nil
+		}
+
+		if err := cdi.Refresh(); err != nil {
+			log.G(ctx).WithError(err).Debug("CDI cache refresh failed, skipping device injection")
+			return nil
+		}
+
+		unresolved, err := cdi.InjectDevices(s, devices...)
+		if err != nil {
+			log.G(ctx).WithError(err).Debug("CDI device injection failed, skipping")
+			return nil
+		}
+
+		if len(unresolved) > 0 {
+			log.G(ctx).WithField("devices", unresolved).Debug("some CDI devices unresolved")
+		} else {
+			log.G(ctx).WithField("devices", devices).Info("CDI devices injected")
+		}
+
+		return nil
+	}
 }
 
 // withBootstrap adds container options to grant read-write access to the underlying

--- a/sources/host-ctr/go.mod
+++ b/sources/host-ctr/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
 	k8s.io/cri-api v0.34.2
+	tags.cncf.io/container-device-interface v1.0.1
 )
 
 // containerd still uses the v1alpha2 APIs in k8s.io/cri-api.
@@ -171,6 +172,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.1 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
-	tags.cncf.io/container-device-interface v1.0.1 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.0.0 // indirect
 )


### PR DESCRIPTION
**Description of changes:**
Add Container Device Interface (CDI) support to host-ctr, enabling NVIDIA GPU tools to be available in superpowered containers.


**Testing done:**
Using this core kit the admin container finds `nvidia-smi` which sees all the devices:
```
[ssm-user@control]$ enter-admin-container
Confirming admin container is enabled...
Waiting for admin container to start...
Entering admin container
          Welcome to Bottlerocket's admin container!
    ╱╲
   ╱┄┄╲   This container provides access to the Bottlerocket host
   │▗▖│   filesystems (see /.bottlerocket/rootfs) and contains common
  ╱│  │╲  tools for inspection and troubleshooting.  It is based on
  │╰╮╭╯│  Amazon Linux 2023, and most things are in the same places you
    ╹╹    would find them on an AL2023 host.

To permit more intrusive troubleshooting, including actions that mutate the
running state of the Bottlerocket host, we provide a tool called "sheltie"
(`sudo sheltie`).  When run, this tool drops you into a root shell in the
Bottlerocket host's root filesystem.
[root@admin]# nvidia-smi
Mon Mar 23 16:24:58 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA L4                      On  |   00000000:5F:00.0 Off |                    0 |
| N/A   37C    P8             12W /   72W |       0MiB /  23034MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA L4                      On  |   00000000:61:00.0 Off |                    0 |
| N/A   36C    P8             12W /   72W |       0MiB /  23034MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA L4                      On  |   00000000:63:00.0 Off |                    0 |
| N/A   38C    P8             12W /   72W |       0MiB /  23034MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
|   3  NVIDIA L4                      On  |   00000000:65:00.0 Off |                    0 |
| N/A   36C    P8             12W /   72W |       0MiB /  23034MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```
Also confirmed a non-NVIDIA instance still launched the admin container without issue.

The spec of the admin container showing the additional mounts:

<details>

```
bash-5.2# ctr --address /run/host-containerd/containerd.sock -n default containers info admin --spec
{
    "ID": "admin",
    "Labels": null,
    "Image": "664055591149.dkr.ecr.us-west-2.amazonaws.com/bottlerocket-admin:test-20260318165748",
    "Runtime": {
        "Name": "io.containerd.runc.v2",
        "Options": {
            "type_url": "containerd.runc.v1.Options",
            "value": "OhkvcnVuL2hvc3QtY29udGFpbmVyZC9ydW5j"
        }
    },
    "SnapshotKey": "admin-snapshot",
    "Snapshotter": "overlayfs",
    "CreatedAt": "2026-03-18T17:07:46.596069275Z",
    "UpdatedAt": "2026-03-18T17:07:46.596069275Z",
    "Extensions": {},
    "SandboxID": "",
    "Spec": {
        "ociVersion": "1.2.1",
        "process": {
            "user": {
                "uid": 0,
                "gid": 0,
                "additionalGids": [
                    0
                ]
            },
            "args": [
                "/bin/bash",
                "-c",
                "/usr/sbin/start_admin.sh"
            ],
            "env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "NO_PROXY=localhost,127.0.0.1,4026288066eed5dfbc81e8fd2fb53459.gr7.us-west-2.eks.amazonaws.com,.cluster.local",
                "no_proxy=localhost,127.0.0.1,4026288066eed5dfbc81e8fd2fb53459.gr7.us-west-2.eks.amazonaws.com,.cluster.local",
                "NVIDIA_CTK_LIBCUDA_DIR=/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla",
                "NVIDIA_VISIBLE_DEVICES=void"
            ],
            "cwd": "/",
            "capabilities": {
                "bounding": [
                    "CAP_CHOWN",
                    "CAP_DAC_OVERRIDE",
                    "CAP_DAC_READ_SEARCH",
                    "CAP_FOWNER",
                    "CAP_FSETID",
                    "CAP_KILL",
                    "CAP_SETGID",
                    "CAP_SETUID",
                    "CAP_SETPCAP",
                    "CAP_LINUX_IMMUTABLE",
                    "CAP_NET_BIND_SERVICE",
                    "CAP_NET_BROADCAST",
                    "CAP_NET_ADMIN",
                    "CAP_NET_RAW",
                    "CAP_IPC_LOCK",
                    "CAP_IPC_OWNER",
                    "CAP_SYS_MODULE",
                    "CAP_SYS_RAWIO",
                    "CAP_SYS_CHROOT",
                    "CAP_SYS_PTRACE",
                    "CAP_SYS_PACCT",
                    "CAP_SYS_ADMIN",
                    "CAP_SYS_BOOT",
                    "CAP_SYS_NICE",
                    "CAP_SYS_RESOURCE",
                    "CAP_SYS_TIME",
                    "CAP_SYS_TTY_CONFIG",
                    "CAP_MKNOD",
                    "CAP_LEASE",
                    "CAP_AUDIT_WRITE",
                    "CAP_AUDIT_CONTROL",
                    "CAP_SETFCAP",
                    "CAP_MAC_OVERRIDE",
                    "CAP_MAC_ADMIN",
                    "CAP_SYSLOG",
                    "CAP_WAKE_ALARM",
                    "CAP_BLOCK_SUSPEND",
                    "CAP_AUDIT_READ",
                    "CAP_PERFMON",
                    "CAP_BPF",
                    "CAP_CHECKPOINT_RESTORE"
                ],
                "effective": [
                    "CAP_CHOWN",
                    "CAP_DAC_OVERRIDE",
                    "CAP_DAC_READ_SEARCH",
                    "CAP_FOWNER",
                    "CAP_FSETID",
                    "CAP_KILL",
                    "CAP_SETGID",
                    "CAP_SETUID",
                    "CAP_SETPCAP",
                    "CAP_LINUX_IMMUTABLE",
                    "CAP_NET_BIND_SERVICE",
                    "CAP_NET_BROADCAST",
                    "CAP_NET_ADMIN",
                    "CAP_NET_RAW",
                    "CAP_IPC_LOCK",
                    "CAP_IPC_OWNER",
                    "CAP_SYS_MODULE",
                    "CAP_SYS_RAWIO",
                    "CAP_SYS_CHROOT",
                    "CAP_SYS_PTRACE",
                    "CAP_SYS_PACCT",
                    "CAP_SYS_ADMIN",
                    "CAP_SYS_BOOT",
                    "CAP_SYS_NICE",
                    "CAP_SYS_RESOURCE",
                    "CAP_SYS_TIME",
                    "CAP_SYS_TTY_CONFIG",
                    "CAP_MKNOD",
                    "CAP_LEASE",
                    "CAP_AUDIT_WRITE",
                    "CAP_AUDIT_CONTROL",
                    "CAP_SETFCAP",
                    "CAP_MAC_OVERRIDE",
                    "CAP_MAC_ADMIN",
                    "CAP_SYSLOG",
                    "CAP_WAKE_ALARM",
                    "CAP_BLOCK_SUSPEND",
                    "CAP_AUDIT_READ",
                    "CAP_PERFMON",
                    "CAP_BPF",
                    "CAP_CHECKPOINT_RESTORE"
                ],
                "permitted": [
                    "CAP_CHOWN",
                    "CAP_DAC_OVERRIDE",
                    "CAP_DAC_READ_SEARCH",
                    "CAP_FOWNER",
                    "CAP_FSETID",
                    "CAP_KILL",
                    "CAP_SETGID",
                    "CAP_SETUID",
                    "CAP_SETPCAP",
                    "CAP_LINUX_IMMUTABLE",
                    "CAP_NET_BIND_SERVICE",
                    "CAP_NET_BROADCAST",
                    "CAP_NET_ADMIN",
                    "CAP_NET_RAW",
                    "CAP_IPC_LOCK",
                    "CAP_IPC_OWNER",
                    "CAP_SYS_MODULE",
                    "CAP_SYS_RAWIO",
                    "CAP_SYS_CHROOT",
                    "CAP_SYS_PTRACE",
                    "CAP_SYS_PACCT",
                    "CAP_SYS_ADMIN",
                    "CAP_SYS_BOOT",
                    "CAP_SYS_NICE",
                    "CAP_SYS_RESOURCE",
                    "CAP_SYS_TIME",
                    "CAP_SYS_TTY_CONFIG",
                    "CAP_MKNOD",
                    "CAP_LEASE",
                    "CAP_AUDIT_WRITE",
                    "CAP_AUDIT_CONTROL",
                    "CAP_SETFCAP",
                    "CAP_MAC_OVERRIDE",
                    "CAP_MAC_ADMIN",
                    "CAP_SYSLOG",
                    "CAP_WAKE_ALARM",
                    "CAP_BLOCK_SUSPEND",
                    "CAP_AUDIT_READ",
                    "CAP_PERFMON",
                    "CAP_BPF",
                    "CAP_CHECKPOINT_RESTORE"
                ]
            },
            "rlimits": [
                {
                    "type": "RLIMIT_NOFILE",
                    "hard": 1024,
                    "soft": 1024
                }
            ],
            "selinuxLabel": "system_u:system_r:super_t:s0-s0:c0.c1023"
        },
        "root": {
            "path": "rootfs"
        },
        "mounts": [
            {
                "destination": "/proc",
                "type": "proc",
                "source": "proc",
                "options": [
                    "nosuid",
                    "noexec",
                    "nodev"
                ]
            },
            {
                "destination": "/dev",
                "type": "tmpfs",
                "source": "tmpfs",
                "options": [
                    "nosuid",
                    "strictatime",
                    "mode=755",
                    "size=65536k"
                ]
            },
            {
                "destination": "/sys",
                "type": "sysfs",
                "source": "sysfs",
                "options": [
                    "nosuid",
                    "noexec",
                    "nodev",
                    "rw"
                ]
            },
            {
                "destination": "/run",
                "type": "tmpfs",
                "source": "tmpfs",
                "options": [
                    "nosuid",
                    "strictatime",
                    "mode=755",
                    "size=65536k"
                ]
            },
            {
                "destination": "/dev/pts",
                "type": "devpts",
                "source": "devpts",
                "options": [
                    "nosuid",
                    "noexec",
                    "newinstance",
                    "ptmxmode=0666",
                    "mode=0620",
                    "gid=5"
                ]
            },
            {
                "destination": "/dev/shm",
                "type": "tmpfs",
                "source": "shm",
                "options": [
                    "nosuid",
                    "noexec",
                    "nodev",
                    "mode=1777",
                    "size=65536k"
                ]
            },
            {
                "destination": "/dev/mqueue",
                "type": "mqueue",
                "source": "mqueue",
                "options": [
                    "nosuid",
                    "noexec",
                    "nodev"
                ]
            },
            {
                "destination": "/etc/hosts",
                "type": "bind",
                "source": "/etc/hosts",
                "options": [
                    "rbind",
                    "ro"
                ]
            },
            {
                "destination": "/etc/resolv.conf",
                "type": "bind",
                "source": "/etc/resolv.conf",
                "options": [
                    "rbind",
                    "ro"
                ]
            },
            {
                "destination": "/run/api.sock",
                "source": "/run/api.sock",
                "options": [
                    "bind",
                    "rw",
                    "rprivate"
                ]
            },
            {
                "destination": "/etc/bottlerocket-release",
                "source": "/etc/os-release",
                "options": [
                    "bind",
                    "ro",
                    "rprivate"
                ]
            },
            {
                "destination": "/.bottlerocket/certs",
                "source": "/etc/pki/tls/certs",
                "options": [
                    "bind",
                    "ro",
                    "rprivate"
                ]
            },
            {
                "destination": "/.bottlerocket/support",
                "type": "bind",
                "source": "/var/log/support",
                "options": [
                    "bind",
                    "ro",
                    "rprivate"
                ]
            },
            {
                "destination": "/.bottlerocket/rootfs",
                "type": "bind",
                "source": "/",
                "options": [
                    "rbind",
                    "ro",
                    "rprivate"
                ]
            },
            {
                "destination": "/lib/modules",
                "type": "bind",
                "source": "/lib/modules",
                "options": [
                    "rbind",
                    "ro",
                    "rprivate"
                ]
            },
            {
                "destination": "/sys/firmware",
                "type": "bind",
                "source": "/sys/firmware",
                "options": [
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/.bottlerocket/host-containers/admin",
                "source": "/local/host-containers/admin",
                "options": [
                    "rbind",
                    "rw",
                    "rprivate"
                ]
            },
            {
                "destination": "/sys/fs/cgroup",
                "type": "cgroup",
                "source": "cgroup",
                "options": [
                    "rw",
                    "nosuid",
                    "noexec",
                    "nodev",
                    "rprivate"
                ]
            },
            {
                "destination": "/.bottlerocket/host-containers/current",
                "source": "/local/host-containers/admin",
                "options": [
                    "rbind",
                    "rw",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/src/kernels",
                "type": "bind",
                "source": "/usr/src/kernels",
                "options": [
                    "rbind",
                    "rw",
                    "rprivate"
                ]
            },
            {
                "destination": "/sys/kernel/debug",
                "type": "bind",
                "source": "/sys/kernel/debug",
                "options": [
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/.bottlerocket/rootfs/mnt",
                "type": "bind",
                "source": "/mnt",
                "options": [
                    "rbind",
                    "rshared"
                ]
            },
            {
                "destination": "/run/nvidia-persistenced/socket",
                "source": "/run/nvidia-persistenced/socket",
                "options": [
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate",
                    "noexec"
                ]
            },
            {
                "destination": "/usr/bin/nvidia-cuda-mps-control",
                "source": "/usr/bin/nvidia-cuda-mps-control",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/bin/nvidia-cuda-mps-server",
                "source": "/usr/bin/nvidia-cuda-mps-server",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/bin/nvidia-debugdump",
                "source": "/usr/bin/nvidia-debugdump",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/bin/nvidia-imex",
                "source": "/usr/bin/nvidia-imex",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/bin/nvidia-imex-ctl",
                "source": "/usr/bin/nvidia-imex-ctl",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/bin/nvidia-persistenced",
                "source": "/usr/bin/nvidia-persistenced",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/bin/nvidia-smi",
                "source": "/usr/bin/nvidia-smi",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/local/bin/apiclient",
                "source": "/usr/bin/apiclient",
                "options": [
                    "bind",
                    "ro",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/local/sbin/modprobe",
                "type": "bind",
                "source": "/usr/bin/kmod",
                "options": [
                    "bind",
                    "ro",
                    "exec",
                    "rprivate"
                ]
            },
            {
                "destination": "/etc/vulkan/icd.d/nvidia_icd.json",
                "source": "/usr/share/vulkan/icd.d/nvidia_icd.json",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/etc/vulkan/icd.d/nvidia_layers.json",
                "source": "/usr/share/vulkan/icd.d/nvidia_layers.json",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/etc/vulkan/implicit_layer.d/nvidia_layers.json",
                "source": "/usr/share/vulkan/implicit_layer.d/nvidia_layers.json",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/share/nvidia/nvoptix.bin",
                "source": "/usr/share/nvidia/nvoptix.bin",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/var/lib/bottlerocket/inventory/application.json",
                "source": "/usr/share/bottlerocket/application-inventory.json",
                "options": [
                    "bind",
                    "ro",
                    "rprivate"
                ]
            },
            {
                "destination": "/lib/firmware/nvidia/580.126.09/gsp_ga10x.bin",
                "source": "/lib/firmware/nvidia/580.126.09/gsp_ga10x.bin",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/lib/firmware/nvidia/580.126.09/gsp_tu10x.bin",
                "source": "/lib/firmware/nvidia/580.126.09/gsp_tu10x.bin",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json",
                "source": "/usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json",
                "source": "/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/usr/share/glvnd/egl_vendor.d/10_nvidia.json",
                "source": "/usr/share/glvnd/egl_vendor.d/10_nvidia.json",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libEGL.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libEGL.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libEGL_nvidia.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libEGL_nvidia.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLESv1_CM_nvidia.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLESv1_CM_nvidia.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLESv2_nvidia.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLESv2_nvidia.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLX_nvidia.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLX_nvidia.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libcuda.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libcuda.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libcudadebugger.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libcudadebugger.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvcuvid.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvcuvid.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-allocator.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-allocator.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-cfg.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-cfg.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-eglcore.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-eglcore.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-encode.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-encode.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-fbc.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-fbc.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-glcore.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-glcore.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-glsi.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-glsi.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-glvkspirv.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-glvkspirv.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-gpucomp.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-gpucomp.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-ml.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-ml.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-ngx.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-ngx.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-nvvm.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-nvvm.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-opencl.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-opencl.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-opticalflow.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-opticalflow.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-pkcs11-openssl3.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-pkcs11-openssl3.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-pkcs11.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-pkcs11.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-present.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-present.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-ptxjitcompiler.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-ptxjitcompiler.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-rtcore.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-rtcore.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-tls.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-tls.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvoptix.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvoptix.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            },
            {
                "destination": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libvdpau_nvidia.so.580.126.09",
                "source": "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libvdpau_nvidia.so.580.126.09",
                "options": [
                    "ro",
                    "nosuid",
                    "nodev",
                    "rbind",
                    "rprivate"
                ]
            }
        ],
        "hooks": {
            "createContainer": [
                {
                    "path": "/usr/bin/nvidia-cdi-hook",
                    "args": [
                        "nvidia-cdi-hook",
                        "create-symlinks",
                        "--link",
                        "../libnvidia-allocator.so.1::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/gbm/nvidia-drm_gbm.so"
                    ],
                    "env": [
                        "NVIDIA_CTK_DEBUG=false"
                    ]
                },
                {
                    "path": "/usr/bin/nvidia-cdi-hook",
                    "args": [
                        "nvidia-cdi-hook",
                        "create-symlinks",
                        "--link",
                        "libEGL.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libEGL.so.1",
                        "--link",
                        "libEGL_nvidia.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libEGL_nvidia.so.0",
                        "--link",
                        "libGLESv1_CM_nvidia.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLESv1_CM_nvidia.so.1",
                        "--link",
                        "libGLESv2_nvidia.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLESv2_nvidia.so.2",
                        "--link",
                        "libGLX_nvidia.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLX_indirect.so.0",
                        "--link",
                        "libGLX_nvidia.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libGLX_nvidia.so.0",
                        "--link",
                        "libcuda.so.1::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libcuda.so",
                        "--link",
                        "libcuda.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libcuda.so.1",
                        "--link",
                        "libcudadebugger.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libcudadebugger.so.1",
                        "--link",
                        "libnvcuvid.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvcuvid.so.1",
                        "--link",
                        "libnvidia-allocator.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-allocator.so.1",
                        "--link",
                        "libnvidia-cfg.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-cfg.so.1",
                        "--link",
                        "libnvidia-encode.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-encode.so.1",
                        "--link",
                        "libnvidia-fbc.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-fbc.so.1",
                        "--link",
                        "libnvidia-ml.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-ml.so.1",
                        "--link",
                        "libnvidia-ngx.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-ngx.so.1",
                        "--link",
                        "libnvidia-nvvm.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-nvvm.so.4",
                        "--link",
                        "libnvidia-opencl.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-opencl.so.1",
                        "--link",
                        "libnvidia-opticalflow.so.1::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-opticalflow.so",
                        "--link",
                        "libnvidia-opticalflow.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-opticalflow.so.1",
                        "--link",
                        "libnvidia-ptxjitcompiler.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-ptxjitcompiler.so.1",
                        "--link",
                        "libnvoptix.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvoptix.so.1",
                        "--link",
                        "libvdpau_nvidia.so.580.126.09::/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libvdpau_nvidia.so.1"
                    ],
                    "env": [
                        "NVIDIA_CTK_DEBUG=false"
                    ]
                },
                {
                    "path": "/usr/bin/nvidia-cdi-hook",
                    "args": [
                        "nvidia-cdi-hook",
                        "enable-cuda-compat",
                        "--host-driver-version=580.126.09"
                    ],
                    "env": [
                        "NVIDIA_CTK_DEBUG=false"
                    ]
                },
                {
                    "path": "/usr/bin/nvidia-cdi-hook",
                    "args": [
                        "nvidia-cdi-hook",
                        "update-ldcache",
                        "--folder",
                        "/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla"
                    ],
                    "env": [
                        "NVIDIA_CTK_DEBUG=false"
                    ]
                },
                {
                    "path": "/usr/bin/nvidia-cdi-hook",
                    "args": [
                        "nvidia-cdi-hook",
                        "disable-device-node-modification"
                    ],
                    "env": [
                        "NVIDIA_CTK_DEBUG=false"
                    ]
                }
            ]
        },
        "linux": {
            "resources": {
                "devices": [
                    {
                        "allow": true,
                        "access": "rwm"
                    },
                    {
                        "allow": true,
                        "type": "c",
                        "major": 195,
                        "minor": 254,
                        "access": "rwm"
                    },
                    {
                        "allow": true,
                        "type": "c",
                        "major": 239,
                        "minor": 0,
                        "access": "rwm"
                    },
                    {
                        "allow": true,
                        "type": "c",
                        "major": 239,
                        "minor": 1,
                        "access": "rwm"
                    },
                    {
                        "allow": true,
                        "type": "c",
                        "major": 195,
                        "minor": 255,
                        "access": "rwm"
                    },
                    {
                        "allow": true,
                        "type": "c",
                        "major": 195,
                        "minor": 0,
                        "access": "rwm"
                    }
                ]
            },
            "cgroupsPath": "/default/admin",
            "namespaces": [
                {
                    "type": "ipc"
                },
                {
                    "type": "uts"
                },
                {
                    "type": "mount"
                }
            ],
            "devices": [
                {
                    "path": "/dev/nvidia-modeset",
                    "type": "c",
                    "major": 195,
                    "minor": 254
                },
                {
                    "path": "/dev/nvidia-uvm",
                    "type": "c",
                    "major": 239,
                    "minor": 0
                },
                {
                    "path": "/dev/nvidia-uvm-tools",
                    "type": "c",
                    "major": 239,
                    "minor": 1
                },
                {
                    "path": "/dev/nvidiactl",
                    "type": "c",
                    "major": 195,
                    "minor": 255
                },
                {
                    "path": "/dev/nvidia0",
                    "type": "c",
                    "major": 195,
                    "minor": 0
                }
            ],
            "rootfsPropagation": "rshared",
            "mountLabel": "system_u:object_r:secret_t:s0"
        }
    }
}
```

</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
