### PR TITLE
host-ctr: make --superpowered capability set caller-independent

### DIFF
--- a/sources/host-ctr/cmd/host-ctr/main.go
+++ b/sources/host-ctr/cmd/host-ctr/main.go
@@ -613,6 +613,15 @@ func withSuperpowered() oci.SpecOpts {
 		oci.WithHostNamespace(runtimespec.PIDNamespace),
 		oci.WithParentCgroupDevices,
 		oci.WithPrivileged,
+		// oci.WithPrivileged applies WithAllCurrentCapabilities, which
+		// derives the spec's capability set from the *caller's* CapEff.
+		// When host-ctr is invoked from a context with a reduced
+		// bounding set (e.g. from inside a bootstrap container), that
+		// yields a superpowered container with only that subset of
+		// capabilities. Overwrite with the fixed kernel-known list so
+		// --superpowered means the same thing regardless of who
+		// invokes host-ctr; the shim is daemon-forked and can grant it.
+		oci.WithAllKnownCapabilities,
 		oci.WithNewPrivileges,
 		oci.WithSelinuxLabel("system_u:system_r:super_t:s0:c0.c1023"),
 		oci.WithAllDevicesAllowed,


### PR DESCRIPTION
  **Issue number:**

  N/A — discussed with @arnaldo2792 who greenlit a direct PR. Happy to open an issue first if preferred.

  **Description of changes:**

  `withSuperpowered()` uses `oci.WithPrivileged`, which composes `WithAllCurrentCapabilities` — that reads the *caller process's* `/proc/self/status` `CapEff` and writes it into `spec.process.capabilities` ([`oci/spec_opts_linux.go:63-71`](https://github.com/containerd/containerd/blob/v1.7.33/oci/spec_opts_linux.go#L63-L71) →
  [`pkg/cap/cap_linux.go:118`](https://github.com/containerd/containerd/blob/v1.7.33/pkg/cap/cap_linux.go#L118)). Its own doc-comment notes: *"The capability set may differ from WithAllKnownCapabilities when running in a container."*

  So the capability set a `--superpowered` container receives depends on who invokes `host-ctr`:

  - `host-containers@.service` → parent is PID 1 (full `CapBnd`) → spec asks for ~40 caps → container gets ~40 ✓
  - A bootstrap container (`withBootstrap()`: 5 caps on top of the OCI default ≈ 17 total) that `chroot`s into the host root and runs `host-ctr run --superpowered` → spec asks for ~17 caps → the "superpowered" container is missing `CAP_SYS_PTRACE`, `SYS_RESOURCE`, `DAC_READ_SEARCH`, `IPC_LOCK`, everything ≥ bit 32 (`BPF`, `PERFMON`, `CHECKPOINT_RESTORE`, …).

  This change adds `oci.WithAllKnownCapabilities` immediately after `oci.WithPrivileged`. `Compose` is last-writer-wins, so the caller-derived set is overwritten with the fixed kernel-known list. The task is created via `NewTask()` gRPC, so the shim is forked by the containerd *daemon* (full `CapBnd`) and can grant whatever the spec requests.

  No behavior change for the `host-containers@.service` path, which already had the full set.

  **Testing done:**

  Reproduced on `aws-ecs-4` variant, Bottlerocket 1.61.0, t3.medium:

  - A superpowered host-container launched via `host-ctr run --superpowered` from inside a bootstrap-container (chroot into `/.bottlerocket/rootfs`) reports `CapEff: 00000000e82535fb` (17 caps). SELinux label is correct (`system_u:system_r:super_t:s0:c0.c1023`) — only the caps are clamped.
  - Every `open("/proc/1/ns/*")` from that container returns `EACCES` (missing `CAP_SYS_PTRACE` for `PTRACE_MODE_READ_FSCREDS` on non-dumpable PID 1); `nsenter -t 1 -m -p -u` fails with `cannot open /proc/1/ns/uts: Permission denied`.
  - Verified the fix mechanism by patching the container's `spec.process.capabilities` to the full `cap.Known()` list post-hoc via `containers.Update` and recreating the task (`tasks.Delete` → `tasks.Create` → `tasks.Start`) — the daemon-forked shim then delivers `CapEff: 000001ffffffffff` (41 caps) and `nsenter -t 1` works. This is the same effect this PR's one-line change produces at spec-build time.

  **Terms of contribution:**

  By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.