### PR TITLE
feat(release): add no-data-partitions and no-private-partition image features

### DIFF
--- a/docs/ENCRYPTED_STORAGE.md
+++ b/docs/ENCRYPTED_STORAGE.md
@@ -14,6 +14,20 @@ Bottlerocket's encrypted storage feature provides:
 
 All encryption keys are sealed to TPM2 PCRs, ensuring data can only be decrypted when the system boots in a trusted state.
 
+## Compatibility with partition-omitting image features
+
+Encrypted storage relies on both the `BOTTLEROCKET-DATA` partition (LUKS device) and the `BOTTLEROCKET-PRIVATE` partition (datastore directory and keystore). It is therefore mutually exclusive with the following image features:
+
+- `no-data-partitions` — omits the `BOTTLEROCKET-DATA-{A,B}` filesystems.
+- `no-private-partition` — omits the `BOTTLEROCKET-PRIVATE` filesystem.
+
+This is enforced two ways:
+
+1. **Build time.** `release-crypt` declares `Conflicts: image-feature(no-data-partitions)` and `Conflicts: image-feature(no-private-partition)`, so a variant cannot enable both `encrypted-storage` and either of the partition-omitting flags. RPM dependency resolution fails with a clear conflict.
+2. **Runtime.** Even if `ENCRYPTED_STORAGE=true` is set in `/usr/share/bottlerocket/image-features.env` on a build that does not actually have the partitions, `apiserver`'s `should_encrypt()` returns `false` when either `NO_DATA_PARTITIONS` or `NO_PRIVATE_PARTITION` is true, so the ephemeral-storage flow does not attempt encryption.
+
+See [`PARTITION_FEATURES.md`](PARTITION_FEATURES.md) for how the kit boots on partition-omitting builds and how operators attach persistent storage at runtime.
+
 ## Architecture
 
 ### Components

