### PR TITLE
containerd: advertise remap-ids capability for soci proxy plugin

### DIFF
--- a/packages/containerd-1.7/snapshotter-toml
+++ b/packages/containerd-1.7/snapshotter-toml
@@ -9,6 +9,7 @@ snapshotter = "soci"
 disable_snapshot_annotations = false
 # Plug soci snapshotter into containerd
 [proxy_plugins.soci]
+capabilities = ["remap-ids"]
 type = "snapshot"
 address = "/run/soci-snapshotter/soci-snapshotter.sock"
 [proxy_plugins.soci.exports]

--- a/packages/containerd-2.1/snapshotter-toml
+++ b/packages/containerd-2.1/snapshotter-toml
@@ -13,6 +13,7 @@ snapshotter = "soci"
 
 # Plug soci snapshotter into containerd
 [proxy_plugins.soci]
+capabilities = ["remap-ids"]
 type = "snapshot"
 address = "/run/soci-snapshotter/soci-snapshotter.sock"
 [proxy_plugins.soci.exports]

--- a/packages/containerd-2.2/snapshotter-toml
+++ b/packages/containerd-2.2/snapshotter-toml
@@ -13,6 +13,7 @@ snapshotter = "soci"
 
 # Plug soci snapshotter into containerd
 [proxy_plugins.soci]
+capabilities = ["remap-ids"]
 type = "snapshot"
 address = "/run/soci-snapshotter/soci-snapshotter.sock"
 [proxy_plugins.soci.exports]


### PR DESCRIPTION
**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket/issues/4854

**Description of changes:**

Add the `remap-ids` capability to the soci snapshotter configuration, allowing it to start pods with `hostUsers: false`

**Testing done:**

Simple manual configuration change on running node (adding the line) and restarting containerd. Let's see what CI says :)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
