### PR TITLE
Update systemd 252 and systemd 257

### DIFF
--- a/advisories/staging/BRSA-9xs23u3cauv2.toml
+++ b/advisories/staging/BRSA-9xs23u3cauv2.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "BRSA-9xs23u3cauv2"
+title = "systemd CVE-2026-40225"
+cve = "CVE-2026-40225"
+severity = "moderate"
+description = "A flaw was found in systemd-nspawn where pivot_root path parsing only validated that paths were absolute but did not check normalization, allowing path traversal via non-normalized paths."
+
+[[advisory.products]]
+package-name = "systemd-252"
+patched-version = "252.39"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "systemd-257"
+patched-version = "257.13"
+patched-epoch = "0"
+
+[updateinfo]
+author = "maherhom"
+issue-date = 2026-07-15T23:36:55Z
+arches = ["x86_64", "aarch64"]
+version = "staging"

--- a/advisories/staging/BRSA-jk0fvdm3ylf0.toml
+++ b/advisories/staging/BRSA-jk0fvdm3ylf0.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "BRSA-jk0fvdm3ylf0"
+title = "systemd CVE-2026-29111"
+cve = "CVE-2026-29111"
+severity = "moderate"
+description = "A flaw was found in systemd where the GetUnitByControlGroup D-Bus method accepted non-absolute and non-normalized cgroup paths, potentially allowing path traversal."
+
+[[advisory.products]]
+package-name = "systemd-252"
+patched-version = "252.39"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "systemd-257"
+patched-version = "257.13"
+patched-epoch = "0"
+
+[updateinfo]
+author = "maherhom"
+issue-date = 2026-07-15T23:30:17Z
+arches = ["aarch64", "x86_64"]
+version = "staging"

--- a/advisories/staging/BRSA-zavixeztokdt.toml
+++ b/advisories/staging/BRSA-zavixeztokdt.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "BRSA-zavixeztokdt"
+title = "systemd CVE-2026-40226"
+cve = "CVE-2026-40226"
+severity = "moderate"
+description = "A flaw was found in systemd-nspawn where Ephemeral and BindUser settings from .nspawn settings files were applied regardless of whether the file was trusted, potentially allowing privilege escalation."
+
+[[advisory.products]]
+package-name = "systemd-252"
+patched-version = "252.39"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "systemd-257"
+patched-version = "257.13"
+patched-epoch = "0"
+
+[updateinfo]
+author = "maherhom"
+issue-date = 2026-07-15T23:37:07Z
+arches = ["x86_64", "aarch64"]
+version = "staging"

