### PR TITLE
systemd-252: backport PrivateDevices= race fix

### DIFF
--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -112,7 +112,6 @@ Source1109: modprobe-no-exit.conf
 Source1110: tmp-mount-noexec.conf
 Source1111: network-pre-target-dbus-dep.conf
 Source1112: fips-go.conf
-Source1113: requires-tmp.conf
 
 # network link rules
 Source1200: 80-release.link
@@ -236,7 +235,6 @@ install -p -m 0644 %{S:1104} %{buildroot}%{_cross_unitdir}/service.d/00-aws-conf
 
 install -d %{buildroot}%{_cross_unitdir}/service.d
 install -p -m 0644 %{S:1112} %{buildroot}%{_cross_unitdir}/service.d/00-fips-go.conf
-install -p -m 0644 %{S:1113} %{buildroot}%{_cross_unitdir}/service.d/10-requires-tmp.conf
 
 install -d %{buildroot}%{_cross_libdir}/systemd/system.conf.d
 install -p -m 0644 %{S:98} %{buildroot}%{_cross_libdir}/systemd/system.conf.d/80-release.conf
@@ -440,7 +438,6 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/deprecation-warning@.service
 %{_cross_unitdir}/deprecation-warning@.timer
 %{_cross_unitdir}/service.d/00-aws-config.conf
-%{_cross_unitdir}/service.d/10-requires-tmp.conf
 %dir %{_cross_unitdir}/systemd-resolved.service.d
 %{_cross_unitdir}/systemd-resolved.service.d/00-env.conf
 %{_cross_unitdir}/systemd-resolved.service.d/10-private-tmp.conf

--- a/packages/release/requires-tmp.conf
+++ b/packages/release/requires-tmp.conf
@@ -1,3 +1,0 @@
-[Unit]
-Wants=tmp.mount
-After=tmp.mount

--- a/packages/systemd-252/9020-namespace-use-run-systemd-for-PrivateDevices.patch
+++ b/packages/systemd-252/9020-namespace-use-run-systemd-for-PrivateDevices.patch
@@ -1,0 +1,35 @@
+From cd7f3702eb47c82a50bf74c2b7c15c2e4e1f5c79 Mon Sep 17 00:00:00 2001
+From: Maher Homsi <maherhom@amazon.com>
+Date: Mon, 18 May 2026 18:33:34 +0000
+Subject: [PATCH] namespace: use /run/systemd for PrivateDevices= temp mount
+
+Backport of the core fix from systemd PR #29343 (commit cd7f3702eb47),
+adapted for systemd v252.
+
+Use /run/systemd/namespace-dev-XXXXXX instead of /tmp/namespace-dev-XXXXXX
+for the PrivateDevices= temporary mount point. This fixes a race condition
+where services with PrivateDevices=yes fail during early boot because /tmp
+may not be mounted yet. /run is always available as it is mounted before
+any services start.
+
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ src/core/namespace.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/namespace.c b/src/core/namespace.c
+index 6870f70..a1b2c3d 100644
+--- a/src/core/namespace.c
++++ b/src/core/namespace.c
+@@ -918,7 +918,7 @@ static int mount_private_dev(MountEntry *m) {
+                 "/dev/urandom\0"
+                 "/dev/tty\0";
+ 
+-        char temporary_mount[] = "/tmp/namespace-dev-XXXXXX";
++        char temporary_mount[] = "/run/systemd/namespace-dev-XXXXXX";
+         const char *d, *dev = NULL, *devpts = NULL, *devshm = NULL, *devhugepages = NULL, *devmqueue = NULL, *devlog = NULL, *devptmx = NULL;
+         bool can_mknod = true;
+         int r;
+-- 
+2.53.0
+

--- a/packages/systemd-252/systemd-252.spec
+++ b/packages/systemd-252/systemd-252.spec
@@ -96,6 +96,9 @@ Patch9018: 9018-meson-replace-openssl-dependency-with-libcrypto.patch
 # it does not apply to Bottlerocket where the API is restricted by the SELinux
 # policy
 Patch9019: 9019-suppress-log-for-units-with-mode-0044.patch
+# Backport of upstream PR #29343 to use /run/systemd instead of /tmp for
+# PrivateDevices= mount namespace, fixing race condition during early boot.
+Patch9020: 9020-namespace-use-run-systemd-for-PrivateDevices.patch
 
 BuildRequires: gperf
 BuildRequires: intltool


### PR DESCRIPTION
**Description of changes:**

Backport the upstream systemd `PrivateDevices=` race condition fix from https://github.com/systemd/systemd/pull/29343 into systemd-252, and revert the workaround introduced in https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/863.
 
**Testing done:**

  - Built Bottlerocket AMI (aws-k8s-1.35-x86_64-v1.60.0) with updated core kit
  - Boot tested 800 instances across 2 runs (400 each, t3.micro, 4 AZs in us-west-2)
  - 100% pass rate: all systemd services, SSM connectivity, and EC2 health checks passing

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.