### PR TITLE
Bug fixes for thar-be-registries port inference

### DIFF
--- a/sources/api/thar-be-registries/src/host_ns.rs
+++ b/sources/api/thar-be-registries/src/host_ns.rs
@@ -23,12 +23,22 @@ impl Endpoint {
 
     /// Checks if this endpoint has a path component beyond "/".
     pub fn has_path_component(&self) -> bool {
+        // Try parsing as-is first (handles URLs with scheme like https://host/path)
+        // Only accept if it has a host (registry:5000 parses as scheme with no host)
         if let Ok(url) = Url::parse(&self.0) {
-            let p = url.path();
-            !p.is_empty() && p != "/"
-        } else {
-            false
+            if let Some(_host) = url.host_str() {
+                return !url.path().is_empty() && url.path() != "/";
+            }
         }
+
+        // Parse bare hostname with https:// prefix (handles registry:5000/v2/path)
+        if let Ok(url) = Url::parse(&format!("https://{}", &self.0)) {
+            if let Some(_host) = url.host_str() {
+                return !url.path().is_empty() && url.path() != "/";
+            }
+        }
+
+        false
     }
 }
 
@@ -153,8 +163,34 @@ mod tests {
 
     #[test]
     fn test_endpoint_has_path_component() {
+        // === With scheme, no path ===
         assert!(!Endpoint::new("https://mirror.example.com").has_path_component());
         assert!(!Endpoint::new("https://mirror.example.com/").has_path_component());
+        assert!(!Endpoint::new("http://mirror.example.com").has_path_component());
+        assert!(!Endpoint::new("https://192.168.1.1").has_path_component());
+        assert!(!Endpoint::new("https://192.168.1.1:443").has_path_component());
+        assert!(!Endpoint::new("http://192.168.1.1:80").has_path_component());
+        assert!(!Endpoint::new("https://192.168.1.1:5000").has_path_component());
+
+        // === With scheme, with path ===
         assert!(Endpoint::new("https://mirror.example.com/v2/docker-hub").has_path_component());
+        assert!(Endpoint::new("http://mirror.example.com/v2/docker-hub").has_path_component());
+        assert!(Endpoint::new("https://192.168.1.1:443/v2/myrepo").has_path_component());
+        assert!(Endpoint::new("http://192.168.1.1:80/v2/myrepo").has_path_component());
+        assert!(Endpoint::new("https://192.168.1.1:5000/path/to/resource").has_path_component());
+        assert!(Endpoint::new("https://registry.example.com/v2/mirror").has_path_component());
+
+        // === Schemeless, no path ===
+        assert!(!Endpoint::new("196.18.8.18:443").has_path_component());
+        assert!(!Endpoint::new("192.168.1.1:5000").has_path_component());
+        assert!(!Endpoint::new("registry.example.com:5000").has_path_component());
+        assert!(!Endpoint::new("mirror.example.com").has_path_component());
+
+        // === Schemeless, with path ===
+        assert!(Endpoint::new("196.18.8.18:443/v2/eks-a-test").has_path_component());
+        assert!(Endpoint::new("192.168.1.1:5000/path/to/resource").has_path_component());
+        assert!(Endpoint::new("192.168.1.1:80/v2/myrepo").has_path_component());
+        assert!(Endpoint::new("registry.example.com:5000/v2/mirror").has_path_component());
+        assert!(Endpoint::new("registry.example.com/v2/mirror").has_path_component());
     }
 }

--- a/sources/api/thar-be-registries/src/main.rs
+++ b/sources/api/thar-be-registries/src/main.rs
@@ -273,6 +273,58 @@ mod tests {
     &[r#"server = "http://registry.local:5000""#]
     ; "explicit http scheme preserved"
   )]
