### PR TITLE
packages: add managed subpackage in release

### DIFF
--- a/packages/release/activate-multi-user-managed.conf
+++ b/packages/release/activate-multi-user-managed.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=reboot-if-required.service
+Requires=reboot-if-required.service

--- a/packages/release/activate-multi-user.service
+++ b/packages/release/activate-multi-user.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Activate multi-user.target
-After=configured.target reboot-if-required.service
-Requires=configured.target reboot-if-required.service
+After=configured.target
+Requires=configured.target
 
 [Service]
 Type=oneshot

--- a/packages/release/drivers-target-managed.conf
+++ b/packages/release/drivers-target-managed.conf
@@ -1,0 +1,2 @@
+[Unit]
+Before=settings-applier.service

--- a/packages/release/drivers.target
+++ b/packages/release/drivers.target
@@ -2,7 +2,7 @@
 Description=Driver units
 AllowIsolate=yes
 After=basic.target
-Before=preconfigured.target settings-applier.service
+Before=preconfigured.target
 Requires=basic.target
 
 [Install]

--- a/packages/release/prepare-local-fs-managed.conf
+++ b/packages/release/prepare-local-fs-managed.conf
@@ -1,0 +1,6 @@
+[Service]
+# Stop and mask the repart-data-* oneshots in case they're waiting on non-existent data partitions.
+# 'BOTTLEROCKET-DATA' already exists so we can move on.
+ExecStart=/usr/bin/systemctl stop repart-data-preferred repart-data-fallback --no-block
+ExecStart=/usr/bin/ln -s /dev/null /etc/systemd/system/repart-data-preferred.service
+ExecStart=/usr/bin/ln -s /dev/null /etc/systemd/system/repart-data-fallback.service

--- a/packages/release/prepare-local-fs.service
+++ b/packages/release/prepare-local-fs.service
@@ -16,12 +16,6 @@ Environment=DATA_PARTITION_BLOCK_DEVICE=/dev/disk/by-partlabel/BOTTLEROCKET-DATA
 # Create the filesystem on the partition, if it doesn't exist.
 ExecStart=/usr/lib/systemd/systemd-makefs ${DATA_PARTITION_FILESYSTEM} ${DATA_PARTITION_BLOCK_DEVICE}
 
-# Stop and mask the repart-data-* oneshots in case they're waiting on non-existent data partitions.
-# 'BOTTLEROCKET-DATA' already exists so we can move on.
-ExecStart=/usr/bin/systemctl stop repart-data-preferred repart-data-fallback --no-block
-ExecStart=/usr/bin/ln -s /dev/null /etc/systemd/system/repart-data-preferred.service
-ExecStart=/usr/bin/ln -s /dev/null /etc/systemd/system/repart-data-fallback.service
-
 RemainAfterExit=true
 StandardError=journal+console
 

--- a/packages/release/release-managed-tmpfiles.conf
+++ b/packages/release/release-managed-tmpfiles.conf
@@ -1,0 +1,3 @@
+d /etc/deprecated-settings 0700 root root -
+d /var/log/kdump 0700 root root -
+T /var/log/kdump - - - - security.selinux=system_u:object_r:secret_t:s0

--- a/packages/release/release-tmpfiles.conf
+++ b/packages/release/release-tmpfiles.conf
@@ -1,11 +1,8 @@
 C /etc/nsswitch.conf - - - -
-d /etc/deprecated-settings 0700 root root -
-d /var/log/kdump 0700 root root -
 d /sys/fs/cgroup/cpuset/runtime.slice 0755 root root -
 d /sys/fs/cgroup/hugetlb/runtime.slice 0755 root root -
 d /sys/fs/cgroup/cpuset/system.slice 0755 root root -
 d /sys/fs/cgroup/hugetlb/system.slice 0755 root root -
-T /var/log/kdump - - - - security.selinux=system_u:object_r:secret_t:s0
 d /var/log/support 0755 root root -
 T /var/log/support - - - - security.selinux=system_u:object_r:secret_t:s0
 d /run/cache 0755 root root -

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -165,52 +165,66 @@ Source1700: generate-fips-env.service
 Source1701: create-fips-marker.service
 Source1702: fips-go.env
 
