### PR TITLE
Normalize NVIDIA library paths to /usr/lib/

### DIFF
--- a/packages/nvidia-container-toolkit/0002-add-additional-symlinks-flag.patch
+++ b/packages/nvidia-container-toolkit/0002-add-additional-symlinks-flag.patch
@@ -1,0 +1,190 @@
+From 75fb6b8355f68b1559818573736a7aa8c955065c Mon Sep 17 00:00:00 2001
+From: Maher Homsi <maherhom@amazon.com>
+Date: Wed, 17 Jun 2026 00:16:32 +0000
+Subject: [PATCH] Add --additional-symlinks flag for library path compatibility
+
+Add a --additional-symlinks flag to  that takes
+a directory path. When specified, for each discovered nvidia library
+mounted into the container, a symlink is created from
+<additional-symlinks-dir>/<lib> pointing to the actual library path.
+
+This enables backwards compatibility for workloads that expect nvidia
+libraries at /usr/lib/nvidia/tesla/ after libraries move to /usr/lib/.
+
+Usage:
+  nvidia-ctk cdi generate --additional-symlinks /usr/lib/nvidia/tesla
+
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ cmd/nvidia-ctk/cdi/generate/generate.go |  8 ++++
+ internal/discover/lib_path_symlinks.go  | 54 +++++++++++++++++++++++++
+ pkg/nvcdi/driver-nvml.go                | 10 +++++
+ pkg/nvcdi/lib.go                        |  2 +
+ pkg/nvcdi/options.go                    |  9 +++++
+ 5 files changed, 83 insertions(+)
+ create mode 100644 internal/discover/lib_path_symlinks.go
+
+diff --git a/cmd/nvidia-ctk/cdi/generate/generate.go b/cmd/nvidia-ctk/cdi/generate/generate.go
+index 2fff6ea..097eb07 100644
+--- a/cmd/nvidia-ctk/cdi/generate/generate.go
++++ b/cmd/nvidia-ctk/cdi/generate/generate.go
+@@ -68,6 +68,7 @@ type options struct {
+ 	enabledHooks       []string
+ 
+ 	featureFlags []string
++	libDirSymlinksDir string
+ 
+ 	csv struct {
+ 		files               []string
+@@ -243,6 +244,12 @@ func (m command) build() *cli.Command {
+ 				Destination: &opts.featureFlags,
+ 				Sources:     cli.EnvVars("NVIDIA_CTK_CDI_GENERATE_FEATURE_FLAGS"),
+ 			},
++			&cli.StringFlag{
++				Name:        "additional-symlinks",
++				Destination: &opts.libDirSymlinksDir,
++				Usage:       "Create symlinks in the specified directory pointing to each nvidia library. This enables backwards compatibility for workloads expecting libraries at a legacy path.",
++				Sources:     cli.EnvVars("NVIDIA_CTK_CDI_GENERATE_ADDITIONAL_SYMLINKS"),
++			},
+ 			&cli.BoolFlag{
+ 				Name:        "no-all-device",
+ 				Usage:       "Don't generate an `all` device for the resultant spec",
+@@ -397,6 +404,7 @@ func (m command) generateSpecs(opts *options) ([]generatedSpecs, error) {
+ 		nvcdi.WithDisabledHooks(opts.disabledHooks...),
+ 		nvcdi.WithEnabledHooks(opts.enabledHooks...),
+ 		nvcdi.WithFeatureFlags(opts.featureFlags...),
++		nvcdi.WithLibDirSymlinksDir(opts.libDirSymlinksDir),
+ 		// We set the following to allow for dependency injection:
+ 		nvcdi.WithNvmlLib(opts.nvmllib),
+ 	}
+diff --git a/internal/discover/lib_path_symlinks.go b/internal/discover/lib_path_symlinks.go
+new file mode 100644
+index 0000000..7c13dc3
+--- /dev/null
++++ b/internal/discover/lib_path_symlinks.go
+@@ -0,0 +1,54 @@
++package discover
++
++import (
++	"fmt"
++	"path/filepath"
++)
++
++type libDirSymlinks struct {
++	Discover
++	hookCreator HookCreator
++	symlinkDir  string
++}
++
++// WithLibDirSymlinks decorates the provided discoverer to add a hook that
++// creates symlinks in symlinkDir pointing to each discovered library.
++func WithLibDirSymlinks(mounts Discover, hookCreator HookCreator, symlinkDir string) Discover {
++	if symlinkDir == "" {
++		return mounts
++	}
++	return &libDirSymlinks{
++		Discover:    mounts,
++		hookCreator: hookCreator,
++		symlinkDir:  symlinkDir,
++	}
++}
++
++// Hooks returns hooks from the wrapped discoverer plus a create-symlinks hook
++// that creates symlinks in the configured directory.
++func (d *libDirSymlinks) Hooks() ([]Hook, error) {
++	hooks, err := d.Discover.Hooks()
++	if err != nil {
++		return nil, fmt.Errorf("failed to get hooks: %v", err)
++	}
++
++	mounts, err := d.Mounts()
++	if err != nil {
++		return nil, fmt.Errorf("failed to get library mounts: %v", err)
++	}
++
++	var links []string
++	for _, mount := range mounts {
++		basename := filepath.Base(mount.Path)
++		link := fmt.Sprintf("%s::%s", mount.Path, filepath.Join(d.symlinkDir, basename))
++		links = append(links, link)
++	}
++
++	symlinkHook := d.hookCreator.Create(CreateSymlinksHook, links...)
++	if symlinkHook != nil {
++		hookList, _ := symlinkHook.Hooks()
++		hooks = append(hooks, hookList...)
++	}
++
++	return hooks, nil
++}
+diff --git a/pkg/nvcdi/driver-nvml.go b/pkg/nvcdi/driver-nvml.go
+index dd4f2b3..b9ebd55 100644
+--- a/pkg/nvcdi/driver-nvml.go
++++ b/pkg/nvcdi/driver-nvml.go
+@@ -110,6 +110,16 @@ func (l *nvcdilib) NewDriverLibraryDiscoverer(version string, libcudaSoParentDir
+ 	cudaCompatLibHookDiscoverer := discover.NewCUDACompatHookDiscoverer(l.logger, l.hookCreator, &discover.EnableCUDACompatHookOptions{HostDriverVersion: version})
+ 	discoverers = append(discoverers, cudaCompatLibHookDiscoverer)
+ 
++	if l.libDirSymlinksDir != "" {
++		l.logger.Infof("Adding additional symlinks discoverer for directory %q", l.libDirSymlinksDir)
++		libDirSymlinksDiscoverer := discover.WithLibDirSymlinks(
++			libraries,
++			l.hookCreator,
++			l.libDirSymlinksDir,
++		)
++		discoverers = append(discoverers, libDirSymlinksDiscoverer)
++	}
++
+ 	updateLDCache, _ := discover.NewLDCacheUpdateHook(l.logger, libraries, l.hookCreator)
+ 	discoverers = append(discoverers, updateLDCache)
+ 
+diff --git a/pkg/nvcdi/lib.go b/pkg/nvcdi/lib.go
+index fa84e19..4a9f564 100644
+--- a/pkg/nvcdi/lib.go
++++ b/pkg/nvcdi/lib.go
+@@ -45,6 +45,7 @@ type nvcdilib struct {
+ 
+ 	hookCreator  discover.HookCreator
+ 	editsFactory edits.Factory
++	libDirSymlinksDir string
+ }
+ 
+ // New creates a new nvcdi library
+@@ -72,6 +73,7 @@ func New(opts ...Option) (Interface, error) {
+ 			discover.WithDisabledHooks(o.disabledHooks...),
+ 		),
+ 		editsFactory: o.editsFactory,
++		libDirSymlinksDir: o.libDirSymlinksDir,
+ 	}
+ 
+ 	var factory deviceSpecGeneratorFactory
+diff --git a/pkg/nvcdi/options.go b/pkg/nvcdi/options.go
+index a5e2b1c..f099dcf 100644
+--- a/pkg/nvcdi/options.go
++++ b/pkg/nvcdi/options.go
+@@ -55,6 +55,7 @@ type options struct {
+ 	enabledHooks  []discover.HookName
+ 
+ 	editsFactory edits.Factory
++	libDirSymlinksDir string
+ }
+ 
+ type platformlibs struct {
+@@ -344,6 +345,14 @@ func WithFeatureFlags[T string | FeatureFlag](featureFlags ...T) Option {
+ 	}
+ }
+ 
++// WithLibDirSymlinksDir sets the directory where additional library
++// symlinks should be created in the container.
++func WithLibDirSymlinksDir(dir string) Option {
++	return func(o *options) {
++		o.libDirSymlinksDir = dir
++	}
++}
++
+ // WithDisabledHook allows specific hooks to be disabled.
+ // This option can be specified multiple times for each hook.
+ //
+-- 
+2.54.0
+

--- a/packages/nvidia-container-toolkit/generate-cdi-specs.service
+++ b/packages/nvidia-container-toolkit/generate-cdi-specs.service
@@ -27,12 +27,15 @@ RefuseManualStop=true
 Type=oneshot
 # Explanation of the options:
 # --format json: to be consistent across Bottlerocket's variants
+# --additional-symlinks: create backwards-compat symlinks at this path so
+#                        libraries appear in containers
 # --mode nvml: the default mode ("auto") resolves to this already, make it explicit
 # --device-name-strategy uuid: the ECS agent only supports device UUIDs; for k8s
 #                              this is irrelevant because these specs will be used
 #                              only when NVIDIA_VISIBLE_DEVICES is "all"
 # --output /etc/cdi/nvidia.json: store the CDI specifications at this location
 ExecStart=/usr/bin/nvidia-ctk cdi generate --format json \
+  --additional-symlinks /usr/lib/nvidia/tesla \
   --mode nvml \
   --device-name-strategy uuid \
   --output /etc/cdi/nvidia.json

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -24,6 +24,7 @@ Source5: nvidia-container-toolkit-tmpfiles-k8s.conf
 Source6: nvidia-container-toolkit-config-k8s
 Source7: generate-cdi-specs.service
 Patch0001: 0001-discover-reduce-missing-resource-warnings-to-debug-l.patch
+Patch0002: 0002-add-additional-symlinks-flag.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 Requires: %{_cross_os}libnvidia-container

--- a/packages/nvidia-k8s-device-plugin/1002-Enable-library-path-compatibility-symlinks.patch
+++ b/packages/nvidia-k8s-device-plugin/1002-Enable-library-path-compatibility-symlinks.patch
@@ -1,0 +1,95 @@
+From 977d56b4afabd8f7740e9da11effa6a76ec53020 Mon Sep 17 00:00:00 2001
+From: Maher Homsi <maherhom@amazon.com>
+Date: Tue, 16 Jun 2026 21:55:00 +0000
+Subject: [PATCH] Enable library path compatibility symlinks
+
+Add a --cdi-enabled-hooks CLI flag to allow explicitly enabling hooks
+during CDI spec generation. This replaces the previously hardcoded
+enablement of CreateLibSymlinksHook with a flag-driven approach.
+
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ cmd/nvidia-device-plugin/main.go           | 7 +++++++
+ cmd/nvidia-device-plugin/plugin-manager.go | 1 +
+ internal/cdi/cdi.go                        | 4 ++++
+ internal/cdi/options.go                    | 8 ++++++++
+ 4 files changed, 20 insertions(+)
+
+diff --git a/cmd/nvidia-device-plugin/main.go b/cmd/nvidia-device-plugin/main.go
+index 7aee63f..1e336cb 100644
+--- a/cmd/nvidia-device-plugin/main.go
++++ b/cmd/nvidia-device-plugin/main.go
+@@ -45,6 +45,7 @@ type options struct {
+ 	configFile      string
+ 	kubeletSocket   string
+ 	cdiFeatureFlags cli.StringSlice
++	cdiEnabledHooks cli.StringSlice
+ }
+ 
+ func main() {
+@@ -180,6 +181,12 @@ func main() {
+ 			EnvVars:     []string{"CDI_FEATURE_FLAGS"},
+ 			Destination: &o.cdiFeatureFlags,
+ 		},
++		&cli.StringSliceFlag{
++			Name:        "cdi-enabled-hooks",
++			Usage:       "A set of hooks to explicitly enable when generating CDI specifications",
++			EnvVars:     []string{"CDI_ENABLED_HOOKS"},
++			Destination: &o.cdiEnabledHooks,
++		},
+ 	}
+ 	o.flags = c.Flags
+ 
+diff --git a/cmd/nvidia-device-plugin/plugin-manager.go b/cmd/nvidia-device-plugin/plugin-manager.go
+index e2681b5..d4617cb 100644
+--- a/cmd/nvidia-device-plugin/plugin-manager.go
++++ b/cmd/nvidia-device-plugin/plugin-manager.go
+@@ -63,6 +63,7 @@ func GetPlugins(ctx context.Context, infolib info.Interface, nvmllib nvml.Interf
+ 		cdi.WithMofedEnabled(*config.Flags.MOFEDEnabled),
+ 		cdi.WithImexChannels(imexChannels),
+ 		cdi.WithFeatureFlags(o.cdiFeatureFlags.Value()...),
++		cdi.WithEnabledHooks(o.cdiEnabledHooks.Value()...),
+ 		cdi.WithDeviceDiscoveryStrategy(resolvedStrategy),
+ 	)
+ 	if err != nil {
+diff --git a/internal/cdi/cdi.go b/internal/cdi/cdi.go
+index 02cc6c0..9de02b3 100644
+--- a/internal/cdi/cdi.go
++++ b/internal/cdi/cdi.go
+@@ -62,6 +62,9 @@ type cdiHandler struct {
+ 	// nvcdiFeatureFlags allows finer control over CDI spec generation.
+ 	nvcdiFeatureFlags []string
+ 
++	// nvcdiEnabledHooks is a list of hooks to explicitly enable when generating CDI specs.
++	nvcdiEnabledHooks []string
++
+ 	gdsEnabled     bool
+ 	mofedEnabled   bool
+ 	gdrcopyEnabled bool
+@@ -132,6 +135,7 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
+ 		nvcdi.WithNvmlLib(c.nvmllib),
+ 		nvcdi.WithVendor(c.vendor),
+ 		nvcdi.WithDisabledHook(nvcdi.EnableCudaCompatHook),
++		nvcdi.WithEnabledHooks(c.nvcdiEnabledHooks...),
+ 	}
+ 
+ 	// On Tegra (CSV mode), the default CSV files live under the driver root.
+diff --git a/internal/cdi/options.go b/internal/cdi/options.go
+index f9f62ca..b178b30 100644
+--- a/internal/cdi/options.go
++++ b/internal/cdi/options.go
+@@ -124,3 +124,11 @@ func WithDeviceDiscoveryStrategy(strategy string) Option {
+ 		c.deviceDiscoveryStrategy = strategy
+ 	}
+ }
++
++// WithEnabledHooks sets the list of hooks to explicitly enable during CDI
++// spec generation.
++func WithEnabledHooks(hooks ...string) Option {
++	return func(c *cdiHandler) {
++		c.nvcdiEnabledHooks = hooks
++	}
++}
+-- 
+2.54.0
+

--- a/packages/nvidia-k8s-device-plugin/1003-vendor-add-CreateLibSymlinksHook.patch
+++ b/packages/nvidia-k8s-device-plugin/1003-vendor-add-CreateLibSymlinksHook.patch
@@ -1,0 +1,164 @@
+From a368b776c966394725bb59b67d55ebe260364e6a Mon Sep 17 00:00:00 2001
+From: Maher Homsi <maherhom@amazon.com>
+Date: Tue, 16 Jun 2026 22:34:09 +0000
+Subject: [PATCH] vendor: add CreateLibSymlinksHook to vendored
+ nvidia-container-toolkit
+
+Update the vendored nvidia-container-toolkit to include the
+CreateLibSymlinksHook feature. This is needed because patch 1002 enables
+this hook in the device plugin, but the vendored toolkit code does not
+include it.
+
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ .../internal/discover/hooks.go                | 15 ++++-
+ .../internal/discover/lib_path_symlinks.go    | 57 +++++++++++++++++++
+ .../nvidia-container-toolkit/pkg/nvcdi/api.go |  2 +
+ .../pkg/nvcdi/driver-nvml.go                  |  3 +
+ 4 files changed, 74 insertions(+), 3 deletions(-)
+ create mode 100644 vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/lib_path_symlinks.go
+
+diff --git a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/hooks.go b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/hooks.go
+index fb16f85..a831b3d 100644
+--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/hooks.go
++++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/hooks.go
+@@ -36,6 +36,8 @@ const (
+ 	ChmodHook = HookName("chmod")
+ 	// A CreateSymlinksHook is used to create symlinks in the container.
+ 	CreateSymlinksHook = HookName("create-symlinks")
++	// A CreateLibSymlinksHook is used to create library path compatibility symlinks.
++	CreateLibSymlinksHook = HookName("create-lib-symlinks")
+ 	// DisableDeviceNodeModificationHook refers to the hook used to ensure that
+ 	// device nodes are not created by libnvidia-ml.so or nvidia-smi in a
+ 	// container.
+@@ -57,6 +59,8 @@ var defaultDisabledHooks = []HookName{
+ 	// ChmodHook is disabled by default as it was a workaround for older
+ 	// versions of crun that has since been fixed.
+ 	ChmodHook,
++	// CreateLibSymlinksHook is disabled by default; opt-in for backwards compat.
++	CreateLibSymlinksHook,
+ }
+ 
+ var _ Discover = (*Hook)(nil)
+@@ -213,20 +217,25 @@ func (c cdiHookCreator) isDisabled(name HookName, args ...string) bool {
+ 
+ 	// still reject hooks that require args if none were provided
+ 	switch name {
+-	case CreateSymlinksHook, ChmodHook:
++	case CreateSymlinksHook, CreateLibSymlinksHook, ChmodHook:
+ 		return len(args) == 0
+ 	}
+ 	return false
+ }
+ 
+ func (c cdiHookCreator) requiredArgs(name HookName) []string {
+-	return append(c.fixedArgs, string(name))
++	cliName := name
++	switch name {
++	case CreateLibSymlinksHook:
++		cliName = CreateSymlinksHook
++	}
++	return append(c.fixedArgs, string(cliName))
+ }
+ 
+ func (c cdiHookCreator) transformArgs(name HookName, args ...string) []string {
+ 	var transformedArgs []string
+ 	switch name {
+-	case CreateSymlinksHook:
++	case CreateSymlinksHook, CreateLibSymlinksHook:
+ 		for _, arg := range args {
+ 			transformedArgs = append(transformedArgs, "--link", arg)
+ 		}
+diff --git a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/lib_path_symlinks.go b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/lib_path_symlinks.go
+new file mode 100644
+index 0000000..8b8b7a1
+--- /dev/null
++++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/lib_path_symlinks.go
+@@ -0,0 +1,57 @@
++package discover
++
++import (
++	"fmt"
++	"path/filepath"
++)
++
++const defaultLegacyLibPath = "/usr/lib/nvidia/tesla"
++
++type libPathSymlinks struct {
++	Discover
++	hookCreator   HookCreator
++	legacyLibPath string
++}
++
++// WithLibPathSymlinks decorates the provided discoverer to add a hook that
++// creates backwards-compatibility symlinks from legacyLibPath/<lib> to the
++// actual library paths.
++func WithLibPathSymlinks(mounts Discover, hookCreator HookCreator, legacyLibPath string) Discover {
++	if legacyLibPath == "" {
++		legacyLibPath = defaultLegacyLibPath
++	}
++	return &libPathSymlinks{
++		Discover:      mounts,
++		hookCreator:   hookCreator,
++		legacyLibPath: legacyLibPath,
++	}
++}
++
++// Hooks returns hooks from the wrapped discoverer plus a hook to create
++// library path compatibility symlinks.
++func (d *libPathSymlinks) Hooks() ([]Hook, error) {
++	hooks, err := d.Discover.Hooks()
++	if err != nil {
++		return nil, fmt.Errorf("failed to get hooks: %v", err)
++	}
++
++	mounts, err := d.Mounts()
++	if err != nil {
++		return nil, fmt.Errorf("failed to get library mounts: %v", err)
++	}
++
++	var links []string
++	for _, mount := range mounts {
++		basename := filepath.Base(mount.Path)
++		link := fmt.Sprintf("%s::%s", mount.Path, filepath.Join(d.legacyLibPath, basename))
++		links = append(links, link)
++	}
++
++	symlinkHook := d.hookCreator.Create(CreateLibSymlinksHook, links...)
++	if symlinkHook != nil {
++		hookList, _ := symlinkHook.Hooks()
++		hooks = append(hooks, hookList...)
++	}
++
++	return hooks, nil
++}
+diff --git a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/api.go b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/api.go
+index 7bf2fdc..08320c1 100644
+--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/api.go
++++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/api.go
+@@ -63,6 +63,8 @@ const (
+ 	EnableCudaCompatHook = discover.EnableCudaCompatHook
+ 	// An UpdateLDCacheHook is used to update the ldcache in the container.
+ 	UpdateLDCacheHook = discover.UpdateLDCacheHook
++	// A CreateLibSymlinksHook is used to create library path compatibility symlinks.
++	CreateLibSymlinksHook = discover.CreateLibSymlinksHook
+ 
+ 	// Deprecated: Use CreateSymlinksHook instead.
+ 	HookCreateSymlinks = CreateSymlinksHook
+diff --git a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/driver-nvml.go b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/driver-nvml.go
+index dd4f2b3..cd9ed8e 100644
+--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/driver-nvml.go
++++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/driver-nvml.go
+@@ -110,6 +110,9 @@ func (l *nvcdilib) NewDriverLibraryDiscoverer(version string, libcudaSoParentDir
+ 	cudaCompatLibHookDiscoverer := discover.NewCUDACompatHookDiscoverer(l.logger, l.hookCreator, &discover.EnableCUDACompatHookOptions{HostDriverVersion: version})
+ 	discoverers = append(discoverers, cudaCompatLibHookDiscoverer)
+ 
++	libPathSymlinksDiscoverer := discover.WithLibPathSymlinks(libraries, l.hookCreator, "")
++	discoverers = append(discoverers, libPathSymlinksDiscoverer)
++
+ 	updateLDCache, _ := discover.NewLDCacheUpdateHook(l.logger, libraries, l.hookCreator)
+ 	discoverers = append(discoverers, updateLDCache)
+ 
+-- 
+2.54.0
+

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf.in
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf.in
@@ -34,7 +34,7 @@ flags:
     deviceListStrategy: "volume-mounts"
     {{/if}}
     deviceIDStrategy: {{default "index" settings.kubelet-device-plugins.nvidia.device-id-strategy}}
-    containerDriverRoot: "/"
+    containerDriverRoot: "__PREFIX__"
 {{#if settings.kubelet-device-plugins.nvidia.device-sharing-strategy}}
 {{#if (eq settings.kubelet-device-plugins.nvidia.device-sharing-strategy "time-slicing")}}
 sharing:

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-exec-start-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-exec-start-conf
@@ -11,7 +11,7 @@ ExecStart=
 # A brief sleep is needed to avoid the `test` failing its first check
 ExecStartPre=/usr/bin/sleep 0.1
 ExecStartPre=/usr/bin/test -S /var/lib/kubelet/device-plugins/kubelet.sock
-ExecStart=/usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml
+ExecStart=/usr/bin/nvidia-device-plugin --config-file=/etc/nvidia-k8s-device-plugin/settings.yaml --cdi-enabled-hooks create-lib-symlinks
 RemainAfterExit=true
 {{else}}
 Restart=no

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.service
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.service
@@ -8,7 +8,13 @@ Wants=kubelet.service
 # A brief sleep is needed to avoid the `test` failing its first check
 ExecStartPre=/usr/bin/sleep 0.1
 ExecStartPre=/usr/bin/test -S /var/lib/kubelet/device-plugins/kubelet.sock
-ExecStart=/usr/bin/nvidia-device-plugin --device-list-strategy volume-mounts --device-id-strategy index --pass-device-specs=true
+# --cdi-enabled-hooks create-lib-symlinks: enable backwards-compatibility
+# symlinks so libraries appear at both /usr/lib/ and /usr/lib/nvidia/tesla/
+ExecStart=/usr/bin/nvidia-device-plugin \
+    --device-list-strategy volume-mounts \
+    --device-id-strategy index \
+    --pass-device-specs=true \
+    --cdi-enabled-hooks create-lib-symlinks
 Type=simple
 TimeoutSec=0
 RestartSec=2

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -14,7 +14,7 @@ License: Apache-2.0
 URL: https://github.com/NVIDIA/k8s-device-plugin
 Source0: https://%{goimport}/archive/v%{gover}/v%{gover}.tar.gz#/k8s-device-plugin-%{gover}.tar.gz
 Source1: nvidia-k8s-device-plugin.service
-Source2: nvidia-k8s-device-plugin-conf
+Source2: nvidia-k8s-device-plugin-conf.in
 Source3: nvidia-k8s-device-plugin-exec-start-conf
 Source4: nvidia-k8s-device-plugin-mig-conf
 Source5: nvidia-mps-control-daemon.service
@@ -22,6 +22,8 @@ Source6: nvidia-mps-control-daemon-exec-start-conf
 
 Patch0001: 0001-Update-MPS-roots-for-immutable-host-OS.patch
 Patch1001: 1001-Ensure-that-generated-CDI-specs-do-not-contain-enabl.patch
+Patch1002: 1002-Enable-library-path-compatibility-symlinks.patch
+Patch1003: 1003-vendor-add-CreateLibSymlinksHook.patch
 
 BuildRequires: %{_cross_os}glibc-devel
 
@@ -53,7 +55,8 @@ install -p -m 0644 %{S:1} %{buildroot}%{_cross_unitdir}
 install -p -m 0644 %{S:5} %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
 install -d %{buildroot}%{_cross_unitdir}/nvidia-mps-control-daemon.service.d
-install -D -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-conf
+sed -e 's|__PREFIX__|/%{_cross_arch}-bottlerocket-linux-gnu/sys-root|g' %{S:2} > nvidia-k8s-device-plugin-conf
+install -D -m 0644 nvidia-k8s-device-plugin-conf %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-conf
 install -D -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-exec-start-conf
 install -D -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/nvidia-k8s-device-plugin-mig-conf
 install -D -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/nvidia-mps-control-daemon-exec-start-conf


### PR DESCRIPTION
Merge with https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/425

**Description of changes:**

Normalize NVIDIA library paths in containers so libraries appear at `/usr/lib/` instead of the Bottlerocket cross-compilation sysroot path (`/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/`).

- nvidia-container-toolkit: Add `--additional-symlinks` flag patch to `nvidia-ctk cdi generate` that creates backwards-compatibility symlinks in a specified directory pointing to each discovered library. Configure `generate-cdi-specs.service` with `--additional-symlinks /usr/lib/nvidia/tesla`.
- nvidia-k8s-device-plugin: Set `containerDriverRoot` to the Bottlerocket sysroot path so the device plugin discovers libraries correctly and generates CDI specs with normalized `/usr/lib/` container paths. Enable `CreateLibSymlinksHook` via patch 1002 so the device plugin's CDI spec includes backwards-compat symlinks. Add `--cdi-enabled-hooks create-lib-symlinks` to the exec-start template to pass the hook enablement through the systemd drop-in. Fix `containerDriverRoot` macro expansion from `%{_cross_sysroot}` (undefined) to `/%{_target_cpu}-bottlerocket-linux-gnu/sys-root`.

Result: containers see libraries at `/usr/lib/libcuda.so.580.159.03` with backwards-compat symlinks at `/usr/lib/nvidia/tesla/libcuda.so.580.159.03` pointing to `/usr/lib/libcuda.so.580.159.03`.

Note: Backwards-compat symlinks are supported in `cdi-cri` mode (the default device-list-strategy). The legacy `volume-mounts` mode does not use CDI hooks and therefore does not create symlinks in containers.

**In future variants we will be removing this symlink change.  This will only be available in existing variants**

**Testing done:**

- Built core-kit for x86_64, published, and built aws-k8s-1.35-nvidia variant AMI
- Launched g6.xlarge node on EKS cluster in ap-northeast-1
- Verified `containerDriverRoot` resolves to `/x86_64-bottlerocket-linux-gnu/sys-root`
- Verified device plugin starts and registers GPUs with kubelet
- Verified `nvidia-smi` works in container
- Verified libraries at `/usr/lib/` inside container
- Verified backwards-compat symlinks at `/usr/lib/nvidia/tesla/` point to `/usr/lib/`
- Verified `generate-cdi-specs.service` passes on boot
- Verified CDI spec at `/var/run/cdi/` includes symlink hooks
- Verified `ldconfig` resolves `libcuda.so.1` on host
- Verified no `ld.so.conf.d` entry needed (libs in standard path)
- Verified `nvidia-smi` works on host (dlopen via both paths)
- Tested negative case: without `--cdi-enabled-hooks`, symlinks do not appear in containers
- Ran nvidia smoke tests - all passed

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
