### PR TITLE
kmod: enable PIE for static builds

### DIFF
--- a/packages/kmod/0001-meson-add-support-for-static-builds.patch
+++ b/packages/kmod/0001-meson-add-support-for-static-builds.patch
@@ -18,7 +18,7 @@ index a0cf675..4b16d6a 100644
  
 +kmod_link_args = []
 +if get_option('default_library') == 'static'
-+  kmod_link_args += ['-static']
++  kmod_link_args += ['-static-pie']
 +endif
 +
  kmod = executable(


### PR DESCRIPTION
Closes #394 

**Description of changes:**
- Update linker flag in kmod to build PIE in case of static builds.


**Testing done:**
- AMI builds, instance boots, joins cluster
- Checksec result
Mounted bottlerocket root partition locally
```
$ checksec --dir=/mnt/bottlerocket-staticpie/usr/bin | grep kmod
Full RELRO      No canary found   NX enabled    PIE enabled     No RPATH   No RUNPATH   3599 Symbols      N/A   0               0     /mnt/bottlerocket-staticpie/usr/bin/kmod
```
From admin container (had to `yum install -y checksec`)
```
[root@admin]# checksec --dir=.bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin | grep kmod
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   3599) Symbols     No    0               0               .bottlerocket/rootfs/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/kmod
```
- nvidia-smoke-test succeeds
```
$ kubectl get nodes -A --kubeconfig bottlerocket-cluster-134.kubeconfig 
NAME                                           STATUS   ROLES    AGE     VERSION
ip-192-168-16-212.us-west-2.compute.internal   Ready    <none>   5m55s   v1.34.4-eks-f69f56f

$ kubectl get pods -A --kubeconfig bottlerocket-cluster-134.kubeconfig 
NAMESPACE     NAME                              READY   STATUS      RESTARTS   AGE
default       nvidia-smoke-test                 0/1     Completed   0          51s
kube-system   aws-node-6c7cg                    2/2     Running     0          6m2s
kube-system   coredns-7ccc7b7d9b-f277n          1/1     Running     0          7m14s
kube-system   coredns-7ccc7b7d9b-nvdw4          1/1     Running     0          7m14s
kube-system   kube-proxy-799tp                  1/1     Running     0          6m2s
kube-system   metrics-server-585b84fb9d-6n888   1/1     Running     0          7m17s
kube-system   metrics-server-585b84fb9d-vcdx7   1/1     Running     0          7m17s
```
- `nvidia-smi` shows the device is loaded (driver works)
```
bash-5.2# nvidia-smi
Wed May 13 02:19:55 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.159.03             Driver Version: 580.159.03     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  Tesla T4                       On  |   00000000:00:1E.0 Off |                    0 |
| N/A   33C    P8              9W /   70W |       0MiB /  15360MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
