### PR TITLE
Third party dev package updates

### DIFF
--- a/packages/coreutils/Cargo.toml
+++ b/packages/coreutils/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://ftp.gnu.org/gnu/coreutils"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/coreutils/coreutils-9.10.tar.xz"
-sha512 = "976ccfb8b906273a687ec330938a25ab72fb130988ca2fcad4fb6e12f4b621eb76b6e9ee091ad060361e95a8da26835b2484fffd3b5f9c7cdb100c1eb7b7d676"
+url = "https://ftp.gnu.org/gnu/coreutils/coreutils-9.11.tar.xz"
+sha512 = "73f4192747ab793fd29cccafeda35c499a11800830227ea4d26b00afb2c496dd69cb493005691d0f62a168beea6b55c1e28e82b6cf795e7370f9d53d13555410"
 
 [[package.metadata.build-package.external-files]]
-url = "https://ftp.gnu.org/gnu/coreutils/coreutils-9.10.tar.xz.sig"
-sha512 = "83ec7f4a313ed425bf362bf3512042f9562df20daa03465090025a54e85f98c301b7be770340b08193bdf78b413a3bd87b218b71234443e756472205ce840c67"
+url = "https://ftp.gnu.org/gnu/coreutils/coreutils-9.11.tar.xz.sig"
+sha512 = "63bd88bd5d2e0e453e22404bbc28e3aede0660aa6f213131a5d528b721f84985593727d453a4b8915172e8ad5711edc17a5d53b72f5c1c975df2f64f1a29a38c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/coreutils/coreutils.spec
+++ b/packages/coreutils/coreutils.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}coreutils
-Version: 9.10
+Version: 9.11
 Release: 1%{?dist}
 Summary: A set of basic GNU tools
 License: GPL-3.0-or-later

--- a/packages/ethtool/Cargo.toml
+++ b/packages/ethtool/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://kernel.org/pub/software/network/ethtool/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.19.tar.xz"
-sha512 = "b91adb6eb2cd5bf395371cbe68b5542645691d4fb1a860e1edf2d07d7b13e88710715c8fb0dda16279b57ccd0a9ac3782d37b38374bb477382cfc44363de381e"
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-7.0.tar.xz"
+sha512 = "f8f0d08fe3da11f10cf7eb1f6348ebccd69175bfcdeb22726a8b86613d0dc7c8538b7d7075264102c9695f0100bb94cae03fd8dbe3b5bbe1fe758e1cb936a9c9"
 
 [[package.metadata.build-package.external-files]]
-url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-6.19.tar.sign"
-sha512 = "0263a0b3bf76a244a71469ef6828b118ea73262eb3c34fb91c6c7854d39b411965402a46ea4e33ea5149b0923ab654263bb35c6009c6a8aeb5860877db0af533"
+url = "https://mirrors.edge.kernel.org/pub/software/network/ethtool/ethtool-7.0.tar.sign"
+sha512 = "0706ba4f8f9bbb37cffcdd6609f5217026c7ec5d0e70e6dfd8fca914e8dd2bb3d461343aece55b53321a696a73d1650db7ad0460788ffb434e1754ba57172049"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ethtool/ethtool.spec
+++ b/packages/ethtool/ethtool.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}ethtool
-Version: 6.19
+Version: 7.0
 Release: 1%{?dist}
 Summary: Settings tool for Ethernet NICs
 License: GPL-2.0-only AND GPL-2.0-or-later

--- a/packages/iproute/Cargo.toml
+++ b/packages/iproute/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "http://kernel.org/pub/linux/utils/net/iproute2"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.19.0.tar.xz"
-sha512 = "0ca41b0ccfc253ab80cc5f9c687c92ec685d4e25cfbbb7cc512b919784c3248e20cc7c928420e271f8b24a4f56d6a4282f3ba394e27267552004701662e56494"
+url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-7.1.0.tar.xz"
+sha512 = "17052405c4d220da7a93a52b9c9ea01c9fa4a8889b5d4758cae86c8c97c78ed4011d74ea3153ea44c0dd632215961e6cd6e5f9e369acb19bec0a822d2eb844b8"
 
 [[package.metadata.build-package.external-files]]
