### PR TITLE
containerd: configure transfer service remote snapshot annotations

### DIFF
--- a/packages/containerd-2.1/snapshotter-toml
+++ b/packages/containerd-2.1/snapshotter-toml
@@ -6,13 +6,18 @@ std = { version = "v1" }
 {{#if (eq settings.container-runtime.snapshotter "soci" )}}
 [plugins."io.containerd.cri.v1.images"]
 snapshotter = "soci"
-disable_snapshot_annotations = false
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+platform = "linux"
+snapshotter = "soci"
+
 # Plug soci snapshotter into containerd
 [proxy_plugins.soci]
 type = "snapshot"
 address = "/run/soci-snapshotter/soci-snapshotter.sock"
 [proxy_plugins.soci.exports]
 root = "/var/lib/soci-snapshotter"
+enable_remote_snapshot_annotations = "true"
 {{else}}
 [plugins."io.containerd.cri.v1.images"]
 snapshotter = "overlayfs"

--- a/packages/containerd-2.2/snapshotter-toml
+++ b/packages/containerd-2.2/snapshotter-toml
@@ -6,13 +6,18 @@ std = { version = "v1" }
 {{#if (eq settings.container-runtime.snapshotter "soci" )}}
 [plugins."io.containerd.cri.v1.images"]
 snapshotter = "soci"
-disable_snapshot_annotations = false
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+platform = "linux"
+snapshotter = "soci"
+
 # Plug soci snapshotter into containerd
 [proxy_plugins.soci]
 type = "snapshot"
 address = "/run/soci-snapshotter/soci-snapshotter.sock"
 [proxy_plugins.soci.exports]
 root = "/var/lib/soci-snapshotter"
+enable_remote_snapshot_annotations = "true"
 {{else}}
 [plugins."io.containerd.cri.v1.images"]
 snapshotter = "overlayfs"

--- a/packages/kubernetes-1.33/prestart-load-pause-ctr.conf
+++ b/packages/kubernetes-1.33/prestart-load-pause-ctr.conf
@@ -1,8 +1,13 @@
 [Service]
+Environment=ACTIVE_SNAPSHOTTER=overlayfs
+EnvironmentFile=-/var/cache/containerd/active-snapshotter
+
 # load the built-in pause image
 ExecStartPre=/usr/bin/ctr \
     --namespace=k8s.io \
     image import \
+    --snapshotter=${ACTIVE_SNAPSHOTTER} \
+    --local \
     --all-platforms \
     /usr/libexec/kubernetes/kubernetes-pause.tar
 

--- a/packages/kubernetes-1.34/prestart-load-pause-ctr.conf
+++ b/packages/kubernetes-1.34/prestart-load-pause-ctr.conf
@@ -1,8 +1,13 @@
 [Service]
+Environment=ACTIVE_SNAPSHOTTER=overlayfs
+EnvironmentFile=-/var/cache/containerd/active-snapshotter
+
 # load the built-in pause image
 ExecStartPre=/usr/bin/ctr \
     --namespace=k8s.io \
     image import \
+    --snapshotter=${ACTIVE_SNAPSHOTTER} \
+    --local \
     --all-platforms \
     /usr/libexec/kubernetes/kubernetes-pause.tar
 

--- a/packages/kubernetes-1.35/prestart-load-pause-ctr.conf
+++ b/packages/kubernetes-1.35/prestart-load-pause-ctr.conf
@@ -1,8 +1,13 @@
 [Service]
+Environment=ACTIVE_SNAPSHOTTER=overlayfs
+EnvironmentFile=-/var/cache/containerd/active-snapshotter
+
 # load the built-in pause image
 ExecStartPre=/usr/bin/ctr \
     --namespace=k8s.io \
     image import \
+    --snapshotter=${ACTIVE_SNAPSHOTTER} \
+    --local \
     --all-platforms \
     /usr/libexec/kubernetes/kubernetes-pause.tar
 

--- a/packages/kubernetes-1.36/prestart-load-pause-ctr.conf
+++ b/packages/kubernetes-1.36/prestart-load-pause-ctr.conf
@@ -1,8 +1,13 @@
 [Service]
+Environment=ACTIVE_SNAPSHOTTER=overlayfs
+EnvironmentFile=-/var/cache/containerd/active-snapshotter
+
 # load the built-in pause image
 ExecStartPre=/usr/bin/ctr \
     --namespace=k8s.io \
     image import \
+    --snapshotter=${ACTIVE_SNAPSHOTTER} \
+    --local \
     --all-platforms \
     /usr/libexec/kubernetes/kubernetes-pause.tar
 


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

For containerd configurations making use of the transfer service, in
combination with remote snapshotters, the configuration of
enable_remote_snapshot_annotations = true must be set for pulls to route
through the containerd transfer service to the remote snapshotter.



containerd docs highlight this:
https://github.com/containerd/containerd/blob/2976f38ccbfcda5ef1364d63d60b0a304e4bf94a/docs/cri/config.md?plain=1#L191-L214

| CRI Image Config Option | Local Pull | Transfer Service Pull |
|------------------------|------------|---------------------|
| DisableSnapshotAnnotations | ✅ Supported | ⚠️ Must be configured in snapshotter plugin:<br>`[proxy_plugins.stargz.exports]`<br>`enable_remote_snapshot_annotations = "true"` |

**Testing done:**

Tested on k8s-1.34 node with both soci (remote snapshotter) and image verifiers (routed through transfer service) enabled. (https://github.com/bottlerocket-os/bottlerocket/pull/4832)

Before:

```
bash-5.2# journalctl -u containerd | grep warn
May 12 02:56:27 ip-192-168-9-180.us-west-2.compute.internal containerd[1718]: time="2026-05-12T02:56:27.075019003Z" level=info msg="loading plugin" id=io.containerd.warning.v1.deprecations type=io.containerd.warning.v1
May 12 02:56:27 ip-192-168-9-180.us-west-2.compute.internal containerd[1718]: time="2026-05-12T02:56:27.094178863Z" level=warning msg="Found 'DisableSnapshotAnnotations' in CRI config which is incompatible with transfer service (moved to snapshotter plugin when using transfer service). Falling back to local image pull mode."
```

And all images could be pulled without verification enforcement.

After:

```
bash-5.2# journalctl -u containerd | grep warn
May 12 20:37:42 ip-192-168-7-138.us-west-2.compute.internal containerd[1720]: time="2026-05-12T20:37:42.086816836Z" level=info msg="loading plugin" id=io.containerd.warning.v1.deprecations type=io.containerd.warning.v1
May 12 20:37:54 ip-192-168-7-138.us-west-2.compute.internal containerd[1720]: time="2026-05-12T20:37:54.438507669Z" level=warning msg="Image verifier blockedpull" digest="sha256:dbba6c54e51aaf079aa7c471f71bb63adf9eb828bdc64fde2bc8a3a256026c76" name="602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.34.6-eksbuild.2" ok=false reason="verifier digestion-image-verifier rejected image (exit code 1): image verification failed: digest not in allowlist" verifier=bindir
```

Testing backwards compat for a base k8s node to ensure pause image import does not regress:

```
# Node is ready
ip-192-168-31-133.us-west-2.compute.internal   Ready    <none>   20s   v1.34.4-eks-f69f56f

bash-5.2# systemctl status kubelet
● kubelet.service - Kubelet
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 10-requires-tmp.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service.d
             └─dockershim-symlink.conf
             /etc/systemd/system/kubelet.service.d
             └─exec-start.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kubelet.service.d
             └─make-kubelet-dirs.conf, prestart-load-pause-ctr.conf
     Active: active (running) since Tue 2026-05-12 20:56:10 UTC; 48s ago

bash-5.2# systemctl status containerd
● containerd.service - containerd container runtime
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/containerd.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/containerd.service.d
             └─005-disable-pigz.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─10-requires-tmp.conf
     Active: active (running) since Tue 2026-05-12 20:56:08 UTC; 1min 4s ago
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