+# Managed release drop-ins and configs
+Source1750: activate-multi-user-managed.conf
+Source1751: drivers-target-managed.conf
+Source1752: prepare-local-fs-managed.conf
+Source1753: release-managed-tmpfiles.conf
+
+# Base requires
 Requires: %{_cross_os}audit
 Requires: %{_cross_os}auditd
-Requires: %{_cross_os}chrony
 Requires: %{_cross_os}conntrack-tools
 Requires: %{_cross_os}containerd
 Requires: %{_cross_os}coreutils
 Requires: %{_cross_os}dbus-broker
 Requires: %{_cross_os}e2fsprogs
-Requires: %{_cross_os}early-boot-config
-Requires: %{_cross_os}ethtool
-Requires: %{_cross_os}libgcc
-Requires: %{_cross_os}libstd-rust
 Requires: %{_cross_os}filesystem
 Requires: %{_cross_os}findutils
 Requires: %{_cross_os}glibc
 Requires: %{_cross_os}grep
+Requires: %{_cross_os}iproute
+Requires: %{_cross_os}iptables
+Requires: %{_cross_os}keyutils
+Requires: %{_cross_os}libgcc
+Requires: %{_cross_os}libkcapi
+Requires: %{_cross_os}libstd-rust
+Requires: %{_cross_os}policycoreutils
+Requires: %{_cross_os}procps
+Requires: %{_cross_os}selinux-policy
+Requires: %{_cross_os}systemd
+Requires: %{_cross_os}util-linux
+Requires: %{_cross_os}xfsprogs
+
+Requires: (%{name}-fips if %{_cross_os}image-feature(fips))
+Requires: (%{name}-managed if %{_cross_os}image-feature(no-standalone-image))
+
+%description
+%{summary}.
+
+%package managed
+Summary: Bottlerocket release - managed
+Requires: (%{_cross_os}image-feature(no-standalone-image) and %{name})
+Requires: %{_cross_os}chrony
+Requires: %{_cross_os}early-boot-config
+Requires: %{_cross_os}ethtool
 # For newer versions of twoliter that support UKIs, explicitly request the bootloader(efi) capability
 Requires: (%{_cross_os}bootloader(efi) if (%{_cross_os}image-feature(uki-image) or %{_cross_os}image-feature(no-uki-image)))
 # Older versions of twoliter that don't support UKIs always get GRUB
 Requires: (%{_cross_os}grub or %{_cross_os}image-feature(uki-image) or %{_cross_os}image-feature(no-uki-image))
-Requires: %{_cross_os}iproute
-Requires: %{_cross_os}iptables
 Requires: %{_cross_os}kexec-tools
-Requires: %{_cross_os}keyutils
 Requires: %{_cross_os}makedumpfile
 Requires: %{_cross_os}mdadm
 Requires: %{_cross_os}netdog
 Requires: %{_cross_os}os
 Requires: %{_cross_os}pciutils
-Requires: %{_cross_os}policycoreutils
-Requires: %{_cross_os}procps
 Requires: (%{_cross_os}rdma-core if %{_cross_os}variant-platform(aws))
-Requires: %{_cross_os}selinux-policy
 Requires: %{_cross_os}shim
-Requires: %{_cross_os}systemd
-Requires: %{_cross_os}util-linux
-Requires: %{_cross_os}xfsprogs
-Requires: %{_cross_os}libkcapi
-Requires: (%{name}-fips if %{_cross_os}image-feature(fips))
 Requires: (%{name}-crypt if %{_cross_os}image-feature(encrypted-storage))
-Requires: (%{name}-ephemeral-crypt if %{_cross_os}image-feature(ephemeral-encryption-keys))
 
 
-%description
+%description managed
 %{summary}.
-
 
 %package fips
 Summary: Bottlerocket release, FIPS boot configuration
