### PR TITLE
Build changes to bash and systemd

### DIFF
--- a/packages/bash/bash.spec
+++ b/packages/bash/bash.spec
@@ -55,6 +55,11 @@ echo %{release} > _patchlevel
 rm y.tab.*
 
 %build
+
+# GCC 15 defaults to -std=gnu23 which breaks bash compilation.
+export CFLAGS="%{_cross_cflags} -std=gnu17"
+export CFLAGS_FOR_BUILD="-std=gnu17"
+
 (
 export \
   ac_cv_rl_prefix="%{_cross_sysroot}" \
@@ -87,7 +92,7 @@ export \
   --with-installed-readline
 )
 
-make "CPPFLAGS=-D_GNU_SOURCE -DRECYCLES_PIDS -DDEFAULT_PATH_VALUE='\"/usr/local/bin:/usr/bin\"'" %{?_smp_mflags}
+%make_build "CPPFLAGS=-D_GNU_SOURCE -DRECYCLES_PIDS -DDEFAULT_PATH_VALUE='\"/usr/local/bin:/usr/bin\"'"
 
 %install
 %make_install install-headers

--- a/packages/systemd-252/systemd-252.spec
+++ b/packages/systemd-252/systemd-252.spec
@@ -23,8 +23,8 @@ Source103: org.freedesktop.systemd1.toml
 # Reference issue: github.com/systemd/systemd/issues/25441
 Patch1001: 1001-sd-netlink-make-calc_elapse-return-USEC_INFINITY-whe.patch
 Patch1002: 1002-sd-netlink-make-the-default-timeout-configurable-by-.patch
-# Backport of upstream patch to change `Failed to execute <filepath> No such file 
-# or directory` error logs to debug 
+# Backport of upstream patch to change `Failed to execute <filepath> No such file
+# or directory` error logs to debug
 Patch1003: 1003-exec-util-make-missing-agents-a-gracefull-handled-issues.patch
 
 # Local patch to work around the fact that /var is a bind mount from
@@ -263,6 +263,8 @@ CONFIGURE_OPTS=(
  -Dcertificate-root='%{_cross_sysconfdir}/ssl'
  -Dpkgconfigdatadir='%{_cross_pkgconfigdir}'
  -Dpkgconfiglibdir='%{_cross_pkgconfigdir}'
+ -Dmount-path='%{_cross_bindir}/mount'
+ -Dumount-path='%{_cross_bindir}/umount'
 
  -Ddefault-hierarchy=unified
 

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -18,8 +18,8 @@ Source103: org.freedesktop.systemd1.toml
 Source1: systemd-mount-rate-bootconfig.conf
 Source2: systemd-cgroup-legacy-force-bootconfig.conf
 
-# Backport of upstream patch to change `Failed to execute <filepath> No such file 
-# or directory` error logs to debug 
+# Backport of upstream patch to change `Failed to execute <filepath> No such file
+# or directory` error logs to debug
 Patch1001: 1001-exec-util-make-missing-agents-a-gracefull-handled-issues.patch
 
 # Local patch to add the acquire the id for VMware
@@ -243,6 +243,8 @@ CONFIGURE_OPTS=(
  -Dcertificate-root='%{_cross_sysconfdir}/ssl'
  -Dpkgconfigdatadir='%{_cross_pkgconfigdir}'
  -Dpkgconfiglibdir='%{_cross_pkgconfigdir}'
+ -Dmount-path='%{_cross_bindir}/mount'
+ -Dumount-path='%{_cross_bindir}/umount'
 
  -Dadm-group=false
  -Dwheel-group=false


### PR DESCRIPTION
**Description of changes:**
- Bash follows C17 standard which we have hardcoded here. Newer versions of GCC default to newer standards which break compilation.
- Hardcoding mount and umount path in systemd meson build parameters - util-linux package in bottlerocket installs mount and umount to /usr/bin (`%{_cross_bindir}`) and this change makes sure we honour that instead of defaulting to the path used by host OS.


**Testing done:**
1. core-kit builds ✅
2. instance boots ✅ 
3. bash commands work ✅  


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
