### PR TITLE
 update core-kit with k8s-1.36 prod sources

### DIFF
--- a/packages/ecr-credential-provider-1.36/Cargo.toml
+++ b/packages/ecr-credential-provider-1.36/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.36"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/refs/tags/v1.35.1.tar.gz"
-sha512 = "8737fe2f20e4f9ded0bab6d9bf965fa9ea34f08ef0a5cc7628ec7964b75c34a35aab3d7aa3c2bc5900fc890e2178e2c5849dccae8a86429e830377ef867508e3"
-path = "cloud-provider-aws-1.35.1.tar.gz"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/refs/tags/v1.36.0.tar.gz"
+sha512 = "3619ef804c1a677e710fdb3a1558e90d0899614d1fc05e0c6fd8b9e4b7fad01f9f1056eb824c4a59cfe84abc2a029011bf948fb5060792b8ec6043f80425833c"
+path = "cloud-provider-aws-1.36.0.tar.gz"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.36/clarify.toml
+++ b/packages/ecr-credential-provider-1.36/clarify.toml
@@ -3,3 +3,10 @@ expression = "MIT AND BSD-3-Clause AND Apache-2.0"
 license-files = [
     { path = "LICENSE", hash = 0x617d80bc },
 ]
+
+[clarify."github.com/grpc-ecosystem/go-grpc-middleware/v2"]
+expression = "Apache-2.0"
+license-files = [
+    { path = "COPYRIGHT", hash = 0x4bba7b1 },
+    { path = "LICENSE", hash = 0x6a39c900 }
+]

--- a/packages/ecr-credential-provider-1.36/ecr-credential-provider-1.36.spec
+++ b/packages/ecr-credential-provider-1.36/ecr-credential-provider-1.36.spec
@@ -2,8 +2,8 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.35.1
-%global rpmver 1.36.0
+%global gover 1.36.0
+%global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
 
@@ -37,6 +37,7 @@ Requires: %{_cross_os}aws-signing-helper
 %set_cross_go_flags
 
 export GOTOOLCHAIN=local
+export GO_MAJOR="1.26"
 
 go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
 

--- a/packages/kubernetes-1.36/Cargo.toml
+++ b/packages/kubernetes-1.36/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.36"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-36/releases/1/artifacts/kubernetes/v1.36.0-rc.0/kubernetes-src.tar.gz"
-sha512 = "6a2c3f09b6c0df32b0ea02f9e659b73e091e7edc07544f5d7a6d9c50828fb368c7c2ef4540ccddecc4816c7fb536fb5e6ec90524e79137236dfa9864367efea4"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-36/releases/2/artifacts/kubernetes/v1.36.0/kubernetes-src.tar.gz"
+sha512 = "942a7e410dc66cd8f79fe5ec9945c463a404205b7528f68956209306f928332c8194e8e7893e3e2f6067e28fd4b850167fbf014a497b600a5b91949ba911b4fc"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.36/kubernetes-1.36.spec
+++ b/packages/kubernetes-1.36/kubernetes-1.36.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 1
+%global releasever 2
 %global gover 1.36.0
 %global rpmver %{gover}
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: https://github.com/bottlerocket-os/bottlerocket/issues/4816

**Description of changes:**
-  update `ecr-credential-provider` and `kubernetes-1.36` with latest sources from upstream


**Testing done:**
- Core-kit builds with the new packages
- Conformance testing of all variants and arches
- Nvidia functional testing
- MIG and EFA functionality tests
-  EBS CSI driver testing
-  ECR credential provider testing
- VMWare testing 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
