### PR TITLE
feat: add hugepages support

### DIFF
--- a/packages/os/configure-hugepages.service
+++ b/packages/os/configure-hugepages.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Reserves static hugepages at early boot
+After=settings-applier.service
+Requires=settings-applier.service
+# Block manual interactions with this service, since we want to run it only at boot time
+RefuseManualStart=true
+RefuseManualStop=true
+ConditionPathExists=/etc/corndog.toml
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/corndog allocate-hugepages
+RemainAfterExit=yes
+StandardError=journal+console
+
+[Install]
+RequiredBy=preconfigured.target

--- a/packages/os/corndog-toml
+++ b/packages/os/corndog-toml
@@ -1,5 +1,6 @@
 [required-extensions]
 kernel = "v1"
+std = { version = "v1", helpers = ["default"] }
 +++
 {{#if settings.kernel.lockdown}}
 lockdown = "{{{settings.kernel.lockdown}}}"
@@ -9,4 +10,25 @@ lockdown = "{{{settings.kernel.lockdown}}}"
 {{#each settings.kernel.sysctl}}
 "{{@key}}" = "{{{this}}}"
 {{/each}}
+{{/if}}
+{{#if settings.kernel.hugepages}}
+{{#if settings.kernel.hugepages.static}}
+[hugepages.static]
+essential = {{default false settings.kernel.hugepages.static.essential}}
+{{#each settings.kernel.hugepages.static}}
+{{#if this.count}}
+[hugepages.static."{{@key}}"]
+count = "{{{this.count}}}"
+{{/if}}
+{{/each}}
+{{/if}}
+{{#if settings.kernel.hugepages.transparent}}
+[hugepages.transparent]
+{{#if settings.kernel.hugepages.transparent.enabled}}
+enabled = "{{{settings.kernel.hugepages.transparent.enabled}}}"
+{{/if}}
+{{#if settings.kernel.hugepages.transparent.defrag}}
+defrag = "{{{settings.kernel.hugepages.transparent.defrag}}}"
+{{/if}}
+{{/if}}
 {{/if}}

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -70,6 +70,7 @@ Source122: has-boot-ever-succeeded.service
 Source123: pluto.service
 Source124: bootstrap-commands.service
 Source125: whippet.service
+Source126: configure-hugepages.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -770,7 +771,7 @@ install -p -m 0644 \
   %{S:100} %{S:102} %{S:103} %{S:105} \
   %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
   %{S:113} %{S:114} %{S:120} %{S:122} %{S:123} %{S:124} \
-  %{S:125} \
+  %{S:125} %{S:126} \
   %{buildroot}%{_cross_unitdir}
 
 install -p -m 0644 %{S:10} %{buildroot}%{_cross_templatedir}
@@ -829,6 +830,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %files -n %{_cross_os}corndog
 %{_cross_bindir}/corndog
 %{_cross_templatedir}/corndog-toml
+%{_cross_unitdir}/configure-hugepages.service
 
 %files -n %{_cross_os}sundog
 %{_cross_bindir}/sundog

--- a/sources/api/corndog/README.md
+++ b/sources/api/corndog/README.md
@@ -6,6 +6,7 @@ corndog is a delicious way to get at the meat inside the kernels.
 It sets kernel-related settings, for example:
 * sysctl values, based on key/value pairs in `settings.kernel.sysctl`
 * lockdown mode, based on the value of `settings.kernel.lockdown`
+* static and transparent hugepage settings, based on the values of `settings.kernel.hugepages`
 
 corndog also provides a settings generator for hugepages, subcommand "generate-hugepages-setting".
 

--- a/sources/api/corndog/src/hugepages.rs
+++ b/sources/api/corndog/src/hugepages.rs
@@ -1,0 +1,329 @@
+use bottlerocket_modeled_types::{
+    HugepageConfig, HugepageSize, HugepagesStatic, HugepagesTransparent,
+    TransparentHugepageDefragPolicy, TransparentHugepagePolicy,
+};
+use log::{info, warn};
+use snafu::{ensure, OptionExt, ResultExt};
+use std::path::Path;
+
+/// Sysfs directory controlling Transparent Huge Pages (THP) policy (e.g. `enabled`, `defrag`).
+const TRANSPARENT_HUGEPAGE_SYSFS_ROOT: &str = "/sys/kernel/mm/transparent_hugepage";
+/// Sysfs directory holding the node-agnostic (global) huge page pools, with one
+/// `hugepages-<size>kB` subdirectory per supported page size.
+const HUGEPAGES_SYSFS_ROOT: &str = "/sys/kernel/mm/hugepages";
+/// Sysfs directory exposing per-NUMA-node state; each `node<N>` subdirectory has its own
+/// `hugepages` pool used for per-node allocations.
+const NODE_SYSFS_ROOT: &str = "/sys/devices/system/node";
+
+/// A NUMA node index.
+type Node = usize;
+/// A count of huge pages to allocate.
+type HugepageCount = u64;
+
+/// A parsed hugepage allocation count: either a node-agnostic global total or a single
+/// per-NUMA-node count.
+#[derive(Debug, PartialEq, Eq)]
+enum AllocationType {
+    Global(HugepageCount),
+    PerNode(Node, HugepageCount),
+}
+
+struct HugepageAllocation {
+    size: HugepageSize,
+    allocation_type: AllocationType,
+}
+
+impl HugepageAllocation {
+    fn parse_hugepage_setting(size: &HugepageSize, pool: &HugepageConfig) -> Result<Vec<Self>> {
+        let count = pool.count.trim();
+        ensure!(!count.is_empty(), error::EmptyAllocationSnafu);
+
+        // case when a node-agnostic hugepages are requested
+        if !count.contains(':') {
+            let total = count
+                .parse::<HugepageCount>()
+                .ok()
+                .context(error::MalformedAllocationSnafu { value: count })?;
+            return Ok(vec![Self {
+                size: size.clone(),
+                allocation_type: AllocationType::Global(total),
+            }]);
+        }
+
+        let mut allocations = Vec::new();
+        for pair in count.split(',') {
+            let (node, pages) = pair
+                .split_once(':')
+                .context(error::MalformedAllocationSnafu { value: count })?;
+            let node = node
+                .parse::<Node>()
+                .ok()
+                .context(error::MalformedAllocationSnafu { value: count })?;
+            let pages = pages
+                .parse::<HugepageCount>()
+                .ok()
+                .context(error::MalformedAllocationSnafu { value: count })?;
+            allocations.push(Self {
+                size: size.clone(),
+                allocation_type: AllocationType::PerNode(node, pages),
+            });
+        }
+
+        ensure!(!allocations.is_empty(), error::EmptyAllocationSnafu);
+        Ok(allocations)
+    }
+
+    fn request_hugepages(&self, essential: bool) -> Result<()> {
+        let page_size = self
+            .size
+            .as_kib()
+            .context(error::InvalidHugepageSettingsSnafu {})?;
+        let size_dir_name = format!("hugepages-{page_size}kB");
+
+        let (size_dir, requested) = match &self.allocation_type {
+            AllocationType::Global(requested) => (
+                Path::new(HUGEPAGES_SYSFS_ROOT).join(&size_dir_name),
+                *requested,
+            ),
+            AllocationType::PerNode(node, requested) => {
+                let node_dir = Path::new(NODE_SYSFS_ROOT)
+                    .join(format!("node{node}"))
+                    .join("hugepages");
+                ensure!(
+                    node_dir.exists(),
+                    error::NumaNodeUnavailableSnafu { node: *node }
+                );
+                (node_dir.join(&size_dir_name), *requested)
+            }
+        };
+
+        ensure!(
+            size_dir.exists(),
+            error::UnsupportedHugepageSizeSnafu {
+                size_kib: page_size,
+            }
+        );
+
+        let hugepage_path = size_dir.join("nr_hugepages");
+        match reserve_hugepages(&hugepage_path, requested, page_size) {
+            Ok(()) => Ok(()),
+            // Failing to reserve every requested page is only fatal for essential requests;
+            // for non-essential requests we log the shortfall and carry on.
+            Err(e @ error::Error::HugepageShortfall { .. }) => {
+                if essential {
+                    Err(e)
+                } else {
+                    warn!("{e}");
+                    Ok(())
+                }
+            }
+            // Any other failure (I/O, parse, unsupported size or node) is always fatal.
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// This function actually reserves hugepages. It does this by writing the requested value to the
+/// sysfs file. The value written to the file is the allocated number of hugepages. We Error out
+/// if we get less than the requested allocation.
+fn reserve_hugepages(hugepage_path: &Path, requested: HugepageCount, page_size: u64) -> Result<()> {
+    info!("reserving {requested} pages of {page_size} kiB huge pages via {hugepage_path:?}");
+
+    std::fs::write(hugepage_path, requested.to_string()).context(error::WriteSysfsSnafu {
+        path: hugepage_path.to_path_buf(),
+    })?;
+
+    let read_back = std::fs::read_to_string(hugepage_path).context(error::ReadSysfsSnafu {
+        path: hugepage_path.to_path_buf(),
+    })?;
+
+    let allocated: u64 = read_back.trim().parse().context(error::ParseSysfsSnafu {
+        path: hugepage_path.to_path_buf(),
+        value: read_back,
+    })?;
+
+    ensure!(
+        allocated == requested,
+        error::HugepageShortfallSnafu {
+            size_kib: page_size,
+            requested,
+            allocated,
+        }
+    );
+
+    Ok(())
+}
+
+/// Sets the requested hugepage settings in the kernel.
+///
+/// The settings are rendered at boot only. Because the hugepage allocation is best-effort
+/// from kernel side, we re-verify the number of allocated hugepages from sysfs. Depending
+/// on `settings.kernel.hugepages.static.essential`, we error out if we fail to get the
+/// requested number of hugepages.
+pub fn set_static_hugepages(static_hugepages: &HugepagesStatic) -> Result<()> {
+    let essential = static_hugepages.essential;
+    let mut allocations: Vec<HugepageAllocation> = Vec::new();
+
+    for (size, pool) in &static_hugepages.hugepages_config {
+        allocations.extend(HugepageAllocation::parse_hugepage_setting(size, pool)?);
+    }
+
+    allocations.sort_by_key(|allocation| std::cmp::Reverse(allocation.size.as_kib().unwrap_or(0)));
+    allocations
+        .into_iter()
+        .try_for_each(|allocation| allocation.request_hugepages(essential))
+}
+
+/// Sets the requested transparent hugepages settings in the kernel.
+///
+/// The settings are rendered at boot only. We set the settings to kernel's defaults. i.e.
+/// enabled and defrag set to madvise. If not explicitly set, defrag is dependent on the
+/// enabled setting.
+pub fn set_transparent_hugepages(transparent_hugepages: &HugepagesTransparent) -> Result<()> {
+    let thp_sysfs_root = Path::new(TRANSPARENT_HUGEPAGE_SYSFS_ROOT);
+
+    // The settings model itself has a default `madvise` for the enabled setting
+    let thp_enabled = transparent_hugepages.enabled.clone().unwrap_or_default();
+    // When `defrag` isn't set explicitly, derive it from the `enabled` policy.
+    let thp_defrag = transparent_hugepages
+        .defrag
+        .clone()
+        .unwrap_or(match thp_enabled {
+            TransparentHugepagePolicy::Always => TransparentHugepageDefragPolicy::Madvise,
+            TransparentHugepagePolicy::Madvise => TransparentHugepageDefragPolicy::Madvise,
+            TransparentHugepagePolicy::Never => TransparentHugepageDefragPolicy::Never,
+        });
+
+    info!("Setting transparent-hugepage enabled to {thp_enabled}");
+    std::fs::write(thp_sysfs_root.join("enabled"), thp_enabled.to_string()).context(
+        error::TransparentHugepageSnafu {
+            setting: "enabled",
+            transparent_hugepage: thp_enabled,
+        },
+    )?;
+
+    info!("Setting transparent-hugepage defrag to {thp_defrag}");
+    std::fs::write(thp_sysfs_root.join("defrag"), thp_defrag.to_string()).context(
+        error::TransparentHugepageSnafu {
+            setting: "defrag",
+            transparent_hugepage: thp_defrag,
+        },
+    )?;
+
+    Ok(())
+}
+
+pub mod error {
+    use snafu::Snafu;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub(super)))]
+    pub enum Error {
+        #[snafu(display("Invalid Hugepages settings provided"))]
+        InvalidHugepageSettings {},
+
+        #[snafu(display("Unsupported huge page size {} kiB", size_kib))]
+        UnsupportedHugepageSize { size_kib: u64 },
+
+        #[snafu(display("NUMA node {} is not available", node))]
+        NumaNodeUnavailable { node: usize },
+
+        #[snafu(display("Empty huge page allocation count"))]
+        EmptyAllocation {},
+
+        #[snafu(display("Malformed huge page allocation count '{}'", value))]
+        MalformedAllocation { value: String },
+
+        #[snafu(display(
+            "{} kiB huge page pool short: requested {} pages but only {} were allocated",
+            size_kib,
+            requested,
+            allocated
+        ))]
+        HugepageShortfall {
+            size_kib: u64,
+            requested: u64,
+            allocated: u64,
+        },
+
+        #[snafu(display("Failed to write huge page count to '{}': {}", path.display(), source))]
+        WriteSysfs {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to read huge page count from '{}': {}", path.display(), source))]
+        ReadSysfs {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Failed to parse huge page count '{}' from '{}': {}", value, path.display(), source))]
+        ParseSysfs {
+            path: PathBuf,
+            value: String,
+            source: std::num::ParseIntError,
+        },
+
+        #[snafu(display(
+            "Failed to change transparent-hugepage '{}' setting to '{}': {}",
+            setting,
+            transparent_hugepage,
+            source
+        ))]
+        TransparentHugepage {
+            setting: String,
+            transparent_hugepage: String,
+            source: std::io::Error,
+        },
+    }
+}
+
+pub type Result<T> = std::result::Result<T, error::Error>;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_hugepage_setting_total() {
+        let size = HugepageSize::try_from("2Mi").unwrap();
+        let pool = HugepageConfig {
+            count: "512".try_into().unwrap(),
+        };
+        let allocations = HugepageAllocation::parse_hugepage_setting(&size, &pool).unwrap();
+        assert_eq!(allocations.len(), 1);
+        assert_eq!(allocations[0].size, size);
+        assert_eq!(allocations[0].allocation_type, AllocationType::Global(512));
+    }
+
+    #[test]
+    fn test_parse_hugepage_setting_per_node() {
+        let size = HugepageSize::try_from("2Mi").unwrap();
+
+        let pool = HugepageConfig {
+            count: "0:128,1:256".try_into().unwrap(),
+        };
+        let allocations = HugepageAllocation::parse_hugepage_setting(&size, &pool).unwrap();
+        assert_eq!(allocations.len(), 2);
+        assert_eq!(
+            allocations[0].allocation_type,
+            AllocationType::PerNode(0, 128)
+        );
+        assert_eq!(
+            allocations[1].allocation_type,
+            AllocationType::PerNode(1, 256)
+        );
+
+        let pool = HugepageConfig {
+            count: "2:512".try_into().unwrap(),
+        };
+        let allocations = HugepageAllocation::parse_hugepage_setting(&size, &pool).unwrap();
+        assert_eq!(allocations.len(), 1);
+        assert_eq!(
+            allocations[0].allocation_type,
+            AllocationType::PerNode(2, 512)
+        );
+    }
+}

--- a/sources/api/corndog/src/main.rs
+++ b/sources/api/corndog/src/main.rs
@@ -3,11 +3,14 @@ corndog is a delicious way to get at the meat inside the kernels.
 It sets kernel-related settings, for example:
 * sysctl values, based on key/value pairs in `settings.kernel.sysctl`
 * lockdown mode, based on the value of `settings.kernel.lockdown`
+* static and transparent hugepage settings, based on the values of `settings.kernel.hugepages`
 
 corndog also provides a settings generator for hugepages, subcommand "generate-hugepages-setting".
 */
+mod hugepages;
 
-use bottlerocket_modeled_types::{Lockdown, SysctlKey};
+use crate::hugepages::*;
+use bottlerocket_modeled_types::{HugepagesSettings, Lockdown, SysctlKey};
 use log::{debug, info, trace, warn};
 use serde::{Deserialize, Serialize};
 use simplelog::{Config as LogConfig, LevelFilter, SimpleLogger};
@@ -26,6 +29,7 @@ const SYSCTL_CONFIG_DIR: &str = "/etc/sysctl.d";
 const SYSCTL_CONFIG_FILENAME: &str = "95-corndog.conf";
 const SYSTEMD_SYSCTL_BIN: &str = "/usr/lib/systemd/systemd-sysctl";
 const NR_HUGEPAGES_PATH_SYSCTL: &str = "/proc/sys/vm/nr_hugepages";
+
 /// Number of hugepages we will assign per core.
 /// See [`compute_hugepages_for_efa`] for more detail on the computation consideration.
 const HUGEPAGES_2MB_PER_CORE: u64 = 110;
@@ -44,6 +48,8 @@ struct KernelSettings {
     // Values are almost always a single line and often just an integer... but not always.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     sysctl: Option<HashMap<SysctlKey, String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    hugepages: Option<HugepagesSettings>,
 }
 
 /// Trait for executing system commands
@@ -83,6 +89,13 @@ fn run() -> Result<()> {
             if let Some(lockdown) = kernel.lockdown {
                 debug!("Setting lockdown: {lockdown:#?}");
                 set_lockdown(&lockdown)?;
+            }
+        }
+        "allocate-hugepages" => {
+            let kernel = get_kernel_settings(args.config_path)?;
+            if let Some(hugepages) = kernel.hugepages {
+                debug!("Applying hugepages settings: {hugepages:#?}");
+                apply_hugepages(&hugepages)?;
             }
         }
         "generate-hugepages-setting" => {
@@ -255,6 +268,19 @@ fn set_lockdown(lockdown: &str) -> Result<()> {
     fs::write(LOCKDOWN_PATH, lockdown).context(error::LockdownSnafu { current, lockdown })
 }
 
+fn apply_hugepages(hugepages: &HugepagesSettings) -> Result<()> {
+    if let Some(static_hugepages) = &hugepages.static_hugepages {
+        set_static_hugepages(static_hugepages).context(error::HugepagesSnafu)?;
+    }
+
+    // Setting transparent hugepages settings.
+    if let Some(transparent_hugepages) = &hugepages.transparent_hugepages {
+        set_transparent_hugepages(transparent_hugepages).context(error::HugepagesSnafu)?;
+    }
+
+    Ok(())
+}
+
 /// The Linux kernel provides human-readable output like `[none] integrity confidentiality` when
 /// you read settings from virtual files like /sys/kernel/security/lockdown.  This parses out the
 /// current value of the setting from that human-readable output.
@@ -288,6 +314,7 @@ fn usage() -> ! {
         sysctl
         lockdown
         generate-hugepages-setting
+        allocate-hugepages,
 
     Global arguments:
         --config-path PATH
@@ -305,14 +332,17 @@ fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
 }
 
 /// Parses the arguments to the program and return a representative `Args`.
-fn parse_args(args: env::Args) -> Args {
+fn parse_args<A>(args: A) -> Args
+where
+    A: Iterator<Item = String>,
+{
     let mut log_level = None;
     let mut config_path = None;
     let mut subcommand = None;
 
     let mut iter = args.skip(1);
     while let Some(arg) = iter.next() {
-        match arg.as_ref() {
+        match arg.as_str() {
             "--log-level" => {
                 let log_level_str = iter
                     .next()
@@ -330,7 +360,9 @@ fn parse_args(args: env::Args) -> Args {
                 )
             }
 
-            "sysctl" | "lockdown" | "generate-hugepages-setting" => subcommand = Some(arg),
+            "sysctl" | "lockdown" | "generate-hugepages-setting" | "allocate-hugepages" => {
+                subcommand = Some(arg)
+            }
 
             _ => usage(),
         }
@@ -393,6 +425,11 @@ mod error {
         #[snafu(display("Logger setup error: {}", source))]
         Logger { source: log::SetLoggerError },
 
+        #[snafu(display("Failed to apply hugepage settings: {}", source))]
+        Hugepages {
+            source: crate::hugepages::error::Error,
+        },
+
         #[snafu(display("Failed to create temporary file in {}: {}", path.display(), source))]
         CreateTempFile { path: PathBuf, source: io::Error },
 
@@ -424,6 +461,10 @@ type Result<T> = std::result::Result<T, error::Error>;
 #[cfg(test)]
 mod test {
     use super::*;
+    use bottlerocket_modeled_types::{
+        HugepageSize, TransparentHugepageDefragPolicy, TransparentHugepagePolicy,
+    };
+    use std::fs;
     use std::os::unix::process::ExitStatusExt;
     use std::process::ExitStatus;
     use tempfile::TempDir;
@@ -556,6 +597,55 @@ mod test {
         let num_cores: usize = 2;
         let computed_hugepages = compute_hugepages_for_efa(num_cores);
         assert_eq!(computed_hugepages, "220")
+    }
+
+    #[test]
+    fn test_deserialize_hugepages_settings() {
+        let toml_str = r#"
+        [hugepages.static]
+        essential = true
+        "2Mi" = { count = "512" }
+        "1Gi" = { count = "4" }
+
+        [hugepages.transparent]
+        enabled = "always"
+        defrag = "defer+madvise"
+        "#;
+        let kernel: KernelSettings = toml::from_str(toml_str).unwrap();
+        let hugepages = kernel.hugepages.expect("hugepages should be present");
+
+        let two_mi = HugepageSize::try_from("2Mi").unwrap();
+        let one_gi = HugepageSize::try_from("1Gi").unwrap();
+        let static_hugepages = hugepages
+            .static_hugepages
+            .as_ref()
+            .expect("static block should be present");
+
+        assert!(static_hugepages.essential);
+        let two_mi_pool = static_hugepages
+            .hugepages_config
+            .get(&two_mi)
+            .expect("2Mi pool should be present");
+        assert_eq!(two_mi_pool.count, "512");
+        assert_eq!(
+            static_hugepages
+                .hugepages_config
+                .get(&one_gi)
+                .map(|c| &c.count),
+            Some(&"4".try_into().unwrap())
+        );
+        // Neither the block-level `essential` nor the named `transparent` field leaks into the
+        // flattened static pool map.
+        assert_eq!(static_hugepages.hugepages_config.len(), 2);
+
+        let transparent = hugepages
+            .transparent_hugepages
+            .expect("transparent should be present");
+        assert_eq!(transparent.enabled, Some(TransparentHugepagePolicy::Always));
+        assert_eq!(
+            transparent.defrag,
+            Some(TransparentHugepageDefragPolicy::DeferMadvise)
+        );
     }
 
     #[test_case("".to_string(), "0".to_string())]


### PR DESCRIPTION
issue: https://github.com/bottlerocket-os/bottlerocket/issues/4385

**Description of changes:**
- Add support for hugepages and transparent hugepages

**Testing done:**
1. Kits and AMI build ✅ 
3. cat /proc/meminfo shows correct values  ✅ 
4. kubectl describe node advertises correct values  ✅ 
5. Pods are able to use it and we can benchmark with pointer chasing experiments ✅ 
6. EFA Test
7. Test both arches - x86 and aarch64 support diffferent set of sizes ✅ 
8. Instance fails to boot if required hugepages don't get allocated: ✅ 

This is a 256GB instance, so the following request is unreasonable.
user-data:
```
[settings.kernel.hugepages.static]
essential = true
[settings.kernel.hugepages.static."2Mi"]
count = "200"
[settings.kernel.hugepages.static."1Gi"]
count = "254"
[settings.kernel.hugepages.transparent]
enabled = "always"
```
logs:
```
[FAILED] Failed to start Reserves static hugepages at early boot.
See 'systemctl status configure-hugepages.service' for details.
[DEPEND] Dependency failed for Bottlerocket initial configuration complete.
[DEPEND] Dependency failed for Activate configured.target.
[DEPEND] Dependency failed for TPM PCR Barrier (Preconfigured).
```

8. Instance boots with the same settings if essential is false: ✅ 
Also, it can be seen that default THP defrag has defaulted to `[madvise]` when enabled is set to `[always]`

user-data:
```
[settings.kernel.hugepages.static]
essential = true
[settings.kernel.hugepages.static."2Mi"]
count = "200"
[settings.kernel.hugepages.static."1Gi"]
count = "254"
[settings.kernel.hugepages.transparent]
enabled = "always"
```
test:
```
bash-5.2# cat /proc/meminfo | grep ^Huge
HugePages_Total:     200
HugePages_Free:      200
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:        247873536 kB
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/enabled
[always] madvise never
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/defrag
always defer defer+madvise [madvise] never
bash-5.2# cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
116
bash-5.2# cat /sys/devices/system/node/node1/hugepages/hugepages-1048576kB/nr_hugepages
120
```

9. Test defaults for THP enabled: always  ✅ 

```
[root@admin]# sheltie
bash-5.2# apiclient get settings.kernel.hugepages
{
  "settings": {
    "kernel": {
      "hugepages": {
        "static": {
          "1Gi": {
            "count": "0:30,1:25"
          },
          "2Mi": {
            "count": "200"
          },
          "essential": true
        },
        "transparent": {
          "enabled": "always"
        }
      }
    }
  }
}
bash-5.2# cat /proc/meminfo | grep ^Huge
HugePages_Total:     200
HugePages_Free:      200
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:        58081280 kB
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/enabled
[always] madvise never
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/defrag
always defer defer+madvise [madvise] never
bash-5.2# cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
30
bash-5.2# cat /sys/devices/system/node/node1/hugepages/hugepages-1048576kB/nr_hugepages
25
bash-5.2#
```

11. Test defaults for THP enabled: never  ✅ 

```
bash-5.2# apiclient get settings.kernel.hugepages
{
  "settings": {
    "kernel": {
      "hugepages": {
        "static": {
          "1Gi": {
            "count": "0:30,1:25"
          },
          "2Mi": {
            "count": "200"
          },
          "essential": true
        },
        "transparent": {
          "enabled": "never"
        }
      }
    }
  }
}
bash-5.2# cat /proc/meminfo | grep ^Huge
HugePages_Total:     200
HugePages_Free:      200
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:        58081280 kB
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/enabled
always madvise [never]
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/defrag
always defer defer+madvise madvise [never]
bash-5.2# cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
30
bash-5.2# cat /sys/devices/system/node/node1/hugepages/hugepages-1048576kB/nr_hugepages
25
bash-5.2#
```

12. Test defaults for THP enabled: madvise  ✅ 

```
bash-5.2# apiclient get settings.kernel.hugepages
{
  "settings": {
    "kernel": {
      "hugepages": {
        "static": {
          "1Gi": {
            "count": "0:30,1:25"
          },
          "2Mi": {
            "count": "200"
          },
          "essential": true
        },
        "transparent": {
          "enabled": "madvise"
        }
      }
    }
  }
}
bash-5.2# cat /proc/meminfo | grep ^Huge
HugePages_Total:     200
HugePages_Free:      200
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:        58081280 kB
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/enabled
always [madvise] never
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/defrag
always defer defer+madvise [madvise] never
bash-5.2# cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
30
bash-5.2# cat /sys/devices/system/node/node1/hugepages/hugepages-1048576kB/nr_hugepages
25
```

13. Additional sizes available in aarch64 variant  ✅ 

user-data:
```
[settings.kernel.hugepages.static]
essential = false
[settings.kernel.hugepages.static."32768Ki"]
count = "20"
[settings.kernel.hugepages.static."1Gi"]
count = "10"
[settings.kernel.hugepages.transparent]
enabled = "always"
```
describe node output:
```
kubectl describe node --kubeconfig bottlerocket-cluster-136.kubeconfig 
Name:               ip-192-168-91-54.us-west-2.compute.internal
Roles:              <none>
Labels:             alpha.eksctl.io/cluster-name=bottlerocket-cluster-136
                    alpha.eksctl.io/nodegroup-name=bottlerocket-cluster-136-ng
                    beta.kubernetes.io/arch=arm64
                    beta.kubernetes.io/instance-type=c6gd.16xlarge
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=us-west-2
                    failure-domain.beta.kubernetes.io/zone=us-west-2d
                    k8s.io/cloud-provider-aws=cabe22ae3a9eeb98d99d398383db1184
                    kubernetes.io/arch=arm64
                    kubernetes.io/hostname=ip-192-168-91-54.us-west-2.compute.internal
                    kubernetes.io/os=linux
                    node.kubernetes.io/instance-type=c6gd.16xlarge
                    topology.k8s.aws/zone-id=usw2-az4
                    topology.kubernetes.io/region=us-west-2
                    topology.kubernetes.io/zone=us-west-2d
Annotations:        alpha.kubernetes.io/provided-node-ip: 192.168.91.54
                    node.alpha.kubernetes.io/ttl: 0
                    volumes.kubernetes.io/controller-managed-attach-detach: true
CreationTimestamp:  Fri, 17 Jul 2026 09:24:10 +0000
Taints:             <none>
Unschedulable:      false
Lease:
  HolderIdentity:  ip-192-168-91-54.us-west-2.compute.internal
  AcquireTime:     <unset>
  RenewTime:       Fri, 17 Jul 2026 09:28:45 +0000
Conditions:
  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
  ----             ------  -----------------                 ------------------                ------                       -------
  MemoryPressure   False   Fri, 17 Jul 2026 09:27:08 +0000   Fri, 17 Jul 2026 09:24:11 +0000   KubeletHasSufficientMemory   kubelet has sufficient memory available
  DiskPressure     False   Fri, 17 Jul 2026 09:27:08 +0000   Fri, 17 Jul 2026 09:24:11 +0000   KubeletHasNoDiskPressure     kubelet has no disk pressure
  PIDPressure      False   Fri, 17 Jul 2026 09:27:08 +0000   Fri, 17 Jul 2026 09:24:11 +0000   KubeletHasSufficientPID      kubelet has sufficient PID available
  Ready            True    Fri, 17 Jul 2026 09:27:08 +0000   Fri, 17 Jul 2026 09:27:08 +0000   KubeletReady                 kubelet is posting ready status
Addresses:
  InternalIP:   192.168.91.54
  ExternalIP:   35.85.253.118
  InternalDNS:  ip-192-168-91-54.us-west-2.compute.internal
  Hostname:     ip-192-168-91-54.us-west-2.compute.internal
  ExternalDNS:  ec2-35-85-253-118.us-west-2.compute.amazonaws.com
Capacity:
  cpu:                64
  ephemeral-storage:  20768772Ki
  hugepages-1Gi:      10Gi
  hugepages-2Mi:      0
  hugepages-32Mi:     640Mi
  hugepages-64Ki:     0
  memory:             129539464Ki
  pods:               737
Allocatable:
  cpu:                63770m
  ephemeral-storage:  18066758420
  hugepages-1Gi:      10Gi
  hugepages-2Mi:      0
  hugepages-32Mi:     640Mi
  hugepages-64Ki:     0
  memory:             109733256Ki
  pods:               737
System Info:
  Machine ID:                 ec28d8ff605ba7d5debd7a8cc8e14933
  System UUID:                ec28d8ff-605b-a7d5-debd-7a8cc8e14933
  Boot ID:                    066c5d02-cc39-4b57-b892-cdc054ebd9c6
  Kernel Version:             6.18.33
  OS Image:                   Bottlerocket OS 1.64.0 (aws-k8s-1.36)
  Operating System:           linux
  Architecture:               arm64
  Container Runtime Version:  containerd://2.2.5+bottlerocket
  Kubelet Version:            v1.36.1-eks-a3a0722
  Kube-Proxy Version:         
ProviderID:                   aws:///us-west-2d/i-04b4db2fd7561f8cb
Non-terminated Pods:          (6 in total)
  Namespace                   Name                              CPU Requests  CPU Limits  Memory Requests  Memory Limits  Age
  ---------                   ----                              ------------  ----------  ---------------  -------------  ---
  kube-system                 aws-node-xwmgt                    50m (0%)      0 (0%)      0 (0%)           0 (0%)         2m
  kube-system                 coredns-58bc85895d-n2526          100m (0%)     0 (0%)      70Mi (0%)        170Mi (0%)     2m2s
  kube-system                 coredns-58bc85895d-spsxc          100m (0%)     0 (0%)      70Mi (0%)        170Mi (0%)     2m2s
  kube-system                 kube-proxy-97fqk                  100m (0%)     0 (0%)      0 (0%)           0 (0%)         2m
  kube-system                 metrics-server-5dc98b585-2rr2t    100m (0%)     0 (0%)      200Mi (0%)       400Mi (0%)     2m6s
  kube-system                 metrics-server-5dc98b585-gxljs    100m (0%)     0 (0%)      200Mi (0%)       400Mi (0%)     2m6s
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource           Requests    Limits
  --------           --------    ------
  cpu                550m (0%)   0 (0%)
  memory             540Mi (0%)  1140Mi (1%)
  ephemeral-storage  0 (0%)      0 (0%)
  hugepages-1Gi      0 (0%)      0 (0%)
  hugepages-2Mi      0 (0%)      0 (0%)
  hugepages-32Mi     0 (0%)      0 (0%)
  hugepages-64Ki     0 (0%)      0 (0%)
Events:
  Type    Reason          Age    From                   Message
  ----    ------          ----   ----                   -------
  Normal  Synced          4m37s  cloud-node-controller  Node synced successfully
  Normal  RegisteredNode  4m35s  node-controller        Node ip-192-168-91-54.us-west-2.compute.internal event: Registered Node ip-192-168-91-54.us-west-2.compute.internal in C
```
pointer chasing experiments work. Pods are able to use the advertised hugepages.

14. Requested hugepages. The following are the journal logs.  ✅ 

```
[root@admin]# sheltie
bash-5.2# journalctl | grep corndog
Jul 17 09:42:42 localhost thar-be-settings[8788]: 09:42:42 [INFO] restart commands ["/usr/bin/corndog sysctl"]
Jul 17 09:42:42 localhost thar-be-settings[8788]: 09:42:42 [INFO] restart commands ["/usr/bin/corndog lockdown"]
Jul 17 09:42:42 localhost corndog[9079]: 09:42:42 [INFO] reserving 30 pages of 1048576 kiB huge pages via "/sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages"
Jul 17 09:42:43 ip-172-31-10-90.us-west-2.compute.internal corndog[9079]: 09:42:43 [INFO] reserving 250 pages of 1048576 kiB huge pages via "/sys/devices/system/node/node1/hugepages/hugepages-1048576kB/nr_hugepages"
Jul 17 09:42:44 ip-172-31-10-90.us-west-2.compute.internal corndog[9079]: 09:42:44 [WARN] 1048576 kiB huge page pool short: requested 250 pages but only 122 were allocated
Jul 17 09:42:44 ip-172-31-10-90.us-west-2.compute.internal corndog[9079]: 09:42:44 [INFO] reserving 200 pages of 2048 kiB huge pages via "/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
Jul 17 09:42:44 ip-172-31-10-90.us-west-2.compute.internal corndog[9079]: 09:42:44 [INFO] Setting transparent-hugepage enabled to never
Jul 17 09:42:44 ip-172-31-10-90.us-west-2.compute.internal corndog[9079]: 09:42:44 [INFO] Setting transparent-hugepage defrag to never
bash-5.2# apiclient get settings.kernel.hugepages
{
  "settings": {
    "kernel": {
      "hugepages": {
        "static": {
          "1Gi": {
            "count": "0:30,1:250"
          },
          "2Mi": {
            "count": "200"
          },
          "essential": false
        },
        "transparent": {
          "enabled": "never"
        }
      }
    }
  }
}
bash-5.2# cat /proc/meminfo | grep ^Huge
HugePages_Total:     200
HugePages_Free:      200
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:        159793152 kB
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/enabled
always madvise [never]
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/defrag
always defer defer+madvise madvise [never]
bash-5.2# cat /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages
30
bash-5.2# cat /sys/devices/system/node/node1/hugepages/hugepages-1048576kB/nr_hugepages
122
```
15. Test transparent hugepages settings  ✅ 
```
bash-5.2# apiclient get settings.kernel.hugepages.transparent
{
  "settings": {
    "kernel": {
      "hugepages": {
        "transparent": {
          "defrag": "defer",
          "enabled": "always"
        }
      }
    }
  }
}
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/enabled
[always] madvise never
bash-5.2# cat /sys/kernel/mm/transparent_hugepage/defrag
always [defer] defer+madvise madvise never
```
16. The settings don't apply if settings-sdk in bob is not updated
```
bash-5.2# find . -name corndog-toml
./.bottlerocket/datastore/v1.63.0_uSJM5brP2I6tYSJN/live/configuration-files/corndog-toml
./var/lib/bottlerocket/datastore/v1.63.0_uSJM5brP2I6tYSJN/live/configuration-files/corndog-toml
./x86_64-bottlerocket-linux-gnu/sys-root/usr/share/templates/corndog-toml
bash-5.2# apiclient apply <<EOF
> [settings.kernel.hugepages.static]
> essential = false
> [settings.kernel.hugepages.static."2Mi"]
> count = "200"
> [settings.kernel.hugepages.static."1Gi"]
> count = "0:30,1:250"
> [settings.kernel.hugepages.transparent]
> enabled = "madvise"
> defrag = "defer"
> EOF
Failed to apply settings: Failed to PATCH settings from '-' to '/settings?tx=apiclient-apply-UEQAVTdUNPKHLxfL': Status 400 when PATCHing /settings?tx=apiclient-apply-UEQAVTdUNPKHLxfL: Json deserialize error: unknown field `hugepages`, expected one of `lockdown`, `modules`, `sysctl` at line 1 column 22
bash-5.2# cat ./x86_64-bottlerocket-linux-gnu/sys-root/usr/share/templates/corndog-toml
[required-extensions]
kernel = "v1"
std = { version = "v1", helpers = ["default"] }
+++
{{#if settings.kernel.lockdown}}
lockdown = "{{{settings.kernel.lockdown}}}"
{{/if}}
{{#if settings.kernel.sysctl}}
[sysctl]
{{#each settings.kernel.sysctl}}
"{{@key}}" = "{{{this}}}"
{{/each}}
{{/if}}
{{#if settings.kernel.hugepages}}
{{#if settings.kernel.hugepages.static}}
[hugepages.static]
essential = {{default false settings.kernel.hugepages.static.essential}}
{{#each settings.kernel.hugepages.static}}
{{#if this.count}}
[hugepages.static."{{@key}}"]
count = "{{{this.count}}}"
{{/if}}
{{/each}}
{{/if}}
{{#if settings.kernel.hugepages.transparent}}
[hugepages.transparent]
{{#if settings.kernel.hugepages.transparent.enabled}}
enabled = "{{{settings.kernel.hugepages.transparent.enabled}}}"
{{/if}}
{{#if settings.kernel.hugepages.transparent.defrag}}
defrag = "{{{settings.kernel.hugepages.transparent.defrag}}}"
{{/if}}
{{/if}}
{{/if}}
bash-5.2#
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.