### PR TITLE
feat: k8s: gate kubelet --container-runtime-endpoint on setting

### DIFF
--- a/packages/kubernetes-1.30/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.30/kubelet-exec-start-conf
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/kubelet \
     --cloud-provider "" \
 {{/unless}}
     --config /etc/kubernetes/kubelet/config \
-    --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+    --container-runtime-endpoint={{default "unix:///run/containerd/containerd.sock" settings.kubernetes.container-runtime-endpoint}} \
     --containerd=/run/containerd/containerd.sock \
     --root-dir /var/lib/kubelet \
     --cert-dir /var/lib/kubelet/pki \

--- a/packages/kubernetes-1.31/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.31/kubelet-exec-start-conf
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/kubelet \
     --cloud-provider "" \
 {{/unless}}
     --config /etc/kubernetes/kubelet/config \
-    --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+    --container-runtime-endpoint={{default "unix:///run/containerd/containerd.sock" settings.kubernetes.container-runtime-endpoint}} \
     --containerd=/run/containerd/containerd.sock \
     --root-dir /var/lib/kubelet \
     --cert-dir /var/lib/kubelet/pki \

--- a/packages/kubernetes-1.32/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.32/kubelet-exec-start-conf
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/kubelet \
     --cloud-provider "" \
 {{/unless}}
     --config /etc/kubernetes/kubelet/config \
-    --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+    --container-runtime-endpoint={{default "unix:///run/containerd/containerd.sock" settings.kubernetes.container-runtime-endpoint}} \
     --containerd=/run/containerd/containerd.sock \
     --root-dir /var/lib/kubelet \
     --cert-dir /var/lib/kubelet/pki \

--- a/packages/kubernetes-1.33/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.33/kubelet-exec-start-conf
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/kubelet \
     --cloud-provider "" \
 {{/unless}}
     --config /etc/kubernetes/kubelet/config \
-    --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+    --container-runtime-endpoint={{default "unix:///run/containerd/containerd.sock" settings.kubernetes.container-runtime-endpoint}} \
     --containerd=/run/containerd/containerd.sock \
     --root-dir /var/lib/kubelet \
     --cert-dir /var/lib/kubelet/pki \

--- a/packages/kubernetes-1.34/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.34/kubelet-exec-start-conf
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/kubelet \
     --cloud-provider "" \
 {{/unless}}
     --config /etc/kubernetes/kubelet/config \
-    --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+    --container-runtime-endpoint={{default "unix:///run/containerd/containerd.sock" settings.kubernetes.container-runtime-endpoint}} \
     --containerd=/run/containerd/containerd.sock \
     --root-dir /var/lib/kubelet \
     --cert-dir /var/lib/kubelet/pki \

--- a/packages/kubernetes-1.35/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.35/kubelet-exec-start-conf
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/kubelet \
     --cloud-provider "" \
 {{/unless}}
     --config /etc/kubernetes/kubelet/config \
-    --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+    --container-runtime-endpoint={{default "unix:///run/containerd/containerd.sock" settings.kubernetes.container-runtime-endpoint}} \
     --containerd=/run/containerd/containerd.sock \
     --root-dir /var/lib/kubelet \
     --cert-dir /var/lib/kubelet/pki \

--- a/packages/kubernetes-1.36/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.36/kubelet-exec-start-conf
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/kubelet \
     --cloud-provider "" \
 {{/unless}}
     --config /etc/kubernetes/kubelet/config \
-    --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
+    --container-runtime-endpoint={{default "unix:///run/containerd/containerd.sock" settings.kubernetes.container-runtime-endpoint}} \
     --containerd=/run/containerd/containerd.sock \
     --root-dir /var/lib/kubelet \
     --cert-dir /var/lib/kubelet/pki \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
Wrap the `--container-runtime-endpoint` kubelet CLI flag in each kubelet-exec-start-conf template on `settings.kubernetes.container-runtime-endpoint`, falling back to the current `unix:///run/containerd/containerd.sock` default when unset.


**Testing done:**
1. make build ARCH=x86_64



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
