### PR TITLE
corgid: add upload application-inventory

### DIFF
--- a/packages/os/corgid.service
+++ b/packages/os/corgid.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Inspector SBOM telemetry sender
+# Guarantee this runs late in the boot
+After=multi-user.target
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/corgid
+# Retry transient issues on failure since manual restart is refused.
+Restart=on-failure
+RestartSec=30
+StartLimitBurst=3
+StartLimitIntervalSec=300
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -70,6 +70,7 @@ Source122: has-boot-ever-succeeded.service
 Source123: pluto.service
 Source124: bootstrap-commands.service
 Source125: whippet.service
+Source126: corgid.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -122,7 +123,7 @@ Requires: (%{_cross_os}updog or %{_cross_os}image-feature(no-in-place-updates))
 Requires: (%{_cross_os}pluto if %{_cross_os}variant-family(aws-k8s))
 Requires: (%{_cross_os}shibaken if %{_cross_os}variant-platform(aws))
 Requires: (%{_cross_os}cfsignal if %{_cross_os}variant-platform(aws))
-
+Requires: (%{_cross_os}corgid if %{_cross_os}variant-platform(aws))
 Requires: (%{_cross_os}warm-pool-wait if %{_cross_os}variant-family(aws-k8s))
 
 %description
@@ -377,6 +378,28 @@ Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}cfsignal-bin)
 %description -n %{_cross_os}cfsignal-fips-bin
 %{summary}.
 
+%package -n %{_cross_os}corgid
+Summary: Inspector SBOM telemetry sender
+Requires: %{_cross_os}corgid(binaries)
+%description -n %{_cross_os}corgid
+%{summary}.
+
+%package -n %{_cross_os}corgid-bin
+Summary: Inspector SBOM telemetry sender binaries
+Provides: %{_cross_os}corgid(binaries)
+Requires: (%{_cross_os}image-feature(no-fips) and %{_cross_os}corgid)
+Conflicts: (%{_cross_os}image-feature(fips) or %{_cross_os}corgid-fips-bin)
+%description -n %{_cross_os}corgid-bin
+%{summary}.
+
+%package -n %{_cross_os}corgid-fips-bin
+Summary: Inspector SBOM telemetry sender binaries, FIPS edition
+Provides: %{_cross_os}corgid(binaries)
+Requires: (%{_cross_os}image-feature(fips) and %{_cross_os}corgid)
+Conflicts: (%{_cross_os}image-feature(no-fips) or %{_cross_os}corgid-bin)
+%description -n %{_cross_os}corgid-fips-bin
+%{summary}.
+
 %package -n %{_cross_os}driverdog
 Summary: Tool to load additional drivers
 Requires: %{_cross_os}binutils
@@ -530,6 +553,7 @@ exec 1>"${aws_sdk_output}" 2>&1
   %cargo_build_aws_sdk --manifest-path %{_builddir}/sources/Cargo.toml \
   -p pluto \
   -p cfsignal \
+  -p corgid \
   &
 # Save the PID so we can wait for it later.
 aws_sdk_pid="$!"
@@ -541,6 +565,7 @@ exec 1>"${fips_aws_sdk_output}" 2>&1
   %cargo_build_fips_aws_sdk --manifest-path %{_builddir}/sources/Cargo.toml \
   -p pluto \
   -p cfsignal \
+  -p corgid \
   &
 # Save the PID so we can wait for it later.
 fips_aws_sdk_pid="$!"
@@ -680,6 +705,7 @@ done
 for p in \
   pluto \
   cfsignal \
+  corgid \
 ; do
   install -p -m 0755 %{__cargo_outdir_aws_sdk}/${p} %{buildroot}%{_cross_bindir}
   install -p -m 0755 %{__cargo_outdir_aws_sdk_fips}/${p} %{buildroot}%{_cross_fips_bindir}
@@ -770,7 +796,7 @@ install -p -m 0644 \
   %{S:100} %{S:102} %{S:103} %{S:105} \
   %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
   %{S:113} %{S:114} %{S:120} %{S:122} %{S:123} %{S:124} \
-  %{S:125} \
+  %{S:125} %{S:126} \
   %{buildroot}%{_cross_unitdir}
 
 install -p -m 0644 %{S:10} %{buildroot}%{_cross_templatedir}
@@ -938,6 +964,15 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 
 %files -n %{_cross_os}cfsignal-fips-bin
 %{_cross_fips_bindir}/cfsignal
+
+%files -n %{_cross_os}corgid
+%{_cross_unitdir}/corgid.service
+
+%files -n %{_cross_os}corgid-bin
+%{_cross_bindir}/corgid
+
+%files -n %{_cross_os}corgid-fips-bin
+%{_cross_fips_bindir}/corgid
 
 %files -n %{_cross_os}driverdog
 %{_cross_bindir}/driverdog

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -2083,6 +2083,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533d38ecd2709b7608fb8e18e4504deb99e9a72879e6aa66373a76d8dc4259ea"
 
 [[package]]
