### PR TITLE
fix: correct advisory version for microcode advisories

### DIFF
--- a/advisories/2.5.0/BRSA-7esrdcy2k3ug.toml
+++ b/advisories/2.5.0/BRSA-7esrdcy2k3ug.toml
@@ -7,7 +7,7 @@ description = "A protection mechanism failure in some 3rd, 4th, and 5th Generati
 
 [[advisory.products]]
 package-name = "microcode"
-patched-version = "20240813"
+patched-version = "0"
 patched-release = "0"
 patched-epoch = "0"
 

--- a/advisories/2.5.0/BRSA-c1vgkakbz9ik.toml
+++ b/advisories/2.5.0/BRSA-c1vgkakbz9ik.toml
@@ -7,7 +7,7 @@ description = "Incorrect behavior in transition order between executive monitor 
 
 [[advisory.products]]
 package-name = "microcode"
-patched-version = "20240813"
+patched-version = "0"
 patched-release = "0"
 patched-epoch = "0"
 

--- a/advisories/2.5.0/BRSA-jj7szsofncjh.toml
+++ b/advisories/2.5.0/BRSA-jj7szsofncjh.toml
@@ -7,7 +7,7 @@ description = "Improper isolation in some Intel processors stream cache mechanis
 
 [[advisory.products]]
 package-name = "microcode"
-patched-version = "20240813"
+patched-version = "0"
 patched-release = "0"
 patched-epoch = "0"
 

--- a/advisories/2.5.0/BRSA-jopjxfpj3jhn.toml
+++ b/advisories/2.5.0/BRSA-jopjxfpj3jhn.toml
@@ -7,7 +7,7 @@ description = "Improper validation in a model specific register (MSR) could allo
 
 [[advisory.products]]
 package-name = "microcode"
-patched-version = "20240813"
+patched-version = "0"
 patched-release = "0"
 patched-epoch = "0"
 

--- a/advisories/2.5.0/BRSA-qjoq6rc94pgu.toml
+++ b/advisories/2.5.0/BRSA-qjoq6rc94pgu.toml
@@ -7,7 +7,7 @@ description = "Protection mechanism failure of bus lock regulator for some Intel
 
 [[advisory.products]]
 package-name = "microcode"
-patched-version = "20240813"
+patched-version = "0"
 patched-release = "0"
 patched-epoch = "0"
 

--- a/advisories/2.5.0/BRSA-xkiohgssmbvc.toml
+++ b/advisories/2.5.0/BRSA-xkiohgssmbvc.toml
@@ -7,7 +7,7 @@ description = "Non-transparent sharing of return predictor targets between conte
 
 [[advisory.products]]
 package-name = "microcode"
-patched-version = "20240813"
+patched-version = "0"
 patched-release = "0"
 patched-epoch = "0"
 

--- a/advisories/2.5.0/BRSA-zuu29qrc3hzy.toml
+++ b/advisories/2.5.0/BRSA-zuu29qrc3hzy.toml
@@ -7,7 +7,7 @@ description = "Mirrored regions with different values in 3rd Generation Intel Xe
 
 [[advisory.products]]
 package-name = "microcode"
-patched-version = "20240813"
+patched-version = "0"
 patched-release = "0"
 patched-epoch = "0"
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**


The microcode advisories from 2.5.0 core-kit release incorrectly include
a patched-version. However, version information for this package is
intentionally made "0.0"

See https://github.com/bottlerocket-os/bottlerocket-kernel-kit/blob/6965cb0d797bd7cab9f7c9b8f597291668aa4626/packages/microcode/microcode.spec#L4-L10



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