--- a/docs/PARTITION_FEATURES.md
+++ b/docs/PARTITION_FEATURES.md
@@ -1,0 +1,117 @@
+# Partition-Omitting Image Features
+
+Bottlerocket exposes two opt-in image features that omit on-disk
+partitions, intended primarily for diskless / minimal deployments
+where the operator attaches persistent storage at runtime:
+
+- `no-data-partitions` — omits the `BOTTLEROCKET-DATA-{A,B}` filesystems.
+- `no-private-partition` — omits the `BOTTLEROCKET-PRIVATE` filesystem.
+
+Both flags default to **off**. With neither flag set, behavior is
+identical to a stock Bottlerocket image — there is no behavioral diff.
+
+## What gets omitted
+
+| Image feature           | GPT entries dropped              | Filesystem normally mounted at |
+|-------------------------|----------------------------------|--------------------------------|
+| `no-data-partitions`    | `BOTTLEROCKET-DATA-A`, `-B`      | `/local`                       |
+| `no-private-partition`  | `BOTTLEROCKET-PRIVATE`           | `/var/lib/bottlerocket`        |
+
+The rootfs is built with `dm-verity` and is mounted read-only, so the
+in-rootfs paths under `/var`, `/opt`, `/var/lib/bottlerocket`, and `/mnt`
+are unwritable. **Writable storage at those paths is mandatory** for the
+API server, datastore, container runtimes, and orchestrator to function.
+When a partition is omitted, the operator is responsible for attaching a
+labeled persistent device before boot. There is no in-image fallback; if
+no device with the matching `PARTLABEL=` is attached, the units that
+mount and prepare these filesystems will fail. This is the expected
+failure mode for a misconfigured deployment.
+
+## Operator-attached persistent storage
+
+Operators attach persistent storage at runtime by exposing a virtio-blk
+device with the correct partition label.
+
+For `/local`:
+
+1. Create a partition table on the backing device with at least one
+   partition labeled `BOTTLEROCKET-DATA`.
+2. Attach the device to the Firecracker VM as a virtio-blk drive before
+   boot.
+
+On boot, `/dev/disk/by-partlabel/BOTTLEROCKET-DATA` exists, and:
+
+- `prepare-local-fs.service` runs `systemd-makefs` on the device,
+  formatting it if empty.
+- `local.mount` mounts the partition at `/local`.
+- The standard `/local/{var,opt,mnt}` bind pattern (`var.mount`,
+  `opt.mount`, `mnt.mount`) takes over from there.
+
+For `/var/lib/bottlerocket`: same pattern with label
+`BOTTLEROCKET-PRIVATE`. The partition-backed `bottlerocket.mount`
+(mounting `/.bottlerocket`) and `var-lib-bottlerocket.mount` (rbinding
+`/.bottlerocket` → `/var/lib/bottlerocket`) handle the rest.
+
+Operators must attach storage **before** boot. Hot-plugging a labeled
+partition device into a running VM is not supported; partition discovery
+and mount activation happen during early boot.
+
+### Failure mode when no device is attached
+
+If a build with `no-data-partitions` (or `no-private-partition`) boots
+without a matching labeled device:
+
+- `local.mount` / `bottlerocket.mount` will fail to find their
+  `What=/dev/disk/by-partlabel/...` source and report a mount failure
+  to the journal.
+- Dependent units (`var.mount`, `opt.mount`, the datastore, the API
+  server) will not start.
+- `local-fs.target` and `preconfigured.target` will not reach
+  isolation; the system will not finish booting.
+
+This is intentional. These builds are designed for environments where
+operator-attached storage is part of the deployment contract; failing
+to provide it is a configuration error, and the resulting boot failure
+surfaces it loudly rather than masking it with an ephemeral fallback.
+
+## Incompatibilities
+
+### `encrypted-storage`
+
+The `encrypted-storage` image feature relies on **both**
+`BOTTLEROCKET-DATA` (LUKS device) and `BOTTLEROCKET-PRIVATE` (datastore
+directory and keystore). It is incompatible with `no-data-partitions`
+and `no-private-partition`.
+
+This is enforced two ways:
+
+1. **Build time.** `release-crypt` declares
+   `Conflicts: image-feature(no-data-partitions)` and
+   `Conflicts: image-feature(no-private-partition)`. RPM dependency
+   resolution fails with a clear conflict if a variant tries to enable
+   both.
+2. **Runtime.** Even if `ENCRYPTED_STORAGE=true` is set on a build that
+   omits the partitions, `apiserver`'s ephemeral-storage logic returns
+   `should_encrypt = false` when either `NO_DATA_PARTITIONS` or
+   `NO_PRIVATE_PARTITION` is true, so the encryption flow is skipped.
+
+Operator-attached persistent storage on a `no-data-partitions` /
+`no-private-partition` build is **plaintext only**. There is no
+TPM-backed unlocking path on these builds.
+
+See [`ENCRYPTED_STORAGE.md`](ENCRYPTED_STORAGE.md) for the full encrypted
+storage design.
+
+## Implementation summary
+
+- The two image features add image-feature flags only; no in-image
+  fallback units are shipped.
+- `apiserver` is taught to read the flags from
+  `/usr/share/bottlerocket/image-features.env` and force
+  `should_encrypt = false` when either is set.
+- `release-crypt` declares `Conflicts:` against both image features.
+- Standard unit files (`local.mount`, `bottlerocket.mount`,
+  `prepare-local-fs.service`, `repart-*`, `encrypt-*`, `unlock-*`,
+  `opt-{civ,cni,csi}.mount`, `lib-modules.mount`, kernel-devel mounts)
+  are unchanged from a stock build. They mount or fail based on the
+  presence of the `PARTLABEL=` device at boot.

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -197,6 +197,11 @@ Conflicts: %{_cross_os}image-feature(no-fips)
 Summary: Bottlerocket release, with encrypted storage
 Requires: (%{_cross_os}image-feature(encrypted-storage) and %{name})
 Requires: %{_cross_os}rottweiler