+name = "corgid"
+version = "0.1.0"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "chrono",
+ "flate2",
+ "hex",
+ "hmac",
+ "imdsclient",
+ "log",
+ "reqwest",
+ "rustls 0.23.37",
+ "serde",
+ "serde_json",
+ "sha2",
+ "simplelog",
+ "snafu",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "corndog"
 version = "0.1.0"
 dependencies = [

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -60,6 +60,8 @@ members = [
 
     "cfsignal",
 
+    "corgid",
+
     "logdog",
 
     "models",
@@ -158,6 +160,7 @@ headers = "0.4"
 hex = "0.4"
 hex-literal = "0.4"
 hkdf = { version = "0.12", default-features = false }
+hmac = { version = "0.12", default-features = false }
 http = "0.2"
 httparse = "1"
 httptest = "0.15"
@@ -222,6 +225,7 @@ tracing = "0.1"
 typed-path = "0.9"
 unindent = "0.2"
 url = "2"
+uuid = { version = "1", features = ["v4"] }
 walkdir = "2.5"
 which = "4"
 zbus = { version = "5.11", default-features = false }

--- a/sources/corgid/Cargo.toml
+++ b/sources/corgid/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "corgid"
+version = "0.1.0"
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+publish = false
+exclude = ["README.md"]
+
+[features]
+fips = ["rustls/fips", "aws-lc-rs/fips"]
+
+[dependencies]
+aws-lc-rs = { workspace = true, features = ["bindgen"] }
+chrono = { workspace = true, features = ["clock"] }
+flate2 = { workspace = true, features = ["default"] }
+base64.workspace = true
+hex.workspace = true
+hmac.workspace = true
+imdsclient.workspace = true
+log.workspace = true
+reqwest = { workspace = true, features = ["blocking", "rustls-tls-native-roots"] }
+rustls.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2.workspace = true
+simplelog.workspace = true
+snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+uuid = { version = "1", features = ["v4"] }

--- a/sources/corgid/README.md
+++ b/sources/corgid/README.md
@@ -1,0 +1,38 @@
+# corgid
+
+Current version: 0.1.0
+
+## Overview
+
+corgid is a Bottlerocket host-side service that sends a CycloneDX SBOM (Software Bill of Materials) to the Amazon Inspector API on every boot.
+
+This supports the latest version of Amazon Inspector, which requires agent-based SBOM submission rather than relying solely on SSM manifests.
+
+## How it works
+
+1. Reads the Bottlerocket application inventory from `/usr/share/bottlerocket/application-inventory.json`
+2. Converts it to a CycloneDX 1.5 SBOM
+3. Fetches instance metadata (region, instance ID) and IAM credentials from IMDS
+4. Sends the SBOM to the `inspector2` API using a session-based protocol:
+   - `StartSession` — begins a scan session
+   - `SendTelemetry` — uploads gzip-compressed SBOM chunks
+   - `StopSession` — closes the session with status
+5. All API requests are signed with SigV4
+
+## Deployment
+
+- Runs as a `Type=oneshot` systemd service (`corgid.service`)
+- Starts after `multi-user.target` to ensure network and other services are available
+- Non-blocking: boot continues regardless of whether corgid succeeds or fails
+- Included only on AWS variants (`variant-platform(aws)`)
+- Supports FIPS variants via the `fips` feature flag
+
+## Fallback behavior
+
+- If IMDS returns no region (e.g., Snowball), falls back to `us-east-1`
+- If IMDS is unreachable, returns an error
+- If SBOM upload fails, the session is still closed cleanly
+
+## Colophon
+
+This file was generated using [cargo-readme](https://crates.io/crates/cargo-readme), and target content is in `src/main.rs`.

--- a/sources/corgid/src/error.rs
+++ b/sources/corgid/src/error.rs
@@ -1,0 +1,49 @@
+//! Error types for the corgid SBOM export service.
+//!
+//! This module uses the `snafu` crate for ergonomic error handling,
+//! providing context-rich error messages for inventory parsing,
+//! IMDS interactions, and Inspector API communication.
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("Failed to read application inventory file: {source}"))]
+    ReadInventory { source: std::io::Error },
+
+    #[snafu(display("Failed to parse application inventory file: {source}"))]
+    ParseInventory { source: serde_json::Error },
+
+    #[snafu(display("Failed to serialize SBOM: {source}"))]
+    SerializeSbom { source: serde_json::Error },
+
+    #[snafu(display("Failed to get IMDS data: {source}"))]
+    Imds { source: imdsclient::Error },
+
+    #[snafu(display("Failed to fetch IMDS credentials: {source}"))]
+    ImdsCredentials { source: reqwest::Error },
+
+    #[snafu(display("Failed to parse IMDS credentials: {source}"))]
+    ParseCredentials { source: serde_json::Error },
+
+    #[snafu(display("HTTP request failed: {source}"))]
+    HttpRequest { source: reqwest::Error },
+
+    #[snafu(display("Inspector API error {status}: {body}"))]
+    Api { status: u16, body: String },
+
+    #[snafu(display("Failed to parse API response: {source}"))]
+    ParseResponse { source: serde_json::Error },
+
+    #[snafu(display("Failed to compress SBOM: {source}"))]
+    Compress { source: std::io::Error },
+
+    #[snafu(display("No IAM role found in IMDS"))]
+    NoIamRole,
+
+    #[snafu(display("No instance ID found in IMDS"))]
+    NoInstanceId,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/sources/corgid/src/inspector.rs
+++ b/sources/corgid/src/inspector.rs
@@ -1,0 +1,407 @@
+//! Amazon Inspector API client.
+//!
+//! This module handles communication with the Inspector2 service for
+//! vulnerability scanning. It manages the session lifecycle: start -> send SBOM -> stop.
+
+use crate::error::{self, Result};
+use crate::sigv4::{sign, SignInput};
+use chrono::Utc;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use snafu::ResultExt;
+use std::io::Write;
+use std::thread;
+use std::time::Duration;
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+/// Serializes byte slices as base64 strings for JSON encoding.
+fn serialize_base64<S: serde::Serializer>(
+    data: &&[u8],
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    serializer.serialize_str(&BASE64.encode(data))
+}
+
+const IMDS_BASE: &str = "http://169.254.169.254";
+const IMDS_TOKEN_PATH: &str = "/latest/api/token";
+const IMDS_ROLE_PATH: &str = "/latest/meta-data/iam/security-credentials/";
+const SERVICE: &str = "inspector2-telemetry";
+/// SBOM chunks are limited to 390KB to stay within API payload limits.
+const CHUNK_SIZE: usize = 390 * 1024;
+/// Retry transient failures up to 3 times with exponential backoff.
+const MAX_RETRIES: u32 = 3;
+const VERSION: &str = "0.1.0";
+
+/// IAM credentials retrieved from IMDS for signing API requests.
+#[derive(Deserialize)]
+pub struct Credentials {
+    #[serde(rename = "AccessKeyId")]
+    pub access_key_id: String,
+    #[serde(rename = "SecretAccessKey")]
+    pub secret_access_key: String,
+    #[serde(rename = "Token")]
+    pub token: String,
+}
+
+/// Wrapper for all API requests.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TelemetryRequest<'a> {
+    resource_id: &'a str,
+    event: TelemetryEvent<'a>,
+}
+
+/// Discriminated union of event types.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+enum TelemetryEvent<'a> {
+    StartSession(StartSessionEvent<'a>),
+    SendTelemetry(SendTelemetryEvent<'a>),
+    StopSession(StopSessionEvent<'a>),
+}
+
+/// Initiates a new vulnerability scan session.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StartSessionEvent<'a> {
+    session_scan_type: &'a str,
+    resource_type: &'a str,
+    agent_version: &'a str,
+}
+
+/// Sends SBOM data chunk within an active session.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SendTelemetryEvent<'a> {
+    session_id: &'a str,
+    capture_time: f64,
+    data: TelemetryData<'a>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TelemetryData<'a> {
+    vulnerability_data: VulnData<'a>,
+}
+
+/// SBOM chunk with integrity hash for verification.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VulnData<'a> {
+    content_hash: &'a str,
+    #[serde(serialize_with = "serialize_base64")]
+    sbom: &'a [u8],
+    sequence_number: u32,
+}
+
+/// Terminates a scan session with final status and metrics.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StopSessionEvent<'a> {
+    session_id: &'a str,
+    session_details: SessionDetails<'a>,
+    scan_details: ScanDetails<'a>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionDetails<'a> {
+    session_status: &'a str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ScanDetails<'a> {
+    scan_job_status: &'a str,
+    data_checksum: &'a str,
+    performance_details: PerformanceDetails,
+}
+
+/// Resource usage metrics (currently placeholder values).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PerformanceDetails {
+    cpu_metrics: CpuMetrics,
+    memory_metrics: MemoryMetrics,
+    artifact_metrics: ArtifactMetrics,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CpuMetrics {
+    average_cpu: f64,
+    max_cpu: f64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MemoryMetrics {
+    average_memory_consumed: f64,
+    max_memory_consumed: f64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ArtifactMetrics {
+    data_collection_in_milliseconds: i64,
+}
+
+/// API response containing optional session start result.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TelemetryResponse {
+    start_session_result: Option<StartSessionResult>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StartSessionResult {
+    session_id: String,
+}
+
+/// Returns the parent domain based on region partition.
+fn parent_domain(region: &str) -> &'static str {
+    // China regions use a different domain suffix
+    if region.starts_with("cn-") {
+        "api.amazonwebservices.com.cn"
+    } else {
+        "api.aws"
+    }
+}
+
+/// Constructs the endpoint URL and host header for a region.
+fn endpoint_and_host(region: &str) -> (String, String) {
+    let host = format!("inspector2-telemetry.{}.{}", region, parent_domain(region));
+    let endpoint = format!("https://{}/telemetry", host);
+    (endpoint, host)
+}
+
+/// Result of starting a session.
+pub struct StartResponse {
+    pub session_id: String,
+}
+
+/// Retrieves inspector IAM credentials from the EC2 Instance Metadata Service.
+///
+/// Uses IMDSv2 with a session token for security.
+pub fn get_credentials(client: &Client) -> Result<Credentials> {
+    // IMDSv2 requires a session token obtained via PUT
+    let token = client
+        .put(format!("{}{}", IMDS_BASE, IMDS_TOKEN_PATH))
+        .header("X-aws-ec2-metadata-token-ttl-seconds", "21600")
+        .send()
+        .context(error::ImdsCredentialsSnafu)?
+        .text()
+        .context(error::ImdsCredentialsSnafu)?;
+
+    // List available IAM roles attached to the instance
+    let roles = client
+        .get(format!("{}{}", IMDS_BASE, IMDS_ROLE_PATH))
+        .header("X-aws-ec2-metadata-token", &token)
+        .send()
+        .context(error::ImdsCredentialsSnafu)?
+        .text()
+        .context(error::ImdsCredentialsSnafu)?;
+
+    let role = roles.lines().next().ok_or(error::Error::NoIamRole)?;
+
+    // Fetch credentials for the first available role
+    let creds_json = client
+        .get(format!("{}{}{}", IMDS_BASE, IMDS_ROLE_PATH, role))
+        .header("X-aws-ec2-metadata-token", &token)
+        .send()
+        .context(error::ImdsCredentialsSnafu)?
+        .text()
+        .context(error::ImdsCredentialsSnafu)?;
+
+    serde_json::from_str(&creds_json).context(error::ParseCredentialsSnafu)
+}
+
+/// Sends a signed POST request with exponential backoff retry.
+///
+/// Retries on 429 (throttling) and 5xx (server errors) up to MAX_RETRIES times.
+/// Each retry doubles the delay starting from 1 second.
+fn post_with_retry(
+    client: &Client,
+    body: &[u8],
+    region: &str,
+    creds: &Credentials,
+) -> Result<String> {
+    let (endpoint, host) = endpoint_and_host(region);
+    let mut delay = Duration::from_secs(1);
+    log::info!("POST {}", endpoint);
+    for attempt in 0..=MAX_RETRIES {
+        // Sign each attempt fresh since timestamp must be current
+        let signed = sign(&SignInput {
+            method: "POST",
+            host: &host,
+            path: "/telemetry",
+            body,
+            region,
+            service: SERVICE,
+            access_key: &creds.access_key_id,
+            secret_key: &creds.secret_access_key,
+            token: &creds.token,
+            time: Utc::now(),
+        });
+
+        let resp = client
+            .post(&endpoint)
+            .header("Content-Type", "application/json")
+            .header("Authorization", &signed.authorization)
+            .header("X-Amz-Date", &signed.x_amz_date)
+            .header("X-Amz-Security-Token", &signed.x_amz_security_token)
+            .header("X-Amz-Content-Sha256", &signed.x_amz_content_sha256)
+            .body(body.to_vec())
+            .send()
+            .context(error::HttpRequestSnafu)?;
+
+        let status = resp.status().as_u16();
+        if (200..300).contains(&status) {
+            return resp.text().context(error::HttpRequestSnafu);
+        }
+        // Retry transient errors: throttling (429) or server errors (5xx)
+        if (status == 429 || status >= 500) && attempt < MAX_RETRIES {
+            thread::sleep(delay);
+            delay *= 2; // Exponential backoff
+            continue;
+        }
+        let body_text = resp.text().unwrap_or_default();
+        return Err(error::Error::Api {
+            status,
+            body: body_text,
+        });
+    }
+    unreachable!()
+}
+
+/// Starts a new vulnerability scan session with Inspector.
+///
+/// Must be called before sending SBOM data. Returns a session ID
+/// that must be used for subsequent send and stop calls.
+pub fn start_session(
+    client: &Client,
+    region: &str,
+    instance_id: &str,
+    creds: &Credentials,
+) -> Result<StartResponse> {
+    let req = TelemetryRequest {
+        resource_id: instance_id,
+        event: TelemetryEvent::StartSession(StartSessionEvent {
+            session_scan_type: "VULNERABILITY_SCAN",
+            resource_type: "AWS_EC2_INSTANCE",
+            agent_version: VERSION,
+        }),
+    };
+    let body = serde_json::to_vec(&req).context(error::SerializeSbomSnafu)?;
+    let resp = post_with_retry(client, &body, region, creds)?;
+    log::info!("StartSession response: {}", &resp);
+    let parsed: TelemetryResponse =
+        serde_json::from_str(&resp).context(error::ParseResponseSnafu)?;
+    let result = parsed
+        .start_session_result
+        .ok_or_else(|| error::Error::Api {
+            status: 500,
+            body: "Missing startSessionResult".to_string(),
+        })?;
+    Ok(StartResponse {
+        session_id: result.session_id,
+    })
+}
+
+/// Sends SBOM data to Inspector within an active session.
+///
+/// The SBOM is gzip-compressed and split into chunks if needed.
+/// Each chunk is hashed and sent with a sequence number for reassembly.
+pub fn send_inspector_sbom(
+    client: &Client,
+    region: &str,
+    instance_id: &str,
+    session_id: &str,
+    sbom: &str,
+    creds: &Credentials,
+) -> Result<()> {
+    // Compress SBOM to reduce payload size
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(sbom.as_bytes())
+        .context(error::CompressSnafu)?;
+    let compressed = encoder.finish().context(error::CompressSnafu)?;
+
+    let capture_time = Utc::now().timestamp() as f64;
+
+    // Split into chunks to stay within API payload limits
+    for (seq, chunk) in compressed.chunks(CHUNK_SIZE).enumerate() {
+        let chunk_hash = hex::encode(Sha256::digest(chunk));
+        let req = TelemetryRequest {
+            resource_id: instance_id,
+            event: TelemetryEvent::SendTelemetry(SendTelemetryEvent {
+                session_id,
+                capture_time,
+                data: TelemetryData {
+                    vulnerability_data: VulnData {
+                        content_hash: &chunk_hash,
+                        sbom: chunk,
+                        sequence_number: seq as u32,
+                    },
+                },
+            }),
+        };
+        let body = serde_json::to_vec(&req).context(error::SerializeSbomSnafu)?;
+        post_with_retry(client, &body, region, creds)?;
+    }
+    Ok(())
+}
+
+/// Terminates a scan session and reports final status.
+///
+/// Should be called after all SBOM data is sent, or on error to clean up.
+/// The session_status is derived from scan_job_status: AGENT_INTERNAL_ERROR
+/// results in FAILURE, all other statuses result in SUCCESSFUL.
+pub fn stop_session(
+    client: &Client,
+    region: &str,
+    instance_id: &str,
+    session_id: &str,
+    sbom_hash: &str,
+    scan_job_status: &str,
+    creds: &Credentials,
+) -> Result<()> {
+    // Map scan job status to session outcome
+    let session_status = if scan_job_status == "AGENT_INTERNAL_ERROR" {
+        "FAILURE"
+    } else {
+        "SUCCESSFUL"
+    };
+    let req = TelemetryRequest {
+        resource_id: instance_id,
+        event: TelemetryEvent::StopSession(StopSessionEvent {
+            session_id,
+            session_details: SessionDetails { session_status },
+            scan_details: ScanDetails {
+                scan_job_status,
+                data_checksum: sbom_hash,
+                performance_details: PerformanceDetails {
+                    cpu_metrics: CpuMetrics {
+                        average_cpu: 0.0,
+                        max_cpu: 0.0,
+                    },
+                    memory_metrics: MemoryMetrics {
+                        average_memory_consumed: 0.0,
+                        max_memory_consumed: 0.0,
+                    },
+                    artifact_metrics: ArtifactMetrics {
+                        data_collection_in_milliseconds: 0,
+                    },
+                },
+            },
+        }),
+    };
+    let body = serde_json::to_vec(&req).context(error::SerializeSbomSnafu)?;
+    post_with_retry(client, &body, region, creds)?;
+    Ok(())
+}

--- a/sources/corgid/src/inventory.rs
+++ b/sources/corgid/src/inventory.rs
@@ -1,0 +1,276 @@
+//! Bottlerocket package inventory to CycloneDX SBOM converter.
+//!
+//! This module reads the system's application inventory and transforms it into
+//! a CycloneDX 1.5 Software Bill of Materials (SBOM) format. The SBOM includes
+//! host metadata properties formatted for Amazon Inspector compatibility.
+
+use crate::error::{self, Result};
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use std::fs;
+use uuid::Uuid;
+
+/// Host and IMDS metadata collected for SBOM property generation.
+///
+/// These fields map to Amazon Inspector's expected property naming scheme,
+/// enabling vulnerability scanning and asset identification.
+#[derive(Default)]
+pub struct HostMetadata {
+    pub hostname: String,
+    pub kernel_name: String,
+    pub kernel_version: String,
+    pub cpu_architecture: String,
+    pub instance_id: String,
+    pub instance_type: String,
+    pub region: String,
+    pub partition: String,
+    pub account_id: String,
+}
+
+/// A key-value property attached to SBOM components.
+#[derive(Serialize)]
+pub struct Property {
+    pub name: String,
+    pub value: String,
+}
+
+/// Wrapper for license information in CycloneDX format.
+#[derive(Serialize)]
+pub struct LicenseEntry {
+    pub license: LicenseId,
+}
+
+/// SPDX license identifier.
+#[derive(Serialize)]
+pub struct LicenseId {
+    pub id: String,
+}
+
+const INVENTORY_PATH: &str = "/usr/share/bottlerocket/application-inventory.json";
+
+const VERSION: &str = "0.1.0";
+
+/// Deserialized application inventory from Bottlerocket's package list.
+#[derive(Deserialize)]
+pub struct Inventory {
+    #[serde(rename = "Content")]
+    pub content: Vec<Package>,
+}
+
+/// Individual package entry from the inventory file.
+#[derive(Deserialize)]
+pub struct Package {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "Publisher")]
+    pub publisher: String,
+    #[serde(rename = "Version")]
+    pub version: String,
+    #[serde(rename = "Release")]
+    pub release: String,
+    #[serde(rename = "Epoch")]
+    pub epoch: String,
+    #[serde(rename = "Architecture")]
+    pub architecture: String,
+    #[serde(rename = "Url")]
+    pub _url: String,
+    #[serde(rename = "Summary")]
+    pub summary: String,
+}
+
+/// Root CycloneDX SBOM document structure.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Sbom {
+    pub bom_format: &'static str,
+    pub spec_version: &'static str,
+    /// Unique identifier for this SBOM instance (UUID v4).
+    pub serial_number: String,
+    pub version: u32,
+    pub metadata: Metadata,
+    pub components: Vec<Component>,
+}
+
+/// SBOM metadata including generation timestamp and tooling info.
+#[derive(Serialize)]
+pub struct Metadata {
+    pub timestamp: String,
+    pub tools: Tools,
+}
+
+/// Container for tool components that generated this SBOM.
+#[derive(Serialize)]
+pub struct Tools {
+    pub components: Vec<ToolComponent>,
+}
+
+/// Describes the tool used to generate the SBOM.
+#[derive(Serialize)]
+pub struct ToolComponent {
+    #[serde(rename = "type")]
+    pub typ: &'static str,
+    pub author: &'static str,
+    pub name: &'static str,
+    pub version: &'static str,
+}
+
+/// A software component entry in the SBOM.
+///
+/// The first component is always the OS itself (with host metadata properties),
+/// followed by individual packages as library components.
+#[derive(Serialize)]
+pub struct Component {
+    #[serde(rename = "bom-ref")]
+    pub bom_ref: String,
+    #[serde(rename = "type")]
+    pub typ: &'static str,
+    pub name: String,
+    pub version: String,
+    /// Package URL per the purl spec for package identification.
+    pub purl: String,
+    pub publisher: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub licenses: Option<Vec<LicenseEntry>>,
+    /// Properties use the `amazon:inspector:sbom_generator:metadata:` prefix
+    /// to conform to Amazon Inspector's expected schema for host/IMDS data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<Vec<Property>>,
+}
+
+/// Reads the Bottlerocket inventory and converts it to CycloneDX SBOM JSON.
+///
+/// The SBOM structure:
+/// 1. OS component (type: operating-system) with host/IMDS metadata as properties
+/// 2. Package components (type: library) with purl identifiers for each installed package
+///
+/// Property names follow Amazon Inspector's naming convention:
+/// `amazon:inspector:sbom_generator:metadata:{category}:{field}`
+/// where category is either `host` (uname data) or `imds` (EC2 instance metadata).
+pub fn read_and_convert(metadata: &HostMetadata) -> Result<String> {
+    let data = fs::read_to_string(INVENTORY_PATH).context(error::ReadInventorySnafu)?;
+    let inv: Inventory = serde_json::from_str(&data).context(error::ParseInventorySnafu)?;
+
+    // Extract Bottlerocket version from the bottlerocket-metadata package
+    let br_version = inv
+        .content
+        .iter()
+        .find(|p| p.name == "bottlerocket-metadata")
+        .map(|p| p.version.as_str())
+        .unwrap_or("unknown");
+
+    let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    // Build properties using Amazon Inspector's expected naming scheme.
+    // The prefix `amazon:inspector:sbom_generator:metadata:` is required for
+    // Inspector to recognize and process these fields during vulnerability scans.
+    let properties = vec![
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:host:hostname".into(),
+            value: metadata.hostname.clone(),
+        },
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:host:kernel_name".into(),
+            value: metadata.kernel_name.clone(),
+        },
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:host:kernel_version".into(),
+            value: metadata.kernel_version.clone(),
+        },
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:host:cpu_architecture".into(),
+            value: metadata.cpu_architecture.clone(),
+        },
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:imds:provider".into(),
+            value: "aws".into(),
+        },
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:imds:instance_id".into(),
+            value: metadata.instance_id.clone(),
+        },
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:imds:instance_type".into(),
+            value: metadata.instance_type.clone(),
+        },
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:imds:instance_location".into(),
+            value: metadata.region.clone(),
+        },
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:imds:instance_partition".into(),
+            value: metadata.partition.clone(),
+        },
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:imds:account_id".into(),
+            value: metadata.account_id.clone(),
+        },
+        Property {
+            name: "amazon:inspector:sbom_generator:metadata:imds:resource_type".into(),
+            value: "ec2:instance".into(),
+        },
+    ];
+
+    // OS component carries all host/IMDS metadata as properties
+    let os_component = Component {
+        bom_ref: "comp-os".into(),
+        typ: "operating-system",
+        name: "bottlerocket".into(),
+        version: br_version.into(),
+        purl: String::new(),
+        publisher: "Amazon Web Services, Inc. (AWS)".into(),
+        description: "Bottlerocket OS".into(),
+        licenses: None,
+        properties: Some(properties),
+    };
+
+    // Package components use purl format for precise identification:
+    // pkg:rpm/bottlerocket/{name}@{version}-{release}?arch={arch}&epoch={epoch}&distro={br_version}
+    let mut components = vec![os_component];
+    components.extend(inv.content.iter().enumerate().map(|(i, p)| Component {
+        bom_ref: format!("comp-{}", i),
+        typ: "library",
+        name: p.name.clone(),
+        version: format!("{}-{}", p.version, p.release),
+        purl: format!(
+            "pkg:rpm/bottlerocket/{}@{}-{}?arch={}&epoch={}&distro={}",
+            p.name,
+            p.version,
+            p.release,
+            p.architecture,
+            if p.epoch.is_empty() { "0" } else { &p.epoch },
+            br_version,
+        ),
+        publisher: p.publisher.clone(),
+        description: p.summary.clone(),
+        licenses: Some(vec![LicenseEntry {
+            license: LicenseId {
+                id: "Apache-2.0 OR MIT".into(),
+            },
+        }]),
+        properties: None,
+    }));
+
+    let sbom = Sbom {
+        bom_format: "CycloneDX",
+        spec_version: "1.5",
+        serial_number: format!("urn:uuid:{}", Uuid::new_v4()),
+        version: 1,
+        metadata: Metadata {
+            timestamp,
+            tools: Tools {
+                components: vec![ToolComponent {
+                    typ: "application",
+                    author: "Amazon Web Services, Inc. (AWS)",
+                    name: "corgid",
+                    version: VERSION,
+                }],
+            },
+        },
+        components,
+    };
+
+    let json = serde_json::to_string_pretty(&sbom).context(error::SerializeSbomSnafu)?;
+    Ok(json)
+}

