### PR TITLE
Update ecs-agent to 1.105.1

### DIFF
--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -14,8 +14,8 @@ releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
 # Verify the Git submodule commit of amazon-vpc-cni-plugins matches what is shipped in ../amazon-vpc-cni-plugins
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.103.2/amazon-ecs-agent-1.103.2.tar.gz"
-sha512 = "5a2bcfe27f711e856e9b479691967c3ef112c8fd4f11fda5e5e4e0be71486b392f2b5f6479b48717a136c20b54db69c9b02f66403a95bc272d9586f186f8bdde"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.105.1/amazon-ecs-agent-1.105.1.tar.gz"
+sha512 = "b409da1e7198d0468bb5ac588ea8c577354eca4294aff9ac5fbde31a77ca9906968bbdc4ce69fcebdb87e0e8082f29ee7cec9f1c978f7c52184fe4dfa89b3e2e"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,10 +2,10 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.103.2
+%global agent_gover 1.105.1
 
 # git rev-parse --short=8
-%global agent_gitrev 08149542
+%global agent_gitrev 8dfceca6
 
 # Construct reproducible tar archives
 # See https://reproducible-builds.org/docs/archives/


### PR DESCRIPTION
**Issue number:**

N/A

**Description of changes:**

Bumps `ecs-agent` from 1.103.2 to 1.105.1 (two minor releases behind upstream):

* 1.104.0: adds ECS S3 Files integration, `ECS_PROPAGATE_TASK_MEMORY_LIMIT_CGROUPV2` opt-in config, bumps containerd 1.7.29 -> 1.7.32
* 1.105.0: adds `LogDriverVolumeConfiguration` to the ACS Volume shape, updates Go to 1.25.11
* 1.105.1: populates `ImageDigest` for Service Connect sidecar containers, bumps containerd 1.7.32 -> 1.7.33, fixes environment file S3 key path validation

No breaking changes are documented in any of the three upstream release notes ([1.104.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.104.0), [1.105.0](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.105.0), [1.105.1](https://github.com/aws/amazon-ecs-agent/releases/tag/v1.105.1)).

The `amazon-vpc-cni-plugins` submodule commit (`a4e9ac07`) is unchanged between v1.103.2 and v1.105.1, so no matching bump is needed in `packages/amazon-vpc-cni-plugins`.

**Testing done:**

- Downloaded the v1.105.1 source tarball and verified its sha512 against the one recorded in `Cargo.toml`.
- Applied all 6 existing Bottlerocket patches in this package against the new source with `patch -p1 --dry-run`; all apply cleanly with no offsets/fuzz.
- Did not run a full variant build (aws-ecs-2/3/4) locally — deferring to CI/maintainer testing given prior bumps of this package were reverted for runtime incompatibilities (#625, #808).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.