### PR TITLE
nvidia-container-toolkit: update to v1.19.1

### DIFF
--- a/packages/libnvidia-container/Cargo.toml
+++ b/packages/libnvidia-container/Cargo.toml
@@ -13,8 +13,8 @@ releases-url = "https://github.com/NVIDIA/libnvidia-container/releases"
 
 # Should match the version of the nvidia-container-toolkit package
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.18.2/libnvidia-container-1.18.2.tar.gz"
-sha512 = "c0b388f558a631e2aae363b069ebad4559607f30d79be8379cf8121d227a54217c094ba260ae121bedf3378adc950aef6893a58ca8ffd4f770dc81496eb57088"
+url = "https://github.com/NVIDIA/libnvidia-container/archive/v1.19.1/libnvidia-container-1.19.1.tar.gz"
+sha512 = "06ef0fe55746fa7ff9c9a20212cd03eae20a2e60230fdbf8453690c5087bab27458153c0c6a6182d5a05aeafd7c6a7cfc561f72c0c1a5b96f132dac21ada8bda"
 
 # Check https://github.com/NVIDIA/libnvidia-container/blob/<LIBNVIDIA_VERSION>/mk/nvidia-modprobe.mk to determine which modprobe version it builds
 [[package.metadata.build-package.external-files]]

--- a/packages/libnvidia-container/libnvidia-container.spec
+++ b/packages/libnvidia-container/libnvidia-container.spec
@@ -1,7 +1,7 @@
 %global nvidia_modprobe_version 550.54.14
 
 Name: %{_cross_os}libnvidia-container
-Version: 1.18.2
+Version: 1.19.1
 Release: 1%{?dist}
 Epoch: 1
 Summary: NVIDIA container runtime library

--- a/packages/nvidia-container-toolkit/Cargo.toml
+++ b/packages/nvidia-container-toolkit/Cargo.toml
@@ -13,8 +13,8 @@ releases-url = "https://github.com/NVIDIA/nvidia-container-toolkit/releases"
 
 # Should match the version of the libnvidia-container package
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.18.2/nvidia-container-toolkit-1.18.2.tar.gz"
-sha512 = "ea4e0c67df944b4399175a190098c0d3a778af90d2d34f262a092572dfc6be3b522f99c3f2b2c9f426d3f145f845170c80e51d53fb16144f766570e7420e4902"
+url = "https://github.com/NVIDIA/nvidia-container-toolkit/archive/v1.19.1/nvidia-container-toolkit-1.19.1.tar.gz"
+sha512 = "4524ab3813d7819b2249aec9b7af6f4053f2f7119ebf23dfa58c9566eafd29d1890183a3126030062cbd35944c388b4469a3493fb774ee96b43af15d0608b40e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/packages/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -2,7 +2,7 @@
 %global gorepo nvidia-container-toolkit
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.18.2
+%global gover 1.19.1
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-container-toolkit
@@ -55,7 +55,7 @@ Conflicts: %{name}-ecs
 
 %build
 %cross_go_configure %{goimport}
-export GO_MAJOR="1.25"
+export GO_MAJOR="1.26"
 
 # We don't set `-Wl,-z,now`, because the binary uses lazy loading
 # to load the NVIDIA libraries in the host

--- a/packages/nvidia-k8s-device-plugin/1001-Ensure-that-generated-CDI-specs-do-not-contain-enabl.patch
+++ b/packages/nvidia-k8s-device-plugin/1001-Ensure-that-generated-CDI-specs-do-not-contain-enabl.patch
@@ -7,6 +7,9 @@ Subject: [PATCH] Ensure that generated CDI specs do not contain
 Signed-off-by: Evan Lezar <elezar@nvidia.com>
 (cherry picked from commit 49dc098d513923505a66bc8380ed80c0ce9a0165)
 Signed-off-by: Piyush Jena <jepiyush@amazon.com>
+
+[rework to apply to latest upstream
+Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>]
 ---
  internal/cdi/cdi.go | 1 +
  1 file changed, 1 insertion(+)
@@ -15,14 +18,13 @@ diff --git a/internal/cdi/cdi.go b/internal/cdi/cdi.go
 index 7cad67cf4..bee83c6e4 100644
 --- a/internal/cdi/cdi.go
 +++ b/internal/cdi/cdi.go
-@@ -126,6 +126,7 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
+@@ -119,6 +119,7 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
  		nvcdi.WithNVIDIACDIHookPath(c.nvidiaCTKPath),
  		nvcdi.WithNvmlLib(c.nvmllib),
  		nvcdi.WithVendor(c.vendor),
-+		nvcdi.WithDisabledHook(nvcdi.HookEnableCudaCompat),
++		nvcdi.WithDisabledHook(nvcdi.EnableCudaCompatHook),
  	}
-
- 	c.cdilibs = make(map[string]nvcdi.SpecGenerator)
---
+ 
+ 	// On Tegra (CSV mode), the default CSV files live under the driver root.
+-- 
 2.52.0
-

--- a/packages/nvidia-k8s-device-plugin/Cargo.toml
+++ b/packages/nvidia-k8s-device-plugin/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/k8s-device-plugin/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.18.2/v0.18.2.tar.gz"
-path = "k8s-device-plugin-0.18.2.tar.gz"
-sha512 = "75ffb9223754ef4aba21bcbabc6c4fb09d8f132744ccdb73a38fd50e017614ab543b72887db26db2ca6fc8b923d600ccea4ccf44818d024e2a40cff3fa085d0f"
+url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.19.2/v0.19.2.tar.gz"
+path = "k8s-device-plugin-0.19.2.tar.gz"
+sha512 = "0fb1221b063ff1eca7c35a4dd58558e1b6569f51ea085f804515005e8a3f3c2e8f73241af441e19253f35d656528e8672870445cf2371eab84dde2343ae3211c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin-conf
@@ -14,6 +14,7 @@ flags:
   {{else}}
   migStrategy: "none"
   {{/if}}
+  mofedEnabled: false
   failOnInitError: true
   nvidiaDriverRoot: "/"
 {{#if settings.kubelet-device-plugins.nvidia.device-sharing-strategy}}

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -2,7 +2,7 @@
 %global gorepo k8s-device-plugin
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.18.2
+%global gover 0.19.2
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-k8s-device-plugin
@@ -34,7 +34,7 @@ BuildRequires: %{_cross_os}glibc-devel
 
 %build
 %cross_go_configure %{goimport}
-export GO_MAJOR="1.25"
+export GO_MAJOR="1.26"
 # We don't set `-Wl,-z,now`, because the binary uses lazy loading
 # to load the NVIDIA libraries in the host
 export CGO_LDFLAGS="-Wl,-z,relro -Wl,--export-dynamic"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**
- Update `nvidia-container-toolkit`, `libnvidia-container`, and `k8s-device-plugin` to v1.19.0. This change brings in a new hook `DisableDeviceNodeModificationHook` when using CDI mode.

    From the [PR in nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit/pull/927):
   ```
    This change adds a hook to disable device node creation for FULL GPUs (i.e. non-MIG devices) or 
    modification in a container by updating the ModifyDeviceFiles driver parameter.

    (This does not include nvidia-caps devices that are required by MIG devices).

    The presence of "extra" device nodes in a container are largely cosmetic since the container should 
    not have the required cgroup access for the additional devices. This does not affect the device 
    nodes on the host.
   ````

This new hook looks safe to update based on the above and testing done.


**Testing done:**
- Tested Nvidia workloads in `cdi-cri` mode and `volume-mounts` mode, with and without MIG enabled.
- Validated testing the new `mofedEnabled: false` by launching pods on EFA enabled instances


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