+# Encrypted storage relies on both BOTTLEROCKET-DATA (LUKS device) and
+# BOTTLEROCKET-PRIVATE (datastore directory). It is incompatible with
+# image features that omit those filesystems.
+Conflicts: %{_cross_os}image-feature(no-data-partitions)
+Conflicts: %{_cross_os}image-feature(no-private-partition)
 
 %description crypt
 %{summary}.

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -526,14 +526,30 @@ pub fn format_device<S: AsRef<OsStr>>(device: S, format: &Filesystem) -> Result<
     Ok(())
 }
 
-/// Checks if ephemeral storage encryption is enabled via image features
+/// Checks if ephemeral storage encryption is enabled via image features.
+///
+/// Encryption requires both the `BOTTLEROCKET-DATA` and `BOTTLEROCKET-PRIVATE`
+/// partitions, so even if `ENCRYPTED_STORAGE=true` is somehow set, we
+/// short-circuit to `false` when either of the partition-omitting features
+/// (`no-data-partitions`, `no-private-partition`) is enabled. This defends
+/// against an out-of-band edit of `image-features.env` on a build that did
+/// not actually create those partitions.
 fn should_encrypt() -> Result<bool> {
     let features = bottlerocket_image_features::parse_image_features().map_err(|e| {
         error::Error::LoadImageFeatures {
             message: e.to_string(),
         }
     })?;
-    Ok(features.encrypted_storage)
+    Ok(should_encrypt_from_features(&features))
+}
+
+/// Pure helper for `should_encrypt` so the partition-feature interaction
+/// can be exercised in unit tests without touching the filesystem.
+fn should_encrypt_from_features(features: &bottlerocket_image_features::ImageFeatures) -> bool {
+    if features.no_data_partitions || features.no_private_partition {
+        return false;
+    }
+    features.encrypted_storage
 }
 
 /// Encrypt ephemeral device using rottweiler
@@ -726,6 +742,47 @@ mod tests {
         ] {
             assert!(allowed_dirs.allowed_exact.contains(dir));
         }
+    }
+
+    #[test]
+    fn test_should_encrypt_from_features() {
+        use bottlerocket_image_features::ImageFeatures;
+
+        // Encryption requested and partitions present: enable.
+        let f = ImageFeatures {
+            in_place_updates: true,
+            encrypted_storage: true,
+            no_data_partitions: false,
+            no_private_partition: false,
+        };
+        assert!(should_encrypt_from_features(&f));
+
+        // Encryption requested but data partition absent: disabled.
+        let f = ImageFeatures {
+            in_place_updates: true,
+            encrypted_storage: true,
+            no_data_partitions: true,
+            no_private_partition: false,
+        };
+        assert!(!should_encrypt_from_features(&f));
+
+        // Encryption requested but private partition absent: disabled.
+        let f = ImageFeatures {
+            in_place_updates: true,
+            encrypted_storage: true,
+            no_data_partitions: false,
+            no_private_partition: true,
+        };
+        assert!(!should_encrypt_from_features(&f));
+
+        // Defaults: encryption off.
+        let f = ImageFeatures {
+            in_place_updates: true,
+            encrypted_storage: false,
+            no_data_partitions: false,
+            no_private_partition: false,
+        };
+        assert!(!should_encrypt_from_features(&f));
     }
 
     #[test]

--- a/sources/bottlerocket-image-features/README.md
+++ b/sources/bottlerocket-image-features/README.md
@@ -18,6 +18,8 @@ Currently supported feature flags:
 
 - `IN_PLACE_UPDATES` - Controls whether in-place updates are enabled (default: true)
 - `ENCRYPTED_STORAGE` - Controls whether encrypted storage is enabled (default: false)
