### PR TITLE
glibc: revert malloc lazy thp_init to prevent automatic THP activation

### DIFF
--- a/packages/glibc/0011-Revert-malloc-auto-enable-THP-on-aarch64.patch
+++ b/packages/glibc/0011-Revert-malloc-auto-enable-THP-on-aarch64.patch
@@ -1,0 +1,104 @@
+From 4efa2fa72a9dd68488e196f47963d8f0772a84a8 Mon Sep 17 00:00:00 2001
+From: Yutong Sun <yutongsu@amazon.com>
+Date: Sat, 11 Apr 2026 02:26:29 +0000
+Subject: [PATCH] Revert malloc: auto-enable THP on aarch64
+
+This reverts the following commits which introduced automatic THP
+activation in malloc via thp_init():
+
+  - 321e1fc7 malloc: Enable 2MB THP by default on Aarch64
+  - 1c588a21 malloc: Improve thp_init
+  - bd569425 malloc: Fix clang build after 1c588a2187
+
+The auto-enable causes every glibc-linked process to consume ~22-28MB
+of AnonHugePages, wasting significant memory on container-dense nodes.
+THP in malloc should only activate when explicitly requested via the
+glibc.malloc.hugetlb tunable.
+
+This reverts commit 321e1fc73f53081d92ba357cdd48c56b79292020.
+This reverts commit 1c588a2187a4f348ec155a1441784b51891bb667.
+This reverts commit bd569425330c6f5644c232b4b253e9ab905fcdba.
+
+Signed-off-by: Yutong Sun <yutongsu@amazon.com>
+---
+ malloc/malloc.c                               | 32 +++++--------------
+ .../sysv/linux/aarch64/malloc-hugepages.h     |  2 +-
+ 2 files changed, 9 insertions(+), 25 deletions(-)
+
+diff --git a/malloc/malloc.c b/malloc/malloc.c
+index a49e211925..a8c2c8f53a 100644
+--- a/malloc/malloc.c
++++ b/malloc/malloc.c
+@@ -1902,29 +1902,18 @@ free_perturb (char *p, size_t n)
+ 
+ /* ----------- Routines dealing with transparent huge pages ----------- */
+ 
+-static __always_inline void
+-thp_init (void)
+-{
+-  /* Initialize only once if DEFAULT_THP_PAGESIZE is defined.  */
+-  if (DEFAULT_THP_PAGESIZE == 0 || mp_.thp_mode != malloc_thp_mode_not_supported)
+-    return;
+-
+-  /* Set thp_pagesize even if thp_mode is never.  This reduces frequency
+-     of MORECORE () invocation.  */
+-  mp_.thp_mode = __malloc_thp_mode ();
+-  mp_.thp_pagesize = DEFAULT_THP_PAGESIZE;
+-}
+-
+ static inline void
+ madvise_thp (void *p, INTERNAL_SIZE_T size)
+ {
+ #ifdef MADV_HUGEPAGE
++  /* Only use __madvise if the system is using 'madvise' mode.
++     Otherwise the call is wasteful. */
++  if (mp_.thp_mode != malloc_thp_mode_madvise)
++    return;
+ 
+-  thp_init ();
+-
+-  /* Only use __madvise if the system is using 'madvise' mode and the size
+-     is at least a huge page, otherwise the call is wasteful. */
+-  if (mp_.thp_mode != malloc_thp_mode_madvise || size < mp_.thp_pagesize)
++  /* Do not consider areas smaller than a huge page or if the tunable is
++     not active.  */
++  if (mp_.thp_pagesize == 0 || size < mp_.thp_pagesize)
+     return;
+ 
+   /* Linux requires the input address to be page-aligned, and unaligned
+@@ -2472,9 +2461,6 @@ sysmalloc (INTERNAL_SIZE_T nb, mstate av)
+          previous calls. Otherwise, we correct to page-align below.
+        */
+ 
+-      /* Ensure thp_pagesize is initialized.  */
+-      thp_init ();
+-
+       if (__glibc_unlikely (mp_.thp_pagesize != 0))
+ 	{
+ 	  uintptr_t lastbrk = (uintptr_t) MORECORE (0);
+@@ -5132,9 +5118,7 @@ do_set_mxfast (size_t value)
+ static __always_inline int
+ do_set_hugetlb (size_t value)
+ {
+-  if (value == 0)
+-    mp_.thp_mode = malloc_thp_mode_never;
+-  else if (value == 1)
++  if (value == 1)
+     {
+       mp_.thp_mode = __malloc_thp_mode ();
+       if (mp_.thp_mode == malloc_thp_mode_madvise
+diff --git a/sysdeps/unix/sysv/linux/aarch64/malloc-hugepages.h b/sysdeps/unix/sysv/linux/aarch64/malloc-hugepages.h
+index 2204112e4e..eb7150a0e5 100644
+--- a/sysdeps/unix/sysv/linux/aarch64/malloc-hugepages.h
++++ b/sysdeps/unix/sysv/linux/aarch64/malloc-hugepages.h
+@@ -16,6 +16,6 @@
+    License along with the GNU C Library; see the file COPYING.LIB.  If
+    not, see <https://www.gnu.org/licenses/>.  */
+ 
+-#define DEFAULT_THP_PAGESIZE	(1UL << 21)
++# define DEFAULT_THP_PAGESIZE	1UL << 21
+ 
+ #include_next <malloc-hugepages.h>
+-- 
+2.47.0
+

--- a/packages/glibc/glibc.spec
+++ b/packages/glibc/glibc.spec
@@ -33,6 +33,7 @@ Patch0007: 0007-Linux-In-getlogin_r-use-utmp-fallback-only-for-speci.patch
 Patch0008: 0008-nss-Missing-checks-in-__nss_configure_lookup-__nss_d.patch
 Patch0009: 0009-debug-Fix-build-with-enable-fortify-source-1-BZ-3390.patch
 Patch0010: 0010-Add-BZ-33904-entry-to-NEWS.patch
+Patch0011: 0011-Revert-malloc-auto-enable-THP-on-aarch64.patch
 
 # Fedora patches
 Patch1001: glibc-cs-path.patch


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related #893

**Description of changes:**

This PR reverts the lazy `thp_init()` behavior introduced in glibc 2.43's malloc implementation ([upstream commit](https://sourceware.org/git/?p=glibc.git;a=blobdiff;f=malloc/malloc.c;h=8dd7bbe4f4b896def347d1f1555e71ad537e29ef;hp=2c56c1f1246fca73e6d026d4efe9566b14e1efa8;hb=321e1fc73f53081d92ba357cdd48c56b79292020;hpb=26e6e4d51e26548f68c98bb69b349224b143488e)).

### Problem

The upstream change added a lazy `thp_init()` call to `madvise_thp()` and `sysmalloc()` that automatically calls `madvise(MADV_HUGEPAGE)` on heap allocations when the kernel has THP in `madvise` mode. This happens in every glibc-linked process with no opt-in required.

On Bottlerocket, THP is configured in `madvise` mode by default. This causes significant memory overhead:

- **kubelet**: ~24 MB AnonHugePages
- **containerd**: ~22 MB AnonHugePages
- **containerd-shim-runc-v2**: ~22-28 MB AnonHugePages per pod

### Alternatives Considered

1. **`GLIBC_TUNABLES=glibc.malloc.hugetlb=0`**: A systemd drop-in can disable THP per-process. Testing confirmed this works—kubelet and containerd dropped to 0 kB AnonHugePages after restart. However, this is a workaround rather than a fix.

2. **System-wide THP disable** (`echo never > /sys/kernel/mm/transparent_hugepage/enabled`): Too broad—disables THP for workloads that may benefit from it.

### Solution

This patch reverts the lazy initialization by:
- Removing the `thp_init()` function that auto-detected THP mode
- Removing `thp_init()` calls from `madvise_thp()` and `sysmalloc()`
- Restoring the original `madvise_thp()` logic that only acts when `mp_.thp_pagesize` is explicitly set


**Testing done:**
Launched a `c7g.xlarge` instance that joins an EKS cluster. 

I can verify that the change works. The system service like `kubelet` and `containerd` no longer trigger THP allocation 
```
bash-5.2# grep AnonHugePages /proc/$(pidof -s kubelet)/smaps_rollup
AnonHugePages:         0 kB
bash-5.2# grep AnonHugePages /proc/$(pidof -s containerd)/smaps_rollup
AnonHugePages:         0 kB
```

And the runc shim also does not trigger THP allocations
```
for pid in $(pidof containerd-shim-runc-v2); do echo "PID $pid: $(grep AnonHugePages /proc/$pid/smaps_rollup)"; done
PID 18263: AnonHugePages:         0 kB
PID 18100: AnonHugePages:         0 kB
PID 17886: AnonHugePages:         0 kB
PID 7255: AnonHugePages:         0 kB
PID 4126: AnonHugePages:         0 kB
PID 4071: AnonHugePages:         0 kB
PID 3735: AnonHugePages:         0 kB
PID 3718: AnonHugePages:         0 kB
PID 2132: AnonHugePages:         0 kB
PID 2020: AnonHugePages:         0 kB
PID 1951: AnonHugePages:         0 kB
```

And the host level THP allocation is down to **0KB**
```
bash-5.2# cat /proc/meminfo | grep AnonHuge
AnonHugePages:         0 kB
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
