### PR TITLE
fix: conditional wipefs before systemd-makefs for false-positive signature detection

### DIFF
--- a/packages/release/prepare-local-fs.service
+++ b/packages/release/prepare-local-fs.service
@@ -13,6 +13,13 @@ Type=oneshot
 EnvironmentFile=/usr/share/bottlerocket/image-features.env
 Environment=DATA_PARTITION_BLOCK_DEVICE=/dev/disk/by-partlabel/BOTTLEROCKET-DATA
 
+# Wipe stale or false-positive partition/filesystem signatures before
+# formatting. Only runs when no valid filesystem is detected, so existing
+# data partitions are left untouched. Prevents mkfs.xfs from refusing to
+# format due to pseudorandom data matching signature patterns (e.g. Atari
+# partition table on encrypted EBS volumes).
+ExecStart=-/bin/sh -c '! /usr/sbin/blkid ${DATA_PARTITION_BLOCK_DEVICE} && /usr/sbin/wipefs -a ${DATA_PARTITION_BLOCK_DEVICE}'
+
 # Create the filesystem on the partition, if it doesn't exist.
 ExecStart=/usr/lib/systemd/systemd-makefs ${DATA_PARTITION_FILESYSTEM} ${DATA_PARTITION_BLOCK_DEVICE}
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/bottlerocket-os/bottlerocket/issues/4855

On encrypted EBS volumes, pseudorandom data on the `BOTTLEROCKET-DATA` partition can match an Atari partition table signature (only 2 bytes at a specific offset), causing `mkfs.xfs` to refuse formatting (~1/1800 instance launches). This cascades to prevent all of `/local`, `/var`, `/opt`, `/mnt` from mounting — containerd and kubelet never start, the node never joins the EKS cluster.

This adds a conditional `wipefs -a` before `systemd-makefs` in `prepare-local-fs.service` that only runs when no valid filesystem is detected.

## Implementation Details

- `wipefs -a` erases all magic strings/signatures from a device (partition tables, filesystem superblocks, etc.)
- `blkid` exits 0 when it finds a filesystem, 2 when it does not — the `!` inverts this
- `systemd-makefs` internally checks for existing filesystems and is a no-op if one exists
- The `-` prefix on the ExecStart line makes the entire wipefs step non-fatal
- The encrypted variant (`prepare-local-fs-encrypted.conf`) overrides `DATA_PARTITION_BLOCK_DEVICE` to `/dev/mapper/BOTTLEROCKET-DATA` — the same fix applies to both the plain and encrypted paths since the decrypted mapper device also contains random-looking data before first format

## Test plan

- [ ] Boot a Bottlerocket instance with encrypted EBS data volume and verify `prepare-local-fs.service` succeeds
- [ ] Verify on an instance with an already-formatted data partition that `wipefs` is skipped (blkid returns 0, short-circuits)
- [ ] Simulate the false positive by writing Atari signature bytes to a test block device and confirm wipefs clears them before mkfs runs
