### PR TITLE
release: reduce nf_conntrack_tcp_timeout_syn_sent to 20s

### DIFF
--- a/packages/release/release-sysctl.conf
+++ b/packages/release/release-sysctl.conf
@@ -34,6 +34,8 @@ net.ipv4.ip_local_port_range = 32768 60999
 # Connection tracking to prevent dropped connections
 net.netfilter.nf_conntrack_max = 1048576
 net.netfilter.nf_conntrack_generic_timeout = 120
+# Expire SYN_SENT entries before the VPC CNI IP reuse window (30s default)
+net.netfilter.nf_conntrack_tcp_timeout_syn_sent = 20
 
 # Enable loose mode for reverse path filter
 net.ipv4.conf.lo.rp_filter = 2


### PR DESCRIPTION
In clusters using VPC CNI, pod IPs can be reassigned within the default 30s cooldown after a pod crash. Stale SYN_SENT conntrack entries (120s default) outlast that window, allowing client retries with the same src IP:port to hit a different pod/service via the stale entry even after kube-proxy has updated routing rules.

Setting `nf_conntrack_tcp_timeout_syn_sent=20` ensures entries expire before the minimum IP reuse window. Added alongside existing conntrack tuning in `release-sysctl.conf`.