### PR TITLE
build: run on edits to advisories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ on:
       - '**.tpl'
       # Sample config files and OpenAPI docs
       - '**.yaml'
-      # Bottlerocket Security Advisories
-      - 'advisories/**'
       # VSCode configurations
       - '.vscode/**'
       # Mailmap


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: https://github.com/bottlerocket-os/twoliter/issues/685

**Description of changes:**

Run build on edits to advisories, since advisory checks from twoliter only run on full kit builds. This is costly, but the alternative is skipping these checks. twoliter will be extended to have a targeted make target for just advisory checks; this is a stopgap until then.

**Testing done:**

n/a

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
