### PR TITLE
Update ssm agent to 3.3.4108

### DIFF
--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ssm-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.3598.0/amazon-ssm-agent-3.3.3598.0.tar.gz"
-sha512 = "715353e6adfeec2f1a010a82b18363e2b73c6aee97d5205f6dffafa28b59de25e79265e19d73c837503c2e7591b01c6640ffe8b96b2836f31fc6d59413ed9f25"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.4108.0/amazon-ssm-agent-3.3.4108.0.tar.gz"
+sha512 = "2c90240232b1e4e689aea608304018afd8b1def60be45474a94c0883b92479958be77b8d23adad63e9b33e39d0f79a9b28ce0dac7a236565043f41d147db48a2"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.3.3598.0
+Version: 3.3.4108.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0
@@ -31,6 +31,9 @@ Summary: A statically-linked agent to enable remote management of EC2 instances
 
 %build
 %set_cross_go_flags
+
+export GOTOOLCHAIN=local
+export GO_MAJOR="1.25"
 
 go build -ldflags "${GOLDFLAGS}" -o amazon-ssm-agent \
   ./core/agent.go ./core/agent_unix.go ./core/agent_parser.go


### PR DESCRIPTION
**Description of changes:**

Update SSM agent to 3.3.4108. Set the `GOTOOLCHAIN=local` because the package now requires a minimum toolchain version which will trigger a download from within the build environment. Adding the environment variable prevents this. 

**Testing done:**

- [x] Build locally
- [x] CI builds

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
