### PR TITLE
Third party package updates

### DIFF
--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.8.1/rolesanywhere-credential-helper-v1.8.1.tar.gz"
-sha512 = "d535b90947123ad585ba0e5d541b383034dcccdec499c93d14a0ef77a2541e5691ad1ffb1b0b155d6f9baf26d12c1de664817856b478c3ab0000595fe1cf73c3"
+url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.8.2/rolesanywhere-credential-helper-v1.8.2.tar.gz"
+sha512 = "316a36195e99146ce0b5f48dc446c3b151d85ca282fcbf227773e39ffd916cb52af94b8d16eb227c034736dc33c5095a8cd1e1bc0dc846dff246458f66122885"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo rolesanywhere-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.8.1
+%global gover 1.8.2
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/containerd-1.7/Cargo.toml
+++ b/packages/containerd-1.7/Cargo.toml
@@ -13,8 +13,8 @@ package-name = "containerd-1.7"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v1.7.33/containerd-1.7.33.tar.gz"
-sha512 = "7a0b2c9508f90623109ecf54f3b746868a5be926d5865cea9b1fc5da20e962cc3b709ebff731d052aa49cedec3157f7a121eb444d6c24e259b1c55ae6605c165"
+url = "https://github.com/containerd/containerd/archive/v1.7.34/containerd-1.7.34.tar.gz"
+sha512 = "a7ea6c774e2c034d5421e7371e1002604c27e4f70f129a0baf57ec2a1fa4eadb15e7a663957b09edb966e0e7a0f27b50038554f2bd248256ef58c342142dea2c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/containerd-1.7/containerd-1.7.spec
+++ b/packages/containerd-1.7/containerd-1.7.spec
@@ -2,7 +2,7 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.7.33
+%global gover 1.7.34
 %global rpmver %{gover}
 %global gitrev e8b1a9bc270f9952197c470b8bad573b03a3a608
 

--- a/packages/containerd-2.2/Cargo.toml
+++ b/packages/containerd-2.2/Cargo.toml
@@ -13,8 +13,8 @@ package-name = "containerd-2.2"
 releases-url = "https://github.com/containerd/containerd/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/containerd/containerd/archive/v2.2.5/containerd-2.2.5.tar.gz"
-sha512 = "5d658c8daa48e3b5369995847d15e3dae4367e7221a5a34115bb74723707053378a2d489b29e6f2742e04bdfc2362c02df34fcb403fc0adb144e19bd352d7741"
+url = "https://github.com/containerd/containerd/archive/v2.2.6/containerd-2.2.6.tar.gz"
+sha512 = "42b5d0916a4d60413d582893904fd4313e2164fc78c3b7ac35806a258c4a3e5f4bdbcfb20ce9a5e924b5ad7215a2637bb5355126e3d88a115a8e248e0568fd81"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/containerd-2.2/containerd-2.2.spec
+++ b/packages/containerd-2.2/containerd-2.2.spec
@@ -2,7 +2,7 @@
 %global gorepo containerd
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 2.2.5
+%global gover 2.2.6
 %global rpmver %{gover}
 %global gitrev e53c7c1516c3b2bff98eb76f1f4117477e6f4e66
 

--- a/packages/kubernetes-1.31/Cargo.toml
+++ b/packages/kubernetes-1.31/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.31"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/45/artifacts/kubernetes/v1.31.14/kubernetes-src.tar.gz"
-sha512 = "207a15cdf7c1ea14c305bd04e8fde4ca9cd432db1a0bf373038ed56837e1dd9a56c4327a4da9d8166ac4b847d4755b1d19e9e69a4d5f4e884f81d16f0363feef"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-31/releases/46/artifacts/kubernetes/v1.31.14/kubernetes-src.tar.gz"
+sha512 = "67aff30dbab256f4b6588d10d0d902d349688dc468528f04bd20b90f942bf4aaa6a5e5b74a0f0bb1aa6814e01377d034f35f50b9b22c50ff10a073524f63018c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 45
+%global releasever 46
 %global gover 1.31.14
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.32/Cargo.toml
+++ b/packages/kubernetes-1.32/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.32"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/38/artifacts/kubernetes/v1.32.13/kubernetes-src.tar.gz"
-sha512 = "a05aaaaa2352f416a5a51c7941f02a2a801361378752c8401af2abe298359a9917a552f7ee81ef0b0de06a0ddf1d6a0d80cc6f1966ab3f7759cd2f63d54987d3"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-32/releases/39/artifacts/kubernetes/v1.32.13/kubernetes-src.tar.gz"
+sha512 = "6f4d6850cf43d61b66b78e6be6118d5c178c7e82d5188f713f674e872d724875d801eb855b918816e667dba8762a262e4b54dc4a2bc5da6e12052475ca9e9d26"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -10,7 +10,7 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 38
+%global releasever 39
 %global gover 1.32.13
 %global rpmver %{gover}
 

