### PR TITLE
chore: bump bottlerocket-settings-models to 0.25.0

### DIFF
--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "darling",
  "quote",
@@ -1540,8 +1540,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.16.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+version = "0.17.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1586,7 +1586,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -1610,8 +1610,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.24.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+version = "0.25.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1636,6 +1636,7 @@ dependencies = [
  "settings-extension-kernel",
  "settings-extension-kubelet-device-plugins",
  "settings-extension-kubernetes",
+ "settings-extension-measurement",
  "settings-extension-metrics",
  "settings-extension-motd",
  "settings-extension-network",
@@ -1663,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1676,7 +1677,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "serde",
 ]
@@ -1684,7 +1685,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5501,7 +5502,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5514,7 +5515,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5527,7 +5528,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5541,7 +5542,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5554,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5567,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5580,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5593,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5609,7 +5610,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5622,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5635,7 +5636,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5648,7 +5649,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-image-verifier-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5661,7 +5662,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kernel"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5674,7 +5675,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5687,7 +5688,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubernetes"
 version = "0.10.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5699,9 +5700,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "settings-extension-measurement"
+version = "0.1.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+dependencies = [
+ "bottlerocket-model-derive",
+ "bottlerocket-modeled-types",
+ "bottlerocket-settings-sdk",
+ "env_logger",
+ "serde",
+ "serde_json",
+ "snafu",
+]
+
+[[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5714,7 +5729,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -5727,7 +5742,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5740,7 +5755,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5753,7 +5768,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5766,7 +5781,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5780,7 +5795,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5793,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5806,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.24.0#c8485379bdb663818b8204c1cc0e3b1c82b3496c"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -232,13 +232,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.24.0"
-version = "0.16.0"
+tag = "bottlerocket-settings-models-v0.25.0"
+version = "0.17.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.24.0"
-version = "0.24.0"
+tag = "bottlerocket-settings-models-v0.25.0"
+version = "0.25.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -247,7 +247,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.24.0"
+tag = "bottlerocket-settings-models-v0.25.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
**Description of changes:**
- update settings-sdk to latest

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
