### PR TITLE
bloodhound: move FIPS checks to all variants with runtime detection

### DIFF
--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -399,7 +399,6 @@ Conflicts: %{_cross_os}image-feature(no-host-containers)
 Summary: Compliance check framework
 Requires: (%{_cross_os}bloodhound-k8s if %{_cross_os}variant-runtime(k8s))
 Requires: (%{_cross_os}bloodhound-k8s-overrides if %{_cross_os}variant-runtime(k8s))
-Requires: (%{_cross_os}bloodhound-fips if %{_cross_os}image-feature(fips))
 %description -n %{_cross_os}bloodhound
 %{summary}.
 
@@ -413,12 +412,6 @@ Requires: (%{_cross_os}bloodhound and %{_cross_os}variant-runtime(k8s))
 Summary: CIS Test overrides for Kubernetes variants
 Requires: (%{_cross_os}bloodhound and %{_cross_os}variant-runtime(k8s))
 %description -n %{_cross_os}bloodhound-k8s-overrides
-%{summary}.
-
-%package -n %{_cross_os}bloodhound-fips
-Summary: Compliance checks for FIPS
-Requires: (%{_cross_os}bloodhound and %{_cross_os}image-feature(fips))
-%description -n %{_cross_os}bloodhound-fips
 %{summary}.
 
 %package -n %{_cross_os}xfscli
@@ -711,7 +704,7 @@ install -m 0644 %{S:23} %{buildroot}%{_cross_libexecdir}/cis-checks/bottlerocket
 
 mkdir -p %{buildroot}%{_cross_libexecdir}/fips-checks/bottlerocket
 for p in \
-  fips01000000 fips01010000 fips01020000 fips01030000 \
+  fips01000000 fips01010000 fips01020000 \
 ; do
   ln -rs %{buildroot}%{_cross_bindir}/bottlerocket-fips-checks \
     %{buildroot}%{_cross_libexecdir}/fips-checks/bottlerocket/${p}
@@ -977,7 +970,9 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %files -n %{_cross_os}bloodhound
 %{_cross_bindir}/bloodhound
 %{_cross_bindir}/bottlerocket-cis-checks
+%{_cross_bindir}/bottlerocket-fips-checks
 %{_cross_libexecdir}/cis-checks/bottlerocket
+%{_cross_libexecdir}/fips-checks/bottlerocket
 %exclude %{_cross_libexecdir}/cis-checks/bottlerocket/br03040101.json
 
 %files -n %{_cross_os}bloodhound-k8s
@@ -987,10 +982,6 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %files -n %{_cross_os}bloodhound-k8s-overrides
 %{_cross_libexecdir}/cis-checks/bottlerocket/br03040101.json
 %{_cross_libexecdir}/cis-checks/kubernetes/k8s04021000.json
-
-%files -n %{_cross_os}bloodhound-fips
-%{_cross_bindir}/bottlerocket-fips-checks
-%{_cross_libexecdir}/fips-checks/bottlerocket
 
 %files -n %{_cross_os}xfscli
 %{_cross_sbindir}/xfs_admin

--- a/sources/bloodhound/src/bin/bottlerocket-fips-checks/checks.rs
+++ b/sources/bloodhound/src/bin/bottlerocket-fips-checks/checks.rs
@@ -11,6 +11,20 @@ const EXPECTED_FIPS_NAME: &str = "Amazon Linux 2023 Kernel Cryptographic API";
 const FIPS_KERNEL_CHECK_MARKER: &str = "/etc/.fips-kernel-check-passed";
 const FIPS_MODULE_CHECK_MARKER: &str = "/etc/.fips-module-check-passed";
 
+/// Checks whether kernel FIPS mode is active by reading /proc/sys/crypto/fips_enabled.
+fn is_fips_enabled(sac: &dyn SystemAccess) -> bool {
+    look_for_strings_in_file(sac, CRYPTO_FIPS_ENABLED, &[EXPECTED_FIPS_ENABLED]).unwrap_or(false)
+}
+
+/// Returns a FAIL result indicating FIPS is not enabled on this system.
+fn fail_fips_not_enabled() -> CheckerResult {
+    CheckerResult {
+        status: CheckStatus::FAIL,
+        error: "FIPS mode is not enabled on this system".to_string(),
+        ..Default::default()
+    }
+}
+
 // =>o.o<= =>o.o<= =>o.o<= =>o.o<= =>o.o<= =>o.o<= =>o.o<= =>o.o<= =>o.o<= =>o.o<=
 
 pub struct FIPS01000000Checker {}
