### PR TITLE
twoliter: bump sdk to v0.75.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -4,7 +4,7 @@ project-vendor = "Bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.74.0"
+version = "0.75.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.74.0"
-digest = "JkyAeKTcFAbrjNJKA9yuKbZcAP8kgv9phwX5jkFbFhk="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.75.0"
+digest = "7l4qkyh/nqq6Z+tq/4Bwh2EPba8BfsKfVlnnNwclWzM="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,5 +7,5 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.74.0"
+version = "0.75.0"
 vendor = "bottlerocket"


### PR DESCRIPTION
**Description of changes:**
- Bump bottlerocket-sdk to v0.75.0


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