@@ -222,7 +236,7 @@ Conflicts: %{_cross_os}image-feature(no-fips)
 
 %package crypt
 Summary: Bottlerocket release, with encrypted storage
-Requires: (%{_cross_os}image-feature(encrypted-storage) and %{name})
+Requires: (%{_cross_os}image-feature(encrypted-storage) and %{name}-managed)
 Requires: %{_cross_os}rottweiler
 
 %description crypt
@@ -411,6 +425,8 @@ install -d %{buildroot}%{_cross_datadir}/bottlerocket
 install -p -m 0644 %{S:1702} %{buildroot}%{_cross_datadir}/bottlerocket/fips-go.env
 
 install -d %{buildroot}%{_cross_unitdir}/prepare-local-fs.service.d
+install -p -m 0644 %{S:1752} \
+  %{buildroot}%{_cross_unitdir}/prepare-local-fs.service.d/10-managed.conf
 install -p -m 0644 %{S:1650} %{buildroot}%{_cross_unitdir}/prepare-local-fs.service.d/10-encrypted.conf
 
 install -d %{buildroot}%{_cross_unitdir}/local.mount.d
@@ -442,6 +458,16 @@ install -p -m 0644 %{S:1674} %{buildroot}%{_cross_unitdir}/encrypt-datastore.ser
 
 ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 
+install -d %{buildroot}%{_cross_unitdir}/activate-multi-user.service.d
+install -p -m 0644 %{S:1750} \
+  %{buildroot}%{_cross_unitdir}/activate-multi-user.service.d/10-managed.conf
+
+install -d %{buildroot}%{_cross_unitdir}/drivers.target.d
+install -p -m 0644 %{S:1751} \
+  %{buildroot}%{_cross_unitdir}/drivers.target.d/10-managed.conf
+
+install -p -m 0644 %{S:1753} %{buildroot}%{_cross_tmpfilesdir}/release-managed.conf
+
 %files
 %{_cross_factorydir}%{_cross_sysconfdir}/nsswitch.conf
 %{_cross_factorydir}%{_cross_sysconfdir}/issue
@@ -451,12 +477,10 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_libdir}/os-release
 %dir %{_cross_libdir}/repart.d
 %{_cross_libdir}/repart.d/80-local.conf
-%{_cross_libdir}/systemd/logind.conf.d/80-inhibit-maxdelay.conf
 %{_cross_libdir}/systemd/network/80-release.link
-%{_cross_libdir}/systemd/networkd.conf.d/80-release.conf
 %{_cross_libdir}/systemd/system.conf.d/80-release.conf
-%{_cross_libdir}/modules-load.d/nf_conntrack.conf
 %{_cross_libdir}/systemd/journald.conf.d/journald.conf
+%{_cross_unitdir}/activate-preconfigured.service
 %{_cross_unitdir}/configured.target
 %{_cross_unitdir}/drivers.target
 %{_cross_unitdir}/preconfigured.target
@@ -464,49 +488,24 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/default.target
 %{_cross_unitdir}/activate-configured.service
 %{_cross_unitdir}/activate-multi-user.service
-%{_cross_unitdir}/disable-kexec-load.service
-%{_cross_unitdir}/capture-kernel-dump.service
-%{_cross_unitdir}/load-crash-kernel.service
-%{_cross_unitdir}/prepare-boot.service
 %{_cross_unitdir}/prepare-opt.service
 %{_cross_unitdir}/prepare-var.service
 %{_cross_unitdir}/repart-local.service
-%{_cross_unitdir}/\x2ebottlerocket.mount
-%dir %{_cross_unitdir}/\x2ebottlerocket.mount.d
 %{_cross_unitdir}/var.mount
 %{_cross_unitdir}/opt.mount
 %{_cross_unitdir}/mnt.mount
-%{_cross_unitdir}/etc-cni.mount
-%{_cross_unitdir}/opt-cni.mount
-%{_cross_unitdir}/opt-csi.mount
-%{_cross_unitdir}/opt-civ.mount
-%{_cross_unitdir}/media-cdrom.mount
 %{_cross_unitdir}/local.mount
