### PR TITLE
Package updates: e2fsprogs, iptables, mdadm, xfsprogs, pciutils, util-linux

### DIFF
--- a/advisories/staging/BRSA-jgcxwcxt3sxd.toml
+++ b/advisories/staging/BRSA-jgcxwcxt3sxd.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-jgcxwcxt3sxd"
+title = "util-linux CVE-2026-27456"
+cve = "CVE-2026-27456"
+severity = "moderate"
+description = "A TOCTOU (time-of-check-time-of-use) race condition exists in libmount's loop device hook. The loopcxt_set_backing_file() function uses strdup() instead of ul_canonicalize_path(), and loopcxt_setup_device() does not set O_NOFOLLOW on open() flags for non-root mount operations. This flaw could allow a backing file specified in /etc/fstab to be replaced with a symlink to an arbitrary root-owned file between path resolution and open(), potentially leading to unauthorized file access."
+
+[[advisory.products]]
+package-name = "util-linux"
+patched-version = "2.41.4"
+patched-epoch = "1"
+
+[updateinfo]
+author = "maherhom"
+issue-date = 2026-05-26T23:16:23Z
+arches = ["x86_64", "aarch64"]
+version = "staging"

--- a/packages/e2fsprogs/Cargo.toml
+++ b/packages/e2fsprogs/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.3/e2fsprogs-1.47.3.tar.xz"
-sha512 = "1139b793cfa2f1af4e8ef06439522ff5aa3bab701201f2a4ef74910eb0c4d8c86dbd40d5a8bdc798dc52f121a0ca9e454eda0c6058e2dc5d4a25e82f669e96ae"
+url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.4/e2fsprogs-1.47.4.tar.xz"
+sha512 = "c316ce38d73786fb45b3728cd31991fe81b14a1e61dae645f3471c3f35983c4394e4606b47194c3e607897b7ae5a5ef1d376adb204383afa8c4219db8617d970"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.3/e2fsprogs-1.47.3.tar.sign"
-sha512 = "b31544569bd5ab0ed6485fc5e737309e41d3dbc67f6fc3ecbf9a6fc3875f14a30d9e588cfee471fe102c706502f77c9b770802d2d920ffa73fd0eec5c0c8fa21"
+url = "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.4/e2fsprogs-1.47.4.tar.sign"
+sha512 = "02844b80e97c401203f2ff1693e19dd946a425c18509223f118ab9f19c8c1ca9482d5ae2a6b2b9eac5072a78c44120d7a273b0fa9d2a08954c70c6efe753f669"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/e2fsprogs/e2fsprogs.spec
+++ b/packages/e2fsprogs/e2fsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}e2fsprogs
-Version: 1.47.3
+Version: 1.47.4
 Release: 1%{?dist}
 Epoch: 1
 Summary: Tools for managing ext2, ext3, and ext4 file systems

--- a/packages/iptables/Cargo.toml
+++ b/packages/iptables/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://www.netfilter.org/projects/iptables/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.netfilter.org/projects/iptables/files/iptables-1.8.12.tar.xz"
-sha512 = "b25bd6f6f78a6192699bce44c2b29ca65351ef71198a84fa26d29c47cb24ed695ee0406f6581fa81ece4d30445bb0680def5dc328f7fc708b80cadcd0230fe49"
+url = "https://www.netfilter.org/projects/iptables/files/iptables-1.8.13.tar.xz"
+sha512 = "3aefd76ca60d00f46ba4d6f39cbcfdc60517d03b6714da25dcd67542f6f4eea8d82c4855bdd9124efe18b769f41951772b8340a6eda75b85f8dd52b2289b145b"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.netfilter.org/projects/iptables/files/iptables-1.8.12.tar.xz.sig"
-sha512 = "c1a22b6c6104a0395823a8695eafca6459d82af3467e70e88dc5625aeb6d3feba485a3f2baaf0e8e6ff1b979dc1c764427a6d6614a070476078d1e2f8cd3fd34"
+url = "https://www.netfilter.org/projects/iptables/files/iptables-1.8.13.tar.xz.sig"
+sha512 = "9b8ef597e1f73c2697f29b07ac010313696f52f478f10c65ec4c4e2dc933be50c74c5c236512e4d756220c4d2fd511fded88dc46f2376fc5d7e2bea71fd267ca"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/iptables/iptables.spec
+++ b/packages/iptables/iptables.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}iptables
-Version: 1.8.12
+Version: 1.8.13
 Release: 1%{?dist}
 Epoch: 1
 Summary: Tools for managing Linux kernel packet filtering capabilities

--- a/packages/mdadm/Cargo.toml
+++ b/packages/mdadm/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/md-raid-utilities/mdadm/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/md-raid-utilities/mdadm/archive/mdadm-4.5/mdadm-4.5.tar.gz"
-path = "mdadm-4.5.tar.gz"
-sha512 = "00441dd5a0a25855e52b693610fd68eac2a8f38bfdbeadad175cdd2eff5d0cde622ebd6602251584b835b175153d8e063f42ac177537923007ed1a830ed74501"
+url = "https://github.com/md-raid-utilities/mdadm/archive/mdadm-4.6/mdadm-4.6.tar.gz"
+path = "mdadm-4.6.tar.gz"
+sha512 = "bbcd13fa56951d6b70630616612f0dc6258f6a697a782d46a7577a039ada29f9d470cd5f73a3f8a672d5c5318dc7a93a55cd6bedcc99db399165cf84b1443c4b"
 
 
 [build-dependencies]

