### PR TITLE
Third party package updates

### DIFF
--- a/packages/bash/Cargo.toml
+++ b/packages/bash/Cargo.toml
@@ -55,6 +55,30 @@ sha512 = "094b7dc2abe6fc41c62494c6b69640fbd8c6bd93e7cde0618504bb8589fc51fec2fb16
 url = "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/bash53-009"
 sha512 = "07f37cee118e510ae58ea408f9d97b942017e1378532d4e3cd5a4d7405994ddadaba5d3ddb4bbda6b375760967faa51add7f46914ba919a27c14e7036f64f3be"
 
+[[package.metadata.build-package.external-files]]
+url = "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/bash53-010"
+sha512 = "976e23a734fbc38b8bf705b36d74c1861e5d69e3f3fbde683210ad93b1c14f59c014b3fcd4aea0b0f5b1f35bc23770abb5a741a7a25a2081816ee22da7bdedad"
+
+[[package.metadata.build-package.external-files]]
+url = "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/bash53-011"
+sha512 = "10da4ad156c83a18ce023845339399fd60f627292af15345612c88764a98259231f7f3a75f9d7820beea34ba6b25cb151d2abca8ce871d07e29e32dcee8adb64"
+
+[[package.metadata.build-package.external-files]]
+url = "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/bash53-012"
+sha512 = "e178cd27f1db5d7607ec90bb4305059d996cf95486a1e5e3b4d76f37811a0320433a2a2900e50c5704b199fae946280edb50daedb8ab8aabed9ec83dc2540d2b"
+
+[[package.metadata.build-package.external-files]]
+url = "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/bash53-013"
+sha512 = "a973b7d9c37dc1b271fe1efa3afe3b700c1bebbf9f72e6e4e6a72a8d1f50f7875d82ee26af335e26d20883376d89c78f14b1901a0a70a8f9a9b2418df40f71fc"
+
+[[package.metadata.build-package.external-files]]
+url = "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/bash53-014"
+sha512 = "7beb4a1c39b126189a94deb12d5065b571196f27abdd8ae9c9b340ffccc1f52ed9fec31a475b72fed661097d081b1a93d088fabe53c45c8b2cc286b831c16977"
+
+[[package.metadata.build-package.external-files]]
+url = "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/bash53-015"
+sha512 = "812fbffd1b755cc9bbf730a4632f68a573351c4eeb5a4f495fa8f2f4dd7dbe1587dd22aed0f9c4d5c941130489ecc3def96068c77cc142680326ba8785862432"
+
 [build-dependencies]
 glibc = { path = "../glibc" }
 libncurses = { path = "../libncurses" }

--- a/packages/bash/bash.spec
+++ b/packages/bash/bash.spec
@@ -1,11 +1,14 @@
+%global majorminor 5.3
+%global version %{majorminor}.15
+
 Name: %{_cross_os}bash
-Version: 5.3
+Version: %{version}
 Release: 1%{?dist}
 Summary: The GNU Bourne Again shell
 License: GPL-3.0-or-later
 URL: https://www.gnu.org/software/bash
-Source0: https://ftp.gnu.org/gnu/bash/bash-%{version}.tar.gz
-Source1: https://ftp.gnu.org/gnu/bash/bash-%{version}.tar.gz.sig
+Source0: https://ftp.gnu.org/gnu/bash/bash-%{majorminor}.tar.gz
+Source1: https://ftp.gnu.org/gnu/bash/bash-%{majorminor}.tar.gz.sig
 Source2: gpgkey-7C0135FB088AAF6C66C650B9BB5869F064EA74AB.asc
 
 # Disable loadable builtin examples
@@ -20,6 +23,12 @@ Patch1006: bash53-006
 Patch1007: bash53-007
 Patch1008: bash53-008
 Patch1009: bash53-009
+Patch1010: bash53-010
+Patch1011: bash53-011
+Patch1012: bash53-012
+Patch1013: bash53-013
+Patch1014: bash53-014
+Patch1015: bash53-015
 
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libncurses-devel
@@ -44,7 +53,7 @@ Requires: %{name}
 
 %prep
 %{gpgverify} --data=%{S:0} --signature=%{S:1} --keyring=%{S:2}
-%autosetup -n bash-%{version} -N
+%autosetup -n bash-%{majorminor} -N
 %autopatch -p1 -m0001 -M1000
 %autopatch -p0 -m1001
 