-url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-6.19.0.tar.sign"
-sha512 = "9d6eb456b7af7a7895ef65dde41a9bf20c80e437916ee26fac15f6d7b6ed6baa257ff32f5e16d4f9a361524952ccd31b9bf137942be33551a264c0cfe1180df1"
+url = "https://kernel.org/pub/linux/utils/net/iproute2/iproute2-7.1.0.tar.sign"
+sha512 = "b507f8d282c275aaaa9932a80893cb9cac79f9cfc146be9fa12d1d94d130829060029068723d23c6346a7ec67bb35db8c8f2534ad03abbade471e1e8ae67cf80"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/iproute/iproute.spec
+++ b/packages/iproute/iproute.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}iproute
-Version: 6.19.0
+Version: 7.1.0
 Release: 1%{?dist}
 Summary: Tools for advanced IP routing and network device configuration
 License: GPL-2.0-or-later AND GPL-2.0-only

--- a/packages/makedumpfile/Cargo.toml
+++ b/packages/makedumpfile/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/makedumpfile/makedumpfile/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/makedumpfile/makedumpfile/archive/1.7.8/makedumpfile-1.7.8.tar.gz"
-sha512 = "c5c1944076593eb64a966b61528b4a6c700fb21419d7dd8497f2fdec19afc47d0b437aca6d19f5727af0bf17759c7bd9a13e1c6bf8c97bf4bfbe26823257aaed"
+url = "https://github.com/makedumpfile/makedumpfile/archive/1.7.9/makedumpfile-1.7.9.tar.gz"
+sha512 = "ecd058510993b559a8c6e201583944bf93f8f8096842022d55b8654f5783f1462f33418dc0398bf1ddfb25ee8a617a24594f5d67175663a01475a5f6eca5721c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/makedumpfile/makedumpfile.spec
+++ b/packages/makedumpfile/makedumpfile.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}makedumpfile
-Version: 1.7.8
+Version: 1.7.9
 Release: 1%{?dist}
 Epoch: 1
 Summary: Tool to create dumps from kernel memory images

--- a/packages/open-vm-tools/0003-Update-shutdown-code-to-work-for-Bottlerocket.patch
+++ b/packages/open-vm-tools/0003-Update-shutdown-code-to-work-for-Bottlerocket.patch
@@ -7,14 +7,16 @@ Bottlerocket doesn't have /bin/sh which makes the call system() fail
 with an unexpected error code. This results in the guest shutdown and
 reboot calls via vmtoolsd returning as if the request was successful but
 the call actually failed completely. This commit replaces the current
-call to system() with g_spawn_sync() which should be a drop in
-replacement for system().
+call to system() with g_spawn_command_line_sync() which should be a drop
+in replacement for system().
 
 Signed-off-by: Matthew Yeazel <yeazelm@amazon.com>
+[jpculp: port to open-vm-tools 13.1.0]
+Signed-off-by: Patrick J.P. Culp <jpculp@amazon.com>
 ---
  lib/system/Makefile.am   |  3 +++
- lib/system/systemLinux.c | 14 +++++++++++++-
- 2 files changed, 16 insertions(+), 1 deletion(-)
+ lib/system/systemLinux.c | 26 +++++++++++++++++++-------
+ 2 files changed, 22 insertions(+), 7 deletions(-)
 
 diff --git a/lib/system/Makefile.am b/lib/system/Makefile.am
 index 52b1a1dd..d2613c43 100644
@@ -30,10 +32,10 @@ index 52b1a1dd..d2613c43 100644
  libSystem_la_SOURCES =
  libSystem_la_SOURCES += systemLinux.c
 diff --git a/lib/system/systemLinux.c b/lib/system/systemLinux.c
-index a688ab25..d24e2c4c 100644
+index c7fc6146..c4107a1b 100644
 --- a/lib/system/systemLinux.c
 +++ b/lib/system/systemLinux.c
-@@ -54,6 +54,7 @@
+@@ -55,6 +55,7 @@
  #include <sys/ioctl.h>
  #include <net/if.h>
  #include <sys/ioctl.h>
@@ -41,36 +43,53 @@ index a688ab25..d24e2c4c 100644
  
  #if defined sun || defined __APPLE__
  #   include <utmpx.h>
