### PR TITLE
k8s-1.36 update and patch

### DIFF
--- a/packages/kubernetes-1.36/0001-kubelet-startPodSync-reuse-the-previous-context-to-f.patch
+++ b/packages/kubernetes-1.36/0001-kubelet-startPodSync-reuse-the-previous-context-to-f.patch
@@ -1,0 +1,57 @@
+From ccca5a96bfb9d65a9826c42058eec3b946ef835c Mon Sep 17 00:00:00 2001
+From: Mike Robbins <mrobbins@alum.mit.edu>
+Date: Thu, 18 Jun 2026 15:06:36 -0400
+Subject: [PATCH] kubelet startPodSync: reuse the previous context to fix
+ memory leak regression
+
+---
+ pkg/kubelet/pod_workers.go      | 16 +++++++++++++++-
+ pkg/kubelet/pod_workers_test.go |  1 +
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/pkg/kubelet/pod_workers.go b/pkg/kubelet/pod_workers.go
+index 0f3034e26225e..a71f1fbcbd284 100644
+--- a/pkg/kubelet/pod_workers.go
++++ b/pkg/kubelet/pod_workers.go
+@@ -336,6 +336,16 @@ const (
+ // podSyncStatus tracks per-pod transitions through the three phases of pod
+ // worker sync (setup, terminating, terminated).
+ type podSyncStatus struct {
++	// ctx is reused across normal pod syncs.
++	// A new ctx is created on the next startPodSync after explicit cancellation.
++	//
++	// TODO: remove this from the struct by having the context initialized
++	// in startPodSync, the cancelFn used by UpdatePod, and cancellation of
++	// a parent context for tearing down workers (if needed) on shutdown.
++	// Be careful not to leak contexts (see #139823).
++	// Be careful that long-lived goroutines (such as prober workers) outlive
++	// the lifetime of a single startPodSync cancellation context.
++	ctx context.Context
+ 	// cancelFn if set is expected to cancel the current podSyncer operation.
+ 	cancelFn context.CancelFunc
+ 
+@@ -1152,7 +1162,11 @@ func (p *podWorkers) startPodSync(parentCtx context.Context, podUID types.UID) (
+ 	default:
+ 	}
+ 
+-	ctx, status.cancelFn = context.WithCancel(parentCtx)
++	if status.ctx == nil || status.ctx.Err() != nil {
++		// create a context with parentCtx's values, and reuse it until it is canceled
++		status.ctx, status.cancelFn = context.WithCancel(context.WithoutCancel(parentCtx))
++	}
++	ctx = status.ctx
+ 
+ 	// if we are already started, make our state visible to downstream components
+ 	if status.IsStarted() {
+diff --git a/pkg/kubelet/pod_workers_test.go b/pkg/kubelet/pod_workers_test.go
+index ac446fe133f08..7fad7fb43a7b7 100644
+--- a/pkg/kubelet/pod_workers_test.go
++++ b/pkg/kubelet/pod_workers_test.go
+@@ -602,6 +602,7 @@ func TestUpdatePod(t *testing.T) {
+ 			} else {
+ 				expected.cancelFn, status.cancelFn = nil, nil
+ 			}
++			expected.ctx, status.ctx = nil, nil
+ 		}
+ 		if e, a := expected, status; !reflect.DeepEqual(e, a) {
+ 			t.Fatalf("unexpected status: %s", cmp.Diff(e, a, cmp.AllowUnexported(podSyncStatus{})))

--- a/packages/kubernetes-1.36/Cargo.toml
+++ b/packages/kubernetes-1.36/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.36"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-36/releases/2/artifacts/kubernetes/v1.36.0/kubernetes-src.tar.gz"
-sha512 = "942a7e410dc66cd8f79fe5ec9945c463a404205b7528f68956209306f928332c8194e8e7893e3e2f6067e28fd4b850167fbf014a497b600a5b91949ba911b4fc"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-36/releases/4/artifacts/kubernetes/v1.36.1/kubernetes-src.tar.gz"
+sha512 = "5c048e8006808b37f1b2c9b92cceec8ad43b6dee48605c77d0bb9864e0c6ec303c954dea3991dd78f1bc087c972a4a4e4810f2799fd8760a87dc1f8a5f76b2db"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.36/kubernetes-1.36.spec
+++ b/packages/kubernetes-1.36/kubernetes-1.36.spec
@@ -67,6 +67,8 @@ Source100: pause-config.json
 Source101: pause-manifest.json
 Source102: pod-infra-container-image
 
+Patch0001: 0001-kubelet-startPodSync-reuse-the-previous-context-to-f.patch
+
 Source1000: clarify.toml
 
 BuildRequires: git

--- a/packages/kubernetes-1.36/kubernetes-1.36.spec
+++ b/packages/kubernetes-1.36/kubernetes-1.36.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 2
-%global gover 1.36.0
+%global releasever 4
+%global gover 1.36.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
Upstream PR: https://github.com/kubernetes/kubernetes/pull/140066
Fixes: https://github.com/kubernetes/kubernetes/issues/139823

**Description of changes:**
- Update k8s-1.36 to latest
- Patch k8s-1.36 to fix kubelet memory leak

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
