### PR TITLE
Package update

### DIFF
--- a/packages/aws-otel-collector/Cargo.toml
+++ b/packages/aws-otel-collector/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws-observability/aws-otel-collector/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.47.0/aws-otel-collector-v0.47.0.tar.gz"
-sha512 = "46436c5bd29f7d56d432c5d1731c0e136ae3b452b059de13e8eefb59e3596aff5805482772e95672d43ae76acbbb4cc4acada711006969b74daa43a7daff9e0f"
+url = "https://github.com/aws-observability/aws-otel-collector/archive/v0.48.0/aws-otel-collector-v0.48.0.tar.gz"
+sha512 = "df6f726f56ab1ab904b712bb386253e3407972d80aa3154efc02bb70f7148f0f6c193194d2cc47ca092dd2eb47fc33a6e0a4d6e34cc3df3ca6a95a150a044dfd"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/aws-otel-collector/aws-otel-collector.spec
+++ b/packages/aws-otel-collector/aws-otel-collector.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}aws-otel-collector
-Version: 0.47.0
+Version: 0.48.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: AWS Distro for OpenTelemetry Collector
@@ -28,6 +28,7 @@ BuildRequires: %{_cross_os}glibc-devel
 %build
 
 %set_cross_go_flags
+export GO_MAJOR="1.26"
 go build -ldflags "${GOLDFLAGS}" -o aws-otel-collector ./cmd/awscollector
 
 %install

--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.8.0/rolesanywhere-credential-helper-v1.8.0.tar.gz"
-sha512 = "0ffa745b7c46b826c805857c129c5e98b4db451c21507164dbca1f9be412b41b580b4dba65e67d7d9ba6c55ae098ad669ffd1a43b0315692ec0880e582b610e0"
+url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.8.1/rolesanywhere-credential-helper-v1.8.1.tar.gz"
+sha512 = "d535b90947123ad585ba0e5d541b383034dcccdec499c93d14a0ef77a2541e5691ad1ffb1b0b155d6f9baf26d12c1de664817856b478c3ab0000595fe1cf73c3"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo rolesanywhere-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.8.0
+%global gover 1.8.1
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -35,6 +35,7 @@ Requires: %{_cross_os}package-file(/bin/sh)
 
 %build
 %set_cross_go_flags
+export GO_MAJOR="1.26"
 
 go build -ldflags "-X 'main.Version=${gover}' ${GOLDFLAGS}" -o aws-signing-helper main.go
 

--- a/packages/ecr-credential-provider-1.32/Cargo.toml
+++ b/packages/ecr-credential-provider-1.32/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.32"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.32.7.tar.gz"
-path = "cloud-provider-aws-1.32.7.tar.gz"
-sha512 = "2f02f940ae48a2e741c91d128427992280dffa9085eafcbc14c9a5c2a99941477b6de451f9dfa03fe68098ce616f57bcc4744b1b2c7e3216a0664c8825bc578a"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.32.8.tar.gz"
+path = "cloud-provider-aws-1.32.8.tar.gz"
+sha512 = "fb1065d53a290c955f2aacead43aba4d1bb3a040709195f0f56f784f983f63039ad849c858a989bcea64cc19a5acc4c9ffda964a094290cc21762a3cec7a5e5b"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
+++ b/packages/ecr-credential-provider-1.32/ecr-credential-provider-1.32.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.32.7
+%global gover 1.32.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.33/Cargo.toml
+++ b/packages/ecr-credential-provider-1.33/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.33"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.33.3.tar.gz"
-path = "cloud-provider-aws-1.33.3.tar.gz"
-sha512 = "094991f85de1f8f830bda0a433f18529c0307b403447147aa67368beb0805f76944fba3a2a31704ff9648795cd00e90584e822425ce6c47ff6dd7c2519c3e2ba"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.33.4.tar.gz"
+path = "cloud-provider-aws-1.33.4.tar.gz"
+sha512 = "4e19e6c237e2468194d092153d64366047f194b658c94442f2e4eccf470ed359e083fc666303787cc33e37db5d919be99c7466ed60c80c2da730a8f8aabece38"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
+++ b/packages/ecr-credential-provider-1.33/ecr-credential-provider-1.33.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.33.3
+%global gover 1.33.4
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.34/Cargo.toml
+++ b/packages/ecr-credential-provider-1.34/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.34"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.34.2.tar.gz"
-path = "cloud-provider-aws-1.34.2.tar.gz"
-sha512 = "a4594a172a14a668805fadb85ef23d44fd7bf553b05f1ef1798dd1c64f55a27cfa8572ae350894bab78b69ecf266ff7bce60e4f0327978f7a91e3b6e9a745b6a"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/v1.34.3.tar.gz"
+path = "cloud-provider-aws-1.34.3.tar.gz"
+sha512 = "1372eb15e2593f21534b1cd21187b26e1af065b06c594fc6ede98492d9ceacdc4300c03765c2ce21987930f7eb47e1c16e7959599993ab7caa4b9aab8a62b92a"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.34/ecr-credential-provider-1.34.spec
+++ b/packages/ecr-credential-provider-1.34/ecr-credential-provider-1.34.spec
@@ -2,7 +2,7 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.34.2
+%global gover 1.34.3
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/ecr-credential-provider-1.35/Cargo.toml
+++ b/packages/ecr-credential-provider-1.35/Cargo.toml
@@ -15,9 +15,9 @@ package-name = "ecr-credential-provider-1.35"
 releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/kubernetes/cloud-provider-aws/archive/refs/tags/v1.35.1.tar.gz"
