### PR TITLE
feat: ntp: configure chrony PTP refclock and daemon access

### DIFF
--- a/packages/chrony/chrony-conf
+++ b/packages/chrony/chrony-conf
@@ -4,6 +4,26 @@ ntp = "v1"
 {{#each settings.ntp.time-servers}}
 pool {{this}}{{#each ../settings.ntp.options}} {{this}}{{/each}}
 {{/each}}
+{{#if settings.ntp.refclocks}}
+{{#each settings.ntp.refclocks}}
+refclock {{this.driver}} {{this.parameter}}{{#if this.options}}{{#each this.options}} {{this}}{{/each}}{{/if}}
+{{/each}}
+{{/if}}
+{{#if settings.ntp.allow}}
+{{#each settings.ntp.allow}}
+allow {{this}}
+{{/each}}
+{{/if}}
+{{#if settings.ntp.cmdallow}}
+{{#each settings.ntp.cmdallow}}
+cmdallow {{this}}
+{{/each}}
+{{/if}}
+{{#if settings.ntp.bindcmdaddress}}
+{{#each settings.ntp.bindcmdaddress}}
+bindcmdaddress {{this}}
+{{/each}}
+{{/if}}
 driftfile /var/lib/chrony/drift
 makestep 1.0 3
 dumponexit

--- a/packages/os/ena-ptp.rules
+++ b/packages/os/ena-ptp.rules
@@ -1,0 +1,11 @@
+# Amazon EC2 exposes the Amazon Time Sync Service PTP Hardware Clock (PHC) through
+# the ENA driver when the instance is booted with the `ena.phc_enable=1` kernel
+# parameter. The kernel names PTP character devices /dev/ptpN in probe order, which
+# is not stable, so create a predictable /dev/ptp_ena symlink -- matching the name
+# used by Amazon Linux and the EC2 documentation -- for chrony to reference via
+# `settings.ntp.refclocks` (e.g. `refclock PHC /dev/ptp_ena`).
+ACTION=="remove", GOTO="ena_ptp_end"
+SUBSYSTEM!="ptp", GOTO="ena_ptp_end"
+ATTR{clock_name}=="ena-ptp-*", SYMLINK+="ptp_ena"
+
+LABEL="ena_ptp_end"

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -85,6 +85,7 @@ Source300: ephemeral-storage.rules
 Source301: ebs-volumes.rules
 Source302: ephemeral-ebs-storage.rules
 Source303: supplemental-storage.rules
+Source304: ena-ptp.rules
 
 # 4xx sources: Bottlerocket licenses
 Source400: COPYRIGHT
@@ -793,6 +794,7 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 install -p -m 0644 %{S:301} %{buildroot}%{_cross_udevrulesdir}/81-ebs-volumes.rules
 install -p -m 0644 %{S:302} %{buildroot}%{_cross_udevrulesdir}/82-ephemeral-ebs-storage.rules
 install -p -m 0644 %{S:303} %{buildroot}%{_cross_udevrulesdir}/83-supplemental-storage.rules
+install -p -m 0644 %{S:304} %{buildroot}%{_cross_udevrulesdir}/84-ena-ptp.rules
 
 install -d %{buildroot}%{_cross_datadir}/whippet/
 install -p -m 0644 %{S:22} %{buildroot}%{_cross_datadir}/whippet/system.toml
@@ -813,6 +815,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %{_cross_licensedir}/COPYRIGHT
 %{_cross_licensedir}/LICENSE-MIT
 %{_cross_licensedir}/LICENSE-APACHE
+%{_cross_udevrulesdir}/84-ena-ptp.rules
 
 %files -n %{_cross_os}apiserver
 %{_cross_bindir}/apiserver


### PR DESCRIPTION
**Issue number:**

Addresses bottlerocket-os/bottlerocket#4407 and bottlerocket-os/bottlerocket#4473

**Description of changes:**
Render the new `settings.ntp.*` values in the chrony config template and create a stable device symlink for the Amazon Time Sync Service PTP hardware clock (PHC):

- `packages/chrony/chrony-conf`: render `settings.ntp.refclocks` as chrony `refclock` directives (bottlerocket-os/bottlerocket#4407) and `settings.ntp.{allow,cmdallow,bindcmdaddress}` as the matching access directives (bottlerocket-os/bottlerocket#4473). Each block is guarded with `{{#if}}` because schnauzer renders in strict mode; when the settings are unset the output is byte-identical to today's.
- `packages/os/ena-ptp.rules`: a udev rule that creates the stable `/dev/ptp_ena` symlink for the ENA PHC device (the kernel names PTP devices `/dev/ptpN` in probe order), matching the name used by Amazon Linux and the EC2 documentation. This is what makes `refclock PHC /dev/ptp_ena` work out of the box.

Requires a `bottlerocket-settings-models` release that defines the new `settings.ntp` fields (dep bump handled separately, as in #978); until then the template branches are inert and the default render is unchanged.

**Testing done:**
- `make build` (package builds)
- Rendered `chrony-conf` through schnauzer's renderer for default / PTP / access / combined inputs: default output byte-identical to current; PTP emits `refclock PHC /dev/ptp_ena poll 0 delay 0.000010 prefer`.
- `udevadm verify` on the new rule — passes (systemd 257).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.

---
Blocked by bottlerocket-os/bottlerocket-settings-sdk#143