+- `NO_DATA_PARTITIONS` - When true, the build omits `BOTTLEROCKET-DATA-{A,B}` filesystems (default: false)
+- `NO_PRIVATE_PARTITION` - When true, the build omits the `BOTTLEROCKET-PRIVATE` filesystem (default: false)
 
 ### Usage
 

--- a/sources/bottlerocket-image-features/src/lib.rs
+++ b/sources/bottlerocket-image-features/src/lib.rs
@@ -15,6 +15,8 @@ Currently supported feature flags:
 
 - `IN_PLACE_UPDATES` - Controls whether in-place updates are enabled (default: true)
 - `ENCRYPTED_STORAGE` - Controls whether encrypted storage is enabled (default: false)
+- `NO_DATA_PARTITIONS` - When true, the build omits `BOTTLEROCKET-DATA-{A,B}` filesystems (default: false)
+- `NO_PRIVATE_PARTITION` - When true, the build omits the `BOTTLEROCKET-PRIVATE` filesystem (default: false)
 
 ## Usage
 
@@ -56,6 +58,10 @@ pub struct ImageFeatures {
     pub in_place_updates: bool,
     #[serde(default)]
     pub encrypted_storage: bool,
+    #[serde(default)]
+    pub no_data_partitions: bool,
+    #[serde(default)]
+    pub no_private_partition: bool,
 }
 
 fn default_true() -> bool {
@@ -68,6 +74,8 @@ pub fn parse_image_features() -> Result<ImageFeatures> {
         return Ok(ImageFeatures {
             in_place_updates: true,
             encrypted_storage: false,
+            no_data_partitions: false,
+            no_private_partition: false,
         });
     }
 
@@ -148,5 +156,39 @@ IN_PLACE_UPDATES="false"
         let content = "";
         let features = parse_image_features_from_str(content).unwrap();
         assert_eq!(features.in_place_updates, true);
+        assert_eq!(features.encrypted_storage, false);
+        assert_eq!(features.no_data_partitions, false);
+        assert_eq!(features.no_private_partition, false);
+    }
+
+    #[test]
+    fn test_parse_no_data_partitions_quoted() {
+        let content = r#"NO_DATA_PARTITIONS="true""#;
+        let features = parse_image_features_from_str(content).unwrap();
+        assert_eq!(features.no_data_partitions, true);
+        assert_eq!(features.no_private_partition, false);
+    }
+
+    #[test]
+    fn test_parse_no_private_partition_unquoted() {
+        let content = "NO_PRIVATE_PARTITION=true";
+        let features = parse_image_features_from_str(content).unwrap();
+        assert_eq!(features.no_private_partition, true);
+        assert_eq!(features.no_data_partitions, false);
+    }
+
+    #[test]
+    fn test_parse_mixed_new_flags() {
+        let content = r#"# Image feature configuration
+IN_PLACE_UPDATES="true"
+ENCRYPTED_STORAGE=false
+NO_DATA_PARTITIONS="true"
+NO_PRIVATE_PARTITION=true
+"#;
+        let features = parse_image_features_from_str(content).unwrap();
+        assert_eq!(features.in_place_updates, true);
+        assert_eq!(features.encrypted_storage, false);
+        assert_eq!(features.no_data_partitions, true);
+        assert_eq!(features.no_private_partition, true);
     }
 }


### PR DESCRIPTION
Introduce two opt-in image features that omit the BOTTLEROCKET-DATA-{A,B} and BOTTLEROCKET-PRIVATE filesystems from the image. Both default to off; behavior is unchanged when neither is enabled.

- Extend `bottlerocket-image-features` with `no_data_partitions` and `no_private_partition` fields and tests.
- Make `apiserver`'s `should_encrypt()` return false when either partition-omitting flag is set, with unit-test coverage via a pure helper.
- Declare RPM `Conflicts:` between `release-crypt` and the new image features so encrypted-storage builds cannot drop the required partitions.
- Document the design and operator-attached storage workflow in PARTITION_FEATURES.md and cross-link from ENCRYPTED_STORAGE.md.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