--- a/packages/libglib/Cargo.toml
+++ b/packages/libglib/Cargo.toml
@@ -13,8 +13,8 @@ releases-url = "https://download.gnome.org/sources/glib"
 
 # glib uses the "stable releases use even minor numbers" versioning scheme
 [[package.metadata.build-package.external-files]]
-url = "https://download.gnome.org/sources/glib/2.86/glib-2.86.5.tar.xz"
-sha512 = "e14e56659594cb1f929cf62b01f415b867592f83d7a624a8806c609c762fcdf6ab7bc4c68ab1faafd709f7448a52b8e37a7066a53c84b52607a8b5261bc8f222"
+url = "https://download.gnome.org/sources/glib/2.88/glib-2.88.2.tar.xz"
+sha512 = "d6f40d1ff0f73faccdff8060fabd29b8217cc46139cf33e5792fee05af0665f96cd04e7866995bd84fcd99c9e40c40367d1326f8417bad99c1242dd841ec72a5"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/libglib/libglib.spec
+++ b/packages/libglib/libglib.spec
@@ -1,12 +1,12 @@
 Name: %{_cross_os}libglib
-Version: 2.86.5
+Version: 2.88.2
 Release: 1%{?dist}
 Epoch: 1
 Summary: The GLib libraries
 # glib2 is LGPL-2.1-only
 License: LGPL-2.1-only
 URL: https://www.gtk.org/
-Source0: https://download.gnome.org/sources/glib/2.86/glib-%{version}.tar.xz
+Source0: https://download.gnome.org/sources/glib/2.88/glib-%{version}.tar.xz
 BuildRequires: meson
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libffi-devel

--- a/packages/util-linux/Cargo.toml
+++ b/packages/util-linux/Cargo.toml
@@ -12,12 +12,12 @@ path = "../packages.rs"
 releases-url = "https://www.kernel.org/pub/linux/utils/util-linux"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.4.tar.xz"
-sha512 = "c21ad77b787ab5892169c80cbec1ba46ed6bba36c1db278f2d1cd8712ae237f5cd25bfd20f2dc638334d1c47c5ff6102703147147d42f71c995bd397e735691a"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.42/util-linux-2.42.2.tar.xz"
+sha512 = "7415add0be2930654e322830808dde03ff6d511bd357f0679e6b6287a13ca79fe58ce4ac05edef86b76fb381b3a36ca2da9d3c31b5dc0a1d889c203156a57277"
 
 [[package.metadata.build-package.external-files]]
-url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.4.tar.sign"
-sha512 = "1d4673277e59a2409e414ee8cdc0f3d52cb40f626538f251c74820085128cc572a98bc27a784b10e3b87ed1babe344bbed32fb6a42f4aae67c5f533b24440eb8"
+url = "https://www.kernel.org/pub/linux/utils/util-linux/v2.42/util-linux-2.42.2.tar.sign"
+sha512 = "3922974fa8384be5628938705f01aa3ac433512e24a3943fc5e0b2ae4cb4d9b952966727039d2fd74f58c51cd349228fd53f82ac8cd4d5ad7f61580abd4da229"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -1,5 +1,5 @@
-%global majorminor 2.41
-%global version %{majorminor}.4
+%global majorminor 2.42
+%global version %{majorminor}.2
 
 Name: %{_cross_os}util-linux
 Version: %{version}
@@ -211,11 +211,13 @@ done
 %exclude %{_cross_bindir}/colcrt
 %exclude %{_cross_bindir}/colrm
 %exclude %{_cross_bindir}/column
+%exclude %{_cross_bindir}/copyfilerange
 %exclude %{_cross_bindir}/coresched
 %exclude %{_cross_bindir}/eject
 %exclude %{_cross_bindir}/enosys
 %exclude %{_cross_bindir}/exch
 %exclude %{_cross_bindir}/fincore
+%exclude %{_cross_bindir}/getino
 %exclude %{_cross_bindir}/getopt
 %exclude %{_cross_bindir}/hardlink
 %exclude %{_cross_bindir}/hexdump


### PR DESCRIPTION
**Description of changes:**

* Update `bash` to v5.3.15

* Update `util-linux` to v2.42.2

* Update `libglib` to v2.88.2

**Testing done:**

- [x] bash - used the shell on a VMware variant
- [x] util-linux - `lsblk` and `findmnt`
- [x] libglib - powered on/off a VM

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