--- a/packages/mdadm/mdadm.spec
+++ b/packages/mdadm/mdadm.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}mdadm
-Version: 4.5
+Version: 4.6
 Release: 1%{?dist}
 Summary: mdadm is used for controlling Linux md devices (aka RAID arrays)
 License: GPL-2.0-only

--- a/packages/pciutils/Cargo.toml
+++ b/packages/pciutils/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://www.kernel.org/pub/software/utils/pciutils/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.14.0.tar.gz"
-sha512 = "3b635274263fea621755b30a7c57348830957d8b4dfb9af69e14e269b07cc4a55a575acb092a5b6a66addb939c31082dfcb79a03531f34a31ea3c3ff7c7ce132"
+url = "https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.15.0.tar.gz"
+sha512 = "c03c5617ed0c0f7c2e3b36889d93221521e449b93969256eb7512603b5dccf5ce0e5eb3c58662a091621e59257593a162f8ba36537d93e52386e227641a1a593"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/pciutils/pciutils.spec
+++ b/packages/pciutils/pciutils.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}pciutils
-Version: 3.14.0
+Version: 3.15.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: PCI bus related utilities

--- a/packages/util-linux/Cargo.toml
+++ b/packages/util-linux/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://www.kernel.org/pub/linux/utils/util-linux"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.3.tar.xz"
-sha512 = "3d299f0e05a4c982a04dbcbaaeff1222152feedf51c56c5dbdeb75999c68269d652a994f5cdf4c1ee42bb7b28475dd0792192c299fd9bc3b45198c5b153dad00"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.4.tar.xz"
+sha512 = "c21ad77b787ab5892169c80cbec1ba46ed6bba36c1db278f2d1cd8712ae237f5cd25bfd20f2dc638334d1c47c5ff6102703147147d42f71c995bd397e735691a"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.3.tar.sign"
-sha512 = "5aa90af75595867c534dc2853c16e742e0139f4c9bfb5a9dfc3e54bb27d8516d26bd074e7c24477910bb8ee63be8c1eb289bbdf56356cb60db991998d6793ef4"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.4.tar.sign"
+sha512 = "1d4673277e59a2409e414ee8cdc0f3d52cb40f626538f251c74820085128cc572a98bc27a784b10e3b87ed1babe344bbed32fb6a42f4aae67c5f533b24440eb8"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -1,5 +1,5 @@
 %global majorminor 2.41
-%global version %{majorminor}.3
+%global version %{majorminor}.4
 
 Name: %{_cross_os}util-linux
 Version: %{version}

--- a/packages/xfsprogs/Cargo.toml
+++ b/packages/xfsprogs/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://mirrors.edge.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/"
 
 [[package.metadata.build-package.external-files]]
-url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.18.0.tar.xz"
-sha512 = "95fcbfdd91d9b02ec9adef50e23a39240056bf3bfed3d973e048a50dd0d0b040f80e8cf72537cca7e560718e4444ed1bbcf8b99ee4c82e044ca52d916536f7f5"
+url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.19.0.tar.xz"
+sha512 = "9ca8ba19a3cc3a4e8a03ca4fe641ae958eb5fd9c4a8b09430a9fa4891d27f63506acd543c061887fec5ba22d2883c69f8c52a155f4f58af96206999725e25bf7"
 
 [[package.metadata.build-package.external-files]]
-url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.18.0.tar.sign"
-sha512 = "22453b6dcff989254cc1949419edea7792cd0eaf108d10df970bd9345879a68be7bbe097c8056a0d37f1e5b338c1e79c8fb2da13436fb443fda7851a7a45908e"
+url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.19.0.tar.sign"
+sha512 = "c400342d2596d2e590001d48f10973e8ffdc0b73f3f7570bf026edc224aefadb18d934be845ea317528f326c09992b04a4449b0fb93befd39994bef54703af78"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/xfsprogs/xfsprogs.spec
+++ b/packages/xfsprogs/xfsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}xfsprogs
-Version: 6.18.0
+Version: 6.19.0
 Release: 1%{?dist}
 Summary: Utilities for managing the XFS filesystem
 License: GPL-2.0-only AND LGPL-2.1-only


### PR DESCRIPTION
**Description of changes:**
Update stale packages to their latest upstream versions:
- `e2fsprogs`: 1.47.3 → 1.47.4
- `iptables`: 1.8.12 → 1.8.13
- `mdadm`: 4.5 → 4.6
- `xfsprogs`: 6.18.0 → 6.19.0
- `pciutils`: 3.14.0 → 3.15.0
- `util-linux`: 2.41.3 → 2.41.4

**Testing done:**
- Built kit locally
- Built aws-k8s-1.35 variant and launched on EKS cluster
- Verified updated package versions on running instance: `e2fsprogs 1.47.4`, `iptables 1.8.13`, `mdadm 4.6`, `xfsprogs 6.19.0`, `pciutils 3.15.0`, `util-linux 2.41.4`
- Functional tests: `iptables -L -n`, `ip6tables -L -n`, `mkfs.ext4`, `mkfs.xfs -V`, `mdadm --detail --scan`, `findmnt`, `lspci`  are all passing.
- Node boots, joins cluster, runs workloads; 0 failed systemd units, 0 error journal entries

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