--- a/sources/corgid/src/main.rs
+++ b/sources/corgid/src/main.rs
@@ -1,0 +1,195 @@
+//! corgid - Bottlerocket package inventory reporter for Amazon Inspector
+//!
+//! This binary collects the system's package inventory, converts it to a CycloneDX SBOM,
+//! and sends it to Amazon Inspector for vulnerability scanning. It uses IMDS to gather
+//! instance metadata and IAM credentials for authentication.
+
+#![deny(unused_imports)]
+
+mod error;
+mod inspector;
+mod inventory;
+mod sigv4;
+
+use error::Result;
+use imdsclient::ImdsClient;
+use inspector::{get_credentials, send_inspector_sbom, start_session, stop_session};
+use inventory::{read_and_convert, HostMetadata};
+use log::{info, warn};
+use reqwest::blocking::Client;
+use sha2::{Digest, Sha256};
+use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
+use snafu::{OptionExt, ResultExt};
+use std::process;
+use std::process::Command;
+
+const DEFAULT_REGION: &str = "us-east-1";
+
+#[tokio::main]
+async fn main() {
+    SimpleLogger::init(LevelFilter::Info, LogConfig::default()).expect("logger init");
+
+    if let Err(e) = run().await {
+        eprintln!("{e}");
+        process::exit(1);
+    }
+}
+
+/// Main execution flow for sending inventory to Inspector.
+///
+/// The flow is: fetch metadata -> build SBOM -> start session -> send SBOM -> stop session.
+/// Session cleanup is guaranteed even if sending fails (see deferred error pattern below).
+async fn run() -> Result<()> {
+    // Install rustls crypto provider for TLS operations
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    info!("Fetching metadata");
+    let metadata = fetch_metadata().await?;
+
+    info!("Reading inventory and converting to SBOM");
+    let sbom = read_and_convert(&metadata)?;
+    // Hash used by Inspector to verify SBOM integrity
+    let sbom_hash = hex::encode(Sha256::digest(sbom.as_bytes()));
+
+    let region = &metadata.region;
+    let instance_id = &metadata.instance_id;
+
+    info!("Fetching IAM credentials");
+    let client = Client::new();
+    let creds = get_credentials(&client)?;
+
+    info!("Starting session");
+    let session = start_session(&client, region, instance_id, &creds)?;
+
+    info!("Sending SBOM");
+    // Deferred error pattern: capture send failure but don't return early.
+    // We must always call stop_session to clean up the Inspector session,
+    // regardless of whether sending succeeded. The error is returned after cleanup.
+    let (status, send_err) = match send_inspector_sbom(
+        &client,
+        region,
+        instance_id,
+        &session.session_id,
+        &sbom,
+        &creds,
+    ) {
+        Ok(()) => ("COMPLETED", None),
+        Err(e) => {
+            log::error!("Failed to send SBOM: {e}");
+            ("AGENT_INTERNAL_ERROR", Some(e))
+        }
+    };
+
+    info!("Stopping session");
+    stop_session(
+        &client,
+        region,
+        instance_id,
+        &session.session_id,
+        &sbom_hash,
+        status,
+        &creds,
+    )?;
+
+    // Return deferred send error after session cleanup completes
+    if let Some(e) = send_err {
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+/// Fetches instance metadata from IMDS for SBOM generation.
+///
+/// Region and instance_id are required; other fields gracefully degrade to empty strings.
+async fn fetch_metadata() -> Result<HostMetadata> {
+    let mut imds = ImdsClient::new();
+
+    // Region falls back to us-east-1 if unavailable (common for local testing)
+    let region = match imds.fetch_region().await {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            warn!("IMDS returned no region, using default: {}", DEFAULT_REGION);
+            DEFAULT_REGION.to_string()
+        }
+        Err(e) => {
+            warn!("Failed to fetch region: {e}");
+            DEFAULT_REGION.to_string()
+        }
+    };
+
+    // Instance ID is required - fail if unavailable
+    let instance_id = imds
+        .fetch_instance_id()
+        .await
+        .context(error::ImdsSnafu)?
+        .context(error::NoInstanceIdSnafu)?;
+
+    let meta = HostMetadata {
+        region,
+        instance_id,
+        hostname: imds
+            .fetch_hostname()
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default(),
+        instance_type: imds
+            .fetch_instance_type()
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default(),
+        partition: imds
+            .fetch_partition()
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default(),
+        account_id: fetch_account_id_blocking().unwrap_or_default(),
+        // System info from uname for SBOM metadata
+        kernel_name: uname_field("-s"),
+        kernel_version: uname_field("-r"),
+        cpu_architecture: uname_field("-m"),
+    };
+
+    Ok(meta)
+}
+
+/// Extracts a single field from uname output.
+fn uname_field(flag: &str) -> String {
+    Command::new("uname")
+        .arg(flag)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+/// Fetches AWS account ID directly from IMDS instance identity document.
+///
+/// Uses blocking HTTP because this runs in sync context. IMDSv2 requires
+/// a session token for security.
+fn fetch_account_id_blocking() -> Option<String> {
+    // IMDSv2 requires a PUT to get a session token first
+    let client = Client::new();
+    let token = client
+        .put("http://169.254.169.254/latest/api/token")
+        .header("X-aws-ec2-metadata-token-ttl-seconds", "60")
+        .send()
+        .ok()?
+        .text()
+        .ok()?;
+
+    let text = client
+        .get("http://169.254.169.254/latest/dynamic/instance-identity/document")
+        .header("X-aws-ec2-metadata-token", &token)
+        .send()
+        .ok()?
+        .text()
+        .ok()?;
+
+    let doc: serde_json::Value = serde_json::from_str(&text).ok()?;
+    doc.get("accountId")?.as_str().map(String::from)
+}

--- a/sources/corgid/src/sigv4.rs
+++ b/sources/corgid/src/sigv4.rs
@@ -1,0 +1,100 @@
+//! AWS Signature Version 4 request signing.
+//!
+//! Implements the AWS SigV4 algorithm for authenticating requests to AWS services.
+//! The signing process creates a cryptographic signature using the request details
+//! and AWS credentials, allowing AWS to verify request authenticity and integrity.
+
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Input parameters required to sign an AWS request.
+pub struct SignInput<'a> {
+    pub method: &'a str,
+    pub host: &'a str,
+    pub path: &'a str,
+    pub body: &'a [u8],
+    pub region: &'a str,
+    pub service: &'a str,
+    pub access_key: &'a str,
+    pub secret_key: &'a str,
+    pub token: &'a str,
+    pub time: DateTime<Utc>,
+}
+
+/// Headers produced by the signing process, ready to attach to an HTTP request.
+pub struct SignedRequest {
+    pub authorization: String,
+    pub x_amz_date: String,
+    pub x_amz_security_token: String,
+    pub x_amz_content_sha256: String,
+}
+
+/// Signs an AWS request using the SigV4 algorithm.
+///
+/// Returns headers that must be included in the HTTP request for AWS to
+/// authenticate it. The signature covers the method, path, headers, and body.
+pub fn sign(input: &SignInput) -> SignedRequest {
+    let date_stamp = input.time.format("%Y%m%d").to_string();
+    let amz_date = input.time.format("%Y%m%dT%H%M%SZ").to_string();
+
+    // Hash the payload to ensure body integrity
+    let payload_hash = hex::encode(Sha256::digest(input.body));
+
+    // Canonical headers must be sorted and newline-terminated
+    let canonical_headers = format!(
+        "host:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\nx-amz-security-token:{}\n",
+        input.host, payload_hash, amz_date, input.token
+    );
+    let signed_headers = "host;x-amz-content-sha256;x-amz-date;x-amz-security-token";
+
+    // Canonical request: normalized representation of the request to sign
+    let canonical_request = format!(
+        "{}\n{}\n\n{}\n{}\n{}",
+        input.method, input.path, canonical_headers, signed_headers, payload_hash
+    );
+
+    // Scope binds the signature to a specific date, region, and service
+    let scope = format!(
+        "{}/{}/{}/aws4_request",
+        date_stamp, input.region, input.service
+    );
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+        amz_date,
+        scope,
+        hex::encode(Sha256::digest(canonical_request.as_bytes()))
+    );
+
+    // Key derivation chain: each step scopes the key more narrowly
+    // AWS4 + secret -> date -> region -> service -> signing key
+    let k_date = hmac_sha256(
+        format!("AWS4{}", input.secret_key).as_bytes(),
+        date_stamp.as_bytes(),
+    );
+    let k_region = hmac_sha256(&k_date, input.region.as_bytes());
+    let k_service = hmac_sha256(&k_region, input.service.as_bytes());
+    let k_signing = hmac_sha256(&k_service, b"aws4_request");
+    let signature = hex::encode(hmac_sha256(&k_signing, string_to_sign.as_bytes()));
+
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
+        input.access_key, scope, signed_headers, signature
+    );
+
+    SignedRequest {
+        authorization,
+        x_amz_date: amz_date,
+        x_amz_security_token: input.token.to_string(),
+        x_amz_content_sha256: payload_hash,
+    }
+}
+
+/// Computes HMAC-SHA256 for the key derivation chain.
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Add corgid, a new Rust binary that runs as a oneshot systemd service on boot to send Bottlerocket's package inventory
to the Amazon Inspector telemetry API as a CycloneDX 1.5 SBOM.