-sha512 = "8737fe2f20e4f9ded0bab6d9bf965fa9ea34f08ef0a5cc7628ec7964b75c34a35aab3d7aa3c2bc5900fc890e2178e2c5849dccae8a86429e830377ef867508e3"
-path = "cloud-provider-aws-1.35.1.tar.gz"
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/refs/tags/v1.35.2.tar.gz"
+sha512 = "a8c1c4c7e392cb17fee6c1e1fda3730fa01bec6b7009cff1b5a6879e7a0fefd38ab1b4859799ec822986dd96209fef5ef6ab81391be136149424cf6e7001417c"
+path = "cloud-provider-aws-1.35.2.tar.gz"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/ecr-credential-provider-1.35/ecr-credential-provider-1.35.spec
+++ b/packages/ecr-credential-provider-1.35/ecr-credential-provider-1.35.spec
@@ -2,8 +2,8 @@
 %global gorepo cloud-provider-aws
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.35.1
-%global rpmver 1.35.1
+%global gover 1.35.2
+%global rpmver 1.35.2
 
 %global _dwz_low_mem_die_limit 0
 

--- a/packages/kubernetes-1.30/Cargo.toml
+++ b/packages/kubernetes-1.30/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.30"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/55/artifacts/kubernetes/v1.30.14/kubernetes-src.tar.gz"
-sha512 = "64e3172de1a31bf9c927a5443da4a5541ab5e39d4533a2a975219954b287af999fbf0abd425220941ac6d0bab0ac814488c7f382ca4ea2cd08bd67473fa8c2c9"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-30/releases/56/artifacts/kubernetes/v1.30.14/kubernetes-src.tar.gz"
+sha512 = "ec53bc2d7761514f283939c1a7280293fbab6b7f18adb2300908cf2d7c4efb6b544f3c8244ec34a4c9364116c0fcf887b6756330ee784d30cbd42c8e845865bc"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.30/kubernetes-1.30.spec
+++ b/packages/kubernetes-1.30/kubernetes-1.30.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 55
+%global releasever 56
 %global gover 1.30.14
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/44/artifacts/kubernetes/v1.31.14/kubernetes-src.tar.gz"
-sha512 = "92b051a004040be9f55ef1d5bf138720dc666f81ecd11c0af6afc5dad2c91d2fc23e9e5bf9198de0a474786ee610da1349166bc40469819d2163e15d062a0676"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/45/artifacts/kubernetes/v1.31.14/kubernetes-src.tar.gz"
+sha512 = "207a15cdf7c1ea14c305bd04e8fde4ca9cd432db1a0bf373038ed56837e1dd9a56c4327a4da9d8166ac4b847d4755b1d19e9e69a4d5f4e884f81d16f0363feef"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 44
+%global releasever 45
 %global gover 1.31.14
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.32/Cargo.toml
+++ b/packages/kubernetes-1.32/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.32"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/37/artifacts/kubernetes/v1.32.13/kubernetes-src.tar.gz"
-sha512 = "e1aa797ff8bd70a79df13ad6c58dba26de13d98a6fbcd8321f7a0598a6437847ec49aa283c864827d8600cd7c636d9338ce4015ad3cf225cc5428313d7e32103"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/38/artifacts/kubernetes/v1.32.13/kubernetes-src.tar.gz"
+sha512 = "a05aaaaa2352f416a5a51c7941f02a2a801361378752c8401af2abe298359a9917a552f7ee81ef0b0de06a0ddf1d6a0d80cc6f1966ab3f7759cd2f63d54987d3"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 37
+%global releasever 38
 %global gover 1.32.13
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.33/Cargo.toml
+++ b/packages/kubernetes-1.33/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.33"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/27/artifacts/kubernetes/v1.33.11/kubernetes-src.tar.gz"
-sha512 = "d282ef86652e9cfaaf2858008a1ce48212979905d45ce4a49a3234a8f2537d83b14c0c463ed24b6d4e0f3605706b80f48f973b5bad8d41fce09690fce83b44b2"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/28/artifacts/kubernetes/v1.33.12/kubernetes-src.tar.gz"
+sha512 = "630c8ed4ae3aff31614eb50fbede35290d6d526c2a0164e90351e66e018ae8bc8179ba52cf60da449c7570808b489acf9d4bc774dd56549a67526d0109531281"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 27
-%global gover 1.33.11
+%global releasever 28
+%global gover 1.33.12
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.34/0001-apiserver-drop-unused-go-proxyproto-require.patch
+++ b/packages/kubernetes-1.34/0001-apiserver-drop-unused-go-proxyproto-require.patch
@@ -1,0 +1,32 @@
+From 7ed9e7fc8a7da070ea01a3ee33ec35ce24e3194b Mon Sep 17 00:00:00 2001
+From: Jingwei Wang <jweiw@amazon.com>
+Date: Wed, 1 Jul 2026 22:51:28 +0000
+Subject: [PATCH] apiserver: drop unused go-proxyproto require
+
+The apiserver module lists github.com/pires/go-proxyproto as an
+explicit dependency, but nothing in the tree imports it and it is
+absent from both the vendor directory and vendor/modules.txt.
+Building with -mod=vendor therefore fails with "inconsistent
+vendoring". Remove the orphaned require so go.mod agrees with the
+vendor directory.
+
+Signed-off-by: Jingwei Wang <jweiw@amazon.com>
+---
+ staging/src/k8s.io/apiserver/go.mod | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/staging/src/k8s.io/apiserver/go.mod b/staging/src/k8s.io/apiserver/go.mod
+index 06467cd3..12472b7e 100644
+--- a/staging/src/k8s.io/apiserver/go.mod
++++ b/staging/src/k8s.io/apiserver/go.mod
+@@ -23,7 +23,6 @@ require (
+ 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+ 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+ 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+-	github.com/pires/go-proxyproto v0.7.1-0.20240628150027-b718e7ce4964
+ 	github.com/spf13/pflag v1.0.6
+ 	github.com/stretchr/testify v1.11.1
+ 	go.etcd.io/etcd/api/v3 v3.6.4
+--
+2.51.1
+

--- a/packages/kubernetes-1.34/Cargo.toml
+++ b/packages/kubernetes-1.34/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.34"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/18/artifacts/kubernetes/v1.34.7/kubernetes-src.tar.gz"
-sha512 = "ff3839d95ca839b43a873682411194eaccfac3e206636d8a84f6808c3b46665a9d79a5dd2bfef9961896ae85d7404fcac86005bde614e0d038859c896d928cdd"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/19/artifacts/kubernetes/v1.34.8/kubernetes-src.tar.gz"
+sha512 = "bddb8a71ddc4cfee5a1823cfbd5d0efbd593d2e6fa1650cddf1627ff6d1c4fe60347207f786d8c33743d9d32794259c9881f24778a7885cdb972e2444a0025e4"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.34/kubernetes-1.34.spec
+++ b/packages/kubernetes-1.34/kubernetes-1.34.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 18
-%global gover 1.34.7
+%global releasever 19
+%global gover 1.34.8
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0
@@ -67,6 +67,9 @@ Source101: pause-manifest.json
 Source102: pod-infra-container-image
 
 Source1000: clarify.toml
+
+# Remove an orphaned go-proxyproto require that breaks -mod=vendor builds.
+Patch0001: 0001-apiserver-drop-unused-go-proxyproto-require.patch
 
 BuildRequires: git
 BuildRequires: rsync

--- a/packages/kubernetes-1.35/Cargo.toml
+++ b/packages/kubernetes-1.35/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.35"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-35/releases/9/artifacts/kubernetes/v1.35.4/kubernetes-src.tar.gz"
-sha512 = "d17b64698303f01bebeffc1bb7233ffcdb2d73ba8c113a4022da092ca59c6a5bb7ba3fbeed6c77a08128a1280ecc7fae1d3e39644286c1d8bcc572afef958e4f"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-35/releases/10/artifacts/kubernetes/v1.35.5/kubernetes-src.tar.gz"
+sha512 = "5a5e20137dbcc6b6cc2eca5adae7fc9fa50108ab09a18abeb9eb8e33e726f113076a80d7b91dfa8afe83a1f115be47f4b0f23176568b0c14da4a51c7851adf77"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.35/kubernetes-1.35.spec
+++ b/packages/kubernetes-1.35/kubernetes-1.35.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 9
-%global gover 1.35.4
+%global releasever 10
+%global gover 1.35.5
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/soci-snapshotter/Cargo.toml
+++ b/packages/soci-snapshotter/Cargo.toml
@@ -12,15 +12,15 @@ path = "../packages.rs"
 releases-url = "https://github.com/awslabs/soci-snapshotter/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/v0.13.0/soci-snapshotter-0.13.0.tar.gz"
-sha512 = "afaa4e775d7ee938664c7cc84b3c51ba9523e9bb94c0bcc3dcc00316ff4b9e8c85e090ab67afad5292d210ad46b30baca427f31ec03917d7cb695f6d9e506f33"
-bundle-root-path = "soci-snapshotter-0.13.0/cmd"
+url = "https://github.com/awslabs/soci-snapshotter/archive/v0.14.0/soci-snapshotter-0.14.0.tar.gz"
+sha512 = "2f7ad6f2f1bddc695c33dd95fd5075bfb9c8b843ae67380d2d068696183f3fbbd0440bf45af5b3dac02ab7fa083fbec4e1929621b827db5cb6c50530344ab9ad"
+bundle-root-path = "soci-snapshotter-0.14.0/cmd"
 bundle-output-path = "bundled-cmd.tar.gz"
 bundle-modules = [ "go" ]
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/v0.13.0/soci-snapshotter-0.13.0.tar.gz"
-sha512 = "afaa4e775d7ee938664c7cc84b3c51ba9523e9bb94c0bcc3dcc00316ff4b9e8c85e090ab67afad5292d210ad46b30baca427f31ec03917d7cb695f6d9e506f33"
+url = "https://github.com/awslabs/soci-snapshotter/archive/v0.14.0/soci-snapshotter-0.14.0.tar.gz"
+sha512 = "2f7ad6f2f1bddc695c33dd95fd5075bfb9c8b843ae67380d2d068696183f3fbbd0440bf45af5b3dac02ab7fa083fbec4e1929621b827db5cb6c50530344ab9ad"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -1,7 +1,7 @@
 %global gorepo soci-snapshotter
-%global gover 0.13.0
+%global gover 0.14.0
 %global rpmver %{gover}
-%global gitrev e5a21c6772046d6bc0366666a78b0286260284e4
+%global gitrev 18d119a04693d19bbe96fccbf416f425abb3cb48
 
 Name: %{_cross_os}soci-snapshotter
 Version: %{gover}


### PR DESCRIPTION
**Description of changes:**
package update for
- aws-signing-helper - Update from 1.8.0 → 1.8.1 (released 2026-04-08)
- ecr-credential-provider-1.32 - Update from 1.32.7 → 1.32.8 (released 2026-05-12)
- ecr-credential-provider-1.33 - Update from 1.33.3 → 1.33.4 (released 2026-05-12)
- ecr-credential-provider-1.34 - Update from 1.34.2 → 1.34.3 (released 2026-05-12)
- ecr-credential-provider-1.35 - Update from 1.35.1 → 1.35.2 (released 2026-05-12)
- aws-otel-collector - Update from 0.47.0 → 0.48.0 (released 2026-05-21)
- kubernetes-1.30 - Update from 55 → 56 (released 2026-06-22)
- kubernetes-1.31 - Update from 44 → 45 (released 2026-06-22)
- kubernetes-1.32 - Update from 37 → 38 (released 2026-06-22)
- kubernetes-1.33 - Update from 27 → 28 (released 2026-06-22)
- kubernetes-1.34 - Update from 18 → 19 (released 2026-06-22)
- kubernetes-1.35 - Update from 9 → 10 (released 2026-06-22)
- soci-snapshotter - Update from 0.13.0 → 0.14.0 (released 2026-05-28)
**Testing done:**
- ecr-credential-provider-1.35
```
ip-.us-west-2.compute.internal   Ready    <none>   3m59s   v1.35.5-eks-a3a0722
NAME           READY   STATUS         RESTARTS   AGE
hello-dotnet   0/1     ErrImagePull   0          4s
```
after applied the aws profile
```
hello-dotnet   1/1     Running   1 (10s ago)   10m
``` 
- ecr-credential-provider-1.34
same as above

- ecr-credential-provider-1.33
same as above

- ecr-credential-provider-1.32
same as above

- k8s 1.30 update (test with containerd 1.7) with #954 
```
kubetest2 eksapi \
    --kubernetes-version=1.30 --user-data-format=bottlerocket --unmanaged-nodes \
    --ami=ami-02535f7da109e8148 --instance-types=t3.xlarge --nodes=2 \
    --region=us-west-2 --up --down \
    --test=ginkgo -- \
    --test-package-marker=latest-1.30.txt --parallel=6 \                                                                                                                               --ginkgo-args='--no-color --flake-attempts=3' \                                                                                                                                    --focus-regex='\[Conformance\]' \                                                                                                                                                  --skip-regex='\[Serial\]|\[Disruptive\]|\[Slow\]|Garbage.collector'

Ran 361 of 7197 Specs in 785.583 seconds
SUCCESS! -- 361 Passed | 0 Failed | 0 Pending | 6836 Skipped
```
- k8s 1.31 update (test with containerd 2.1) with #954 
```
kubetest2 eksapi \
    --kubernetes-version=1.31 --user-data-format=bottlerocket --unmanaged-nodes \
    --ami=ami-0c72a1e6238ef2039 --instance-types=t3.xlarge --nodes=2 \
    --region=us-west-2 --up --down \
    --test=ginkgo -- \
    --test-package-marker=latest-1.31.txt --parallel=6 \                                                                                                                               --ginkgo-args='--no-color --flake-attempts=3' \                                                                                                                                    --focus-regex='\[Conformance\]' \                                                                                                                                                  --skip-regex='\[Serial\]|\[Disruptive\]|\[Slow\]|Garbage.collector'


Ran 362 of 6603 Specs in 766.089 seconds
SUCCESS! -- 362 Passed | 0 Failed | 0 Pending | 6241 Skipped
```
- k8s 1.32 update (test with containerd 2.1) with #954 
```
kubetest2 eksapi \
    --kubernetes-version=1.32 --user-data-format=bottlerocket --unmanaged-nodes \
    --ami=ami-06558af111d3aac41 --instance-types=t3.xlarge --nodes=2 \
    --region=us-west-2 --up --down \
    --test=ginkgo -- \
    --test-package-marker=latest-1.32.txt --parallel=6 \                                                                                                                               --ginkgo-args='--no-color --flake-attempts=3' \                                                                                                                                    --focus-regex='\[Conformance\]' \                                                                                                                                                  --skip-regex='\[Serial\]|\[Disruptive\]|\[Slow\]|Garbage.collector'

Ran 372 of 6622 Specs in 719.431 seconds
SUCCESS! -- 372 Passed | 0 Failed | 0 Pending | 6250 Skipped
```

- k8s 1.33 update (test with containerd 2.1) with #954 
```
╰$ kubetest2 eksapi \
    --kubernetes-version=1.33 --user-data-format=bottlerocket --unmanaged-nodes \
    --ami=ami-0f98748931e2a3a2f --instance-types=t3.xlarge --nodes=2 \
    --region=us-west-2 --up --down \
    --test=ginkgo -- \
    --test-package-marker=latest-1.33.txt --parallel=6 \                                                                                                                               --ginkgo-args='--no-color --flake-attempts=3' \                                                                                                                                    --focus-regex='\[Conformance\]' \                                                                                                                                                  --skip-regex='\[Serial\]|\[Disruptive\]|\[Slow\]|Garbage.collector'

Ran 378 of 6729 Specs in 825.672 seconds
SUCCESS! -- 378 Passed | 0 Failed | 0 Pending | 6351 Skipped
```
- k8s 1.34 update (test with containerd 2.1) with #954 
```
kubetest2 eksapi \
    --kubernetes-version=1.34 --user-data-format=bottlerocket --unmanaged-nodes \
    --ami=ami-028f0f14b18d7ac8f --instance-types=t3.xlarge --nodes=2 \
    --region=us-west-2 --up --down \
    --test=ginkgo -- \
    --test-package-marker=latest-1.34.txt --parallel=6 \                                                                                                                               --ginkgo-args='--no-color --flake-attempts=3' \                                                                                                                                    --focus-regex='\[Conformance\]' \                                                                                                                                                  --skip-regex='\[Serial\]|\[Disruptive\]|\[Slow\]|Garbage.collector'

Ran 385 of 7132 Specs in 834.954 seconds
SUCCESS! -- 385 Passed | 0 Failed | 0 Pending | 6747 Skipped
```
- SOCI smoke test on i7ie12xlarge

```
=INFO REPORT==== 9-Jul-2026::01:04:10.230553 ===
    alarm_handler: {set,{{disk_almost_full,"/usr/local/sbin/modprobe"},[]}}
2026-07-09 01:04:11.387114+00:00 [notice] <0.45.0> Application syslog exited with reason: stopped
2026-07-09 01:04:11.389418+00:00 [notice] <0.216.0> Logging: switching to configured handler(s); following messages may not be visible in this log output
2026-07-09 01:04:11.389813+00:00 [notice] <0.216.0> Logging: configured log handlers are now ACTIVE
2026-07-09 01:04:11.394116+00:00 [info] <0.216.0> ra: starting system coordination
2026-07-09 01:04:11.394177+00:00 [info] <0.216.0> starting Ra system: coordination in directory: /var/lib/rabbitmq/mnesia/rabbit@soci-smoke-test/coordination/rabbit@soci-smoke-test
2026-07-09 01:04:11.399252+00:00 [info] <0.223.0> ra_coordination_log_ets: in system coordination initialising. Mem table opts: [set,{write_concurrency,auto},public,{compressed,false}]
2026-07-09 01:04:11.424078+00:00 [info] <0.229.0> ra system 'coordination' running pre init for 0 registered servers
2026-07-09 01:04:11.429451+00:00 [info] <0.230.0> ra: meta data store initialised for system coordination. 0 record(s) recovered
2026-07-09 01:04:11.431745+00:00 [info] <0.233.0> segment_writer: upgrading segment file names to new format in dirctory /var/lib/rabbitmq/mnesia/rabbit@soci-smoke-test/coordination/rabbit@soci-smoke-test
2026-07-09 01:04:11.441544+00:00 [notice] <0.235.0> WAL: ra_coordination_log_wal init, mem-tables table name: ra_coordination_log_open_mem_tables
2026-07-09 01:04:11.446994+00:00 [info] <0.216.0> ra: starting system quorum_queues
2026-07-09 01:04:11.447042+00:00 [info] <0.216.0> starting Ra system: quorum_queues in directory: /var/lib/rabbitmq/mnesia/rabbit@soci-smoke-test/quorum/rabbit@soci-smoke-test
2026-07-09 01:04:11.447285+00:00 [info] <0.239.0> ra_log_ets: in system quorum_queues initialising. Mem table opts: [set,{write_concurrency,auto},public,{compressed,true}]
2026-07-09 01:04:11.447675+00:00 [info] <0.243.0> ra system 'quorum_queues' running pre init for 0 registered servers
2026-07-09 01:04:11.448058+00:00 [info] <0.244.0> ra: meta data store initialised for system quorum_queues. 0 record(s) recovered
2026-07-09 01:04:11.448140+00:00 [info] <0.247.0> segment_writer: upgrading segment file names to new format in dirctory /var/lib/rabbitmq/mnesia/rabbit@soci-smoke-test/quorum/rabbit@soci-smoke-test
2026-07-09 01:04:11.448934+00:00 [notice] <0.249.0> WAL: ra_log_wal init, mem-tables table name: ra_log_open_mem_tables
2026-07-09 01:04:11.449712+00:00 [info] <0.251.0> ra_system_recover: ra system 'quorum_queues' server recovery strategy rabbit_quorum_queue:system_recover
2026-07-09 01:04:11.449767+00:00 [info] <0.251.0> [rabbit_quorum_queue:system_recover/1] rabbit not booted, skipping queue recovery
2026-07-09 01:04:11.449842+00:00 [info] <0.216.0> ra: starting system coordination
2026-07-09 01:04:11.449864+00:00 [info] <0.216.0> starting Ra system: coordination in directory: /var/lib/rabbitmq/mnesia/rabbit@soci-smoke-test/coordination/rabbit@soci-smoke-test
2026-07-09 01:04:11.503752+00:00 [notice] <0.253.0> RabbitMQ metadata store: candidate -> leader in term: 1 machine version: 1, last applied 0
2026-07-09 01:04:11.582416+00:00 [info] <0.216.0>
2026-07-09 01:04:11.582416+00:00 [info] <0.216.0>  Starting RabbitMQ 4.1.0 on Erlang 27.3.4 [jit]
2026-07-09 01:04:11.582416+00:00 [info] <0.216.0>  Copyright (c) 2007-2025 Broadcom Inc and/or its subsidiaries
2026-07-09 01:04:11.582416+00:00 [info] <0.216.0>  Licensed under the MPL 2.0. Website: https://rabbitmq.com

  ##  ##      RabbitMQ 4.1.0
  ##  ##
  ##########  Copyright (c) 2007-2025 Broadcom Inc and/or its subsidiaries
  ######  ##
  ##########  Licensed under the MPL 2.0. Website: https://rabbitmq.com

  Erlang:      27.3.4 [jit]
  TLS Library: OpenSSL - OpenSSL 3.3.3 11 Feb 2025
  Release series support status: see https://www.rabbitmq.com/release-information

  Doc guides:  https://www.rabbitmq.com/docs
  Support:     https://www.rabbitmq.com/docs/contact
  Tutorials:   https://www.rabbitmq.com/tutorials
  Monitoring:  https://www.rabbitmq.com/docs/monitoring
  Upgrading:   https://www.rabbitmq.com/docs/upgrade

  Logs: <stdout>

  Config file(s): /etc/rabbitmq/conf.d/10-defaults.conf
                  /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf

  Starting broker...2026-07-09 01:04:11.583015+00:00 [info] <0.216.0>
2026-07-09 01:04:11.583015+00:00 [info] <0.216.0>  node           : rabbit@soci-smoke-test
2026-07-09 01:04:11.583015+00:00 [info] <0.216.0>  home dir       : /var/lib/rabbitmq
2026-07-09 01:04:11.583015+00:00 [info] <0.216.0>  config file(s) : /etc/rabbitmq/conf.d/10-defaults.conf
2026-07-09 01:04:11.583015+00:00 [info] <0.216.0>                 : /etc/rabbitmq/conf.d/20-management_agent.disable_metrics_collector.conf
2026-07-09 01:04:11.583015+00:00 [info] <0.216.0>  cookie hash    : AeOEXbbYmcWbLfql5+/Z/Q==
2026-07-09 01:04:11.583015+00:00 [info] <0.216.0>  log(s)         : <stdout>
2026-07-09 01:04:11.583015+00:00 [info] <0.216.0>  data dir       : /var/lib/rabbitmq/mnesia/rabbit@soci-smoke-test
2026-07-09 01:04:11.653940+00:00 [info] <0.216.0> Running boot step pre_boot defined by app rabbit
2026-07-09 01:04:11.653993+00:00 [info] <0.216.0> Running boot step rabbit_global_counters defined by app rabbit
2026-07-09 01:04:11.654218+00:00 [info] <0.216.0> Running boot step rabbit_osiris_metrics defined by app rabbit
2026-07-09 01:04:11.654265+00:00 [info] <0.216.0> Running boot step rabbit_core_metrics defined by app rabbit
2026-07-09 01:04:11.655880+00:00 [info] <0.216.0> Running boot step rabbit_alarm defined by app rabbit
2026-07-09 01:04:11.661249+00:00 [info] <0.283.0> Memory high watermark set to 228402 MiB (239496875212 bytes) of 380670 MiB (399161458688 bytes) total
2026-07-09 01:04:11.662966+00:00 [info] <0.285.0> Enabling free disk space monitoring (disk free space: 29421191827456, total memory: 399161458688)
2026-07-09 01:04:11.662989+00:00 [info] <0.285.0> Disk free limit set to 50MB
2026-07-09 01:04:11.663908+00:00 [info] <0.216.0> Running boot step code_server_cache defined by app rabbit
2026-07-09 01:04:11.663966+00:00 [info] <0.216.0> Running boot step file_handle_cache defined by app rabbit
2026-07-09 01:04:11.666995+00:00 [info] <0.288.0> Limiting to approx 65439 file handles (58893 sockets)
2026-07-09 01:04:11.667090+00:00 [info] <0.289.0> FHC read buffering: OFF
2026-07-09 01:04:11.667118+00:00 [info] <0.289.0> FHC write buffering: ON
2026-07-09 01:04:11.667339+00:00 [info] <0.216.0> Running boot step worker_pool defined by app rabbit
2026-07-09 01:04:11.667374+00:00 [info] <0.270.0> Will use 48 processes for default worker pool
2026-07-09 01:04:11.667397+00:00 [info] <0.270.0> Starting worker pool 'worker_pool' with 48 processes in it
2026-07-09 01:04:11.668122+00:00 [info] <0.216.0> Running boot step rabbit_registry defined by app rabbit
2026-07-09 01:04:11.668164+00:00 [info] <0.216.0> Running boot step database defined by app rabbit
2026-07-09 01:04:11.668308+00:00 [info] <0.216.0> Peer discovery: configured backend: rabbit_peer_discovery_classic_config
2026-07-09 01:04:11.669104+00:00 [notice] <0.271.0> Feature flags: attempt to enable `rabbitmq_4.0.0`...
2026-07-09 01:04:11.673555+00:00 [notice] <0.271.0> Feature flags: `rabbitmq_4.0.0` enabled
2026-07-09 01:04:11.673600+00:00 [notice] <0.271.0> Feature flags: attempt to enable `rabbit_exchange_type_local_random`...
2026-07-09 01:04:11.678642+00:00 [notice] <0.271.0> Feature flags: `rabbit_exchange_type_local_random` enabled
2026-07-09 01:04:11.678685+00:00 [notice] <0.271.0> Feature flags: attempt to enable `message_containers_deaths_v2`...
2026-07-09 01:04:11.684067+00:00 [notice] <0.271.0> Feature flags: `message_containers_deaths_v2` enabled
2026-07-09 01:04:11.684103+00:00 [notice] <0.271.0> Feature flags: attempt to enable `quorum_queue_non_voters`...
2026-07-09 01:04:11.689247+00:00 [notice] <0.271.0> Feature flags: `quorum_queue_non_voters` enabled
2026-07-09 01:04:11.689297+00:00 [notice] <0.271.0> Feature flags: attempt to enable `rabbitmq_4.1.0`...
2026-07-09 01:04:11.694255+00:00 [notice] <0.271.0> Feature flags: `rabbitmq_4.1.0` enabled
2026-07-09 01:04:11.694395+00:00 [info] <0.216.0> DB: virgin node -> run peer discovery
2026-07-09 01:04:11.694457+00:00 [warning] <0.216.0> Classic peer discovery backend: list of nodes does not contain the local node []
2026-07-09 01:04:11.699495+00:00 [notice] <0.45.0> Application mnesia exited with reason: stopped
2026-07-09 01:04:11.748743+00:00 [info] <0.216.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
2026-07-09 01:04:11.748814+00:00 [info] <0.216.0> Successfully synced tables from a peer
2026-07-09 01:04:11.748881+00:00 [info] <0.216.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
2026-07-09 01:04:11.748928+00:00 [info] <0.216.0> Successfully synced tables from a peer
2026-07-09 01:04:11.750197+00:00 [info] <0.216.0> Waiting for Mnesia tables for 30000 ms, 9 retries left
2026-07-09 01:04:11.750232+00:00 [info] <0.216.0> Successfully synced tables from a peer
2026-07-09 01:04:11.750319+00:00 [info] <0.216.0> Running boot step tracking_metadata_store defined by app rabbit
2026-07-09 01:04:11.750357+00:00 [info] <0.525.0> Setting up a table for connection tracking on this node: tracked_connection
2026-07-09 01:04:11.750389+00:00 [info] <0.525.0> Setting up a table for per-vhost connection counting on this node: tracked_connection_per_vhost
2026-07-09 01:04:11.750427+00:00 [info] <0.525.0> Setting up a table for per-user connection counting on this node: tracked_connection_per_user
2026-07-09 01:04:11.750448+00:00 [info] <0.525.0> Setting up a table for channel tracking on this node: tracked_channel
2026-07-09 01:04:11.750469+00:00 [info] <0.525.0> Setting up a table for channel tracking on this node: tracked_channel_per_user
2026-07-09 01:04:11.750496+00:00 [info] <0.216.0> Running boot step networking_metadata_store defined by app rabbit
2026-07-09 01:04:11.750521+00:00 [info] <0.216.0> Running boot step feature_flags defined by app rabbit
2026-07-09 01:04:11.750573+00:00 [info] <0.216.0> Running boot step codec_correctness_check defined by app rabbit
2026-07-09 01:04:11.750589+00:00 [info] <0.216.0> Running boot step external_infrastructure defined by app rabbit
2026-07-09 01:04:11.750600+00:00 [info] <0.216.0> Running boot step rabbit_event defined by app rabbit
2026-07-09 01:04:11.750680+00:00 [info] <0.216.0> Running boot step rabbit_auth_mechanism_amqplain defined by app rabbit
2026-07-09 01:04:11.750757+00:00 [info] <0.216.0> Running boot step rabbit_auth_mechanism_anonymous defined by app rabbit
2026-07-09 01:04:11.750794+00:00 [info] <0.216.0> Running boot step rabbit_auth_mechanism_cr_demo defined by app rabbit
2026-07-09 01:04:11.750827+00:00 [info] <0.216.0> Running boot step rabbit_auth_mechanism_plain defined by app rabbit
2026-07-09 01:04:11.750867+00:00 [info] <0.216.0> Running boot step rabbit_exchange_type_direct defined by app rabbit
2026-07-09 01:04:11.750901+00:00 [info] <0.216.0> Running boot step rabbit_exchange_type_fanout defined by app rabbit
2026-07-09 01:04:11.750930+00:00 [info] <0.216.0> Running boot step rabbit_exchange_type_headers defined by app rabbit
2026-07-09 01:04:11.750950+00:00 [info] <0.216.0> Running boot step rabbit_exchange_type_local_random defined by app rabbit
2026-07-09 01:04:11.750980+00:00 [info] <0.216.0> Running boot step rabbit_exchange_type_topic defined by app rabbit
2026-07-09 01:04:11.751006+00:00 [info] <0.216.0> Running boot step rabbit_priority_queue defined by app rabbit
2026-07-09 01:04:11.751023+00:00 [info] <0.216.0> Priority queues enabled, real BQ is rabbit_variable_queue
2026-07-09 01:04:11.751055+00:00 [info] <0.216.0> Running boot step kernel_ready defined by app rabbit
2026-07-09 01:04:11.751065+00:00 [info] <0.216.0> Running boot step pg_local_amqp_connection defined by app rabbit
2026-07-09 01:04:11.753806+00:00 [info] <0.216.0> Running boot step pg_local_amqp_session defined by app rabbit
2026-07-09 01:04:11.753889+00:00 [info] <0.216.0> Running boot step rabbit_sysmon_minder defined by app rabbit
2026-07-09 01:04:11.753959+00:00 [info] <0.216.0> Running boot step rabbit_epmd_monitor defined by app rabbit
2026-07-09 01:04:11.754289+00:00 [info] <0.534.0> epmd monitor knows us, inter-node communication (distribution) port: 25672
2026-07-09 01:04:11.754353+00:00 [info] <0.216.0> Running boot step guid_generator defined by app rabbit
2026-07-09 01:04:11.754828+00:00 [info] <0.216.0> Running boot step rabbit_node_monitor defined by app rabbit
2026-07-09 01:04:11.754923+00:00 [info] <0.538.0> Starting rabbit_node_monitor (in ignore mode)
2026-07-09 01:04:11.754988+00:00 [info] <0.216.0> Running boot step delegate_sup defined by app rabbit
2026-07-09 01:04:11.755260+00:00 [info] <0.216.0> Running boot step rabbit_fifo_dlx_sup defined by app rabbit
2026-07-09 01:04:11.755285+00:00 [info] <0.216.0> Running boot step core_initialized defined by app rabbit
2026-07-09 01:04:11.755296+00:00 [info] <0.216.0> Running boot step rabbit_channel_tracking_handler defined by app rabbit
2026-07-09 01:04:11.755336+00:00 [info] <0.216.0> Running boot step rabbit_classic_queue defined by app rabbit
2026-07-09 01:04:11.755370+00:00 [info] <0.216.0> Running boot step rabbit_connection_tracking_handler defined by app rabbit
2026-07-09 01:04:11.755396+00:00 [info] <0.216.0> Running boot step rabbit_definitions_hashing defined by app rabbit
2026-07-09 01:04:11.755429+00:00 [info] <0.216.0> Running boot step rabbit_exchange_parameters defined by app rabbit
2026-07-09 01:04:11.850734+00:00 [info] <0.216.0> Running boot step rabbit_policies defined by app rabbit
2026-07-09 01:04:11.850954+00:00 [info] <0.216.0> Running boot step rabbit_policy defined by app rabbit
2026-07-09 01:04:11.850984+00:00 [info] <0.216.0> Running boot step rabbit_quorum_memory_manager defined by app rabbit
2026-07-09 01:04:11.851009+00:00 [info] <0.216.0> Running boot step rabbit_quorum_queue defined by app rabbit
2026-07-09 01:04:11.851073+00:00 [info] <0.216.0> Running boot step rabbit_stream_coordinator defined by app rabbit
2026-07-09 01:04:11.851203+00:00 [info] <0.216.0> Running boot step rabbit_vhost_limit defined by app rabbit
2026-07-09 01:04:11.851249+00:00 [info] <0.216.0> Running boot step rabbit_mgmt_db_handler defined by app rabbitmq_management_agent
2026-07-09 01:04:11.851266+00:00 [info] <0.216.0> Management plugin: using rates mode 'basic'
2026-07-09 01:04:11.851385+00:00 [info] <0.216.0> Running boot step recovery defined by app rabbit
2026-07-09 01:04:11.858299+00:00 [info] <0.216.0> Running boot step empty_db_check defined by app rabbit
2026-07-09 01:04:11.858333+00:00 [info] <0.216.0> Will seed default virtual host and user...
2026-07-09 01:04:11.858380+00:00 [info] <0.216.0> Adding vhost '/' (description: 'Default virtual host', tags: [])
2026-07-09 01:04:11.861995+00:00 [info] <0.581.0> Making sure data directory '/var/lib/rabbitmq/mnesia/rabbit@soci-smoke-test/msg_stores/vhosts/628WB79CIFDYO9LJI6DKMI09L' for vhost '/' exists
2026-07-09 01:04:11.862386+00:00 [info] <0.581.0> Setting segment_entry_count for vhost '/' with 0 queues to '2048'
2026-07-09 01:04:11.866246+00:00 [info] <0.581.0> Starting message stores for vhost '/'
2026-07-09 01:04:11.866852+00:00 [info] <0.581.0> Started message store of type transient for vhost '/'
2026-07-09 01:04:11.867085+00:00 [warning] <0.595.0> Message store "628WB79CIFDYO9LJI6DKMI09L/msg_store_persistent": rebuilding indices from scratch
2026-07-09 01:04:11.867528+00:00 [info] <0.581.0> Started message store of type persistent for vhost '/'
2026-07-09 01:04:11.867574+00:00 [info] <0.581.0> Recovering 0 queues of type rabbit_classic_queue took 4ms
2026-07-09 01:04:11.867599+00:00 [info] <0.581.0> Recovering 0 queues of type rabbit_quorum_queue took 0ms
2026-07-09 01:04:11.867620+00:00 [info] <0.581.0> Recovering 0 queues of type rabbit_stream_queue took 0ms
2026-07-09 01:04:11.868656+00:00 [info] <0.216.0> Created user 'guest'
2026-07-09 01:04:11.869045+00:00 [info] <0.216.0> Successfully set user tags for user 'guest' to [administrator]
2026-07-09 01:04:11.869463+00:00 [info] <0.216.0> Successfully set permissions for user 'guest' in virtual host '/' to '.*', '.*', '.*'
2026-07-09 01:04:11.869487+00:00 [info] <0.216.0> Running boot step rabbit_observer_cli defined by app rabbit
2026-07-09 01:04:11.869533+00:00 [info] <0.216.0> Running boot step rabbit_core_metrics_gc defined by app rabbit
2026-07-09 01:04:11.869600+00:00 [info] <0.216.0> Running boot step background_gc defined by app rabbit
2026-07-09 01:04:11.869686+00:00 [info] <0.216.0> Running boot step routing_ready defined by app rabbit
2026-07-09 01:04:11.869707+00:00 [info] <0.216.0> Running boot step pre_flight defined by app rabbit
2026-07-09 01:04:11.869731+00:00 [info] <0.216.0> Running boot step notify_cluster defined by app rabbit
2026-07-09 01:04:11.869764+00:00 [info] <0.216.0> Running boot step networking defined by app rabbit
2026-07-09 01:04:11.869785+00:00 [info] <0.216.0> Running boot step rabbit_quorum_queue_periodic_membership_reconciliation defined by app rabbit
2026-07-09 01:04:11.869854+00:00 [info] <0.216.0> Running boot step definition_import_worker_pool defined by app rabbit
2026-07-09 01:04:11.869884+00:00 [info] <0.270.0> Starting worker pool 'definition_import_pool' with 48 processes in it
2026-07-09 01:04:11.870574+00:00 [info] <0.216.0> Running boot step cluster_name defined by app rabbit
2026-07-09 01:04:11.870615+00:00 [info] <0.216.0> Initialising internal cluster ID to 'rabbitmq-cluster-id-0aCD-nEe2Ld1c--GX-_Uaw'
2026-07-09 01:04:11.871063+00:00 [info] <0.216.0> Running boot step virtual_host_reconciliation defined by app rabbit
2026-07-09 01:04:11.871142+00:00 [info] <0.216.0> Running boot step direct_client defined by app rabbit
2026-07-09 01:04:11.871183+00:00 [info] <0.216.0> Running boot step cluster_tags defined by app rabbit
2026-07-09 01:04:11.871629+00:00 [info] <0.676.0> Resetting node maintenance status
2026-07-09 01:04:11.900851+00:00 [info] <0.699.0> Prometheus metrics: HTTP (non-TLS) listener started on port 15692
2026-07-09 01:04:11.900935+00:00 [info] <0.676.0> Ready to start client connection listeners
2026-07-09 01:04:11.901654+00:00 [info] <0.743.0> started TCP listener on [::]:5672
 completed with 3 plugins.
2026-07-09 01:04:11.939328+00:00 [info] <0.676.0> Server startup complete; 3 plugins started.
2026-07-09 01:04:11.939328+00:00 [info] <0.676.0>  * rabbitmq_prometheus
2026-07-09 01:04:11.939328+00:00 [info] <0.676.0>  * rabbitmq_management_agent
2026-07-09 01:04:11.939328+00:00 [info] <0.676.0>  * rabbitmq_web_dispatch
2026-07-09 01:04:12.072549+00:00 [info] <0.10.0> Time to start RabbitMQ: 1878 ms
```



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
