### PR TITLE
Make FIPS activation runtime-conditional on fips=1 kernel param

### DIFF
--- a/packages/release/create-fips-marker.service
+++ b/packages/release/create-fips-marker.service
@@ -1,0 +1,17 @@
+# This file creates the /etc/system-fips marker file. This file can
+# be mounted into containers for certain distros (RHEL, Amazon Linux)
+# to trigger the use of FIPS certified crypto.
+
+[Unit]
+Description=Create FIPS system marker file
+DefaultDependencies=no
+ConditionKernelCommandLine=fips=1
+Before=sysinit.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/touch /etc/system-fips
+RemainAfterExit=true
+
+[Install]
+WantedBy=sysinit.target

--- a/packages/release/fips-go.conf
+++ b/packages/release/fips-go.conf
@@ -1,6 +1,6 @@
 [Service]
-# Enable Go FIPS 140-3 fips140=on mode. When enabled, Go's crypto packages use the
-# NIST DRBG for randomness, crypto/tls only negotiates FIPS-approved
-# algorithms, and mandatory self-tests run on initialization.
-# See: https://go.dev/blog/fips140
-Environment=GODEBUG=fips140=on
+# When FIPS mode is enabled at runtime via kernel parameter fips=1,
+# the generate-fips-env.service creates /run/fips-go.env with
+# GODEBUG=fips140=on. The "-" prefix means this is optional and
+# will not cause failures if the file does not exist (non-FIPS boot).
+EnvironmentFile=-/run/fips-go.env

--- a/packages/release/fips-go.env
+++ b/packages/release/fips-go.env
@@ -1,0 +1,1 @@
+GODEBUG=fips140=on

--- a/packages/release/generate-fips-env.service
+++ b/packages/release/generate-fips-env.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Generate FIPS Go environment
+DefaultDependencies=no
+Before=sysinit.target
+ConditionKernelCommandLine=fips=1
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/cp /usr/share/bottlerocket/fips-go.env /run/fips-go.env
+RemainAfterExit=true
+
+[Install]
+WantedBy=sysinit.target

--- a/packages/release/release-fips-tmpfiles.conf
+++ b/packages/release/release-fips-tmpfiles.conf
@@ -1,2 +1,2 @@
-f+ /etc/system-fips 0644 root root -
+# Clean up FIPS module check state files from fips-modprobe@.service.
 r /etc/.fips-modprobe.*

--- a/packages/release/release-fips-tmpfiles.conf
+++ b/packages/release/release-fips-tmpfiles.conf
@@ -1,2 +1,1 @@
-# Clean up FIPS module check state files from fips-modprobe@.service.
 r /etc/.fips-modprobe.*

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -143,6 +143,12 @@ Source1650: prepare-local-fs-encrypted.conf
 Source1651: local-mount-encrypted.conf
 Source1652: repart-local-encrypted.conf
 
+# Runtime FIPS activation sources.
+# These are always installed but only activate when fips=1 is on the kernel command line.
+Source1700: generate-fips-env.service
+Source1701: create-fips-marker.service
+Source1702: fips-go.env
+
 Requires: %{_cross_os}audit
 Requires: %{_cross_os}auditd
 Requires: %{_cross_os}chrony
@@ -371,6 +377,12 @@ install -p -m 0644 %{S:1400} %{buildroot}%{_cross_datadir}/logdog.d
 install -d %{buildroot}%{_cross_bootconfigdir}
 install -p -m 0644 %{S:1500} %{buildroot}%{_cross_bootconfigdir}/10-fips.conf
 
+# Runtime FIPS activation: install conditional services and static env file.
+# These are always present but only activate when fips=1 is on the kernel command line.
+install -p -m 0644 %{S:1700} %{S:1701} %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_datadir}/bottlerocket
+install -p -m 0644 %{S:1702} %{buildroot}%{_cross_datadir}/bottlerocket/fips-go.env
+
 install -d %{buildroot}%{_cross_unitdir}/prepare-local-fs.service.d
 install -p -m 0644 %{S:1650} %{buildroot}%{_cross_unitdir}/prepare-local-fs.service.d/10-encrypted.conf
 
@@ -473,10 +485,13 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_datadir}/logdog.d/logdog.common.conf
 %{_cross_unitdir}/configure-snapshotter.service
 %{_cross_templatedir}/selected-snapshotter
