### PR TITLE
Move staged advisories to respective releases

### DIFF
--- a/advisories/14.2.0/BRSA-ljpndu5ez903.toml
+++ b/advisories/14.2.0/BRSA-ljpndu5ez903.toml
@@ -12,6 +12,6 @@ patched-epoch = "1"
 
 [updateinfo]
 author = "maherhom"
-issue-date = 2026-04-20T21:34:38Z
+issue-date = 2026-04-24T16:23:00Z
 arches = ["aarch64", "x86_64"]
-version = "staging"
+version = "14.2.0"

--- a/advisories/14.5.0/BRSA-b8okc9cb56gk.toml
+++ b/advisories/14.5.0/BRSA-b8okc9cb56gk.toml
@@ -12,6 +12,6 @@ patched-epoch = "1"
 
 [updateinfo]
 author = "jpculp"
-issue-date = 2026-05-20T21:38:20Z
+issue-date = 2026-06-02T14:00:00Z
 arches = ["aarch64", "x86_64"]
-version = "staging"
+version = "14.5.0"

--- a/advisories/14.5.0/BRSA-h6zf92f0298p.toml
+++ b/advisories/14.5.0/BRSA-h6zf92f0298p.toml
@@ -12,6 +12,6 @@ patched-epoch = "1"
 
 [updateinfo]
 author = "jpculp"
-issue-date = 2026-05-20T21:38:20Z
+issue-date = 2026-06-02T14:00:00Z
 arches = ["aarch64", "x86_64"]
-version = "staging"
+version = "14.5.0"

--- a/advisories/14.5.0/BRSA-hui7k8rsmbsl.toml
+++ b/advisories/14.5.0/BRSA-hui7k8rsmbsl.toml
@@ -12,6 +12,6 @@ patched-epoch = "1"
 
 [updateinfo]
 author = "jpculp"
-issue-date = 2026-05-20T21:38:20Z
+issue-date = 2026-06-02T14:00:00Z
 arches = ["aarch64", "x86_64"]
-version = "staging"
+version = "14.5.0"

--- a/advisories/14.5.0/BRSA-jgcxwcxt3sxd.toml
+++ b/advisories/14.5.0/BRSA-jgcxwcxt3sxd.toml
@@ -12,6 +12,6 @@ patched-epoch = "1"
 
 [updateinfo]
 author = "maherhom"
-issue-date = 2026-05-26T23:16:23Z
+issue-date = 2026-06-02T14:00:00Z
 arches = ["x86_64", "aarch64"]
-version = "staging"
+version = "14.5.0"

--- a/advisories/14.5.0/BRSA-ldnum2jh8n92.toml
+++ b/advisories/14.5.0/BRSA-ldnum2jh8n92.toml
@@ -12,6 +12,6 @@ patched-epoch = "1"
 
 [updateinfo]
 author = "jpculp"
-issue-date = 2026-05-20T21:38:20Z
+issue-date = 2026-06-02T14:00:00Z
 arches = ["aarch64", "x86_64"]
-version = "staging"
+version = "14.5.0"

--- a/advisories/14.5.0/BRSA-quby27cpefwz.toml
+++ b/advisories/14.5.0/BRSA-quby27cpefwz.toml
@@ -12,6 +12,6 @@ patched-epoch = "1"
 
 [updateinfo]
 author = "jpculp"
-issue-date = 2026-05-20T21:38:20Z
+issue-date = 2026-06-02T14:00:00Z
 arches = ["aarch64", "x86_64"]
-version = "staging"
+version = "14.5.0"


### PR DESCRIPTION
**Description of changes:**
- Move binutils BRSA from staging to 14.2.0 directory
- Move other BRSAs from staging to 14.5.0 directory


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
