### PR TITLE
Containerd 2.2: support setting max-concurrent-unpacks

### DIFF
--- a/packages/containerd-1.7/containerd-1.7.spec
+++ b/packages/containerd-1.7/containerd-1.7.spec
@@ -24,6 +24,7 @@ Source4: containerd-config-toml_k8s_nvidia_containerd_sock
 Source5: containerd-tmpfiles.conf
 Source6: containerd-cri-base-json
 Source7: snapshotter-toml
+Source8: max-concurrent-unpacks-unsupported
 
 # Mount for writing containerd configuration
 Source100: etc-containerd.mount
@@ -125,7 +126,7 @@ install -p -m 0644 %{S:1} %{S:100} %{S:110} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/containerd
-install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{S:7} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{S:7} %{S:8} %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
@@ -147,6 +148,7 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/0
 %{_cross_templatedir}/containerd-config-toml*
 %{_cross_templatedir}/containerd-cri-base-json
 %{_cross_templatedir}/snapshotter-toml
+%{_cross_templatedir}/max-concurrent-unpacks-unsupported
 %{_cross_tmpfilesdir}/containerd.conf
 %{_cross_bindir}/containerd
 %{_cross_bindir}/containerd-shim

--- a/packages/containerd-1.7/max-concurrent-unpacks-unsupported
+++ b/packages/containerd-1.7/max-concurrent-unpacks-unsupported
@@ -1,0 +1,7 @@
+[required-extensions]
+container-runtime = { version = "v1", optional = true }
++++
+{{~#if settings.container-runtime.max-concurrent-unpacks~}}
+UNSUPPORTED_SETTING=container-runtime.max-concurrent-unpacks
+UNSUPPORTED_REASON=This setting requires containerd 2.2 or later.
+{{~/if~}}

--- a/packages/containerd-2.1/containerd-2.1.spec
+++ b/packages/containerd-2.1/containerd-2.1.spec
@@ -23,6 +23,7 @@ Source4: containerd-config-toml_k8s_nvidia_containerd_sock
 Source5: containerd-tmpfiles.conf
 Source6: containerd-cri-base-json
 Source7: snapshotter-toml
+Source8: max-concurrent-unpacks-unsupported
 
 # Mount for writing containerd configuration
 Source100: etc-containerd.mount
@@ -121,7 +122,7 @@ install -p -m 0644 %{S:1} %{S:100} %{S:110} %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_templatedir}
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/containerd
-install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{S:7} %{buildroot}%{_cross_templatedir}
+install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{S:7} %{S:8} %{buildroot}%{_cross_templatedir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
@@ -143,6 +144,7 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/0
 %{_cross_templatedir}/containerd-config-toml*
 %{_cross_templatedir}/containerd-cri-base-json
 %{_cross_templatedir}/snapshotter-toml
+%{_cross_templatedir}/max-concurrent-unpacks-unsupported
 %{_cross_tmpfilesdir}/containerd.conf
 %{_cross_bindir}/containerd
 %{_cross_bindir}/containerd-shim-runc-v2

--- a/packages/containerd-2.1/max-concurrent-unpacks-unsupported
+++ b/packages/containerd-2.1/max-concurrent-unpacks-unsupported
@@ -1,0 +1,7 @@
+[required-extensions]
+container-runtime = { version = "v1", optional = true }
++++
+{{~#if settings.container-runtime.max-concurrent-unpacks~}}
+UNSUPPORTED_SETTING=container-runtime.max-concurrent-unpacks
+UNSUPPORTED_REASON=This setting requires containerd 2.2 or later.
+{{~/if~}}

--- a/packages/containerd-2.2/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.2/containerd-config-toml_k8s_containerd_sock
@@ -46,6 +46,9 @@ enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp
 {{#if settings.container-runtime.max-concurrent-downloads}}
 max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
+{{#if settings.container-runtime.max-concurrent-unpacks}}
+max_concurrent_unpacks = {{settings.container-runtime.max-concurrent-unpacks}}
+{{/if}}
 concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
 
 [[plugins."io.containerd.transfer.v1.local".unpack_config]]

--- a/packages/containerd-2.2/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.2/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -46,6 +46,9 @@ enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp
 {{#if settings.container-runtime.max-concurrent-downloads}}
 max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
 {{/if}}
+{{#if settings.container-runtime.max-concurrent-unpacks}}
+max_concurrent_unpacks = {{settings.container-runtime.max-concurrent-unpacks}}
+{{/if}}
 concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
 
 [[plugins."io.containerd.transfer.v1.local".unpack_config]]

--- a/packages/release/release-tmpfiles.conf
+++ b/packages/release/release-tmpfiles.conf
@@ -1,5 +1,6 @@
 C /etc/nsswitch.conf - - - -
 d /etc/deprecated-settings 0700 root root -
+d /etc/unsupported-settings 0700 root root -
 d /var/log/kdump 0700 root root -
 d /sys/fs/cgroup/cpuset/runtime.slice 0755 root root -
 d /sys/fs/cgroup/hugetlb/runtime.slice 0755 root root -

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -88,6 +88,8 @@ Source1065: check-kernel-integrity.service
 Source1066: check-fips-modules.service
 Source1067: fips-modprobe@.service
 Source1068: configure-snapshotter.service
+Source1069: unsupported-setting-warning@.service
+Source1070: unsupported-setting-warning@.timer
 
 # Mounts that require build-time edits.
 Source1080: var-lib-kernel-devel-lower.mount.in
@@ -269,7 +271,7 @@ install -p -m 0644 \
   %{S:1045} %{S:1046} %{S:1047} %{S:1048} %{S:1049} \
   %{S:1050} \
   %{S:1060} %{S:1061} %{S:1062} %{S:1063} %{S:1064} \
-  %{S:1065} %{S:1066} %{S:1067} %{S:1068} \
+  %{S:1065} %{S:1066} %{S:1067} %{S:1068} %{S:1069} %{S:1070} \
   %{S:1600} %{S:1601} %{S:1602} %{S:1603} %{S:1604} \
   %{S:1605} %{S:1606} %{S:1607} %{S:1608} %{S:1609} \
   %{buildroot}%{_cross_unitdir}
@@ -439,6 +441,8 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/prepare-local-fs.service
 %{_cross_unitdir}/deprecation-warning@.service
 %{_cross_unitdir}/deprecation-warning@.timer
+%{_cross_unitdir}/unsupported-setting-warning@.service
+%{_cross_unitdir}/unsupported-setting-warning@.timer
 %{_cross_unitdir}/service.d/00-aws-config.conf
 %{_cross_unitdir}/service.d/10-requires-tmp.conf
 %dir %{_cross_unitdir}/systemd-resolved.service.d

--- a/packages/release/unsupported-setting-warning@.service
+++ b/packages/release/unsupported-setting-warning@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Unsupported setting warning for %i
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/unsupported-settings/%i
+ExecStart=/usr/bin/logger -p4 The setting "${UNSUPPORTED_SETTING}" is not supported and has no effect. ${UNSUPPORTED_REASON}
+StandardError=journal+console

--- a/packages/release/unsupported-setting-warning@.timer
+++ b/packages/release/unsupported-setting-warning@.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Scheduled unsupported setting warning for %i
+ConditionFileNotEmpty=/etc/unsupported-settings/%i
+
+[Timer]
+Persistent=false
+# Run immediately on startup
+OnStartupSec=0
+# Run every 6 hours thereafter
+OnUnitActiveSec=21600
+AccuracySec=10
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/806

**Description of changes:**

Expose containerd 2.2's `max_concurrent_unpacks` transfer service setting via `settings.container-runtime.max-concurrent-unpacks`, and add warning infrastructure for variants using older containerd versions.

**Containerd 2.2 templates:**
- Added `{{#if settings.container-runtime.max-concurrent-unpacks}}` block to `containerd-config-toml_k8s_containerd_sock` and `containerd-config-toml_k8s_nvidia_containerd_sock`, rendering `max_concurrent_unpacks` under `[plugins."io.containerd.transfer.v1.local"]`

**Unsupported setting warning (containerd 1.7 and 2.1):**
- New `unsupported-setting-warning@.service` and `unsupported-setting-warning@.timer` systemd template units in the release package (same pattern as `deprecation-warning@`)
- Warning template `max-concurrent-unpacks-unsupported` added to containerd-1.7 and containerd-2.1 packages — writes an env file to `/etc/unsupported-settings/` when the setting is configured
- Timer fires on startup and every 6 hours, logging: `The setting "container-runtime.max-concurrent-unpacks" is not supported by the containerd version in this variant and has no effect.`

Depends on https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/119 for the settings model.

**Testing done:**

Built aws-k8s-1.35 variant with both containerd 2.2 and containerd 2.1, using the setting introduced in https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/119. Launched EC2 instances with `settings.container-runtime.max-concurrent-unpacks = 5` in user data.

**Containerd 2.2:**
- `/etc/containerd/config.toml` renders `max_concurrent_unpacks = 5` under `[plugins."io.containerd.transfer.v1.local"]` ✅
- No warning in journal ✅

**Containerd 2.1:**
- `max_concurrent_unpacks` not rendered in containerd config ✅
- Timer active, journal warning: `The setting container-runtime.max-concurrent-unpacks is not supported by the containerd version in this variant and has no effect.` ✅

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.