-%{_cross_tmpfilesdir}/release-fips.conf
+# Runtime FIPS activation — conditional on fips=1 kernel command line parameter.
+# These are always present but are no-ops on non-FIPS boots.
 %{_cross_unitdir}/service.d/00-fips-go.conf
-%{_cross_unitdir}/*-bin.mount
-%{_cross_unitdir}/*-libexec.mount
+%{_cross_unitdir}/generate-fips-env.service
+%{_cross_unitdir}/create-fips-marker.service
+%{_cross_datadir}/bottlerocket/fips-go.env
+%{_cross_tmpfilesdir}/release-fips.conf
 %{_cross_unitdir}/fipscheck.target
 %{_cross_unitdir}/activate-preconfigured.service
 %{_cross_unitdir}/check-kernel-integrity.service
@@ -486,6 +501,8 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 
 %files fips
 %{_cross_bootconfigdir}/10-fips.conf
+%{_cross_unitdir}/*-bin.mount
+%{_cross_unitdir}/*-libexec.mount
 
 %files crypt
 %{_cross_unitdir}/encrypt-datastore.service

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -377,8 +377,6 @@ install -p -m 0644 %{S:1400} %{buildroot}%{_cross_datadir}/logdog.d
 install -d %{buildroot}%{_cross_bootconfigdir}
 install -p -m 0644 %{S:1500} %{buildroot}%{_cross_bootconfigdir}/10-fips.conf
 
-# Runtime FIPS activation: install conditional services and static env file.
-# These are always present but only activate when fips=1 is on the kernel command line.
 install -p -m 0644 %{S:1700} %{S:1701} %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_datadir}/bottlerocket
 install -p -m 0644 %{S:1702} %{buildroot}%{_cross_datadir}/bottlerocket/fips-go.env
@@ -485,13 +483,13 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_datadir}/logdog.d/logdog.common.conf
 %{_cross_unitdir}/configure-snapshotter.service
 %{_cross_templatedir}/selected-snapshotter
-# Runtime FIPS activation — conditional on fips=1 kernel command line parameter.
-# These are always present but are no-ops on non-FIPS boots.
 %{_cross_unitdir}/service.d/00-fips-go.conf
 %{_cross_unitdir}/generate-fips-env.service
 %{_cross_unitdir}/create-fips-marker.service
 %{_cross_datadir}/bottlerocket/fips-go.env
 %{_cross_tmpfilesdir}/release-fips.conf
+%{_cross_unitdir}/*-bin.mount
+%{_cross_unitdir}/*-libexec.mount
 %{_cross_unitdir}/fipscheck.target
 %{_cross_unitdir}/activate-preconfigured.service
 %{_cross_unitdir}/check-kernel-integrity.service
@@ -501,8 +499,6 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 
 %files fips
 %{_cross_bootconfigdir}/10-fips.conf
-%{_cross_unitdir}/*-bin.mount
-%{_cross_unitdir}/*-libexec.mount
 
 %files crypt
 %{_cross_unitdir}/encrypt-datastore.service


### PR DESCRIPTION
The overall purpose of this change is to include most FIPS logic in all BR variants, and to standardize on all of the systemd services only being activated with `ConditionKernelCommandLine=fips=1`, as some already are: https://github.com/bottlerocket-os/bottlerocket-core-kit/blob/748058e55349b1b1ea32d4d4cd304c07bcdcf9cd/packages/release/check-kernel-integrity.service#L9

This gets closer to the "standard" BR AMI being able to be used in FIPS environments, only needing a runtime switch to activate FIPS mode like the following userdata:

```
[settings.boot] 
reboot-to-reconcile = true 
[settings.boot.kernel-parameters] 
fips = ["1"]
```

**Description of changes:**

Move FIPS-related systemd units and drop-ins from the release-fips subpackage into the base release package so they ship in all variants. These units already use ConditionKernelCommandLine=fips=1 or depend on fipscheck.target, so they are no-ops on non-FIPS boots.

Replace the unconditional Environment=GODEBUG=fips140=on drop-in with an EnvironmentFile=-/run/fips-go.env approach: a new service copies the env file into /run only when fips=1 is set. Similarly, replace the tmpfiles-based /etc/system-fips creation with a conditional service.

The bootconfig snippet and FIPS binary overlay mounts remain in the fips subpackage since they require build-time binary selection.

Assisted-by: Cline:anthropic.claude-opus-4-6-v1

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Testing done:**

WIP

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
