### PR TITLE
Prepare core-kit release v14.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # v14.5.1 (2026-06-18)
 
 ### Third Party Package Updates
-- Include CVE fixes for containerd-1.7 ([f4dd7cb2])
-- Update containerd-2.1 from 2.1.7 to 2.1.8 and include CVE patches ([41448816], [e7c6a123])
-- Update containerd-2.2 from 2.2.3 to 2.2.4 and include CVE patches ([e4da5949], [5e0c087f])
+- Include CVE fixes for containerd-1.7 ([#d3898326])
+- Update containerd-2.1 from 2.1.7 to 2.1.8 and include CVE patches ([#6d6e3ba9], [#d05edc04])
+- Update containerd-2.2 from 2.2.3 to 2.2.4 and include CVE patches ([#33f6b6d4], [#f45396d9])
+
+[#d3898326]: https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/d38983261fa858d5d21c2fb96d0bee34a30cecf4
+[#6d6e3ba9]: https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/6d6e3ba905002d3eed388d0cc54ae5ed172021a3
+[#d05edc04]: https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/d05edc045d1abb1987585f2696317c2d25cedb1e
+[#33f6b6d4]: https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/33f6b6d40c5db9318fd64306aaa13e57ad5fbd45
+[#f45396d9]: https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/f45396d93c2555ed7da51a91d33bfaa6dc1bcd10
 
 # v14.5.0 (2026-06-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# v14.6.0 (2026-06-19)
+
+## OS Changes
+- Allow disabling `nvidia-k8s-device-plugin` through API ([#914])
+- Move FIPS components from `release-fips` sub-package to base package controlled via kernel commandline parameter ([#918])
+- Normalize NVIDIA library paths in containers so libraries appear at `/usr/lib` ([#919])
+- Update Rust and Go dependencies for first-party sources ([#949])
+
+### Third Party Package Updates
+- Update `nvidia-container-toolkit`, `libnvidia-container`, `nvidia-k8s-device-plugin` ([#931])
+
+## Build Changes
+- Bump `bottlerocket-settings-models` to 0.24.0 ([#914])
+- Update Twoliter to 0.20.0 ([#936])
+- Update `bottlerocket-sdk` to v0.76.0 ([#942], [#945])
+
+## Orchestrator Changes
+### Kubernetes
+- Add the `remap-ids` capability to the soci-snapshotter configuration, allowing it to start pods with `hostUsers: false` ([#939])  - Thanks @mhulscher!
+
+[#914]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/914
+[#918]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/918
+[#919]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/919
+[#931]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/931
+[#936]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/936
+[#939]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/939
+[#942]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/942
+[#945]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/945
+[#949]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/949
+
 # v14.5.1 (2026-06-18)
 
 ### Third Party Package Updates

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "14.5.1"
+release-version = "14.6.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]


### PR DESCRIPTION
**Description of changes:**
- twoliter bump
- changelog update

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
