### PR TITLE
Add k8s settings: prefer-closest-numa-nodes and max-allowable-numa-nodes

### DIFF
--- a/packages/kubernetes-1.32/kubelet-config
+++ b/packages/kubernetes-1.32/kubelet-config
@@ -125,6 +125,10 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
+{{#if settings.kubernetes.topology-manager-policy-options.prefer-closest-numa-nodes}}
+topologyManagerPolicyOptions:
+  prefer-closest-numa-nodes: "{{settings.kubernetes.topology-manager-policy-options.prefer-closest-numa-nodes}}"
+{{/if}}
 podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
 {{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
 imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}

--- a/packages/kubernetes-1.33/kubelet-config
+++ b/packages/kubernetes-1.33/kubelet-config
@@ -125,6 +125,10 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
+{{#if settings.kubernetes.topology-manager-policy-options.prefer-closest-numa-nodes}}
+topologyManagerPolicyOptions:
+  prefer-closest-numa-nodes: "{{settings.kubernetes.topology-manager-policy-options.prefer-closest-numa-nodes}}"
+{{/if}}
 podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
 {{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
 imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}

--- a/packages/kubernetes-1.34/kubelet-config
+++ b/packages/kubernetes-1.34/kubelet-config
@@ -123,6 +123,10 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
+{{#if settings.kubernetes.topology-manager-policy-options.prefer-closest-numa-nodes}}
+topologyManagerPolicyOptions:
+  prefer-closest-numa-nodes: "{{settings.kubernetes.topology-manager-policy-options.prefer-closest-numa-nodes}}"
+{{/if}}
 podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
 {{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
 imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}

--- a/packages/kubernetes-1.35/kubelet-config
+++ b/packages/kubernetes-1.35/kubelet-config
@@ -123,6 +123,18 @@ topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
 {{#if settings.kubernetes.topology-manager-policy}}
 topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
 {{/if}}
+{{#if settings.kubernetes.topology-manager-policy-options.prefer-closest-numa-nodes}}
+topologyManagerPolicyOptions:
+  prefer-closest-numa-nodes: "{{settings.kubernetes.topology-manager-policy-options.prefer-closest-numa-nodes}}"
+{{#if settings.kubernetes.topology-manager-policy-options.max-allowable-numa-nodes}}
+  max-allowable-numa-nodes: "{{settings.kubernetes.topology-manager-policy-options.max-allowable-numa-nodes}}"
+{{/if}}
+{{else}}
+{{#if settings.kubernetes.topology-manager-policy-options.max-allowable-numa-nodes}}
+topologyManagerPolicyOptions:
+  max-allowable-numa-nodes: "{{settings.kubernetes.topology-manager-policy-options.max-allowable-numa-nodes}}"
+{{/if}}
+{{/if}}
 podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
 {{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
 imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -527,15 +527,15 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "darling",
  "quote",
@@ -1472,8 +1472,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.14.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+version = "0.15.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1518,7 +1518,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -1542,8 +1542,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.21.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+version = "0.23.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1595,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "serde",
 ]
@@ -1616,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2267,9 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -4112,9 +4112,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
@@ -5330,7 +5330,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5343,7 +5343,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5356,7 +5356,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5370,7 +5370,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5383,7 +5383,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5396,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5409,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5422,7 +5422,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5438,7 +5438,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5451,7 +5451,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5464,7 +5464,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5477,7 +5477,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-image-verifier-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5490,7 +5490,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5503,7 +5503,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5515,8 +5515,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubernetes"
-version = "0.9.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+version = "0.10.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5530,7 +5530,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5543,7 +5543,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -5556,7 +5556,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5569,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5582,7 +5582,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5595,7 +5595,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5609,7 +5609,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5622,7 +5622,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5635,7 +5635,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.21.0#ed66ba6ae6e38bc86a1a45f7574a7a3df6f07d96"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -7307,9 +7307,9 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -7318,7 +7318,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -227,18 +227,18 @@ which = "4"
 zbus = { version = "5.11", default-features = false }
 zeroize = { version = "1", default-features = false }
 zvariant = "5.7"
-x509-parser = "0.16"
+x509-parser = "0.18"
 base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.21.0"
-version = "0.14.0"
+tag = "bottlerocket-settings-models-v0.23.0"
+version = "0.15.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.21.0"
-version = "0.21.0"
+tag = "bottlerocket-settings-models-v0.23.0"
+version = "0.23.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -247,7 +247,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.21.0"
+tag = "bottlerocket-settings-models-v0.23.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related to # https://github.com/bottlerocket-os/bottlerocket/issues/4750

Related to: 
- https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/901
- https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/117
- https://github.com/bottlerocket-os/bottlerocket/pull/4778

**Description of changes:**
Add 2 topology manager policy options:
1. `max-allowable-numa-nodes` - GA k8s-1.35+
2. `prefer-closest-numa-nodes` - GA k8s-1.32+


**Testing done:**
Enabled the following settings and rebooted the instance:
```
apiclient set \
  kubernetes.cpu-manager-policy="static" \
  kubernetes.topology-manager-policy="best-effort" \
  kubernetes.topology-manager-policy-options.prefer-closest-numa-nodes="true"
```
Then ran a pod with the following spec:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: numa-test
spec:
  containers:
  - name: numa-test
    image: registry.k8s.io/pause:3.9
    resources:
      requests:
        cpu: "4"
        memory: "100Mi"
      limits:
        cpu: "4"
        memory: "100Mi"
```
Its important that requests and limits are equal for both CPU and memory to ensure it is in the `Guaranteed` QoS class for the CPU pinning as a result of the `static` policy to work properly.

The assigned CPUs for this pod was 1,2,65,66.
The NUMA node ranges for this instances are:
node0: 0-31, 64-95
node1: 32-63, 96-127

All 4 CPUs belong to NUMA node0. The `prefer-closest-numa-nodes` policy worked as expected.


For `max-allowable-numa-nodes` I show the limits enforced by kubernetes are also applied here. 
```
[ssm-user@control]$ apiclient set settings.kubernetes.topology-manager-policy-options.max-allowable-numa-nodes="4"
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-Z6sWPcf69TAMvS9h': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-Z6sWPcf69TAMvS9h: Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error during deserialization: Invalid Kubernetes max-allowable-numa-nodes value '4': must be >= 8 at line 1 column 79
[ssm-user@control]$ apiclient set settings.kubernetes.topology-manager-policy-options.max-allowable-numa-nodes="8"
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
