### PR TITLE
Allow runtime processes to write fifos to content stores

### DIFF
--- a/packages/selinux-policy/rules.cil
+++ b/packages/selinux-policy/rules.cil
@@ -35,6 +35,8 @@
 (roletransition system_r all_o fifo_file object_r)
 ; ... most ephemeral directories
 (typetransition all_s any_t fifo_file any_t)
+; ... containers content store
+(typetransition all_s cache_t fifo_file cache_t)
 ; ... persistent, shared host directories
 (typetransition all_s local_t fifo_file local_t)
 ; ... persistent, read-restricted host directories


### PR DESCRIPTION
**Issue number:**

Related to https://github.com/bottlerocket-os/bottlerocket/issues/4798

**Description of changes:**

[#868] introduced further restrictions on the SELinux policy governing interactions between the container runtime and containers, specifically around how shared pipes are labeled and accessed.

This change inadvertently prevented container runtime processes from writing named fifos to the content store. While uncommon, this occurs with container images that ship a complete root filesystem, including `/dev` and any named fifos within it.

Fix this by allowing type transitions from `runtime_t`-labeled named fifos to `cache_t`, the label assigned to containers' content stores.

[#868]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/868

**Testing done:**

Before this change, the following failure was observed when pulling container images with named fifos in them:

<details>

```bash
[root@admin]# sheltie ctr image pull docker.io/library/oraclelinux:9-slim
docker.io/library/oraclelinux:9-slim:                                             resolved       |++++++++++++++++++++++++++++++++++++++|
index-sha256:2aa0e101d869245238b3a1f3956b95a0782654e9643624803a58a64c4eab9843:    done           |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:a15852237b293bd35fb03aa4447b72b763cde76b62aa882ae640e03fcc013764: done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:d4c7048d1cf1fb6137e2c8f7ae456b3950d5b1e9986feb08e68d4b0d7508481c:    done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:284dce8ea69d1e25d689662c7c673b4a6c1b681d38f3faa5970d520abdfe98db:   done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 2.1 s                                                                    total:  45.1 M (21.5 MiB/s)
unpacking linux/amd64 sha256:2aa0e101d869245238b3a1f3956b95a0782654e9643624803a58a64c4eab9843...
INFO[0002] apply failure, attempting cleanup             error="failed to extract layer sha256:a06588a07d8a70f60d73602f1849bea9e6339d916ad3aaa27984c4e81f4d6777: mount callback failed on /var/lib/containerd/tmpmounts/containerd-mount3363727826: permission denied: unknown" key="extract-314995252-dLd8 sha256:a06588a07d8a70f60d73602f1849bea9e6339d916ad3aaa27984c4e81f4d6777"
ctr: failed to extract layer sha256:a06588a07d8a70f60d73602f1849bea9e6339d916ad3aaa27984c4e81f4d6777: mount callback failed on /var/lib/containerd/tmpmounts/containerd-mount3363727826: permission denied: unknown
[root@admin]#
┌────────────
```

</details>

With the change, the pull succeeds and the fifo gets the correct label:

<details>

```bash
[root@admin]# sheltie ctr image pull docker.io/library/oraclelinux:9-slim
docker.io/library/oraclelinux:9-slim:                                             resolved       |++++++++++++++++++++++++++++++++++++++|
index-sha256:2aa0e101d869245238b3a1f3956b95a0782654e9643624803a58a64c4eab9843:    done           |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:a15852237b293bd35fb03aa4447b72b763cde76b62aa882ae640e03fcc013764: done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:d4c7048d1cf1fb6137e2c8f7ae456b3950d5b1e9986feb08e68d4b0d7508481c:    done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:284dce8ea69d1e25d689662c7c673b4a6c1b681d38f3faa5970d520abdfe98db:   done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 0.5 s                                                                    total:   0.0 B (0.0 B/s)
unpacking linux/amd64 sha256:2aa0e101d869245238b3a1f3956b95a0782654e9643624803a58a64c4eab9843...
done: 981.275118ms
[root@admin]# ls -lZ /.bottlerocket/rootfs/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/7/fs/dev/initctl
prw-------. 1 root root system_u:object_r:cache_t:s0 0 Mar 19 18:33 /.bottlerocket/rootfs/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/7/fs/dev/initctl
[root@admin]#
```

</details>

The fifo transitions from `runtime_t` to `cache_t`. The SELinux policy allows `cache_t` to be written to the `local_t` filesystem, since `cache_t` is treated as `write_restricted_o` and [this rule] allows these files to exist in a filesystem with label `local_t`.

[this rule]: https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/d9fa436e11e22a56e1c6c068335823a7e2e8950a/packages/selinux-policy/rules.cil#L346

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