--- a/packages/kubernetes-1.33/Cargo.toml
+++ b/packages/kubernetes-1.33/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.33"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/28/artifacts/kubernetes/v1.33.12/kubernetes-src.tar.gz"
-sha512 = "630c8ed4ae3aff31614eb50fbede35290d6d526c2a0164e90351e66e018ae8bc8179ba52cf60da449c7570808b489acf9d4bc774dd56549a67526d0109531281"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-33/releases/29/artifacts/kubernetes/v1.33.13/kubernetes-src.tar.gz"
+sha512 = "871d1dca25acaac753310f1cbadacdef34d5fd6b03c701b1297a201e1485896fdaec3ded5d66e1eb591a4af38e2437b894225f14f26a916573106e95707c8f40"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 28
-%global gover 1.33.12
+%global releasever 29
+%global gover 1.33.13
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.34/0001-apiserver-drop-unused-go-proxyproto-require.patch
+++ b/packages/kubernetes-1.34/0001-apiserver-drop-unused-go-proxyproto-require.patch
@@ -19,7 +19,7 @@ diff --git a/staging/src/k8s.io/apiserver/go.mod b/staging/src/k8s.io/apiserver/
 index 06467cd3..12472b7e 100644
 --- a/staging/src/k8s.io/apiserver/go.mod
 +++ b/staging/src/k8s.io/apiserver/go.mod
