### PR TITLE
release: move FIPS runtime components to base package

### DIFF
--- a/packages/filesystem/filesystem.spec
+++ b/packages/filesystem/filesystem.spec
@@ -8,18 +8,10 @@ Epoch: 1
 Summary: The basic directory layout
 License: Apache-2.0 OR MIT
 URL: https://github.com/bottlerocket-os/bottlerocket
-Requires: (%{name}-fips if %{_cross_os}image-feature(fips))
 
 %description
 %{summary}.
 
-%package fips
-Summary: The FIPS directory layout
-Requires: (%{_cross_os}image-feature(fips) and %{name})
-Conflicts: %{_cross_os}image-feature(no-fips)
-
-%description fips
-%{summary}.
 
 %prep
 
@@ -82,11 +74,6 @@ ln -s .%{_sbindir} %{buildroot}/sbin
 /opt
 /srv
 
-%exclude %{_cross_prefix}/fips
-%exclude %{_cross_fips_bindir}
-%exclude %{_cross_fips_libexecdir}
-
-%files fips
 %dir %{_cross_prefix}/fips
 %{_cross_fips_bindir}
 %{_cross_fips_libexecdir}

--- a/packages/release/activate-preconfigured.service
+++ b/packages/release/activate-preconfigured.service
@@ -3,6 +3,7 @@ Description=Activate preconfigured.target
 DefaultDependencies=no
 After=fipscheck.target
 Requires=fipscheck.target
+ConditionKernelCommandLine=fips=1
 
 [Service]
 Type=oneshot

--- a/packages/release/fipscheck.target
+++ b/packages/release/fipscheck.target
@@ -3,6 +3,7 @@ Description=FIPS integrity check
 AllowIsolate=false
 RefuseManualStart=true
 RefuseManualStop=true
+ConditionKernelCommandLine=fips=1
 
 [Install]
 WantedBy=preconfigured.target

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -177,17 +177,18 @@ Requires: %{_cross_os}shim
 Requires: %{_cross_os}systemd
 Requires: %{_cross_os}util-linux
 Requires: %{_cross_os}xfsprogs
+Requires: %{_cross_os}libkcapi
 Requires: (%{name}-fips if %{_cross_os}image-feature(fips))
 Requires: (%{name}-crypt if %{_cross_os}image-feature(encrypted-storage))
 
 %description
 %{summary}.
 
+
 %package fips
-Summary: Bottlerocket release, FIPS edition
+Summary: Bottlerocket release, FIPS boot configuration
 Requires: (%{_cross_os}image-feature(fips) and %{name})
 Conflicts: %{_cross_os}image-feature(no-fips)
-Requires: %{_cross_os}libkcapi
 
 %description fips
 %{summary}.
@@ -203,7 +204,6 @@ Requires: %{_cross_os}rottweiler
 %package swap
 Summary: Bottlerocket release, with zram-based swap
 Requires: %{name}
-Requires: (%{name}-fips if %{_cross_os}image-feature(fips))
 
 %description swap
 %{summary}.
@@ -473,9 +473,6 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_datadir}/logdog.d/logdog.common.conf
 %{_cross_unitdir}/configure-snapshotter.service
 %{_cross_templatedir}/selected-snapshotter
