### PR TITLE
soci-snapshotter: update to v0.15.0

### DIFF
--- a/packages/soci-snapshotter/Cargo.toml
+++ b/packages/soci-snapshotter/Cargo.toml
@@ -12,15 +12,15 @@ path = "../packages.rs"
 releases-url = "https://github.com/awslabs/soci-snapshotter/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/v0.14.1/soci-snapshotter-0.14.1.tar.gz"
-sha512 = "e9e70ec10e9094502295bc1d903f76b6a5fa20fd1bf87f751ba9a8d38262755cae0852ab3338762273c3667e6d81f9e4c4983913efa1609d5771f981bfb5dc15"
-bundle-root-path = "soci-snapshotter-0.14.1/cmd"
+url = "https://github.com/awslabs/soci-snapshotter/archive/v0.15.0/soci-snapshotter-0.15.0.tar.gz"
+sha512 = "01f1402ed07875fc8d7da8075ee30b12355442895e0466152d379d5b6d759b753b6c8861e9e930c35f3989b3a7a76aa3dcef6269566e43a58b8d27c1c3fa4e46"
+bundle-root-path = "soci-snapshotter-0.15.0/cmd"
 bundle-output-path = "bundled-cmd.tar.gz"
 bundle-modules = [ "go" ]
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/awslabs/soci-snapshotter/archive/v0.14.1/soci-snapshotter-0.14.1.tar.gz"
-sha512 = "e9e70ec10e9094502295bc1d903f76b6a5fa20fd1bf87f751ba9a8d38262755cae0852ab3338762273c3667e6d81f9e4c4983913efa1609d5771f981bfb5dc15"
+url = "https://github.com/awslabs/soci-snapshotter/archive/v0.15.0/soci-snapshotter-0.15.0.tar.gz"
+sha512 = "01f1402ed07875fc8d7da8075ee30b12355442895e0466152d379d5b6d759b753b6c8861e9e930c35f3989b3a7a76aa3dcef6269566e43a58b8d27c1c3fa4e46"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/soci-snapshotter/clarify.toml
+++ b/packages/soci-snapshotter/clarify.toml
@@ -1,5 +1,5 @@
 [clarify."sigs.k8s.io/yaml"]
 expression = "MIT AND Apache-2.0"
 license-files = [
-    { path = "LICENSE", hash = 0xcdf3ae00},
+    { path = "LICENSE", hash = 0x617d80bc},
 ]

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -1,7 +1,7 @@
 %global gorepo soci-snapshotter
-%global gover 0.14.1
+%global gover 0.15.0
 %global rpmver %{gover}
-%global gitrev 18d119a04693d19bbe96fccbf416f425abb3cb48
+%global gitrev 7716bd67e813f8e80873948e0a02d0a7c5370854
 
 Name: %{_cross_os}soci-snapshotter
 Version: %{gover}


### PR DESCRIPTION
**Description of changes:** Update soci-snapshotter from v0.14.1 to v0.15.0.

**Testing done:** Tested through SOCI CI. No bottlerocket-specific testing done at the time of PR creation.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