-@@ -23,7 +23,6 @@ require (
+@@ -26,7 +26,6 @@ require (
  	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
  	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
  	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f

--- a/packages/kubernetes-1.34/Cargo.toml
+++ b/packages/kubernetes-1.34/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.34"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/19/artifacts/kubernetes/v1.34.8/kubernetes-src.tar.gz"
-sha512 = "bddb8a71ddc4cfee5a1823cfbd5d0efbd593d2e6fa1650cddf1627ff6d1c4fe60347207f786d8c33743d9d32794259c9881f24778a7885cdb972e2444a0025e4"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-34/releases/20/artifacts/kubernetes/v1.34.9/kubernetes-src.tar.gz"
+sha512 = "9d5dfe656940799ace896cb10ff471153b9b5dd694fa6895cd69b3c3f7df0c43ed955356f592337e57aa6f9aa5725b812c4f65557c31cf64741c16fba4aec66c"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.34/kubernetes-1.34.spec
+++ b/packages/kubernetes-1.34/kubernetes-1.34.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 19
-%global gover 1.34.8
+%global releasever 20
+%global gover 1.34.9
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.35/Cargo.toml
+++ b/packages/kubernetes-1.35/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.35"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-35/releases/10/artifacts/kubernetes/v1.35.5/kubernetes-src.tar.gz"
-sha512 = "5a5e20137dbcc6b6cc2eca5adae7fc9fa50108ab09a18abeb9eb8e33e726f113076a80d7b91dfa8afe83a1f115be47f4b0f23176568b0c14da4a51c7851adf77"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-35/releases/11/artifacts/kubernetes/v1.35.6/kubernetes-src.tar.gz"
+sha512 = "3c02b42dab56deea5d6a8929a557506fd20fd9fb5be67581276f049375caf382af9d4b18610ec236661de65f64ba1af517e165edd0092d8b925d772a41a56728"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.35/kubernetes-1.35.spec
+++ b/packages/kubernetes-1.35/kubernetes-1.35.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 10
-%global gover 1.35.5
+%global releasever 11
+%global gover 1.35.6
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/kubernetes-1.36/Cargo.toml
+++ b/packages/kubernetes-1.36/Cargo.toml
@@ -14,8 +14,8 @@ path = "../packages.rs"
 package-name = "kubernetes-1.36"
 
 [[package.metadata.build-package.external-files]]
-url = "https://distro.eks.amazonaws.com/kubernetes-1-36/releases/4/artifacts/kubernetes/v1.36.1/kubernetes-src.tar.gz"
-sha512 = "5c048e8006808b37f1b2c9b92cceec8ad43b6dee48605c77d0bb9864e0c6ec303c954dea3991dd78f1bc087c972a4a4e4810f2799fd8760a87dc1f8a5f76b2db"
+url = "https://distro.eks.amazonaws.com/kubernetes-1-36/releases/5/artifacts/kubernetes/v1.36.2/kubernetes-src.tar.gz"
+sha512 = "298da522384a0b2f12ebb873324facc61f621a610a995953c85f9ce1ee8bf4f7d0b2255467a04c17e6b9b40fcb95a60ffffb83a08d8814d4e85e687b30175795"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.36/kubernetes-1.36.spec
+++ b/packages/kubernetes-1.36/kubernetes-1.36.spec
@@ -10,8 +10,8 @@
 %global gorepo kubernetes
 %global goimport %{goproject}/%{gorepo}
 
-%global releasever 4
-%global gover 1.36.1
+%global releasever 5
+%global gover 1.36.2
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0

--- a/packages/soci-snapshotter/Cargo.toml
+++ b/packages/soci-snapshotter/Cargo.toml
@@ -12,15 +12,15 @@ path = "../packages.rs"
 releases-url = "https://github.com/awslabs/soci-snapshotter/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/v0.14.0/soci-snapshotter-0.14.0.tar.gz"
-sha512 = "2f7ad6f2f1bddc695c33dd95fd5075bfb9c8b843ae67380d2d068696183f3fbbd0440bf45af5b3dac02ab7fa083fbec4e1929621b827db5cb6c50530344ab9ad"
-bundle-root-path = "soci-snapshotter-0.14.0/cmd"
+url = "https://github.com/awslabs/soci-snapshotter/archive/v0.14.1/soci-snapshotter-0.14.1.tar.gz"
+sha512 = "e9e70ec10e9094502295bc1d903f76b6a5fa20fd1bf87f751ba9a8d38262755cae0852ab3338762273c3667e6d81f9e4c4983913efa1609d5771f981bfb5dc15"
+bundle-root-path = "soci-snapshotter-0.14.1/cmd"
 bundle-output-path = "bundled-cmd.tar.gz"
 bundle-modules = [ "go" ]
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/v0.14.0/soci-snapshotter-0.14.0.tar.gz"
-sha512 = "2f7ad6f2f1bddc695c33dd95fd5075bfb9c8b843ae67380d2d068696183f3fbbd0440bf45af5b3dac02ab7fa083fbec4e1929621b827db5cb6c50530344ab9ad"
+url = "https://github.com/awslabs/soci-snapshotter/archive/v0.14.1/soci-snapshotter-0.14.1.tar.gz"
+sha512 = "e9e70ec10e9094502295bc1d903f76b6a5fa20fd1bf87f751ba9a8d38262755cae0852ab3338762273c3667e6d81f9e4c4983913efa1609d5771f981bfb5dc15"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -1,5 +1,5 @@
 %global gorepo soci-snapshotter
-%global gover 0.14.0
+%global gover 0.14.1
 %global rpmver %{gover}
 %global gitrev 18d119a04693d19bbe96fccbf416f425abb3cb48
 


### PR DESCRIPTION
**Description of changes:**
- Update aws-signing-helper to v1.8.2, containerd-1.7 to v1.7.34, containerd-2.2 to v2.2.6, soci-snapshotter to v0.14.1, kubernetes to latest EKS release


**Testing done:**
- Conformance passed for k8s-1.31 to k8s-1.36 in both arches
- soci smoke test (pull images with the following user-data) passed
```
[settings.container-runtime]
snapshotter = "soci"

[settings.container-runtime-plugins]

[settings.container-runtime-plugins.soci-snapshotter]
pull-mode = "parallel-pull-unpack"

[settings.container-runtime-plugins.soci-snapshotter.parallel-pull-unpack]
concurrent-download-chunk-size = "8mb"
discard-unpacked-layers = true
max-concurrent-downloads = 12
max-concurrent-downloads-per-image = 5
max-concurrent-unpacks = 8
max-concurrent-unpacks-per-image = 4
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