@@ -43,6 +57,9 @@ pub struct FIPS01010000Checker {}
 
 impl Checker for FIPS01010000Checker {
     fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
+        if !is_fips_enabled(sac) {
+            return fail_fips_not_enabled();
+        }
         check_file_contains!(
             sac,
             CRYPTO_FIPS_NAME,
@@ -54,7 +71,7 @@ impl Checker for FIPS01010000Checker {
 
     fn metadata(&self) -> CheckerMetadata {
         CheckerMetadata {
-            title: format!("FIPS module is {EXPECTED_FIPS_NAME}.").to_string(),
+            title: format!("FIPS module is {EXPECTED_FIPS_NAME}."),
             id: "1.1".to_string(),
             level: 0,
             name: "fips01010000".to_string(),
@@ -69,13 +86,16 @@ pub struct FIPS01020000Checker {}
 
 impl Checker for FIPS01020000Checker {
     fn execute(&self, sac: &dyn SystemAccess) -> CheckerResult {
+        if !is_fips_enabled(sac) {
+            return fail_fips_not_enabled();
+        }
+
         let result = check_file_exists!(
             sac,
             FIPS_KERNEL_CHECK_MARKER,
             format!("{FIPS_KERNEL_CHECK_MARKER} not found")
         );
 
-        // Check if we need to continue
         if result.status == CheckStatus::FAIL {
             return result;
         }
@@ -109,9 +129,9 @@ mod tests {
         let usac = UnitTestSystemAccess::default();
         let checker = FIPS01000000Checker {};
         let result = checker.execute(&usac);
-        // skip the test if /proc/sys/crypto/fips_enabled is missing
         assert_eq!(result.status, CheckStatus::SKIP);
     }
+
     #[test]
     pub fn test_fips01000000checker_fips_disabled() {
         let mut usac = UnitTestSystemAccess::default();
@@ -120,6 +140,7 @@ mod tests {
         let result = checker.execute(&usac);
         assert_eq!(result.status, CheckStatus::FAIL);
     }
+
     #[test]
     pub fn test_fips01000000checker_fips_enabled() {
         let mut usac = UnitTestSystemAccess::default();
@@ -130,16 +151,17 @@ mod tests {
     }
 
     #[test]
-    pub fn test_fips01010000checker_missing_fips_name() {
+    pub fn test_fips01010000checker_fips_not_enabled() {
         let usac = UnitTestSystemAccess::default();
         let checker = FIPS01010000Checker {};
         let result = checker.execute(&usac);
-        assert_eq!(result.status, CheckStatus::SKIP);
+        assert_eq!(result.status, CheckStatus::FAIL);
     }
 
     #[test]
     pub fn test_fips01010000checker_wrong_fips_name() {
         let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_ENABLED, EXPECTED_FIPS_ENABLED);
         usac.register_file(CRYPTO_FIPS_NAME, "some wrong name");
         let checker = FIPS01010000Checker {};
         let result = checker.execute(&usac);
@@ -149,6 +171,7 @@ mod tests {
     #[test]
     pub fn test_fips01010000checker_passing() {
         let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_ENABLED, EXPECTED_FIPS_ENABLED);
         usac.register_file(CRYPTO_FIPS_NAME, EXPECTED_FIPS_NAME);
         let checker = FIPS01010000Checker {};
         let result = checker.execute(&usac);
@@ -156,28 +179,68 @@ mod tests {
     }
 
     #[test]
+    pub fn test_fips01020000checker_fips_not_enabled() {
+        let usac = UnitTestSystemAccess::default();
+        let checker = FIPS01020000Checker {};
+        let result = checker.execute(&usac);
+        assert_eq!(result.status, CheckStatus::FAIL);
+    }
+
+    #[test]
     pub fn test_fips01020000checker_missing_module_check_marker() {
         let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_ENABLED, EXPECTED_FIPS_ENABLED);
         usac.register_file(FIPS_KERNEL_CHECK_MARKER, "1");
         let checker = FIPS01020000Checker {};
         let result = checker.execute(&usac);
         assert_eq!(result.status, CheckStatus::FAIL);
     }
+
     #[test]
     pub fn test_fips01020000checker_missing_kernel_check_marker() {
         let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_ENABLED, EXPECTED_FIPS_ENABLED);
         usac.register_file(FIPS_MODULE_CHECK_MARKER, "1");
         let checker = FIPS01020000Checker {};
         let result = checker.execute(&usac);
         assert_eq!(result.status, CheckStatus::FAIL);
     }
+
     #[test]
     pub fn test_fips01020000checker_passing() {
         let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_ENABLED, EXPECTED_FIPS_ENABLED);
         usac.register_file(FIPS_KERNEL_CHECK_MARKER, "1");
         usac.register_file(FIPS_MODULE_CHECK_MARKER, "1");
         let checker = FIPS01020000Checker {};
         let result = checker.execute(&usac);
         assert_eq!(result.status, CheckStatus::PASS);
+    }
+
+    #[test]
+    pub fn test_is_fips_enabled_true() {
+        let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_ENABLED, EXPECTED_FIPS_ENABLED);
+        assert!(is_fips_enabled(&usac));
+    }
+
+    #[test]
+    pub fn test_is_fips_enabled_false() {
+        let mut usac = UnitTestSystemAccess::default();
+        usac.register_file(CRYPTO_FIPS_ENABLED, "0");
+        assert!(!is_fips_enabled(&usac));
+    }
+
+    #[test]
+    pub fn test_is_fips_enabled_missing_file() {
+        let usac = UnitTestSystemAccess::default();
+        assert!(!is_fips_enabled(&usac));
+    }
+
+    #[test]
+    pub fn test_fail_fips_not_enabled() {
+        let result = fail_fips_not_enabled();
+        assert_eq!(result.status, CheckStatus::FAIL);
+        assert!(!result.error.is_empty());
     }
 }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
The FIPS compliance checks were previously packaged separately and only installed on FIPS-specific variants. This prevented runtime FIPS detection on standard variants where FIPS may be enabled at boot via the kernel flag.

delete `fips01030000` in the `os.spec` since there is no `fips01030000` check



**Testing done:**
Testing with #918 
- before the fips turn on on a non fips variant
```
{
  "os": {
    "arch": "x86_64",
    "build_id": "f0dfc999-dirty",
    "pretty_name": "Bottlerocket OS 1.58.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.58.0"
  }
}

Benchmark name:  FIPS Security Policy
Version:         v1.0.0
Reference:       https://csrc.nist.gov/
Benchmark level: 1
Start time:      2026-06-04T18:03:24.108321406Z

[FAIL] 1.0       FIPS mode is enabled. (Automatic)
[FAIL] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
[FAIL] 1.2       FIPS self-tests passed. (Automatic)

Passed:          0
Failed:          3
Skipped:         0
Total checks:    3

Compliance check result: FAIL
```

- after the fips turn on
```
{
  "os": {
    "arch": "x86_64",
    "build_id": "f0dfc999-dirty",
    "pretty_name": "Bottlerocket OS 1.58.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.58.0"
  }
}
Benchmark name:  FIPS Security Policy
Version:         v1.0.0
Reference:       https://csrc.nist.gov/
Benchmark level: 1
Start time:      2026-06-04T18:06:56.263566247Z

[PASS] 1.0       FIPS mode is enabled. (Automatic)
[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
[PASS] 1.2       FIPS self-tests passed. (Automatic)

Passed:          3
Failed:          0
Skipped:         0
Total checks:    3
```
- fips variant
```
{
  "os": {
    "arch": "x86_64",
    "build_id": "f0dfc999-dirty",
    "pretty_name": "Bottlerocket OS 1.58.0 (aws-k8s-1.33-fips)",
    "variant_id": "aws-k8s-1.33-fips",
    "version_id": "1.58.0"
  }
}

Benchmark name:  FIPS Security Policy
Version:         v1.0.0
Reference:       https://csrc.nist.gov/
Benchmark level: 1
Start time:      2026-06-04T18:11:05.078407866Z

[PASS] 1.0       FIPS mode is enabled. (Automatic)
[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
[PASS] 1.2       FIPS self-tests passed. (Automatic)

Passed:          3
Failed:          0
Skipped:         0
Total checks:    3

Compliance check result: PASS
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