-@@ -305,6 +306,8 @@ void
- System_Shutdown(Bool reboot)  // IN: "reboot or shutdown" flag
+@@ -780,10 +781,10 @@ SNEForEachCallback(const char *key,     // IN: environment variable
+  *
+  * SystemRunShutdownCommand --
+  *
+- *   Run a reboot or shutdown command using system() and log a warning if it fails.
++ *   Run a reboot or shutdown command and log a warning if it fails.
+  *
+  * Return value:
+- *    Returns the return value of the system() call.
++ *    Returns the exit status of the command, or -1 on exec failure.
+  *
+  * Side effects:
+  *    None.
+@@ -795,17 +796,28 @@ static int
+ SystemRunShutdownCommand(Bool reboot,     // IN: "reboot or shutdown" flag
+                          const char *cmd) // IN: "command to run"
  {
-    char *cmd;
-+   int exit_status = 0;
+-   int status;
++   int status = 0;
 +   Bool success;
- 
-    if (reboot) {
- #if defined(sun)
-@@ -325,10 +328,19 @@ System_Shutdown(Bool reboot)  // IN: "reboot or shutdown" flag
-       cmd = "/sbin/shutdown -h now";
- #endif
-    }
--   if (system(cmd) == -1) {
 +
 +   success = g_spawn_command_line_sync(cmd,
 +                           NULL,
 +                           NULL,
-+                           &exit_status,
++                           &status,
 +                           NULL);
++
 +   if (!success) {
-       fprintf(stderr, "Unable to execute %s command: \"%s\"\n",
-               reboot ? "reboot" : "shutdown", cmd);
-    }
-+   if ((success) && exit_status != 0) {
-+      fprintf(stderr, "Command %s failed with exit %d\n", cmd, exit_status);
++      Warning("%s: %s command \"%s\": failed to execute\n",
++              __func__, reboot ? "reboot" : "shutdown", cmd);
++      return -1;
 +   }
- }
  
+-   if ((status = system(cmd)) != 0) {
++   if (status != 0) {
+       char cmsg[128];
  
+       Str_Snprintf(cmsg, sizeof(cmsg), "%s: %s command \"%s\"",
+                    __func__, reboot ? "reboot" : "shutdown", cmd);
+ 
+-      if (status == -1) {
+-         Warning("%s: failed. Error: %s\n", cmsg, Err_Errno2String(errno));
+-      } else if (WIFEXITED(status)) {
++      if (WIFEXITED(status)) {
+          Warning("%s exited. status: %d\n", cmsg, WEXITSTATUS(status));
+       } else if (WIFSIGNALED(status)) {
+          Warning("%s terminated by signal: %d\n", cmsg, WTERMSIG(status));
 -- 
 2.37.1 (Apple Git-137.1)
 

--- a/packages/open-vm-tools/Cargo.toml
+++ b/packages/open-vm-tools/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/vmware/open-vm-tools/releases/"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/vmware/open-vm-tools/releases/download/stable-13.0.10/open-vm-tools-13.0.10-25056151.tar.gz"
-sha512 = "c332fd2efb3bc16f2fbb77b7b0d0f4a5bb251b5b4828260bb6cbd96903a38d492f90727dad54ef95e442cf3dcc043032e5581e64e3aee4afb55b9db568a29259"
+url = "https://github.com/vmware/open-vm-tools/releases/download/stable-13.1.0/open-vm-tools-13.1.0-25218885.tar.gz"
+sha512 = "07086e2403bc4ab9727822ccfb7152e479f326a1d33c533bdcfb38b5ade8aa2ed3bc244130ab794ad5b99d9a0b3c3caecf0f37e2e1695bd97213f2236490bbb4"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/open-vm-tools/open-vm-tools.spec
+++ b/packages/open-vm-tools/open-vm-tools.spec
@@ -1,7 +1,7 @@
-%global buildver 25056151
+%global buildver 25218885
 
 Name: %{_cross_os}open-vm-tools
-Version: 13.0.10
+Version: 13.1.0
 Release: 1%{?dist}
 Summary: Tools for VMware
 License: LGPL-2.1-or-later

--- a/packages/strace/Cargo.toml
+++ b/packages/strace/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://strace.io/files"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.19/strace-6.19.tar.xz"
-sha512 = "d8088eef80f8007e0cae0e0a342cd171447cade8e2433f55b2592b33c704e4dcb5016c00104e536e858cf7d5ea5d2e4320073a2691b0bfb1a7ff87d932fac197"
+url = "https://strace.io/files/7.1/strace-7.1.tar.xz"
+sha512 = "81afed51fdb220e2fb8a83adbb0f9c1c702679955550f6a5037c56d0918ad497829274d5e5f64cfd2c3146802488f07e23f60b5590556b2d1d9b6442abe69717"
 
 [[package.metadata.build-package.external-files]]
-url = "https://strace.io/files/6.19/strace-6.19.tar.xz.asc"
-sha512 = "953bd7819692d39f3fc71cc98600c4fdf3aa1ea4ba847a0d6d66cf5f83825e2f5e3424b172d62b91505ee80d85a732f226356692f02cc25f4c6905d0a6ee5990"
+url = "https://strace.io/files/7.1/strace-7.1.tar.xz.asc"
+sha512 = "09001f948e59439ac2d8dba302782367fcb14ea237e9faf206656b311ca176803f7cd79c13d7e4e6d67727cb3ecb4f9bc671641007210ddd9b1ac4ff65773d5e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/strace/strace.spec
+++ b/packages/strace/strace.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}strace
-Version: 6.19
+Version: 7.1
 Release: 1%{?dist}
 Summary: Linux syscall tracer
 License: LGPL-2.1-or-later

--- a/packages/xfsprogs/Cargo.toml
+++ b/packages/xfsprogs/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://mirrors.edge.kernel.org/pub/linux/utils/fs/xfs/xfsprogs/"
 
 [[package.metadata.build-package.external-files]]
-url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.19.0.tar.xz"
-sha512 = "9ca8ba19a3cc3a4e8a03ca4fe641ae958eb5fd9c4a8b09430a9fa4891d27f63506acd543c061887fec5ba22d2883c69f8c52a155f4f58af96206999725e25bf7"
+url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-7.0.1.tar.xz"
+sha512 = "21c235bb48f3b8e43a7cda3968e28ecb0333a28db9f2beac77acb9eebc476decdd5119d55230d44ac11734d9d0d7a88f66a74677cd25fe128fea7e0464083665"
 
 [[package.metadata.build-package.external-files]]
-url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-6.19.0.tar.sign"
-sha512 = "c400342d2596d2e590001d48f10973e8ffdc0b73f3f7570bf026edc224aefadb18d934be845ea317528f326c09992b04a4449b0fb93befd39994bef54703af78"
+url = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-7.0.1.tar.sign"
+sha512 = "6a91fbc55bf256dec554e138ede235f9ed5b97d932bc34dedae4b58d1095d94e4a5af81499ef8a510f9f48168bfaf9207da31e032e46d9bcba1847f434b5c69e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/xfsprogs/xfsprogs.spec
+++ b/packages/xfsprogs/xfsprogs.spec
@@ -1,5 +1,5 @@
 Name: %{_cross_os}xfsprogs
-Version: 6.19.0
+Version: 7.0.1
 Release: 1%{?dist}
 Summary: Utilities for managing the XFS filesystem
 License: GPL-2.0-only AND LGPL-2.1-only
@@ -37,7 +37,8 @@ Requires: %{name}
   --enable-blkid=yes \
   --enable-lto=no \
   --enable-editline=no \
-  --enable-scrub=no
+  --enable-scrub=no \
+  --enable-healer=no
 
 %make_build
 


### PR DESCRIPTION
**Description of changes:**
* Update `coreutils` to v9.11
* Update `ethtool` to v7.0
* Update `iproute` to v7.1.0
* Update `makedumpfile` to v1.7.9
* Update `strace` to v7.1
* Update `xfsprogs` to v7.0.1
* Update `open-vm-tools` to v13.1.0

**Testing done:**

- [x] coreutils - `sha256sum`
- [x] ethtool - `ethtool`
- [x] iproute - `ip addr`
- [x] makedumpfile - `echo 'c' > /proc/sysrq-trigger`
- [x] strace - `strace ls`
- [x] xfsprogs - `mkfs.xfs`
- [x] open-vm-tools - powered on/off a VM

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
