### PR TITLE
amazon-ecs-cni-plugins: Update to version 2026.05.0

### DIFF
--- a/packages/amazon-ecs-cni-plugins/Cargo.toml
+++ b/packages/amazon-ecs-cni-plugins/Cargo.toml
@@ -16,8 +16,8 @@ releases-url = "https://github.com/aws/amazon-ecs-agent/commits/master/amazon-ec
 # This is locked against the version shipped in ecs-agent
 # Verify that the ecs-agent version shipped in bottlerocket tracks the same one here
 # https://github.com/aws/amazon-ecs-agent/releases
-url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/f26629faf64028796b76154d55c1bc7e3bff13c8/amazon-ecs-cni-plugins.tar.gz"
-sha512 = "9d5eb384e4bed620b2ed40d6afdd4c08167ac489cd6cc1c8edb1bde4b46aa492b35bf98d8b707375ee68deabbc6d0fdf1f1c600bd487933ac75cc0778bafff5f"
+url = "https://github.com/aws/amazon-ecs-cni-plugins/archive/8b409a0b23cd9df271cafb1ec09eacf9180bb41a/amazon-ecs-cni-plugins.tar.gz"
+sha512 = "da648a7e564b1b2c82be3f34bb3b4dc2905a7fd450f14ed0f5d41232a5fd32906711f560b7b971f042cbf9c66daca4008ef24ca111ecb6066829c43c85f0b896"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
+++ b/packages/amazon-ecs-cni-plugins/amazon-ecs-cni-plugins.spec
@@ -1,11 +1,11 @@
 %global ecscni_goproject github.com/aws
 %global ecscni_gorepo amazon-ecs-cni-plugins
 %global ecscni_goimport %{ecscni_goproject}/%{ecscni_gorepo}
-%global ecscni_gitrev f26629faf64028796b76154d55c1bc7e3bff13c8
+%global ecscni_gitrev 8b409a0b23cd9df271cafb1ec09eacf9180bb41a
 
 Name: %{_cross_os}amazon-ecs-cni-plugins
-# https://github.com/aws/amazon-ecs-cni-plugins/blob/f26629faf64028796b76154d55c1bc7e3bff13c8/VERSION#L1
-Version: 2026.03.0
+# https://github.com/aws/amazon-ecs-cni-plugins/blob/8b409a0b23cd9df271cafb1ec09eacf9180bb41a/VERSION#L1
+Version: 2026.05.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: Networking plugins for ECS task networking


### PR DESCRIPTION
<!--Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Update amazon-ecs-cni-plugins from commit f26629f to 8b409a0, bumping the version from 2026.03.0 to 2026.05.0.

The new version of the CNI plugin fixes a bug in production.

Corresponds to this upstream PR: https://github.com/aws/amazon-ecs-cni-plugins/pull/124

**Testing done:**

- Unit tests were added as part of the upstream bug fix
- The fix was validated with end to end tests on ECS managed instance hosts

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