--- a/packages/systemd-252/9020-core-validate-input-cgroup-path-more-prudently.patch
+++ b/packages/systemd-252/9020-core-validate-input-cgroup-path-more-prudently.patch
@@ -1,0 +1,36 @@
+From 1d22f706bd04f45f8422e17fbde3f56ece17758a Mon Sep 17 00:00:00 2001
+From: Mike Yuan <me@yhndnzj.com>
+Date: Thu, 26 Feb 2026 11:06:34 +0100
+Subject: [PATCH] core: validate input cgroup path more prudently
+
+commit efa6ba2ab625aaa160ac435a09e6482fc63bdbe8 upstream.
+
+Validate that cgroup paths received via the GetUnitByControlGroup D-Bus
+method are both absolute and normalized before performing the lookup.
+
+Signed-off-by: Mike Yuan <me@yhndnzj.com>
+[maherhom: backported to v252; dropped varlink-unit.c hunk (file does not
+exist in v252), adjusted sd_bus_error_setf parameter from reterr_error to
+error to match v252 API]
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ src/core/dbus-manager.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/core/dbus-manager.c b/src/core/dbus-manager.c
+index 2610442384475..104094dc46c59 100644
+--- a/src/core/dbus-manager.c
++++ b/src/core/dbus-manager.c
+@@ -623,6 +623,12 @@ static int method_get_unit_by_control_group(sd_bus_message *message, void *userd
+         if (r < 0)
+                 return r;
+ 
++        if (!path_is_absolute(cgroup))
++                return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Control group path is not absolute: %s", cgroup);
++
++        if (!path_is_normalized(cgroup))
++                return sd_bus_error_setf(error, SD_BUS_ERROR_INVALID_ARGS, "Control group path is not normalized: %s", cgroup);
++
+         u = manager_get_unit_by_cgroup(m, cgroup);
+         if (!u)
+                 return sd_bus_error_setf(error, BUS_ERROR_NO_SUCH_UNIT,

--- a/packages/systemd-252/9038-nspawn-normalize-pivot_root-paths.patch
+++ b/packages/systemd-252/9038-nspawn-normalize-pivot_root-paths.patch
@@ -1,0 +1,38 @@
+From 1c55a0a5e26a07df828f72092ad1203e221b60db Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@gmail.com>
+Date: Wed, 11 Mar 2026 13:27:14 +0000
+Subject: [PATCH] nspawn: normalize pivot_root paths
+
+commit 7b85f5498a958e5bb660c703b8f4a71cceed3373 upstream.
+
+Add path_is_normalized() validation to pivot_root_parse() for both
+root_new and root_old paths.
+
+Originally reported on yeswehack.com as:
+YWH-PGM9780-116
+
+Follow-up for b53ede699cdc5233041a22591f18863fb3fe2672
+
+Signed-off-by: Luca Boccassi <luca.boccassi@gmail.com>
+(cherry picked from commit 7b85f5498a958e5bb660c703b8f4a71cceed3373)
+[maherhom: backported to v252; patch applies cleanly without modifications]
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ src/nspawn/nspawn-mount.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/nspawn/nspawn-mount.c b/src/nspawn/nspawn-mount.c
+index e7c7c59147b92..8a243e8d03270 100644
+--- a/src/nspawn/nspawn-mount.c
++++ b/src/nspawn/nspawn-mount.c
+@@ -1370,7 +1370,9 @@ int pivot_root_parse(char **pivot_root_new, char **pivot_root_old, const char *s
+ 
+         if (!path_is_absolute(root_new))
+                 return -EINVAL;
+-        if (root_old && !path_is_absolute(root_old))
++        if (!path_is_normalized(root_new))
++                return -EINVAL;
++        if (root_old && (!path_is_absolute(root_old) || !path_is_normalized(root_old)))
+                 return -EINVAL;
+ 
+         free_and_replace(*pivot_root_new, root_new);

--- a/packages/systemd-252/9039-nspawn-apply-BindUser-Ephemeral-from-settings-fil.patch
+++ b/packages/systemd-252/9039-nspawn-apply-BindUser-Ephemeral-from-settings-fil.patch
@@ -1,0 +1,62 @@
+From 61bceb1bff4b1f9c126b18dc971ca3e6d8c71c40 Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@gmail.com>
+Date: Wed, 11 Mar 2026 12:15:26 +0000
+Subject: [PATCH] nspawn: apply BindUser/Ephemeral from settings file only if
+ trusted
+
+commit 61bceb1bff4b1f9c126b18dc971ca3e6d8c71c40 upstream.
+
+Only apply BindUser and Ephemeral settings from .nspawn settings files
+when the file is trusted. Log a warning otherwise.
+
+Originally reported on yeswehack.com as:
+YWH-PGM9780-116
+
+Follow-up for 2f8930449079403b26c9164b8eeac78d5af2c8df
+Follow-up for a2f577fca0be79b23f61f033229b64884e7d840a
+
+Signed-off-by: Luca Boccassi <luca.boccassi@gmail.com>
+(cherry picked from commit 61bceb1bff4b1f9c126b18dc971ca3e6d8c71c40)
+[maherhom: backported to v252; adjusted line offsets in merge_settings()
+(function at different position in v252)]
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ src/nspawn/nspawn.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index 1b3aa7d1ad50a..84e94e845a6b5 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -4329,8 +4329,13 @@ static int merge_settings(Settings *settings, const char *path) {
+         }
+ 
+         if ((arg_settings_mask & SETTING_EPHEMERAL) == 0 &&
+-            settings->ephemeral >= 0)
+-                arg_ephemeral = settings->ephemeral;
++            settings->ephemeral >= 0) {
++
++                if (!arg_settings_trusted)
++                        log_warning("Ignoring ephemeral setting, file %s is not trusted.", path);
++                else
++                        arg_ephemeral = settings->ephemeral;
++        }
+ 
+         if ((arg_settings_mask & SETTING_DIRECTORY) == 0 &&
+             settings->root) {
+@@ -4498,8 +4503,13 @@ static int merge_settings(Settings *settings, const char *path) {
+         }
+ 
+         if ((arg_settings_mask & SETTING_BIND_USER) == 0 &&
+-            !strv_isempty(settings->bind_user))
+-                strv_free_and_replace(arg_bind_user, settings->bind_user);
++            !strv_isempty(settings->bind_user)) {
++
++                if (!arg_settings_trusted)
++                        log_warning("Ignoring bind user setting, file %s is not trusted.", path);
++                else
++                        strv_free_and_replace(arg_bind_user, settings->bind_user);
++        }
+ 
+         if ((arg_settings_mask & SETTING_NOTIFY_READY) == 0 &&
+             settings->notify_ready >= 0)

--- a/packages/systemd-252/systemd-252.spec
+++ b/packages/systemd-252/systemd-252.spec
@@ -96,6 +96,10 @@ Patch9018: 9018-meson-replace-openssl-dependency-with-libcrypto.patch
 # it does not apply to Bottlerocket where the API is restricted by the SELinux
 # policy
 Patch9019: 9019-suppress-log-for-units-with-mode-0044.patch
+# Backport fixes for CVE-2026-29111, CVE-2026-40225, CVE-2026-40226
+Patch9020: 9020-core-validate-input-cgroup-path-more-prudently.patch
+Patch9038: 9038-nspawn-normalize-pivot_root-paths.patch
+Patch9039: 9039-nspawn-apply-BindUser-Ephemeral-from-settings-fil.patch
 
 BuildRequires: gperf
 BuildRequires: intltool

--- a/packages/systemd-257/9012-openssl-util-build-without-ui.patch
+++ b/packages/systemd-257/9012-openssl-util-build-without-ui.patch
@@ -1,4 +1,4 @@
-From cbd9ff7231882d22e79c69b333d5394bcdc144e8 Mon Sep 17 00:00:00 2001
+From f143397edcad1a76e33876cfb5bfa0b51ae17d50 Mon Sep 17 00:00:00 2001
 From: Vighnesh Maheshwari <vighmah@amazon.com>
 Date: Thu, 16 Oct 2025 10:00:47 -0700
 Subject: [PATCH] openssl-util: build without ui.h
@@ -6,13 +6,63 @@ Subject: [PATCH] openssl-util: build without ui.h
 Remove some code that depends on openssl/ui.h which is not provided by
 aws-lc. This can probably be submitted upstream.
 
-Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>
----
- src/shared/openssl-util.h | 11 +++++++++++
- 1 file changed, 11 insertions(+)
+[Refreshed for v257.13: Extended patch to guard new UI_METHOD references
+in openssl-util.c (load_key_from_provider, load_key_from_engine, and
+openssl_load_private_key) that were added upstream since 257.9.]
 
+Signed-off-by: Vighnesh Maheshwari <vighmah@amazon.com>
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ src/shared/openssl-util.c | 17 ++++++++++++++---
+ src/shared/openssl-util.h | 11 +++++++++++
+ 2 files changed, 25 insertions(+), 3 deletions(-)
+
+diff --git a/src/shared/openssl-util.c b/src/shared/openssl-util.c
+index a48bb1c..8d3e9ff 100644
+--- a/src/shared/openssl-util.c
++++ b/src/shared/openssl-util.c
+@@ -1319,7 +1319,11 @@ int pkey_generate_volume_keys(
+ static int load_key_from_provider(
+                 const char *provider,
+                 const char *private_key_uri,
++#ifndef OPENSSL_NO_UI_CONSOLE
+                 UI_METHOD *ui_method,
++#else
++                void *ui_method,
++#endif /* OPENSSL_NO_UI_CONSOLE */
+                 EVP_PKEY **ret) {
+ 
+         assert(provider);
+@@ -1362,7 +1366,13 @@ static int load_key_from_provider(
+ #endif
+ }
+ 
+-static int load_key_from_engine(const char *engine, const char *private_key_uri, UI_METHOD *ui_method, EVP_PKEY **ret) {
++static int load_key_from_engine(const char *engine, const char *private_key_uri,
++#ifndef OPENSSL_NO_UI_CONSOLE
++                UI_METHOD *ui_method,
++#else
++                void *ui_method,
++#endif /* OPENSSL_NO_UI_CONSOLE */
++                EVP_PKEY **ret) {
+         assert(engine);
+         assert(private_key_uri);
+         assert(ret);
+@@ -1659,9 +1669,10 @@ int openssl_load_private_key(
+                 if (r < 0)
+                         return log_debug_errno(r, "Failed to allocate ask-password user interface: %m");
+ 
+-                UI_METHOD *ui_method = NULL;
+ #ifndef OPENSSL_NO_UI_CONSOLE
+-                ui_method = ui->method;
++                UI_METHOD *ui_method = ui->method;
++#else
++                void *ui_method = NULL;
+ #endif
+ 
+                 switch (private_key_source_type) {
 diff --git a/src/shared/openssl-util.h b/src/shared/openssl-util.h
-index e25a175a80..784e764058 100644
+index e25a175..784e764 100644
 --- a/src/shared/openssl-util.h
 +++ b/src/shared/openssl-util.h
 @@ -41,6 +41,9 @@ int parse_openssl_key_source_argument(const char *argument, char **private_key_s

--- a/packages/systemd-257/Cargo.toml
+++ b/packages/systemd-257/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/systemd/systemd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/systemd/systemd/archive/v257.9/systemd-257.9.tar.gz"
-sha512 = "23b3d2764e0f990d8373068ccb41177793413bc193f7bd34e38b03d6fc3cd32d07c86e9dcbf07e32904075bb5eeca208f65beab04d628ac0e0b81ba87a975c1b"
+url = "https://github.com/systemd/systemd/archive/v257.13/systemd-257.13.tar.gz"
+sha512 = "f627e14e19b9ebc1686cad48d674fe7f69964b4d894e0253f9f47eeba3d6feabd1b19de54bdd8d4c2d21993865262830440a809f03d246ffa397320c94c7e46b"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/systemd-257/systemd-257.spec
+++ b/packages/systemd-257/systemd-257.spec
@@ -4,7 +4,7 @@
 %global package_priority_epoch 0
 
 Name: %{_cross_os}systemd-257
-Version: 257.9
+Version: 257.13
 Release: 1%{?dist}
 Summary: System and Service Manager
 License: GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later


### PR DESCRIPTION
**Description of changes:**
**systemd-252:** Backport fixes for CVE-2026-29111, CVE-2026-40225, and CVE-2026-40226 to systemd-252 and update systemd-257 to 257.13.

**systemd-257:** Update from 257.9 to 257.13, which includes upstream fixes for all three CVEs. Refreshed patch 9012 (openssl-util-build-without-ui) to apply cleanly against 257.13.

**Testing done:**
Tested on aws-k8s-1.35 (systemd 257) and aws-k8s-1.32-nvidia (systemd 252) variants:

* Nodes boot cleanly, systemd version confirmed, no failed units
* TasksMax stable across daemon-reload (no regression)
* Fork stress (500 processes)
* journald stable under load, container logs flowing
* networkd stable, zero coredumps, DHCP valid
* Pod-to-pod + cross-node networking
* Deploy/scale/rollout lifecycle
* CVE-2026-29111 validated via busctl (bad cgroup paths rejected)
* CVE-2026-40225/40226: patched nspawn binary confirmed
* Nvidia GPU workload (CUDA smoke tests pass on g4dn.xlarge)
* Neuron detection (inf2.xlarge, neuroncore advertised)
* Scale test (~78 nodes across m5, c6i, r7a instance types)
* 5-day soak (252) + 24hr soak (257): zero coredumps, stable
* Soak/Churn Tests - 14-day continuous pod churn, imagegc, and network soak tests - all CloudWatch alarms OK

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