-
-%files fips
-%{_cross_bootconfigdir}/10-fips.conf
 %{_cross_tmpfilesdir}/release-fips.conf
 %{_cross_unitdir}/service.d/00-fips-go.conf
 %{_cross_unitdir}/*-bin.mount
@@ -486,6 +483,9 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/check-fips-modules.service
 %dir %{_cross_unitdir}/check-fips-modules.service.d
 %{_cross_unitdir}/fips-modprobe@.service
+
+%files fips
+%{_cross_bootconfigdir}/10-fips.conf
 
 %files crypt
 %{_cross_unitdir}/encrypt-datastore.service

--- a/packages/release/usr-bin.mount.in
+++ b/packages/release/usr-bin.mount.in
@@ -3,6 +3,7 @@ Description=Binaries
 DefaultDependencies=no
 Conflicts=umount.target
 Before=umount.target
+ConditionKernelCommandLine=fips=1
 
 [Mount]
 What=overlay

--- a/packages/release/usr-libexec.mount.in
+++ b/packages/release/usr-libexec.mount.in
@@ -3,6 +3,7 @@ Description=Program Binaries
 DefaultDependencies=no
 Conflicts=umount.target
 Before=umount.target opt-civ.mount opt-cni.mount opt-csi.mount
+ConditionKernelCommandLine=fips=1
 
 [Mount]
 What=overlay


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Move FIPS overlay mounts, tmpfiles, systemd units, and integrity check services from the release-fips subpackage into the base release package. Guard these units with ConditionKernelCommandLine= fips=1 so they only activate when FIPS mode is enabled at boot.

The release-fips subpackage now only provides the boot config that sets the fips=1 kernel command line parameter. Similarly, the filesystem-fips subpackage is removed and its FIPS directories are included in the base filesystem package.

`libkcapi` provides sha512hmac used by check-kernel-integrity.service so on non-FIPS variants, libkcapi is installed but never used but will be helpful when user turn on the fips at runtime

**Testing done:**
testing with #908

<details>
<summary> "runtime" fips when fips parameter is not on</summary>

```
ash-5.2# cat /proc/sys/crypto/fips_enabled
0
bash-5.2# ls /etc/.fips-kernel-check-passed /etc/.fips-module-check-passed
ls: cannot access '/etc/.fips-kernel-check-passed': No such file or directory
ls: cannot access '/etc/.fips-module-check-passed': No such file or directory
bash-5.2# systemctl is-active check-kernel-integrity.service
inactive
bash-5.2# systemctl is-active check-fips-modules.service
inactive
bash-5.2# systemctl status fipscheck.target
○ fipscheck.target - FIPS integrity check
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/fipscheck.target; enabled; preset: enabled)
     Active: inactive (dead)
  Condition: start condition failed at Wed 2026-06-03 21:53:41 UTC; 2min 44s ago
             └─ ConditionKernelCommandLine=fips=1 was not met

Jun 03 21:53:38 localhost systemd[1]: FIPS integrity check was skipped because of an unmet condition check (ConditionKernelCommandLine=fips=1).
Jun 03 21:53:41 ip-192-168-43-161.us-west-2.compute.internal systemd[1]: FIPS integrity check was skipped because of an unmet condition check (ConditionKernelCommandLine=fips=1).
Jun 03 21:53:41 ip-192-168-43-161.us-west-2.compute.internal systemd[1]: FIPS integrity check was skipped because of an unmet condition check (ConditionKernelCommandLine=fips=1).
bash-5.2#

{
  "os": {
    "arch": "x86_64",
    "build_id": "f0dfc999-dirty",
    "pretty_name": "Bottlerocket OS 1.58.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.58.0"
  }
}
bash-5.2#
```

</details>

<details>
<summary> "runtime" fips</summary>

fips varants:
```
[root@admin]# sheltie
bash-5.2# cat /proc/sys/crypto/fips_enabled
1
bash-5.2# │systemctl status fipscheck.target
bash: │systemctl: command not found
bash-5.2# systemctl status fipscheck.target
● fipscheck.target - FIPS integrity check
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/fipscheck.target; enabled; preset: enabled)
     Active: active since Fri 2026-05-01 22:16:27 UTC; 1h 8min ago

Notice: journal has been rotated since unit was started, output may be incomplete.
bash-5.2# systemctl status create-fips-marker.service
● create-fips-marker.service - Create FIPS system marker
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/create-fips-marker.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 00-fips-go.conf, 10-requires-tmp.conf
     Active: active (exited) since Fri 2026-05-01 22:16:28 UTC; 1h 8min ago
   Main PID: 627 (code=exited, status=0/SUCCESS)
        CPU: 2ms

Notice: journal has been rotated since unit was started, output may be incomplete.
bash-5.2# systemctl status generate-fips-env.service
● generate-fips-env.service - Generate FIPS Go environment
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/generate-fips-env.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 00-fips-go.conf, 10-requires-tmp.conf
     Active: active (exited) since Fri 2026-05-01 22:16:28 UTC; 1h 9min ago
   Main PID: 628 (code=exited, status=0/SUCCESS)
        CPU: 3ms

Notice: journal has been rotated since unit was started, output may be incomplete.
bash-5.2# cat /run/fips-go.env
GODEBUG=fip
```

nonfips settings:
```
apiclient set --json '{
  "boot": {
    "kernel": {
      "fips": ["1"]
    },
    "init": {
      "systemd.unit": ["fipscheck.target"]
    }
  }
}'
```

```
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "f0dfc999-dirty",
    "pretty_name": "Bottlerocket OS 1.58.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.58.0"
  }
}
[root@admin]# sheltie
bash-5.2# cat /proc/sys/crypto/fips_enabled
1
bash-5.2# systemctl is-active fipscheck.target
e generate-fips-env.serviceactive
bash-5.2# systemctl is-active create-fips-marker.service
active
bash-5.2# systemctl is-active generate-fips-env.service
active
```
</details>

<details>
<summary>fips overlay is empty for non fips</summary>

```
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "f0dfc999-dirty",
    "pretty_name": "Bottlerocket OS 1.58.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.58.0"
  }
}
[root@admin]#

bash-5.2# cd fips
bash-5.2# ls
bin  libexec
bash-5.2# cd bin
bash-5.2# ls
bash-5.2# ls -a
.  ..
bash-5.2# cd ..
bash-5.2# ls
bin  libexec
bash-5.2# cd libexec
bash-5.2# ls
civ  cni  csi
bash-5.2# cd civ
bash-5.2# ls
bin
bash-5.2# cd bin
bash-5.2# ls
bash-5.2# cd ..
bash-5.2# ls
bin
bash-5.2# cd ..
bash-5.2# ls
civ  cni  csi
bash-5.2# cd cni
bash-5.2# ls
bin
bash-5.2# cd bin
bash-5.2# ls
bash-5.2# cd ..
bash-5.2# ls
bin
bash-5.2# cd ..
bash-5.2# ls
civ  cni  csi
bash-5.2# cd csi
bash-5.2# ls
bin
bash-5.2# cd bin
bash-5.2# ls
bash-5.2#
```

</details>

<details>
<summary>fips overlay is not empty for fips</summary>

```
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "f0dfc999-dirty",
    "pretty_name": "Bottlerocket OS 1.58.0 (aws-k8s-1.33-fips)",
    "variant_id": "aws-k8s-1.33-fips",
    "version_id": "1.58.0"
  }
}
[root@admin]# sheltie
bash-5.2# ls
bin  boot  dev  etc  home  lib  lib64  local  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var  x86_64-bottlerocket-linux-gnu
bash-5.2# cd usr
bash-5.2# ls
bin  fips  include  lib  lib64  libexec  sbin  share  src
bash-5.2# cd fips
bash-5.2# ls
bin  libexec
bash-5.2# cd bin
bash-5.2# ls
apiclient  cfsignal  logdog  metricdog  migrator  pluto  updog
bash-5.2# cd li
bash: cd: li: No such file or directory
bash-5.2# cd libexec
bash: cd: libexec: No such file or directory
bash-5.2# cd ..
bash-5.2# ls
bin  libexec
bash-5.2# cd libexec
bash-5.2# ls
civ  cni  csi
bash-5.2# cd civ/bin
bash-5.2# la
bash: la: command not found
bash-5.2# ls -a
.  ..
bash-5.2# cd ...
bash: cd: ...: No such file or directory
bash-5.2# cd ..
bash-5.2# pwd
/usr/fips/libexec/civ
bash-5.2# cd ..
bash-5.2# ls
civ  cni  csi
bash-5.2# ls -a cni/bin
.  ..
bash-5.2# ls -a csi
.  ..  bin
bash-5.2#
```

</details>



<details>
<summary> go fips test</summary>

```
=== RUN   TestFIPSTLS
=== RUN   TestFIPSTLS/fips-tls-pull
=== RUN   TestFIPSTLS/fips-tls-pull/Pull_from_FIPS-cipher_registry_succeeds
    fips_test.go:90: FIPS TLS pull succeeded as expected
=== RUN   TestFIPSTLS/nonfips-tls-pull
=== RUN   TestFIPSTLS/nonfips-tls-pull/Pull_from_non-FIPS-cipher_registry_fails_on_FIPS_node
    fips_test.go:120: Polling test-pull-nonfips: Phase=Pending
    fips_test.go:123:   Container test: Waiting (Reason=ErrImagePull)
    fips_test.go:139: registry-nonfips nginx logs:
        /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
        /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
        /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
        10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
        10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
        /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
        /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
        /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
        /docker-entrypoint.sh: Configuration complete; ready for start up
        2026/04/29 21:56:44 [info] 30#30: *1 SSL_do_handshake() failed (SSL: error:0A0000C1:SSL routines::no shared cipher) while SSL handshaking, client: 127.0.0.1, server: 0.0.0.0:5001
    fips_test.go:139: Verified: FIPS node rejected non-FIPS cipher suite (no shared cipher)
    fips_test.go:140: Non-FIPS TLS pull correctly rejected (ImagePullBackOff)
--- PASS: TestFIPSTLS (5.10s)
    --- PASS: TestFIPSTLS/fips-tls-pull (5.05s)
        --- PASS: TestFIPSTLS/fips-tls-pull/Pull_from_FIPS-cipher_registry_succeeds (5.02s)
    --- PASS: TestFIPSTLS/nonfips-tls-pull (0.06s)
        --- PASS: TestFIPSTLS/nonfips-tls-pull/Pull_from_non-FIPS-cipher_registry_fails_on_FIPS_node (0.04s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/fips   16.132s
```

</details>



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
