### PR TITLE
systemd: set kmod binary path to /usr/bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v14.6.1 (2026-06-23)
+
+## OS Changes
+- Pin `kmod` binary in `systemd` to use `/usr/bin/` ([#957])
+
+[#957]:https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/957
+
 # v14.6.0 (2026-06-19)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "14.6.0"
+release-version = "14.6.1"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/packages/systemd-252/systemd-252.spec
+++ b/packages/systemd-252/systemd-252.spec
@@ -265,7 +265,8 @@ CONFIGURE_OPTS=(
  -Dpkgconfiglibdir='%{_cross_pkgconfigdir}'
  -Dmount-path='%{_cross_bindir}/mount'
  -Dumount-path='%{_cross_bindir}/umount'
-
+ -Dkmod-path='%{_cross_bindir}/kmod'
+ 
  -Ddefault-hierarchy=unified
 
  -Dadm-group=false

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -245,6 +245,8 @@ CONFIGURE_OPTS=(
  -Dpkgconfiglibdir='%{_cross_pkgconfigdir}'
  -Dmount-path='%{_cross_bindir}/mount'
  -Dumount-path='%{_cross_bindir}/umount'
+ -Dkmod-path='%{_cross_bindir}/kmod'
+ 
 
  -Dadm-group=false
  -Dwheel-group=false


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/956

**Description of changes:**
- Set the `kmod` binary path as a meson option to avoid the resolution to an incorrect path
- Update Twoliter.toml to v 14.6.1
- Update the changelog for the release


**Testing done:**
- Verified the rest of the paths in https://github.com/systemd/systemd-stable/blob/654c59868921cb50c0dd4c349165bb9066a79958/meson.build#L677-L703 and those are all either already in `/usr/sbin` or fixed in the meson option (like `mount/umount`)

-  Built and tested a `aws-k8s-1.30` AMI:
```bash
bash-5.2# systemctl show kmod-static-nodes.service | grep kmod
ExecStart={ path=/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/kmod ; argv[]=/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/kmod static-nodes --format=tmpfiles --output=/run/tmpfiles.d/static-nodes.conf ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }
ExecStartEx={ path=/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/kmod ; argv[]=/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/kmod static-nodes --format=tmpfiles --output=/run/tmpfiles.d/static-nodes.conf ; flags= ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }
Id=kmod-static-nodes.service
Names=kmod-static-nodes.service
FragmentPath=/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kmod-static-nodes.service
---
bash-5.2# systemctl status kmod-static-nodes.service
● kmod-static-nodes.service - Create List of Static Device Nodes
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kmod-static-nodes.service; static)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 00-fips-go.conf, 10-requires-tmp.conf
     Active: active (exited) since Tue 2026-06-23 22:27:08 UTC; 1min 56s ago
   Main PID: 381 (code=exited, status=0/SUCCESS)
        CPU: 2ms

Notice: journal has been rotated since unit was started, output may be incomplete.
---
bash-5.2# cat /run/tmpfiles.d/static-nodes.conf
c! /dev/fuse 0600 - - - 10:229
c! /dev/cuse 0600 - - - 10:203
c! /dev/btrfs-control 0600 - - - 10:234
c! /dev/nvram 0600 - - - 10:144
c! /dev/loop-control 0600 - - - 10:237
d /dev/net 0755 - - -
c! /dev/net/tun 0600 - - - 10:200
c! /dev/ppp 0600 - - - 108:0
c! /dev/uinput 0600 - - - 10:223
c! /dev/uhid 0600 - - - 10:239
d /dev/vfio 0755 - - -
c! /dev/vfio/vfio 0600 - - - 10:196
c! /dev/vhost-net 0600 - - - 10:238
c! /dev/vhost-vsock 0600 - - - 10:241
```

- Built and tested a `aws-k8s-1.35` AMI:
```bash
bash-5.2# systemctl show kmod-static-nodes.service | grep kmod
ExecStart={ path=/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/kmod ; argv[]=/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/kmod static-nodes --format=tmpfiles --output=/run/tmpfiles.d/static-nodes.conf ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }
ExecStartEx={ path=/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/kmod ; argv[]=/x86_64-bottlerocket-linux-gnu/sys-root/usr/bin/kmod static-nodes --format=tmpfiles --output=/run/tmpfiles.d/static-nodes.conf ; flags= ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }
Id=kmod-static-nodes.service
Names=kmod-static-nodes.service
FragmentPath=/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kmod-static-nodes.service
---
bash-5.2# systemctl status kmod-static-nodes.service
● kmod-static-nodes.service - Create List of Static Device Nodes
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/kmod-static-nodes.service; static)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 00-fips-go.conf, 10-requires-tmp.conf
     Active: active (exited) since Tue 2026-06-23 22:34:03 UTC; 1min 47s ago
 Invocation: 006450c560054bb7843b36079ffc5f9b
   Main PID: 657 (code=exited, status=0/SUCCESS)
   Mem peak: 1.1M
        CPU: 15ms

Notice: journal has been rotated since unit was started, output may be incomplete.
---
bash-5.2# cat /run/tmpfiles.d/static-nodes.conf
c! /dev/fuse 0600 - - - 10:229
c! /dev/cuse 0600 - - - 10:203
c! /dev/nvram 0600 - - - 10:144
c! /dev/loop-control 0600 - - - 10:237
d /dev/net 0755 - - -
c! /dev/net/tun 0600 - - - 10:200
c! /dev/ppp 0600 - - - 108:0
c! /dev/uinput 0600 - - - 10:223
c! /dev/uhid 0600 - - - 10:239
d /dev/vfio 0755 - - -
c! /dev/vfio/vfio 0600 - - - 10:196
c! /dev/vhost-net 0600 - - - 10:238
c! /dev/vhost-vsock 0600 - - - 10:241
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