**Testing done:**
build variant and check the corgid service
```
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal systemd[1]: Starting Inspector SBOM telemetry sender...
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal corgid[1751]: 21:02:50 [INFO] Fetching metadata
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal corgid[1751]: 21:02:50 [INFO] Received dynamic/instance-identity/document
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal corgid[1751]: 21:02:50 [INFO] Received meta-data/instance-id
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal corgid[1751]: 21:02:50 [INFO] Received meta-data/local-hostname
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal corgid[1751]: 21:02:50 [INFO] Received meta-data/instance-type
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal corgid[1751]: 21:02:50 [INFO] Received meta-data/services/partition
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal corgid[1751]: 21:02:50 [INFO] Reading inventory and converting to SBOM
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal corgid[1751]: 21:02:50 [INFO] Fetching IAM credentials
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal corgid[1751]: 21:02:50 [INFO] Using new /telemetry API endpoint
Apr 14 21:02:50 ip-192-168-36-145.ec2.internal corgid[1751]: 21:02:50 [INFO] Starting session
....
Apr 14 21:02:51 ip-192-168-36-145.ec2.internal systemd[1]: corgid.service: Deactivated successfully.
Apr 14 21:02:51 ip-192-168-36-145.ec2.internal systemd[1]: Finished Inspector SBOM telemetry sender.
bash-5.2#
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
