### PR TITLE
nvidia-k8s-device-plugin: allow disabling plugin through API

### DIFF
--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-exec-start-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-exec-start-conf
@@ -1,8 +1,22 @@
 [required-extensions]
 kubelet-device-plugins = "v1"
+std = { version = "v1", helpers = ["if_not_null", "default"] }
 +++
+{{#if_not_null settings.kubelet-device-plugins.nvidia}}
 [Service]
-{{#if settings.kubelet-device-plugins.nvidia}}
+ExecStartPre=
 ExecStart=
+{{#if (eq (default "true" settings.kubelet-device-plugins.nvidia.enabled) "true")}}
+# Ensure that the kubelet device plugin socket exists before we start
+# A brief sleep is needed to avoid the `test` failing its first check
+ExecStartPre=/usr/bin/sleep 0.1
+ExecStartPre=/usr/bin/test -S /var/lib/kubelet/device-plugins/kubelet.sock
 ExecStart=/usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml
+RemainAfterExit=true
+{{else}}
+Restart=no
+ExecStart=/usr/bin/true
+Type=oneshot
+RemainAfterExit=true
 {{/if}}
+{{/if_not_null}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-mig-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-mig-conf
@@ -1,10 +1,14 @@
 [required-extensions]
 kubelet-device-plugins = "v1"
-std = { version = "v1", helpers = ["if_not_null", "toml_encode"]}
+std = { version = "v1", helpers = ["if_not_null", "default", "toml_encode"]}
 +++
+{{#if_not_null settings.kubelet-device-plugins.nvidia}}
+{{#if (eq (default "true" settings.kubelet-device-plugins.nvidia.enabled) "true")}}
 {{#if_not_null settings.kubelet-device-plugins.nvidia.device-partitioning-strategy}}
 device-partitioning-strategy = "{{{settings.kubelet-device-plugins.nvidia.device-partitioning-strategy}}}"
 {{/if_not_null}}
 {{#if_not_null settings.kubelet-device-plugins.nvidia.mig.profile}}
 profile = {{ toml_encode settings.kubelet-device-plugins.nvidia.mig.profile }}
+{{/if_not_null}}
+{{/if}}
 {{/if_not_null}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-mps-control-daemon-exec-start-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-mps-control-daemon-exec-start-conf
@@ -1,9 +1,12 @@
 [required-extensions]
 kubelet-device-plugins = "v1"
+std = { version = "v1", helpers = ["if_not_null", "default"] }
 +++
+{{#if_not_null settings.kubelet-device-plugins.nvidia}}
+{{#if (eq (default "true" settings.kubelet-device-plugins.nvidia.enabled) "true")}}
+{{#if (eq settings.kubelet-device-plugins.nvidia.device-sharing-strategy "mps")}}
 [Service]
 ExecStart=
-{{#if (eq settings.kubelet-device-plugins.nvidia.device-sharing-strategy "mps")}}
 {{#if (eq settings.kubelet-device-plugins.nvidia.device-partitioning-strategy "mig")}}
 # MPS and MIG are not supported at the same time
 Type=oneshot
@@ -13,8 +16,6 @@ Type=simple
 ExecStart=/usr/bin/mps-control-daemon --config-file /etc/nvidia-k8s-device-plugin/settings.yaml
 RemainAfterExit=no
 {{/if}}
-{{else}}
-Type=oneshot
-ExecStart=/usr/bin/true
-RemainAfterExit=yes
 {{/if}}
+{{/if}}
+{{/if_not_null}}

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "darling",
  "quote",
@@ -1472,8 +1472,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.15.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+version = "0.16.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1518,7 +1518,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -1542,8 +1542,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.23.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+version = "0.24.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1595,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "serde",
 ]
@@ -1616,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5364,7 +5364,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5377,7 +5377,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5390,7 +5390,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5404,7 +5404,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5417,7 +5417,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5430,7 +5430,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5443,7 +5443,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5456,7 +5456,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5472,7 +5472,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5485,7 +5485,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5498,7 +5498,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5511,7 +5511,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-image-verifier-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5524,7 +5524,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5536,8 +5536,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
-version = "0.3.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+version = "0.4.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5550,7 +5550,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.10.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5564,7 +5564,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5577,7 +5577,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -5590,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5616,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5629,7 +5629,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5643,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5656,7 +5656,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5669,7 +5669,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.23.0#d15838381ebd1cf08282f35f796425ac9c0a86d9"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -232,13 +232,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.23.0"
-version = "0.15.0"
+tag = "bottlerocket-settings-models-v0.24.0"
+version = "0.16.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.23.0"
-version = "0.23.0"
+tag = "bottlerocket-settings-models-v0.24.0"
+version = "0.24.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -247,7 +247,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.23.0"
+tag = "bottlerocket-settings-models-v0.24.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
**Description of changes:**

Add an API setting to disable the NVIDIA k8s device plugin. The new setting defaults to enabled, preserving existing behavior. Template rendering gracefully handles the setting being absent for downstreams that don't define it.

**Testing done:**

- Confirmed the template renders and the device plugin starts even when the setting is missing:

<details>

```bash
[root@admin]# apiclient set settings.kubelet-device-plugins.nvidia.enabled=false
Failed to change settings: Failed PATCH request to '/settings/keypair?tx=apiclient-set-cNt2Gszti4V0VSpg': Status 400 when PATCHing /settings/keypair?tx=apiclient-set-cNt2Gszti4V0VSpg: Unable to match your input to the data model.  We may not have enough type information.  Please try the --json input form.  Cause: Error during deserialization: unknown field `enabled`, expected one of `pass-device-specs`, `device-id-strategy`, `device-list-strategy`, `device-sharing-strategy`, `time-slicing`, `mps`, `device-partitioning-strategy`, `mig` at line 1 column 46
[root@admin]# sheltie systemctl status nvidia-k8s-device-plugin.service
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 10-requires-tmp.conf
             /etc/systemd/system/nvidia-k8s-device-plugin.service.d
             └─exec-start.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service.d
             └─grid-license-file-check.conf
     Active: active (running) since Fri 2026-04-24 01:04:13 UTC; 11min ago
 Invocation: 24a100149424447488c8e7aa70c6b3b9
   Main PID: 3374 (nvidia-device-p)
      Tasks: 10 (limit: 36988)
     Memory: 52.6M (peak: 53.5M)
        CPU: 101ms
     CGroup: /system.slice/nvidia-k8s-device-plugin.service
             └─3374 /usr/bin/nvidia-device-plugin --device-list-strategy volume-mounts --device-id-strategy index --pass-device-specs=true

Apr 24 01:04:13 ip-192-168-5-124.us-west-2.compute.internal nvidia-device-plugin[3374]:   "sharing": {
Apr 24 01:04:13 ip-192-168-5-124.us-west-2.compute.internal nvidia-device-plugin[3374]:     "timeSlicing": {}
Apr 24 01:04:13 ip-192-168-5-124.us-west-2.compute.internal nvidia-device-plugin[3374]:   },
Apr 24 01:04:13 ip-192-168-5-124.us-west-2.compute.internal nvidia-device-plugin[3374]:   "imex": {}
Apr 24 01:04:13 ip-192-168-5-124.us-west-2.compute.internal nvidia-device-plugin[3374]: }
Apr 24 01:04:13 ip-192-168-5-124.us-west-2.compute.internal nvidia-device-plugin[3374]: I0424 01:04:13.393914    3374 main.go:369] Retrieving plugins.
Apr 24 01:04:13 ip-192-168-5-124.us-west-2.compute.internal nvidia-device-plugin[3374]: I0424 01:04:13.421322    3374 server.go:197] Starting GRPC server for 'nvidia.com/gpu'
Apr 24 01:04:13 ip-192-168-5-124.us-west-2.compute.internal nvidia-device-plugin[3374]: I0424 01:04:13.422624    3374 server.go:141] Starting to serve 'nvidia.com/gpu' on /var/lib/kubelet/device-plugins/nvidia-gpu.sock
Apr 24 01:04:13 ip-192-168-5-124.us-west-2.compute.internal nvidia-device-plugin[3374]: I0424 01:04:13.424616    3374 server.go:148] Registered device plugin for 'nvidia.com/gpu' with Kubelet
Apr 24 01:04:13 ip-192-168-5-124.us-west-2.compute.internal nvidia-device-plugin[3374]: I0424 01:04:13.426032    3374 health.go:64] Ignoring the following XIDs for health checks: map[13:true 31:true 43:true 45:true 68:true 109:true]
[root@admin]# cat /.bottlerocket/rootfs/etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf
[Service]
ExecStart=
# Ensure that the kubelet device plugin socket exists before we start
# A brief sleep is needed to avoid the `test` failing its first check
ExecStartPre=/usr/bin/sleep 0.1
ExecStartPre=/usr/bin/test -S /var/lib/kubelet/device-plugins/kubelet.sock
ExecStart=/usr/bin/nvidia-device-plugin --device-list-strategy volume-mounts --device-id-strategy index --pass-device-specs=true
Type=simple
RestartSec=2
Restart=always
[root@admin]#
```

</details>

In combination with: https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/135

- Confirmed that the service starts by default:

<details>

```bash
[root@admin]# apiclient get settings.kubelet-device-plugins.nvidia
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "cdi-cri",
        "device-partitioning-strategy": "none",
        "device-sharing-strategy": "none",
        "enabled": true,
        "pass-device-specs": true
      }
    }
  }
}
[root@admin]# cat /.bottlerocket/rootfs/etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf
[Service]
ExecStart=
# Ensure that the kubelet device plugin socket exists before we start
# A brief sleep is needed to avoid the `test` failing its first check
ExecStartPre=/usr/bin/sleep 0.1
ExecStartPre=/usr/bin/test -S /var/lib/kubelet/device-plugins/kubelet.sock
ExecStart=/usr/bin/nvidia-device-plugin --device-list-strategy volume-mounts --device-id-strategy index --pass-device-specs=true
Type=simple
RestartSec=2
Restart=always
[root@admin]# sheltie systemctl status nvidia-k8s-device-plugin.service
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 10-requires-tmp.conf
             /etc/systemd/system/nvidia-k8s-device-plugin.service.d
             └─exec-start.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service.d
             └─grid-license-file-check.conf
     Active: active (running) since Fri 2026-04-24 00:53:55 UTC; 26s ago
 Invocation: d90a78c91bcc4d559be7af4e5bf45e63
    Process: 8135 ExecStartPre=/usr/bin/sleep 0.1 (code=exited, status=0/SUCCESS)
    Process: 8141 ExecStartPre=/usr/bin/test -S /var/lib/kubelet/device-plugins/kubelet.sock (code=exited, status=0/SUCCESS)
    Process: 8146 ExecStartPre=/usr/bin/test -f /etc/drivers/.grid-licensed (code=exited, status=0/SUCCESS)
   Main PID: 8149 (nvidia-device-p)
      Tasks: 10 (limit: 36988)
     Memory: 21.4M (peak: 22.4M)
        CPU: 65ms
     CGroup: /system.slice/nvidia-k8s-device-plugin.service
             └─8149 /usr/bin/nvidia-device-plugin --device-list-strategy volume-mounts --device-id-strategy index --pass-device-specs=true

Apr 24 00:53:55 ip-192-168-36-98.us-west-2.compute.internal nvidia-device-plugin[8149]:   "sharing": {
Apr 24 00:53:55 ip-192-168-36-98.us-west-2.compute.internal nvidia-device-plugin[8149]:     "timeSlicing": {}
Apr 24 00:53:55 ip-192-168-36-98.us-west-2.compute.internal nvidia-device-plugin[8149]:   },
Apr 24 00:53:55 ip-192-168-36-98.us-west-2.compute.internal nvidia-device-plugin[8149]:   "imex": {}
Apr 24 00:53:55 ip-192-168-36-98.us-west-2.compute.internal nvidia-device-plugin[8149]: }
Apr 24 00:53:55 ip-192-168-36-98.us-west-2.compute.internal nvidia-device-plugin[8149]: I0424 00:53:55.589175    8149 main.go:369] Retrieving plugins.
Apr 24 00:53:55 ip-192-168-36-98.us-west-2.compute.internal nvidia-device-plugin[8149]: I0424 00:53:55.621061    8149 server.go:197] Starting GRPC server for 'nvidia.com/gpu'
Apr 24 00:53:55 ip-192-168-36-98.us-west-2.compute.internal nvidia-device-plugin[8149]: I0424 00:53:55.621608    8149 server.go:141] Starting to serve 'nvidia.com/gpu' on /var/lib/kubelet/device-plugins/nvidia-gpu.sock
Apr 24 00:53:55 ip-192-168-36-98.us-west-2.compute.internal nvidia-device-plugin[8149]: I0424 00:53:55.624470    8149 server.go:148] Registered device plugin for 'nvidia.com/gpu' with Kubelet
Apr 24 00:53:55 ip-192-168-36-98.us-west-2.compute.internal nvidia-device-plugin[8149]: I0424 00:53:55.625674    8149 health.go:64] Ignoring the following XIDs for health checks: map[13:true 31:true 43:true 45:true 68:true 109:true]
```

</details>

- Confirmed that the service doesn't run when `enabled = false`:

<details>

```bash
[root@admin]# apiclient set settings.kubelet-device-plugins.nvidia.enabled=false
[root@admin]# cat /.bottlerocket/rootfs/etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf
[Service]
ExecStart=
Type=oneshot
ExecStart=/usr/bin/true
RemainAfterExit=true
[root@admin]# sheltie systemctl status nvidia-k8s-device-plugin.service
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 10-requires-tmp.conf
             /etc/systemd/system/nvidia-k8s-device-plugin.service.d
             └─exec-start.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service.d
             └─grid-license-file-check.conf
     Active: active (exited) since Fri 2026-04-24 00:54:36 UTC; 7s ago
 Invocation: 4fe207d9febe4cd7bad75191150967bb
    Process: 8494 ExecStartPre=/usr/bin/test -f /etc/drivers/.grid-licensed (code=exited, status=0/SUCCESS)
    Process: 8498 ExecStart=/usr/bin/true (code=exited, status=0/SUCCESS)
   Main PID: 8498 (code=exited, status=0/SUCCESS)
   Mem peak: 1.2M
        CPU: 9ms

Apr 24 00:54:36 ip-192-168-36-98.us-west-2.compute.internal systemd[1]: Starting Start NVIDIA kubernetes device plugin...
Apr 24 00:54:36 ip-192-168-36-98.us-west-2.compute.internal systemd[1]: Finished Start NVIDIA kubernetes device plugin.
[root@admin]#
```

</details>

- Confirmed MIG config renders empty when `enabled = false` and is restored when `enabled = true`:

<details>

```bash
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.enabled=false
bash-5.2# cat /etc/nvidia-migmanager/nvidia-migmanager.toml
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.enabled=true
bash-5.2# cat /etc/nvidia-migmanager/nvidia-migmanager.toml
device-partitioning-strategy = "mig"
profile = { "a100.40gb" = "7" }
```

</details>

- Confirmed MPS control daemon stops when `enabled = false` and restarts when `enabled = true`:

<details>

```bash
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.device-partitioning-strategy=none
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.device-sharing-strategy=mps
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.enabled=true
bash-5.2# systemctl status nvidia-mps-control-daemon.service
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Active: active (running) since Fri 2026-06-12 21:46:22 UTC; 5s ago
   Main PID: 19971 (mps-control-dae)
             ├─19971 /usr/bin/mps-control-daemon --config-file /etc/nvidia-k8s-device-plugin/settings.yaml
             ├─20068 nvidia-cuda-mps-control -d
             └─20088 tail -n +1 -f /run/nvidia/mps/nvidia.com/gpu.shared/log/control.log
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.enabled=false
bash-5.2# sleep 2
bash-5.2# systemctl status nvidia-mps-control-daemon.service
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Active: active (exited) since Fri 2026-06-12 21:46:43 UTC; 6s ago
    Process: 20708 ExecStart=/usr/bin/true (code=exited, status=0/SUCCESS)
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.enabled=true
bash-5.2# sleep 2
bash-5.2# systemctl status nvidia-mps-control-daemon.service
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Active: active (running) since Fri 2026-06-12 21:47:11 UTC; 8s ago
   Main PID: 21201 (mps-control-dae)
             ├─21201 /usr/bin/mps-control-daemon --config-file /etc/nvidia-k8s-device-plugin/settings.yaml
             ├─21307 nvidia-cuda-mps-control -d
             └─21327 tail -n +1 -f /run/nvidia/mps/nvidia.com/gpu.shared/log/control.log
```

</details>

- Confirmed all services disabled from boot when `enabled = false` is set in userdata:

<details>

```bash
bash-5.2# apiclient get settings.kubelet-device-plugins.nvidia
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "cdi-cri",
        "device-partitioning-strategy": "mig",
        "device-sharing-strategy": "mps",
        "enabled": false,
        "mig": {
          "profile": {
            "a100.40gb": "7"
          }
        },
        "pass-device-specs": true
      }
    }
  }
}
bash-5.2# systemctl status nvidia-k8s-device-plugin.service
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Active: active (exited) since Fri 2026-06-12 21:44:19 UTC; 1min 41s ago
   Main PID: 16782 (code=exited, status=0/SUCCESS)
bash-5.2# cat /etc/nvidia-migmanager/nvidia-migmanager.toml
bash-5.2# systemctl status nvidia-mps-control-daemon.service
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Active: active (exited) since Fri 2026-06-12 21:44:18 UTC; 1min 43s ago
   Main PID: 16414 (code=exited, status=0/SUCCESS)
```

</details>

- Confirmed backwards compatibility when `enabled` is absent (device plugin and MIG config work normally):

<details>

```bash
bash-5.2# apiclient get settings.kubelet-device-plugins.nvidia.enabled
{}
bash-5.2# cat /etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf
[Service]
ExecStartPre=
ExecStart=
# Ensure that the kubelet device plugin socket exists before we start
# A brief sleep is needed to avoid the `test` failing its first check
ExecStartPre=/usr/bin/sleep 0.1
ExecStartPre=/usr/bin/test -S /var/lib/kubelet/device-plugins/kubelet.sock
ExecStart=/usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml
RemainAfterExit=true
bash-5.2# cat /etc/nvidia-migmanager/nvidia-migmanager.toml
device-partitioning-strategy = "mig"
profile = { "a100.40gb" = "7" }
```

</details>

- Confirmed that the service doesn't run when `enabled = false`:
<details>

```bash
[root@admin]# apiclient set settings.kubelet-device-plugins.nvidia.enabled=false
[root@admin]# cat /.bottlerocket/rootfs/etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf
[Service]
ExecStart=
Type=oneshot
ExecStart=/usr/bin/true
RemainAfterExit=true
[root@admin]# sheltie systemctl status nvidia-k8s-device-plugin.service
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 10-requires-tmp.conf
             /etc/systemd/system/nvidia-k8s-device-plugin.service.d
             └─exec-start.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-k8s-device-plugin.service.d
             └─grid-license-file-check.conf
     Active: active (exited) since Fri 2026-04-24 00:54:36 UTC; 7s ago
 Invocation: 4fe207d9febe4cd7bad75191150967bb
    Process: 8494 ExecStartPre=/usr/bin/test -f /etc/drivers/.grid-licensed (code=exited, status=0/SUCCESS)
    Process: 8498 ExecStart=/usr/bin/true (code=exited, status=0/SUCCESS)
   Main PID: 8498 (code=exited, status=0/SUCCESS)
   Mem peak: 1.2M
        CPU: 9ms

Apr 24 00:54:36 ip-192-168-36-98.us-west-2.compute.internal systemd[1]: Starting Start NVIDIA kubernetes device plugin...
Apr 24 00:54:36 ip-192-168-36-98.us-west-2.compute.internal systemd[1]: Finished Start NVIDIA kubernetes device plugin.
[root@admin]#
```

</details>

- Confirmed MIG and MPS settings render empty when device plugin is disabled:
<details>

```bash
bash-5.2# apiclient get settings.kubelet-device-plugins.nvidia.enabled
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "enabled": false
      }
    }
  }
}
bash-5.2# cat /etc/nvidia-migmanager/nvidia-migmanager.toml
bash-5.2# cat /etc/systemd/system/nvidia-mps-control-daemon.service.d/exec-start.conf
bash-5.2#
```

</details>

- Confirmed MIG config renders empty when `enabled = false` and is restored when `enabled = true`:
<details>

```bash
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.enabled=false
bash-5.2# cat /etc/nvidia-migmanager/nvidia-migmanager.toml
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.enabled=true
bash-5.2# cat /etc/nvidia-migmanager/nvidia-migmanager.toml
device-partitioning-strategy = "mig"
profile = { "a100.40gb" = "7" }
```

</details>

- Confirmed MPS control daemon stops when `enabled = false` and restarts when `enabled = true`:
<details>

```bash
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.device-partitioning-strategy=none
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.device-sharing-strategy=mps
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.enabled=true
bash-5.2# systemctl status nvidia-mps-control-daemon.service
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Active: active (running) since Fri 2026-06-12 21:46:22 UTC; 5s ago
   Main PID: 19971 (mps-control-dae)
             ├─19971 /usr/bin/mps-control-daemon --config-file /etc/nvidia-k8s-device-plugin/settings.yaml
             ├─20068 nvidia-cuda-mps-control -d
             └─20088 tail -n +1 -f /run/nvidia/mps/nvidia.com/gpu.shared/log/control.log
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.enabled=false
bash-5.2# sleep 2
bash-5.2# systemctl status nvidia-mps-control-daemon.service
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Active: active (exited) since Fri 2026-06-12 21:46:43 UTC; 6s ago
    Process: 20708 ExecStart=/usr/bin/true (code=exited, status=0/SUCCESS)
bash-5.2# apiclient set settings.kubelet-device-plugins.nvidia.enabled=true
bash-5.2# sleep 2
bash-5.2# systemctl status nvidia-mps-control-daemon.service
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Active: active (running) since Fri 2026-06-12 21:47:11 UTC; 8s ago
   Main PID: 21201 (mps-control-dae)
             ├─21201 /usr/bin/mps-control-daemon --config-file /etc/nvidia-k8s-device-plugin/settings.yaml
             ├─21307 nvidia-cuda-mps-control -d
             └─21327 tail -n +1 -f /run/nvidia/mps/nvidia.com/gpu.shared/log/control.log
```

</details>

- Confirmed all services disabled from boot when `enabled = false` is set in userdata:
<details>

```bash
bash-5.2# apiclient get settings.kubelet-device-plugins.nvidia
{
  "settings": {
    "kubelet-device-plugins": {
      "nvidia": {
        "device-id-strategy": "index",
        "device-list-strategy": "cdi-cri",
        "device-partitioning-strategy": "mig",
        "device-sharing-strategy": "mps",
        "enabled": false,
        "mig": {
          "profile": {
            "a100.40gb": "7"
          }
        },
        "pass-device-specs": true
      }
    }
  }
}
bash-5.2# systemctl status nvidia-k8s-device-plugin.service
● nvidia-k8s-device-plugin.service - Start NVIDIA kubernetes device plugin
     Active: active (exited) since Fri 2026-06-12 21:44:19 UTC; 1min 41s ago
   Main PID: 16782 (code=exited, status=0/SUCCESS)
bash-5.2# cat /etc/nvidia-migmanager/nvidia-migmanager.toml
bash-5.2# systemctl status nvidia-mps-control-daemon.service
● nvidia-mps-control-daemon.service - NVIDIA MPS Control Daemon
     Active: active (exited) since Fri 2026-06-12 21:44:18 UTC; 1min 43s ago
   Main PID: 16414 (code=exited, status=0/SUCCESS)
```

</details>

- Confirmed backwards compatibility when `enabled` is absent (device plugin and MIG config work normally):
<details>

```bash
bash-5.2# apiclient get settings.kubelet-device-plugins.nvidia.enabled
{}
bash-5.2# cat /etc/systemd/system/nvidia-k8s-device-plugin.service.d/exec-start.conf
[Service]
ExecStartPre=
ExecStart=
# Ensure that the kubelet device plugin socket exists before we start
# A brief sleep is needed to avoid the `test` failing its first check
ExecStartPre=/usr/bin/sleep 0.1
ExecStartPre=/usr/bin/test -S /var/lib/kubelet/device-plugins/kubelet.sock
ExecStart=/usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml
RemainAfterExit=true
bash-5.2# cat /etc/nvidia-migmanager/nvidia-migmanager.toml
device-partitioning-strategy = "mig"
profile = { "a100.40gb" = "7" }
```

</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
