### PR TITLE
feat: render debug section in containerd config for log-level setting

### DIFF
--- a/packages/containerd-1.7/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-1.7/containerd-config-toml_k8s_containerd_sock
@@ -17,6 +17,11 @@ disabled_plugins = [
 
 imports = ["/etc/containerd/config.d/*.toml"]
 
+{{#if settings.container-runtime.log-level}}
+[debug]
+level = "{{settings.container-runtime.log-level}}"
+{{/if}}
+
 [grpc]
 address = "/run/containerd/containerd.sock"
 

--- a/packages/containerd-1.7/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-1.7/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -17,6 +17,11 @@ disabled_plugins = [
 
 imports = ["/etc/containerd/config.d/*.toml"]
 
+{{#if settings.container-runtime.log-level}}
+[debug]
+level = "{{settings.container-runtime.log-level}}"
+{{/if}}
+
 [grpc]
 address = "/run/containerd/containerd.sock"
 

--- a/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_containerd_sock
@@ -19,6 +19,11 @@ disabled_plugins = [
 
 imports = ["/etc/containerd/config.d/*.toml"]
 
+{{#if settings.container-runtime.log-level}}
+[debug]
+level = "{{settings.container-runtime.log-level}}"
+{{/if}}
+
 [grpc]
 address = "/run/containerd/containerd.sock"
 

--- a/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.1/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -19,6 +19,11 @@ disabled_plugins = [
 
 imports = ["/etc/containerd/config.d/*.toml"]
 
+{{#if settings.container-runtime.log-level}}
+[debug]
+level = "{{settings.container-runtime.log-level}}"
+{{/if}}
+
 [grpc]
 address = "/run/containerd/containerd.sock"
 

--- a/packages/containerd-2.2/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.2/containerd-config-toml_k8s_containerd_sock
@@ -19,6 +19,11 @@ disabled_plugins = [
 
 imports = ["/etc/containerd/config.d/*.toml"]
 
+{{#if settings.container-runtime.log-level}}
+[debug]
+level = "{{settings.container-runtime.log-level}}"
+{{/if}}
+
 [grpc]
 address = "/run/containerd/containerd.sock"
 

--- a/packages/containerd-2.2/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.2/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -19,6 +19,11 @@ disabled_plugins = [
 
 imports = ["/etc/containerd/config.d/*.toml"]
 
+{{#if settings.container-runtime.log-level}}
+[debug]
+level = "{{settings.container-runtime.log-level}}"
+{{/if}}
+
 [grpc]
 address = "/run/containerd/containerd.sock"
 


### PR DESCRIPTION
## Summary

- Adds a `[debug]` section to containerd config templates to render the `log-level` setting
- Applies to all containerd versions (1.7, 2.1, 2.2) and both standard and nvidia socket variants

Depends on https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/137
Resolves https://github.com/bottlerocket-os/bottlerocket/issues/4720

## Test plan

- [ ] Verify rendered containerd config includes `[debug]` section with correct log level
- [ ] Test with default (info) and non-default (debug, warn) values
- [ ] Confirm omission when log-level is not set