-%{_cross_unitdir}/*-lower.mount
-%{_cross_unitdir}/*-kernels.mount
 %{_cross_unitdir}/*-licenses.mount
-%{_cross_unitdir}/var-lib-bottlerocket.mount
 %{_cross_unitdir}/*-modules.mount
 %{_cross_unitdir}/runtime.slice
-%{_cross_unitdir}/set-hostname.service
 %{_cross_unitdir}/mask-local-mnt.service
 %{_cross_unitdir}/mask-local-opt.service
 %{_cross_unitdir}/mask-local-var.service
 %dir %{_cross_unitdir}/network-pre.target.d
 %{_cross_unitdir}/network-pre.target.d/00-dbus-dep.conf
-%{_cross_unitdir}/root-.aws.mount
-%{_cross_unitdir}/repart-data-preferred.service
-%{_cross_unitdir}/repart-data-fallback.service
 %{_cross_unitdir}/prepare-local-fs.service
-%{_cross_unitdir}/deprecation-warning@.service
-%{_cross_unitdir}/deprecation-warning@.timer
 %{_cross_unitdir}/service.d/00-aws-config.conf
 %{_cross_unitdir}/service.d/10-requires-tmp.conf
-%dir %{_cross_unitdir}/systemd-resolved.service.d
-%{_cross_unitdir}/systemd-resolved.service.d/00-env.conf
-%{_cross_unitdir}/systemd-resolved.service.d/10-private-tmp.conf
-%dir %{_cross_unitdir}/systemd-networkd.service.d
-%{_cross_unitdir}/systemd-networkd.service.d/00-env.conf
 %dir %{_cross_unitdir}/systemd-tmpfiles-setup.service.d
 %{_cross_unitdir}/systemd-tmpfiles-setup.service.d/00-debug.conf
 %dir %{_cross_unitdir}/systemd-udev-trigger.service.d
@@ -519,36 +518,72 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/modprobe@.service.d/10-remain-after-exit.conf
 %dir %{_cross_unitdir}/tmp.mount.d
 %{_cross_unitdir}/tmp.mount.d/10-no-exec.conf
+%{_cross_unitdir}/configure-snapshotter.service
+%{_cross_unitdir}/*-bin.mount
+%{_cross_unitdir}/*-libexec.mount
+%{_cross_tmpfilesdir}/release-fips.conf
+%{_cross_libdir}/systemd/logind.conf.d/80-inhibit-maxdelay.conf
+%{_cross_libdir}/systemd/networkd.conf.d/80-release.conf
+%{_cross_libdir}/modules-load.d/nf_conntrack.conf
+%dir %{_cross_unitdir}/activate-multi-user.service.d
+%dir %{_cross_unitdir}/drivers.target.d
+%dir %{_cross_unitdir}/prepare-local-fs.service.d
+%{_cross_unitdir}/check-fips-modules.service
+%{_cross_unitdir}/fipscheck.target
+%dir %{_cross_unitdir}/check-fips-modules.service.d
+%dir %{_cross_unitdir}/systemd-resolved.service.d
+%{_cross_unitdir}/systemd-resolved.service.d/00-env.conf
+%{_cross_unitdir}/systemd-resolved.service.d/10-private-tmp.conf
+%dir %{_cross_unitdir}/systemd-networkd.service.d
+%{_cross_unitdir}/systemd-networkd.service.d/00-env.conf
+%{_cross_unitdir}/check-kernel-integrity.service
+%{_cross_unitdir}/generate-fips-hmac-path-uki.service
+%{_cross_unitdir}/generate-fips-hmac-path-vmlinuz.service
+%{_cross_unitdir}/fips-modprobe@.service
 %dir %{_cross_templatedir}
-%{_cross_templatedir}/modprobe-conf
-%{_cross_templatedir}/netdog-toml
+
+%files managed
+%{_cross_tmpfilesdir}/release-managed.conf
+%{_cross_unitdir}/activate-multi-user.service.d/10-managed.conf
+%{_cross_unitdir}/capture-kernel-dump.service
+%{_cross_unitdir}/disable-kexec-load.service
+%{_cross_unitdir}/load-crash-kernel.service
+%{_cross_unitdir}/drivers.target.d/10-managed.conf
+%{_cross_unitdir}/prepare-local-fs.service.d/10-managed.conf
+%{_cross_unitdir}/deprecation-warning@.service
+%{_cross_unitdir}/deprecation-warning@.timer
+%{_cross_unitdir}/prepare-boot.service
+%{_cross_unitdir}/repart-data-preferred.service
+%{_cross_unitdir}/repart-data-fallback.service
+%{_cross_unitdir}/set-hostname.service
+%{_cross_unitdir}/\x2ebottlerocket.mount
+%dir %{_cross_unitdir}/\x2ebottlerocket.mount.d
+%{_cross_unitdir}/etc-cni.mount
+%{_cross_unitdir}/media-cdrom.mount
+%{_cross_unitdir}/opt-cni.mount
+%{_cross_unitdir}/opt-csi.mount
+%{_cross_unitdir}/opt-civ.mount
+%{_cross_unitdir}/root-.aws.mount
+%{_cross_unitdir}/var-lib-bottlerocket.mount
+%{_cross_unitdir}/*-lower.mount
+%{_cross_unitdir}/*-kernels.mount
+%{_cross_datadir}/logdog.d/logdog.common.conf
 %{_cross_templatedir}/motd
 %{_cross_templatedir}/proxy-env
 %{_cross_templatedir}/hostname-env
 %{_cross_templatedir}/hosts
+%{_cross_templatedir}/modprobe-conf
+%{_cross_templatedir}/netdog-toml
 %{_cross_templatedir}/aws-config
 %{_cross_templatedir}/aws-credentials
 %{_cross_templatedir}/modules-load
 %{_cross_templatedir}/log4j-hotpatch-enabled
-%{_cross_udevrulesdir}/61-mount-cdrom.rules
-%{_cross_datadir}/logdog.d/logdog.common.conf
-%{_cross_unitdir}/configure-snapshotter.service
 %{_cross_templatedir}/selected-snapshotter
 %{_cross_unitdir}/service.d/00-fips-go.conf
 %{_cross_unitdir}/generate-fips-env.service
 %{_cross_unitdir}/create-fips-marker.service
 %{_cross_datadir}/bottlerocket/fips-go.env
-%{_cross_tmpfilesdir}/release-fips.conf
-%{_cross_unitdir}/*-bin.mount
-%{_cross_unitdir}/*-libexec.mount
-%{_cross_unitdir}/fipscheck.target
-%{_cross_unitdir}/activate-preconfigured.service
-%{_cross_unitdir}/check-kernel-integrity.service
-%{_cross_unitdir}/generate-fips-hmac-path-uki.service
-%{_cross_unitdir}/generate-fips-hmac-path-vmlinuz.service
-%{_cross_unitdir}/check-fips-modules.service
-%dir %{_cross_unitdir}/check-fips-modules.service.d
-%{_cross_unitdir}/fips-modprobe@.service
+%{_cross_udevrulesdir}/61-mount-cdrom.rules
 
 %files fips
 %{_cross_bootconfigdir}/10-fips.conf


### PR DESCRIPTION
**Description of changes:**
Refactor the release package into a shared base with two mutually exclusive subpackages (release-managed and
release-unmanaged), selected automatically by the `standalone-image` image feature.

The base release package contains the minimal set of shared systemd units, configs, and mounts used by both managed and unmanaged variants. The release-managed subpackage extends the base via systemd drop-ins (adding dependencies on reboot-if-required, settings-applier, and repart-data masking) and includes all managed-only services, mounts, templates, and configs. The release-unmanaged subpackage provides a minimal configuration for variants without the first-party management stack.

In some systemd config and rules there are few things I didn't delete because I'm not sure, but happy to hear any feedback.


**Testing done:**
- aws-k8s-1.33-fips variant

<details>
<summary>fips related service</summary>

```
bash-5.2# systemctl status fipscheck.target
● fipscheck.target - FIPS integrity check
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/fipscheck.target; enabled; preset: enabled)
     Active: active since Mon 2026-06-22 23:46:50 UTC; 8min ago

Notice: journal has been rotated since unit was started, output may be incomplete.
bash-5.2# systemctl status check-kernel-integrity.service
● check-kernel-integrity.service - Run FIPS kernel integrity check
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/check-kernel-integrity.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 00-fips-go.conf, 10-requires-tmp.conf
     Active: active (exited) since Mon 2026-06-22 23:46:49 UTC; 8min ago
   Main PID: 404 (code=exited, status=0/SUCCESS)
        CPU: 55ms

Notice: journal has been rotated since unit was started, output may be incomplete.
bash-5.2# systemctl status check-fips-modules.service
● check-fips-modules.service - Run FIPS crypto module check
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/check-fips-modules.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 00-fips-go.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/check-fips-modules.service.d
             └─000-sha1.conf, 001-sha224.conf, 002-sha256.conf, 003-sha384.conf, 004-sha512.conf, 005-sha3-224.conf, 006-sha3-256.conf, 007-sha3-384.conf, 008-sha3-512.conf, 009-crc32c.conf, 010-crct10dif.conf, 011-ghash.conf, 012-xxhash64.conf, 013-ghash_clmulni_intel.conf, 014-sha1-ssse3.conf, 015-sha256-ssse3.conf, 016-sha512-ssse3.conf, 017-cipher_null.conf, 018-des3_ede.conf, 019-aes.conf, 020-cfb.conf, 021-dh.conf, 022-ecdh.conf, 023-aesni-intel.conf, 024-ecb.conf, 025-cbc.conf, 026-ctr.conf, 027-xts.conf, 028-gcm.conf, 029-ccm.conf, 030-authenc.conf, 031-hmac.conf, 032-cmac.conf, 033-ofb.conf, 034-cts.conf, 035-lzo.conf, 036-essiv.conf, 037-seqiv.conf, 038-drbg.conf, 039-aead.conf, 040-cryptomgr.conf, 041-crypto_user.conf, 042-rsa.conf
             /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─10-requires-tmp.conf
     Active: active (exited) since Mon 2026-06-22 23:46:50 UTC; 8min ago
   Main PID: 606 (code=exited, status=0/SUCCESS)
        CPU: 220ms

Notice: journal has been rotated since unit was started, output may be incomplete.
bash-5.2#
```

</details>

- aws-k8s-1.33 variant

```
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "8ef015e0-dirty",
    "pretty_name": "Bottlerocket OS 1.61.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.61.0"
  }
}
```

<details>
<summary>systemd is working</summary>

```
bash-5.2# systemctl --failed
  UNIT LOAD ACTIVE SUB DESCRIPTION
0 loaded units listed.
bash-5.2# exit
exit
[root@admin]# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "8ef015e0-dirty",
    "pretty_name": "Bottlerocket OS 1.61.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.61.0"
  }
}
[root@admin]#
```

```
bash-5.2# systemctl cat activate-multi-user.service | grep -E "After|Requires"
After=configured.target
Requires=configured.target
RemainAfterExit=true
After=reboot-if-required.service
Requires=reboot-if-required.service
After=tmp.mount
bash-5.2# systemctl cat drivers.target | grep "Before"
Before=preconfigured.target
Before=settings-applier.service
bash-5.2# systemctl cat drivers.target | grep "Before"
Before=preconfigured.target
Before=settings-applier.service
bash-5.2# systemctl cat prepare-local-fs.service | grep -A1 "repart"
# Stop and mask the repart-data-* oneshots in case they're waiting on non-existent data partitions.
# 'BOTTLEROCKET-DATA' already exists so we can move on.
ExecStart=/usr/bin/systemctl stop repart-data-preferred repart-data-fallback --no-block
ExecStart=/usr/bin/ln -s /dev/null /etc/systemd/system/repart-data-preferred.service
ExecStart=/usr/bin/ln -s /dev/null /etc/systemd/system/repart-data-fallback.service
```
</details>

- test with aws-dev and variant definition is in below. Create s pre-format EBS volume/snapshot. Lunch and boot a instance with pre-formate EBS volume.
```
[package]
name = "aws-dev"
version = "0.1.0"
edition = "2021"
publish = false
build = "../build.rs"
# Don't rebuild crate just because of changes to README.
exclude = ["README.md"]

[package.metadata.build-variant.image-features]
first-party-stack = false
xfs-data-partition = true
erofs-root-partition = true
in-place-updates = false
host-containers = false
external-kmod-development = false
encrypted-storage = false

[package.metadata.build-variant.image-layout]
partition-plan = "unified"

[package.metadata.build-variant]
kernel-parameters = [
    "console=ttyS0,115200n8",
    "net.ifnames=0",
    "quiet",
    "systemd.unified_cgroup_hierarchy=1",
]

included-packages = [
# core
    "release",
    "kernel-6.18",
    "containerd-2.2",
    "systemd-257",
    "nftables",
# boot (needed for EC2/UEFI)
    "grub",
    "shim",
# docker
    "docker-cli-29",
    "docker-engine-29",
    "docker-init",
# tools
    "login",
]

[lib]
path = "../variants.rs"

[build-dependencies]
settings-defaults = { path = "../../packages/settings-defaults" }
settings-plugins = { path = "../../packages/settings-plugins" }
settings-migrations = { path = "../../packages/settings-migrations" }
```

<details>
<summary>Docker Hello World</summary>

```
bash-5.3# docker run --rm hello-world

Hello from Docker!
This message shows that your installation appears to be working correctly.

To generate this message, Docker took the following steps:
 1. The Docker client contacted the Docker daemon.
 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
    (amd64)
 3. The Docker daemon created a new container from that image which runs the
    executable that produces the output you are currently reading.
 4. The Docker daemon streamed that output to the Docker client, which sent it
    to your terminal.

To try something more ambitious, you can run an Ubuntu container with:
 $ docker run -it ubuntu bash

Share images, automate workflows, and more with a free Docker ID:
 https://hub.docker.com/

For more examples and ideas, visit:
 https://docs.docker.com/get-started/

bash-5.3#
```
</details>

<details>
<summary>systemctl status</summary>

```
bash-5.3# systemctl --failed
  UNIT LOAD ACTIVE SUB DESCRIPTION

0 loaded units listed.

bash-5.3# systemctl status
● localhost
    State: running
    Units: 265 loaded (incl. loaded aliases)
     Jobs: 0 queued
   Failed: 0 units
    Since: Tue 2026-07-07 23:34:47 UTC; 12min ago
  systemd: 257.9
  Tainted: unmerged-bin
   CGroup: /
           ├─init.scope
           │ └─1 /sbin/init systemd.log_target=journal-or-kmsg systemd.log_color=0 systemd.show_status=true
           ├─runtime.slice
           │ └─containerd.service
           │   └─1450 /usr/bin/containerd
           └─system.slice
             ├─docker.service
             │ └─1493 /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
             ├─system-getty.slice
             │ └─getty@tty1.service
             │   └─1389 /sbin/agetty -o "-- \\u" --noreset --noclear - linux
             ├─system-serial\x2dgetty.slice
             │ └─serial-getty@ttyS0.service
             │   ├─1393 bash --login
             │   ├─1841 systemctl status
             │   └─1842 "(pager)"
             ├─systemd-journald.service
             │ └─615 /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/systemd-journald
             ├─systemd-logind.service
             │ └─1454 /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/systemd-logind
             ├─systemd-udevd.service
             │ └─udev
             │   └─657 /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/systemd-udevd
             └─whippet.service
               ├─653 /usr/bin/whippet
               └─993 /usr/bin/dbus-broker --log 12 --controller 11 --machine-id ec2fe60d50e8614b3befd42254f7f4b2 --max-bytes 536870912 --max-fds 4096 --max-matches 16384
bash-5.3# 
```
</details>


<details>
<summary>overlay mount status</summary>

```
bash-5.3# mount | grep -E "/local|/var|/opt|/mnt|/tmp"
tmpfs on /tmp type tmpfs (rw,nosuid,nodev,noexec,seclabel,size=7960816k,nr_inodes=1048576)
/dev/nvme1n1p1 on /local type xfs (rw,nosuid,nodev,noatime,seclabel,inode64,logbufs=8,logbsize=32k,sunit=8,swidth=8,noquota)
/dev/nvme1n1p1 on /mnt type xfs (rw,nosuid,nodev,noatime,seclabel,inode64,logbufs=8,logbsize=32k,sunit=8,swidth=8,noquota)
/dev/nvme1n1p1 on /opt type xfs (rw,nosuid,nodev,noatime,seclabel,inode64,logbufs=8,logbsize=32k,sunit=8,swidth=8,noquota)
/dev/nvme1n1p1 on /var type xfs (rw,nosuid,nodev,noatime,seclabel,inode64,logbufs=8,logbsize=32k,sunit=8,swidth=8,noquota)
/dev/dm-0 on /local/mnt type erofs (ro,nosuid,nodev,noexec,relatime,seclabel,user_xattr,acl,cache_strategy=readaround)
/dev/dm-0 on /local/opt type erofs (ro,nosuid,nodev,noexec,relatime,seclabel,user_xattr,acl,cache_strategy=readaround)
/dev/dm-0 on /local/var type erofs (ro,nosuid,nodev,noexec,relatime,seclabel,user_xattr,acl,cache_strategy=readaround)
overlay on /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/modules type overlay (rw,nosuid,nodev,noexec,noatime,context=system_u:object_r:state_t:s0,lowerdir=/lib/modules,upperdir=/var/lib/kernel-modules/.overlay/upper,workdir=/var/lib/kernel-modules/.overlay/work,uuid=on)
```
</details>

<details>
<summary>partition</summary>

```
bash-5.3# ls -la /dev/disk/by-partlabel/
ls -la /dev/disk/ephemeral/ 2>/dev/null
ls -la /dev/disk/by-volume-type-partuuid/ 2>/dev/null
total 0
drwxr-xr-x.  2 root root 160 Jul  7 23:34 .
drwxr-xr-x. 11 root root 220 Jul  7 23:34 ..
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 BIOS-BOOT -> ../../nvme0n1p1
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 BOTTLEROCKET-BOOT-A -> ../../nvme0n1p3
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 BOTTLEROCKET-DATA -> ../../nvme1n1p1
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 BOTTLEROCKET-HASH-A -> ../../nvme0n1p5
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 BOTTLEROCKET-ROOT-A -> ../../nvme0n1p4
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 EFI-SYSTEM -> ../../nvme0n1p2
total 0
drwxr-xr-x.  2 root root 160 Jul  7 23:34 .
drwxr-xr-x. 11 root root 220 Jul  7 23:34 ..
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 nvme-ebs-16942332-0fc3-414a-9814-86c78baa77d6 -> ../../nvme0n1p2
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 nvme-ebs-1f25261c-1d0f-4685-bafb-4b17c955400b -> ../../nvme1n1p1
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 nvme-ebs-2804000f-0c52-449c-8366-5f3c61c60e4e -> ../../nvme0n1p4
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 nvme-ebs-69483bda-512e-40b2-9c15-1c5d757fbd2a -> ../../nvme0n1p5
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 nvme-ebs-bbae782a-a5d6-4258-bda5-378df33783e4 -> ../../nvme0n1p1
lrwxrwxrwx.  1 root root  15 Jul  7 23:34 nvme-ebs-f04b125d-59a9-480a-9051-addc8bb80f1e -> ../../nvme0n1p3
```
</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