+    #[test_case(
+    "docker.io",
+    &["https://10.0.0.1:443/path/to/resource"],
+    "docker.io/hosts.toml",
+    &[r#"[host."https://10.0.0.1:443/path/to/resource"]"#, "override_path = true"]
+    ; "https ip port 443 with path sets override_path"
+  )]
+    #[test_case(
+    "registry.example.com",
+    &["https://172.16.0.5:8443/path/to/resource"],
+    "registry.example.com/hosts.toml",
+    &[r#"[host."https://172.16.0.5:8443/path/to/resource"]"#, "override_path = true"]
+    ; "https ip custom port with path sets override_path"
+  )]
+    // Schemeless endpoints with path — override_path must be set
+    #[test_case(
+    "public.ecr.aws",
+    &["196.18.8.18:443/v2/eks-a-test"],
+    "public.ecr.aws/hosts.toml",
+    &[r#"[host."196.18.8.18:443/v2/eks-a-test"]"#, "override_path = true"]
+    ; "schemeless ip port 443 with path against public.ecr.aws sets override_path"
+  )]
+    #[test_case(
+    "registry.example.com",
+    &["192.168.1.1:5000/path/to/resource"],
+    "registry.example.com/hosts.toml",
+    &[r#"[host."192.168.1.1:5000/path/to/resource"]"#, "override_path = true"]
+    ; "schemeless ip custom port with path sets override_path"
+  )]
+    #[test_case(
+    "registry.example.com",
+    &["mirror.local:5000/path/to/resource"],
+    "registry.example.com/hosts.toml",
+    &[r#"[host."mirror.local:5000/path/to/resource"]"#, "override_path = true"]
+    ; "schemeless hostname custom port with path sets override_path"
+  )]
+    // http scheme with path — override_path
+    #[test_case(
+    "registry.example.com",
+    &["http://mirror.local:5000/path/to/resource"],
+    "registry.example.com/hosts.toml",
+    &[r#"[host."http://mirror.local:5000/path/to/resource"]"#, "override_path = true"]
+    ; "http hostname custom port with path sets override_path"
+  )]
+    // Hostname no port with path
+    #[test_case(
+    "docker.io",
+    &["https://mirror.example.com/path/to/resource"],
+    "docker.io/hosts.toml",
+    &[r#"[host."https://mirror.example.com/path/to/resource"]"#, "override_path = true"]
+    ; "https hostname no port with path sets override_path"
+  )]
     fn test_write_hosts_toml(
         registry: &str,
         endpoints: &[&str],

--- a/sources/api/thar-be-registries/src/main.rs
+++ b/sources/api/thar-be-registries/src/main.rs
@@ -259,6 +259,20 @@ mod tests {
     &[r#"server = "https://registry.example.com:443""#]
     ; "port 443 preserves port in directory and server"
   )]
+    #[test_case(
+    "registry.example.com:80",
+    &["http://mirror.local"],
+    "registry.example.com_80_/hosts.toml",
+    &[r#"server = "http://registry.example.com:80""#]
+    ; "port 80 infers http scheme"
+  )]
+    #[test_case(
+    "http://registry.local:5000",
+    &["http://mirror.local:5000"],
+    "registry.local_5000_/hosts.toml",
+    &[r#"server = "http://registry.local:5000""#]
+    ; "explicit http scheme preserved"
+  )]
     fn test_write_hosts_toml(
         registry: &str,
         endpoints: &[&str],
@@ -308,6 +322,13 @@ mod tests {
     "registry.example.com_443_/credentials.toml",
     &[r#"username = "user""#, r#"password = "pass""#]
     ; "port 443 encodes directory name"
+  )]
+    #[test_case(
+    "registry.example.com:80",
+    Some("user"), Some("pass"), None, None,
+    "registry.example.com_80_/credentials.toml",
+    &[r#"username = "user""#, r#"password = "pass""#]
+    ; "port 80 encodes directory name"
   )]
     fn test_write_credentials_toml(
         registry: &str,

--- a/sources/api/thar-be-registries/src/main.rs
+++ b/sources/api/thar-be-registries/src/main.rs
@@ -252,6 +252,13 @@ mod tests {
     &[r#"[host."https://mirror.global"]"#]
     ; "global mirror"
   )]
+    #[test_case(
+    "registry.example.com:443",
+    &["https://mirror.local"],
+    "registry.example.com_443_/hosts.toml",
+    &[r#"server = "https://registry.example.com:443""#]
+    ; "port 443 preserves port in directory and server"
+  )]
     fn test_write_hosts_toml(
         registry: &str,
         endpoints: &[&str],
@@ -294,6 +301,13 @@ mod tests {
     "registry.example.com/credentials.toml",
     &[r#"auth = "dXNlcjpwYXNz""#]
     ; "auth only"
+  )]
+    #[test_case(
+    "registry.example.com:443",
+    Some("user"), Some("pass"), None, None,
+    "registry.example.com_443_/credentials.toml",
+    &[r#"username = "user""#, r#"password = "pass""#]
+    ; "port 443 encodes directory name"
   )]
     fn test_write_credentials_toml(
         registry: &str,

--- a/sources/api/thar-be-registries/src/registry.rs
+++ b/sources/api/thar-be-registries/src/registry.rs
@@ -135,6 +135,20 @@ mod tests {
     // [fe80::443] has no port — the "443" is part of the address, not a port.
     #[test_case("[fe80::443]", "[fe80::443]", "https"; "ipv6 addr containing 443 no port")]
     #[test_case("https://[fe80::443]", "[fe80::443]", "https"; "ipv6 addr containing 443 with scheme no port")]
+    // URLs with IP, port, and path — parse_registry extracts only host:port and scheme.
+    // With scheme
+    #[test_case("https://10.0.0.1:443/path/to/resource", "10.0.0.1:443", "https"; "https ip with 443 and path")]
+    #[test_case("http://172.16.0.5:80/path/to/resource", "172.16.0.5:80", "http"; "http ip with 80 and path")]
+    #[test_case("https://10.0.0.1:8443/path/to/resource", "10.0.0.1:8443", "https"; "https ip with custom port and path")]
+    #[test_case("https://registry.example.com/path/to/resource", "registry.example.com", "https"; "https hostname no port with path")]
+    #[test_case("https://registry.example.com:5000/path/to/resource", "registry.example.com:5000", "https"; "https hostname custom port with path")]
+    #[test_case("http://registry.example.com:80/path/to/resource", "registry.example.com:80", "http"; "http hostname port 80 with path")]
+    // Schemeless with path
+    #[test_case("196.18.8.18:443/path/to/resource", "196.18.8.18:443", "https"; "schemeless ip port 443 with path")]
+    #[test_case("192.168.1.1:5000/path/to/resource", "192.168.1.1:5000", "https"; "schemeless ip custom port with path")]
+    #[test_case("192.168.1.1:80/path/to/resource", "192.168.1.1:80", "http"; "schemeless ip port 80 with path")]
+    #[test_case("registry.example.com:5000/path/to/resource", "registry.example.com:5000", "https"; "schemeless hostname custom port with path")]
+    #[test_case("registry.example.com:443/path/to/resource", "registry.example.com:443", "https"; "schemeless hostname port 443 with path")]
     fn test_parse_registry(input: &str, expected_host: &str, expected_scheme: &str) {
         let (host, scheme) = parse_registry(input).unwrap();
         assert_eq!(host, expected_host);

--- a/sources/api/thar-be-registries/src/registry.rs
+++ b/sources/api/thar-be-registries/src/registry.rs
@@ -7,9 +7,18 @@ use crate::error::{ParseRegistrySnafu, Result};
 pub(crate) const DOCKER_HUB_HOST: &str = "docker.io";
 pub(crate) const DOCKER_HUB_REGISTRY: &str = "registry-1.docker.io";
 
-/// Parse registry string, extracting host:port and optional scheme.
-/// Works with full URLs (https://docker.io) or bare hostnames (docker.io, registry:5000).
-/// Defaults to https scheme when none is provided.
+/// Parse a registry string into its `(host, scheme)` components.
+///
+/// Returns:
+/// - `host`: The registry host and optional port (e.g. `docker.io`, `registry.example.com:5000`).
+///   Used to construct the directory name under `certs.d/` and the `server` URL in `hosts.toml`.
+/// - `scheme`: Either `http` or `https`. Written into the `server` field of `hosts.toml`
+///   (e.g. `server = "https://registry.example.com:5000"`).
+///
+/// Scheme is determined as follows:
+/// - Explicit scheme in input (`http://` or `https://`) → preserved as-is.
+/// - No scheme, port 80 → `http`.
+/// - No scheme, any other port or no port → `https`.
 pub(crate) fn parse_registry(registry: &str) -> Result<(String, String)> {
     // Try parsing as-is first (handles URLs with scheme like https://docker.io)
     // Only accept if it has a host (registry:5000 parses as scheme with no host)
@@ -24,7 +33,8 @@ pub(crate) fn parse_registry(registry: &str) -> Result<(String, String)> {
     if let Ok(url) = Url::parse(&format!("https://{}", registry)) {
         if let Some(host) = url.host_str() {
             let port = parsed_port(&url, registry);
-            return Ok((format_host_port(host, port), "https".to_string()));
+            let scheme = if port == Some(80) { "http" } else { "https" };
+            return Ok((format_host_port(host, port), scheme.to_string()));
         }
     }
 
@@ -103,19 +113,22 @@ mod tests {
     #[test_case("http://registry.local:5000", "registry.local:5000", "http"; "http url with port")]
     // Default port preservation: explicit :443 and :80 must be retained
     #[test_case("192.168.1.1:443", "192.168.1.1:443", "https"; "bare host with explicit 443")]
-    #[test_case("192.168.1.1:80", "192.168.1.1:80", "https"; "bare host with explicit 80")]
+    #[test_case("192.168.1.1:80", "192.168.1.1:80", "http"; "bare host with explicit 80")]
     #[test_case("registry.example.com:443", "registry.example.com:443", "https"; "bare hostname with explicit 443")]
-    #[test_case("registry.example.com:80", "registry.example.com:80", "https"; "bare hostname with explicit 80")]
+    #[test_case("registry.example.com:80", "registry.example.com:80", "http"; "bare hostname with explicit 80")]
     #[test_case("https://192.168.1.1:443", "192.168.1.1:443", "https"; "https url with explicit 443")]
     #[test_case("http://192.168.1.1:80", "192.168.1.1:80", "http"; "http url with explicit 80")]
     #[test_case("https://registry.example.com:443", "registry.example.com:443", "https"; "https hostname with explicit 443")]
     #[test_case("http://registry.example.com:80", "registry.example.com:80", "http"; "http hostname with explicit 80")]
+    // Explicit scheme always wins over port-based inference.
+    #[test_case("https://registry.example.com:80", "registry.example.com:80", "https"; "explicit https on port 80")]
+    #[test_case("http://registry.example.com:443", "registry.example.com:443", "http"; "explicit http on port 443")]
     // Bare IP with no port defaults to https.
     #[test_case("192.168.1.1", "192.168.1.1", "https"; "bare ip no port")]
     // IPv6 addresses
     #[test_case("[::1]:5000", "[::1]:5000", "https"; "ipv6 loopback with port")]
     #[test_case("[2001:db8::1]:443", "[2001:db8::1]:443", "https"; "ipv6 with explicit 443")]
-    #[test_case("[2001:db8::1]:80", "[2001:db8::1]:80", "https"; "ipv6 with explicit 80")]
+    #[test_case("[2001:db8::1]:80", "[2001:db8::1]:80", "http"; "ipv6 with explicit 80")]
     #[test_case("https://[::1]:443", "[::1]:443", "https"; "ipv6 https with explicit 443")]
     #[test_case("http://[::1]:80", "[::1]:80", "http"; "ipv6 http with explicit 80")]
     // Ensure port-like patterns in IPv6 do not cause false positives.

--- a/sources/api/thar-be-registries/src/registry.rs
+++ b/sources/api/thar-be-registries/src/registry.rs
@@ -15,18 +15,38 @@ pub(crate) fn parse_registry(registry: &str) -> Result<(String, String)> {
     // Only accept if it has a host (registry:5000 parses as scheme with no host)
     if let Ok(url) = Url::parse(registry) {
         if let Some(host) = url.host_str() {
-            return Ok((format_host_port(host, url.port()), url.scheme().to_string()));
+            let port = parsed_port(&url, registry);
+            return Ok((format_host_port(host, port), url.scheme().to_string()));
         }
     }
 
     // Parse bare hostname with https:// prefix (handles docker.io or registry:5000)
     if let Ok(url) = Url::parse(&format!("https://{}", registry)) {
         if let Some(host) = url.host_str() {
-            return Ok((format_host_port(host, url.port()), "https".to_string()));
+            let port = parsed_port(&url, registry);
+            return Ok((format_host_port(host, port), "https".to_string()));
         }
     }
 
     ParseRegistrySnafu { registry }.fail()
+}
+
+/// Returns the port from a parsed URL, preserving explicit default ports (e.g. :443, :80)
+/// that `Url::port()` would strip.
+fn parsed_port(url: &Url, original_url: &str) -> Option<u16> {
+    if let Some(port) = url.port() {
+        return Some(port);
+    }
+    if let Some(default_port) = url.port_or_known_default() {
+        if original_url.contains(&format!(
+            "{}:{}",
+            url.host_str().unwrap_or_default(),
+            default_port
+        )) {
+            return Some(default_port);
+        }
+    }
+    None
 }
 
 /// Encode registry name to directory name, replacing `:port` with `_port_`.
@@ -63,6 +83,14 @@ mod tests {
     #[test_case("docker.io", "docker.io"; "no port unchanged")]
     #[test_case("gcr.io", "gcr.io"; "gcr unchanged")]
     #[test_case("registry.example.com:5000", "registry.example.com_5000_"; "port encoded")]
+    // Default port preservation: explicit :443 and :80 must be retained
+    #[test_case("192.168.1.1:443", "192.168.1.1_443_"; "bare host with explicit 443")]
+    #[test_case("192.168.1.1:80", "192.168.1.1_80_"; "bare host with explicit 80")]
+    #[test_case("registry.example.com:443", "registry.example.com_443_"; "bare hostname with explicit 443")]
+    #[test_case("registry.example.com:80", "registry.example.com_80_"; "bare hostname with explicit 80")]
+    // IPv6 with port
+    #[test_case("[::1]:5000", "[::1]_5000_"; "ipv6 loopback with port encoded")]
+    #[test_case("[2001:db8::1]:443", "[2001:db8::1]_443_"; "ipv6 with 443 encoded")]
     fn test_encode_registry_name(input: &str, expected: &str) {
         assert_eq!(encode_registry_name(input), expected);
     }
@@ -73,6 +101,27 @@ mod tests {
     #[test_case("registry.example.com:5000", "registry.example.com:5000", "https"; "hostname with port")]
     #[test_case("https://docker.io", "docker.io", "https"; "https url")]
     #[test_case("http://registry.local:5000", "registry.local:5000", "http"; "http url with port")]
+    // Default port preservation: explicit :443 and :80 must be retained
+    #[test_case("192.168.1.1:443", "192.168.1.1:443", "https"; "bare host with explicit 443")]
+    #[test_case("192.168.1.1:80", "192.168.1.1:80", "https"; "bare host with explicit 80")]
+    #[test_case("registry.example.com:443", "registry.example.com:443", "https"; "bare hostname with explicit 443")]
+    #[test_case("registry.example.com:80", "registry.example.com:80", "https"; "bare hostname with explicit 80")]
+    #[test_case("https://192.168.1.1:443", "192.168.1.1:443", "https"; "https url with explicit 443")]
+    #[test_case("http://192.168.1.1:80", "192.168.1.1:80", "http"; "http url with explicit 80")]
+    #[test_case("https://registry.example.com:443", "registry.example.com:443", "https"; "https hostname with explicit 443")]
+    #[test_case("http://registry.example.com:80", "registry.example.com:80", "http"; "http hostname with explicit 80")]
+    // Bare IP with no port defaults to https.
+    #[test_case("192.168.1.1", "192.168.1.1", "https"; "bare ip no port")]
+    // IPv6 addresses
+    #[test_case("[::1]:5000", "[::1]:5000", "https"; "ipv6 loopback with port")]
+    #[test_case("[2001:db8::1]:443", "[2001:db8::1]:443", "https"; "ipv6 with explicit 443")]
+    #[test_case("[2001:db8::1]:80", "[2001:db8::1]:80", "https"; "ipv6 with explicit 80")]
+    #[test_case("https://[::1]:443", "[::1]:443", "https"; "ipv6 https with explicit 443")]
+    #[test_case("http://[::1]:80", "[::1]:80", "http"; "ipv6 http with explicit 80")]
+    // Ensure port-like patterns in IPv6 do not cause false positives.
+    // [fe80::443] has no port — the "443" is part of the address, not a port.
+    #[test_case("[fe80::443]", "[fe80::443]", "https"; "ipv6 addr containing 443 no port")]
+    #[test_case("https://[fe80::443]", "[fe80::443]", "https"; "ipv6 addr containing 443 with scheme no port")]
     fn test_parse_registry(input: &str, expected_host: &str, expected_scheme: &str) {
         let (host, scheme) = parse_registry(input).unwrap();
         assert_eq!(host, expected_host);


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

`thar-be-registries` has two interrelated bugs in registry URL parsing that cause containerd to fail resolving certain registry configurations:

1. Default ports stripped from directory names: Rust's `Url::port()` strips default ports (80, 443, 21), but containerd preserves them. When a user configures a registry like `registry.example.com:443`, the generated directory path omits the port, creating a mismatch with containerd's expected lookup path under `certs.d/`.
```bash
# Output of: find /etc/containerd/certs.d
/etc/containerd/certs.d
/etc/containerd/certs.d/196.18.89.98
/etc/containerd/certs.d/196.18.89.98/credentials.toml
/etc/containerd/certs.d/public.ecr.aws
/etc/containerd/certs.d/public.ecr.aws/credentials.toml
/etc/containerd/certs.d/public.ecr.aws/hosts.toml
```

2. Incorrect scheme for port-80 registries: `parse_registry()` defaults to `https` for bare hostnames. This produces `server = "https://registry:80"` in `hosts.toml`, causing containerd to attempt a TLS handshake against a plaintext HTTP server.

3. Incorrect path validation for hosts: When using a registry without a scheme, the `hosts.toml` would omit the `override_path` flag leading to incorrect configurations:
```bash
bash-5.2# cat /etc/containerd/certs.d/docker.io/hosts.toml
server = "https://registry-1.docker.io"

[host."196.18.8.18:443/v2/eks-a-test"]
capabilities = ["pull", "resolve"]
bash-5.2# cat /etc/containerd/certs.d/public.ecr.aws/hosts.toml
server = "https://public.ecr.aws"

[host."196.18.8.18:443/v2/eks-a-test"]
capabilities = ["pull", "resolve"]
```

**Description of changes:**
- Adds a `parsed_port()` helper that checks the original input string for an explicit `:80` or `:443` suffix when `Url::port()` returns `None
- Also When no explicit scheme is provided, the scheme is now inferred from the port:
  - Port 80 → http
  - All other ports / no port → https
Explicit schemes (http:// or https://) are always preserved regardless of port.

- Update `Endpoint::has_path_component()` with an explicit retry call to `Url::Parse` with a scheme when provided a url without a scheme

- All unit tests updated.

**Testing done:**
- Validate that `/etc/containerd/certs.d/` folders are generated correctly for user-data using port 443
```bash
bash-5.2# find /etc/containerd/certs.d/
/etc/containerd/certs.d/
/etc/containerd/certs.d/192.168.176.179_443_
/etc/containerd/certs.d/192.168.176.179_443_/credentials.toml
/etc/containerd/certs.d/public.ecr.aws
/etc/containerd/certs.d/public.ecr.aws/hosts.toml
```
- Validate `hosts.toml` are generated with the correct `override_path` flag
```bash
bash-5.2# cat /etc/containerd/certs.d/docker.io/hosts.toml
server = "https://registry-1.docker.io"

[host."196.18.8.18:443/v2/eks-a-test"]
capabilities = ["pull", "resolve"]
override_path = true
bash-5.2# cat /etc/containerd/certs.d/public.ecr.aws/hosts.toml
server = "https://public.ecr.aws"

[host."196.18.8.18:443/v2/eks-a-test"]
capabilities = ["pull", "resolve"]
override_path = true
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
