### PR TITLE
feat: add support for ephemeral-encryption-keys

### DIFF
--- a/packages/release/bottlerocket-mount-encrypted.conf
+++ b/packages/release/bottlerocket-mount-encrypted.conf
@@ -1,0 +1,8 @@
+[Unit]
+# mount the LUKS mapper instead of the raw partition and only after the
+# partition has been encrypted, unlocked and formatted.
+After=unlock-private-fs.service prepare-private-fs.service
+Requires=prepare-private-fs.service
+
+[Mount]
+What=/dev/mapper/BOTTLEROCKET-PRIVATE

--- a/packages/release/encrypt-datastore-ephemeral.conf
+++ b/packages/release/encrypt-datastore-ephemeral.conf
@@ -1,0 +1,4 @@
+[Service]
+# Drop the "only if unencrypted" guard so the datastore directory is
+# re-encrypted with a freshly generated key on every boot.
+ExecCondition=

--- a/packages/release/encrypt-datastore-private-luks.conf
+++ b/packages/release/encrypt-datastore-private-luks.conf
@@ -1,0 +1,7 @@
+[Service]
+# In case of ephemeral-encryption-keys, we format the BOTTLEROCKET-PRIVATE with
+# `encrypt` feature flag. So, we drop the tune2fs call, which is used to enable
+# the flag and generate the key and encrypt the datastore.
+ExecStart=
+ExecStart=/usr/bin/rottweiler generate-key datastore
+ExecStart=/usr/bin/rottweiler encrypt directory ${DATASTORE_DIR} datastore

--- a/packages/release/encrypt-datastore.service
+++ b/packages/release/encrypt-datastore.service
@@ -11,6 +11,7 @@ RefuseManualStop=true
 [Service]
 Type=oneshot
 Environment=DATASTORE_DIR=/.bottlerocket/datastore
+EnvironmentFile=/usr/share/bottlerocket/image-features.env
 
 # Only run if the directory is not yet encrypted.
 ExecCondition=/usr/bin/rottweiler check directory ${DATASTORE_DIR} unencrypted

--- a/packages/release/encrypt-local-fs-ephemeral.conf
+++ b/packages/release/encrypt-local-fs-ephemeral.conf
@@ -1,0 +1,4 @@
+[Service]
+# Drop the "only if unencrypted" guard so the Data partition is
+# re-encrypted with a freshly generated key on every boot.
+ExecCondition=

--- a/packages/release/encrypt-local-fs.service
+++ b/packages/release/encrypt-local-fs.service
@@ -12,6 +12,7 @@ RefuseManualStop=true
 [Service]
 Type=oneshot
 Environment=BOTTLEROCKET_DATA=/dev/disk/by-partlabel/BOTTLEROCKET-DATA
+EnvironmentFile=/usr/share/bottlerocket/image-features.env
 
 # Only format if not already encrypted.
 ExecCondition=/usr/bin/rottweiler check block-device ${BOTTLEROCKET_DATA} unencrypted

--- a/packages/release/encrypt-private-fs.service
+++ b/packages/release/encrypt-private-fs.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Encrypt Private Filesystem (/.bottlerocket)
+DefaultDependencies=no
+Conflicts=umount.target
+Wants=dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dPRIVATE.device
+After=dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dPRIVATE.device tpm2.target cryptsetup-pre.target
+Before=unlock-private-fs.service
+ConditionSecurity=tpm2
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+Environment=BOTTLEROCKET_PRIVATE=/dev/disk/by-partlabel/BOTTLEROCKET-PRIVATE
+EnvironmentFile=/usr/share/bottlerocket/image-features.env
+
+# Generate the per-boot key into the /run keystore and LUKS2-format PRIVATE.
+ExecStart=/usr/bin/rottweiler generate-key bottlerocket-private
+ExecStart=/usr/bin/rottweiler encrypt block-device ${BOTTLEROCKET_PRIVATE} bottlerocket-private
+
+UMask=0077
+RemainAfterExit=true
+StandardOutput=journal+console
+StandardError=inherit
+
+[Install]
+RequiredBy=unlock-private-fs.service

--- a/packages/release/prepare-private-fs.service
+++ b/packages/release/prepare-private-fs.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Prepare Private Filesystem (/.bottlerocket)
+DefaultDependencies=no
+Conflicts=umount.target
+Wants=dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dPRIVATE.device
+After=dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dPRIVATE.device unlock-private-fs.service
+BindsTo=unlock-private-fs.service
+Before=\x2ebottlerocket.mount
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+Environment=PRIVATE_PARTITION_BLOCK_DEVICE=/dev/mapper/BOTTLEROCKET-PRIVATE
+# Relative to the ext4 defaults, we:
+# - adjust the inode ratio since we expect lots of small files
+# - retain the inode size to allow most settings to be stored inline
+# - retain the block size to handle worse-case alignment for hardware
+# - enable the ext4's native per-file encryption capability
+ExecStart=/usr/sbin/mkfs.ext4 -b 4096 -i 4096 -I 256 -F -O encrypt ${PRIVATE_PARTITION_BLOCK_DEVICE}
+
+RemainAfterExit=true
+StandardOutput=journal
+StandardError=journal+console
+
+[Install]
+RequiredBy=\x2ebottlerocket.mount

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -64,6 +64,7 @@ Source1027: root-.aws.mount
 Source1028: opt-cni.mount
 Source1029: opt-csi.mount
 Source1030: opt-civ.mount
+Source1031: run-rottweiler.mount
 
 # Mounts that require helper programs.
 Source1040: prepare-boot.service
@@ -145,6 +146,19 @@ Source1650: prepare-local-fs-encrypted.conf
 Source1651: local-mount-encrypted.conf
 Source1652: repart-local-encrypted.conf
 
+# Ephemeral (per-boot) encryption key drop-ins.
+Source1661: encrypt-datastore-ephemeral.conf
+Source1662: unlock-datastore-ephemeral.conf
+Source1663: encrypt-local-fs-ephemeral.conf
+Source1664: repart-local-ephemeral.conf
+
+# Full private-partition LUKS encryption units (ephemeral-encryption-keys).
+Source1670: encrypt-private-fs.service
+Source1671: unlock-private-fs.service
+Source1672: prepare-private-fs.service
+Source1673: bottlerocket-mount-encrypted.conf
+Source1674: encrypt-datastore-private-luks.conf
+
 # Runtime FIPS activation sources.
 # These are always installed but only activate when fips=1 is on the kernel command line.
 Source1700: generate-fips-env.service
@@ -191,6 +205,8 @@ Requires: %{_cross_os}xfsprogs
 Requires: %{_cross_os}libkcapi
 Requires: (%{name}-fips if %{_cross_os}image-feature(fips))
 Requires: (%{name}-crypt if %{_cross_os}image-feature(encrypted-storage))
+Requires: (%{name}-ephemeral-crypt if %{_cross_os}image-feature(ephemeral-encryption-keys))
+
 
 %description
 %{summary}.
@@ -210,6 +226,13 @@ Requires: (%{_cross_os}image-feature(encrypted-storage) and %{name})
 Requires: %{_cross_os}rottweiler
 
 %description crypt
+%{summary}.
+
+%package ephemeral-crypt
+Summary: Bottlerocket release, with ephemeral encryption keys
+Requires: (%{_cross_os}image-feature(ephemeral-encryption-keys) and %{name}-crypt)
+
+%description ephemeral-crypt
 %{summary}.
 
 %package swap
@@ -275,7 +298,7 @@ install -p -m 0644 \
   %{S:1006} %{S:1007} %{S:1008} %{S:1009} %{S:1010} \
   %{S:1020} %{S:1021} %{S:1022} %{S:1023} %{S:1024} \
   %{S:1025} %{S:1026} %{S:1027} %{S:1028} %{S:1029} \
-  %{S:1030} \
+  %{S:1030} %{S:1031} \
   %{S:1040} %{S:1041} %{S:1042} %{S:1043} %{S:1044} \
   %{S:1045} %{S:1046} %{S:1047} %{S:1048} %{S:1049} \
   %{S:1050} \
@@ -396,6 +419,27 @@ install -p -m 0644 %{S:1651} %{buildroot}%{_cross_unitdir}/local.mount.d/10-encr
 install -d %{buildroot}%{_cross_unitdir}/repart-local.service.d
 install -p -m 0644 %{S:1652} %{buildroot}%{_cross_unitdir}/repart-local.service.d/10-encrypted.conf
 
+install -d %{buildroot}%{_cross_unitdir}/encrypt-datastore.service.d
+install -p -m 0644 %{S:1661} %{buildroot}%{_cross_unitdir}/encrypt-datastore.service.d/20-ephemeral.conf
+
+install -d %{buildroot}%{_cross_unitdir}/unlock-datastore.service.d
+install -p -m 0644 %{S:1662} %{buildroot}%{_cross_unitdir}/unlock-datastore.service.d/20-ephemeral.conf
+
+install -d %{buildroot}%{_cross_unitdir}/encrypt-local-fs.service.d
+install -p -m 0644 %{S:1663} %{buildroot}%{_cross_unitdir}/encrypt-local-fs.service.d/20-ephemeral.conf
+
+install -d %{buildroot}%{_cross_unitdir}/repart-local.service.d
+install -p -m 0644 %{S:1664} %{buildroot}%{_cross_unitdir}/repart-local.service.d/20-ephemeral.conf
+
+# Full private-partition LUKS encryption units (ephemeral-encryption-keys).
+install -p -m 0644 %{S:1670} %{S:1671} %{S:1672} %{buildroot}%{_cross_unitdir}
+
+BOTTLEROCKET_PATH=$(systemd-escape --path /.bottlerocket)
+install -d %{buildroot}%{_cross_unitdir}/${BOTTLEROCKET_PATH}.mount.d
+install -p -m 0644 %{S:1673} %{buildroot}%{_cross_unitdir}/${BOTTLEROCKET_PATH}.mount.d/10-encrypted.conf
+
+install -p -m 0644 %{S:1674} %{buildroot}%{_cross_unitdir}/encrypt-datastore.service.d/30-private-luks.conf
+
 ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 
 %files
@@ -428,6 +472,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/prepare-var.service
 %{_cross_unitdir}/repart-local.service
 %{_cross_unitdir}/\x2ebottlerocket.mount
+%dir %{_cross_unitdir}/\x2ebottlerocket.mount.d
 %{_cross_unitdir}/var.mount
 %{_cross_unitdir}/opt.mount
 %{_cross_unitdir}/mnt.mount
@@ -510,7 +555,9 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 
 %files crypt
 %{_cross_unitdir}/encrypt-datastore.service
+%dir %{_cross_unitdir}/encrypt-datastore.service.d
 %{_cross_unitdir}/encrypt-local-fs.service
+%dir %{_cross_unitdir}/encrypt-local-fs.service.d
 %{_cross_unitdir}/measure-cmdline.service
 %{_cross_unitdir}/measure-settings.service
 %{_cross_unitdir}/systemd-pcrphase-configured.service
@@ -518,10 +565,23 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %{_cross_unitdir}/systemd-pcrphase-preconfigured.service
 %{_cross_unitdir}/systemd-pcrphase-sysinit.service
 %{_cross_unitdir}/unlock-datastore.service
+%dir %{_cross_unitdir}/unlock-datastore.service.d
 %{_cross_unitdir}/unlock-local-fs.service
 %{_cross_unitdir}/local.mount.d/10-encrypted.conf
 %{_cross_unitdir}/prepare-local-fs.service.d/10-encrypted.conf
 %{_cross_unitdir}/repart-local.service.d/10-encrypted.conf
+
+%files ephemeral-crypt
+%{_cross_unitdir}/encrypt-datastore.service.d/20-ephemeral.conf
+%{_cross_unitdir}/encrypt-datastore.service.d/30-private-luks.conf
+%{_cross_unitdir}/unlock-datastore.service.d/20-ephemeral.conf
+%{_cross_unitdir}/encrypt-local-fs.service.d/20-ephemeral.conf
+%{_cross_unitdir}/repart-local.service.d/20-ephemeral.conf
+%{_cross_unitdir}/encrypt-private-fs.service
+%{_cross_unitdir}/unlock-private-fs.service
+%{_cross_unitdir}/prepare-private-fs.service
+%{_cross_unitdir}/\x2ebottlerocket.mount.d/10-encrypted.conf
+%{_cross_unitdir}/run-rottweiler.mount
 
 %files swap
 %{_cross_sysctldir}/81-release-swap.conf

--- a/packages/release/repart-local-ephemeral.conf
+++ b/packages/release/repart-local-ephemeral.conf
@@ -1,0 +1,5 @@
+[Service]
+EnvironmentFile=/usr/share/bottlerocket/image-features.env
+# Delete the sealed data-partition encryption key after it has been used for the
+# time in the boot, forcing format and fresh key generation in the next boot.
+ExecStartPost=/usr/bin/rottweiler delete-key bottlerocket-data

--- a/packages/release/run-rottweiler.mount
+++ b/packages/release/run-rottweiler.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Ephemeral keystore directory
+DefaultDependencies=no
+Conflicts=umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+Before=encrypt-datastore.service encrypt-local-fs.service encrypt-private-fs.service
+
+[Mount]
+What=tmpfs
+Where=/run/rottweiler
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,noswap,context=system_u:object_r:private_t:s0,mode=0700
+
+[Install]
+RequiredBy=local-fs.target

--- a/packages/release/unlock-datastore-ephemeral.conf
+++ b/packages/release/unlock-datastore-ephemeral.conf
@@ -1,0 +1,5 @@
+[Service]
+# Delete the key used to encrypt the datastore after it has been used for the final
+# time in the boot, forcing new key generation and a complete rebuild of the datastore
+# in the subsequent boot.
+ExecStartPost=/usr/bin/rottweiler delete-key datastore

--- a/packages/release/unlock-datastore.service
+++ b/packages/release/unlock-datastore.service
@@ -9,6 +9,7 @@ RefuseManualStop=true
 [Service]
 Type=oneshot
 Environment=DATASTORE_DIR=/.bottlerocket/datastore
+EnvironmentFile=/usr/share/bottlerocket/image-features.env
 
 ExecStart=/usr/bin/rottweiler unlock directory ${DATASTORE_DIR} datastore
 

--- a/packages/release/unlock-local-fs.service
+++ b/packages/release/unlock-local-fs.service
@@ -13,6 +13,7 @@ RefuseManualStop=true
 [Service]
 Type=oneshot
 Environment=BOTTLEROCKET_DATA=/dev/disk/by-partlabel/BOTTLEROCKET-DATA
+EnvironmentFile=/usr/share/bottlerocket/image-features.env
 
 ExecStart=/usr/bin/rottweiler attach block-device ${BOTTLEROCKET_DATA} bottlerocket-data
 ExecStop=/usr/bin/rottweiler detach block-device ${BOTTLEROCKET_DATA}

--- a/packages/release/unlock-private-fs.service
+++ b/packages/release/unlock-private-fs.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Unlock Private Filesystem (/.bottlerocket)
+DefaultDependencies=no
+Conflicts=umount.target
+IgnoreOnIsolate=true
+After=cryptsetup-pre.target systemd-udevd-kernel.socket dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dPRIVATE.device
+Wants=dev-disk-by\x2dpartlabel-BOTTLEROCKET\x2dPRIVATE.device blockdev@dev-mapper-BOTTLEROCKET\x2dPRIVATE.target
+Before=cryptsetup.target blockdev@dev-mapper-BOTTLEROCKET\x2dPRIVATE.target
+ConditionSecurity=tpm2
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+Environment=BOTTLEROCKET_PRIVATE=/dev/disk/by-partlabel/BOTTLEROCKET-PRIVATE
+EnvironmentFile=/usr/share/bottlerocket/image-features.env
+
+ExecStart=/usr/bin/rottweiler attach block-device ${BOTTLEROCKET_PRIVATE} bottlerocket-private
+# Delete the private-partition encryption key from the tmpfs keystore after it has
+# been used to unlock the volume, so a fresh key is generated on the next boot.
+ExecStartPost=/usr/bin/rottweiler delete-key bottlerocket-private
+ExecStop=/usr/bin/rottweiler detach block-device ${BOTTLEROCKET_PRIVATE}
+
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal+console
+
+[Install]
+RequiredBy=prepare-private-fs.service

--- a/sources/bottlerocket-image-features/README.md
+++ b/sources/bottlerocket-image-features/README.md
@@ -18,6 +18,7 @@ Currently supported feature flags:
 
 - `IN_PLACE_UPDATES` - Controls whether in-place updates are enabled (default: true)
 - `ENCRYPTED_STORAGE` - Controls whether encrypted storage is enabled (default: false)
+- `EPHEMERAL_ENCRYPTION_KEYS` - Controls whether encryption keys are regenerated every boot (default: false)
 
 ### Usage
 

--- a/sources/bottlerocket-image-features/src/lib.rs
+++ b/sources/bottlerocket-image-features/src/lib.rs
@@ -15,6 +15,7 @@ Currently supported feature flags:
 
 - `IN_PLACE_UPDATES` - Controls whether in-place updates are enabled (default: true)
 - `ENCRYPTED_STORAGE` - Controls whether encrypted storage is enabled (default: false)
+- `EPHEMERAL_ENCRYPTION_KEYS` - Controls whether encryption keys are regenerated every boot (default: false)
 
 ## Usage
 
@@ -56,6 +57,8 @@ pub struct ImageFeatures {
     pub in_place_updates: bool,
     #[serde(default)]
     pub encrypted_storage: bool,
+    #[serde(default)]
+    pub ephemeral_encryption_keys: bool,
 }
 
 fn default_true() -> bool {
@@ -68,6 +71,7 @@ pub fn parse_image_features() -> Result<ImageFeatures> {
         return Ok(ImageFeatures {
             in_place_updates: true,
             encrypted_storage: false,
+            ephemeral_encryption_keys: false,
         });
     }
 
@@ -148,5 +152,26 @@ IN_PLACE_UPDATES="false"
         let content = "";
         let features = parse_image_features_from_str(content).unwrap();
         assert_eq!(features.in_place_updates, true);
+        assert_eq!(features.ephemeral_encryption_keys, false);
+    }
+
+    #[test]
+    fn test_parse_env_ephemeral_encryption_keys_false() {
+        let content = r#"EPHEMERAL_ENCRYPTION_KEYS="false""#;
+        let features = parse_image_features_from_str(content).unwrap();
+        assert_eq!(features.ephemeral_encryption_keys, false);
+    }
+
+    #[test]
+    fn test_parse_env_ephemeral_encryption_keys_true() {
+        let content = r#"EPHEMERAL_ENCRYPTION_KEYS="true""#;
+        let features = parse_image_features_from_str(content).unwrap();
+        assert_eq!(features.ephemeral_encryption_keys, true);
+    }
+
+    #[test]
+    fn test_parse_env_ephemeral_encryption_keys_invalid() {
+        let content = r#"EPHEMERAL_ENCRYPTION_KEYS="yes""#;
+        assert!(parse_image_features_from_str(content).is_err());
     }
 }

--- a/sources/rottweiler/README.md
+++ b/sources/rottweiler/README.md
@@ -15,6 +15,7 @@ interface for encrypting and managing encrypted storage resources including:
 
 #### Key Management
 - `generate-key <key-id>` - Generate an encryption key
+- `delete-key <key-id>` - Delete an encryption key from the keystore
 
 #### Block Device Operations
 - `encrypt block-device <path> <key-id>` - Encrypt a block device using LUKS

--- a/sources/rottweiler/src/key.rs
+++ b/sources/rottweiler/src/key.rs
@@ -1,6 +1,6 @@
 use snafu::prelude::*;
 use std::fs;
-use std::io::Read;
+use std::io::{self, Read};
 use std::path::PathBuf;
 use zeroize::Zeroizing;
 
@@ -12,15 +12,21 @@ const DEV_RANDOM: &str = "/dev/random";
 const KEYSTORE: &str = "/.bottlerocket/keystore";
 const KEY_SIZE: usize = 64;
 
+fn validate_key_id(key_id: &str) -> Result<()> {
+    snafu::ensure_whatever!(
+        !key_id.is_empty()
+            && key_id
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_'),
+        "key_id must be non-empty and contain only alphanumerics, dashes, and underscores"
+    );
+
+    Ok(())
+}
+
 /// Generate a random encryption key and encrypt it with TPM2 PCRs 7+14
 pub fn generate(key_id: String) -> Result<()> {
-    if !key_id
-        .chars()
-        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
-    {
-        whatever!("key_id must contain only alphanumerics, dashes, and underscores");
-    }
-
+    validate_key_id(&key_id)?;
     let key_path = PathBuf::from(KEYSTORE).join(&key_id);
 
     // Skip generation if key already exists
@@ -48,8 +54,27 @@ pub fn generate(key_id: String) -> Result<()> {
     Ok(())
 }
 
+/// Delete a sealed key from the keystore.
+pub fn delete(key_id: String) -> Result<()> {
+    validate_key_id(&key_id)?;
+    let key_path = PathBuf::from(KEYSTORE).join(&key_id);
+
+    // Skip deletion if key doesn't exists
+    if !key_path.exists() {
+        return Ok(());
+    }
+
+    match fs::remove_file(&key_path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e)
+            .with_whatever_context(|_| format!("failed to delete key '{}'", key_path.display())),
+    }
+}
+
 /// Load and decrypt a TPM2-encrypted key from the keystore
 pub fn load(key_id: String) -> Result<Zeroizing<Vec<u8>>> {
+    validate_key_id(&key_id)?;
     let key_path = PathBuf::from(KEYSTORE).join(&key_id);
 
     let encrypted = fs::read(&key_path)

--- a/sources/rottweiler/src/key.rs
+++ b/sources/rottweiler/src/key.rs
@@ -9,8 +9,26 @@ use crate::system;
 type Result<T> = std::result::Result<T, snafu::Whatever>;
 
 const DEV_RANDOM: &str = "/dev/random";
-const KEYSTORE: &str = "/.bottlerocket/keystore";
+const KEYSTORE_PERMANENT: &str = "/.bottlerocket/keystore";
+const KEYSTORE_EPHEMERAL: &str = "/run/rottweiler";
 const KEY_SIZE: usize = 64;
+
+/// Checks if ephemeral encryption keys feature is enabled via image features
+fn ephemeral_encryption_keys_enabled() -> Result<bool> {
+    let features = bottlerocket_image_features::parse_image_features()
+        .with_whatever_context(|_| "failed to load image features")?;
+    Ok(features.ephemeral_encryption_keys)
+}
+
+fn keystore_dir() -> PathBuf {
+    let is_ephemeral_encryption_keys_enabled = ephemeral_encryption_keys_enabled().unwrap_or(false);
+    // If ephemeral encryption keys are enabled, we store the keys in tmpfs rather than the disk
+    if is_ephemeral_encryption_keys_enabled {
+        PathBuf::from(KEYSTORE_EPHEMERAL)
+    } else {
+        PathBuf::from(KEYSTORE_PERMANENT)
+    }
+}
 
 fn validate_key_id(key_id: &str) -> Result<()> {
     snafu::ensure_whatever!(
@@ -27,7 +45,8 @@ fn validate_key_id(key_id: &str) -> Result<()> {
 /// Generate a random encryption key and encrypt it with TPM2 PCRs 7+14
 pub fn generate(key_id: String) -> Result<()> {
     validate_key_id(&key_id)?;
-    let key_path = PathBuf::from(KEYSTORE).join(&key_id);
+    let keystore = keystore_dir();
+    let key_path = keystore.join(&key_id);
 
     // Skip generation if key already exists
     if key_path.exists() {
@@ -45,8 +64,12 @@ pub fn generate(key_id: String) -> Result<()> {
 
     let encrypted = system::systemd_creds_encrypt(&key_id, &random_bytes)?;
 
-    fs::create_dir_all(KEYSTORE)
-        .with_whatever_context(|_| format!("failed to create keystore directory '{}'", KEYSTORE))?;
+    fs::create_dir_all(&keystore).with_whatever_context(|_| {
+        format!(
+            "failed to create keystore directory '{}'",
+            keystore.display()
+        )
+    })?;
 
     fs::write(&key_path, encrypted)
         .with_whatever_context(|_| format!("failed to write key to '{}'", key_path.display()))?;
@@ -57,7 +80,7 @@ pub fn generate(key_id: String) -> Result<()> {
 /// Delete a sealed key from the keystore.
 pub fn delete(key_id: String) -> Result<()> {
     validate_key_id(&key_id)?;
-    let key_path = PathBuf::from(KEYSTORE).join(&key_id);
+    let key_path = keystore_dir().join(&key_id);
 
     // Skip deletion if key doesn't exists
     if !key_path.exists() {
@@ -75,7 +98,7 @@ pub fn delete(key_id: String) -> Result<()> {
 /// Load and decrypt a TPM2-encrypted key from the keystore
 pub fn load(key_id: String) -> Result<Zeroizing<Vec<u8>>> {
     validate_key_id(&key_id)?;
-    let key_path = PathBuf::from(KEYSTORE).join(&key_id);
+    let key_path = keystore_dir().join(&key_id);
 
     let encrypted = fs::read(&key_path)
         .with_whatever_context(|_| format!("failed to read key from '{}'", key_path.display()))?;

--- a/sources/rottweiler/src/main.rs
+++ b/sources/rottweiler/src/main.rs
@@ -12,6 +12,7 @@ interface for encrypting and managing encrypted storage resources including:
 
 ### Key Management
 - `generate-key <key-id>` - Generate an encryption key
+- `delete-key <key-id>` - Delete an encryption key from the keystore
 
 ### Block Device Operations
 - `encrypt block-device <path> <key-id>` - Encrypt a block device using LUKS
@@ -92,6 +93,7 @@ fn main() -> Result<()> {
 
     match args.command {
         Command::GenerateKey(cmd) => key::generate(cmd.key_id),
+        Command::DeleteKey(cmd) => key::delete(cmd.key_id),
         Command::Encrypt(cmd) => match cmd.resource {
             EncryptResource::BlockDevice(cmd) => block_device::encrypt(cmd.path, cmd.key_id),
             EncryptResource::Directory(cmd) => directory::encrypt(cmd.path, cmd.key_id),
@@ -193,6 +195,7 @@ struct Args {
 #[argh(subcommand)]
 enum Command {
     GenerateKey(GenerateKeyCmd),
+    DeleteKey(DeleteKeyCmd),
     Encrypt(EncryptCmd),
     Attach(AttachCmd),
     Detach(DetachCmd),
@@ -207,6 +210,14 @@ enum Command {
 #[argh(subcommand, name = "generate-key")]
 /// Generate an encryption key
 struct GenerateKeyCmd {
+    #[argh(positional)]
+    key_id: String,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "delete-key")]
+/// Delete an encryption key from the keystore
+struct DeleteKeyCmd {
     #[argh(positional)]
     key_id: String,
 }


### PR DESCRIPTION
**Description of changes:**
- Adds support for ephemeral encryption keys. The encryption keys are placed in `tmpfs` (`/run`) instead of the keystore and deleted after unlock.
- As part of this feature, we encrypt the private partition with `LUKS2` cipher. Because the encryption key is temporary, we format the partition every boot (with the same parameters) and re-encrypt every boot.
- The datastore inside of private partition is further encrypted with `fscrypt`. This requires an additional fs feature to be enabled (`encrypt`) which we pass in the previous step (or using `tune2fs` in case of data partition). 
- Data Partition is formatted with the default parameters which is why we use `systemd-makefs`. We force the reformat by running `wipefs` first. This deletes all fs related signatures tricking `systemd-makefs` into reformatting and avoiding the additional overhead of writing 0s to the entire partition.
- Additionally we use image features environment variables in various places to choose keystore path or trick `early-boot-config` into populating the datastore every boot (because we format the private partition every boot).

**Testing done:**
- The tmpfs keystore has SELinux label `private_t`
```
bash-5.2# ls -lZ /run/rottweiler
total 0
bash-5.2# ls -lZ /run | grep rottweiler
drwx------.  2 root   root   system_u:object_r:private_t:s0     40 Aug 12 16:22 rottweiler
```
- Verified the new keystore doesn't contain the keys.
```
[root@admin]# sheltie
bash-5.2# ls -lia /run/rottweiler/
total 0
918 drwx------.  2 root root  40 Aug 10 23:13 .
  1 drwxr-xr-x. 21 root root 520 Aug 10 23:13 ..
```
- Verified the filesystems and the directories are encrypted.
```
bash-5.2# lsblk -o NAME,TYPE,FSTYPE,MOUNTPOINT
NAME                     TYPE  FSTYPE         MOUNTPOINT
nvme1n1                  disk
`-nvme1n1p1              part  crypto_LUKS
  `-BOTTLEROCKET-DATA    crypt xfs            /local
nvme0n1                  disk
|-nvme0n1p1              part
|-nvme0n1p2              part  vfat
|-nvme0n1p3              part  vfat           /boot
|-nvme0n1p4              part  erofs
|-nvme0n1p5              part  DM_verity_hash
|-nvme0n1p6              part
|-nvme0n1p7              part  crypto_LUKS
| `-BOTTLEROCKET-PRIVATE crypt ext4           /var/lib/bottlerocket
`-nvme0n1p8              part
bash-5.2# rottweiler check directory /.bottlerocket/datastore encrypted
directory '/.bottlerocket/datastore' is encrypted
```
- Reboot (with user-data) works - used bootstrap commands as user data to change `settings.motd` and in every boot its the updated value
user-data
```
[settings.bootstrap-commands.mybootstrap]
commands = [["apiclient", "set", "settings.motd=hello"]]
essential = true
mode = "always"
```
output:
```
bash-5.2# apiclient get settings.motd
{
  "settings": {
    "motd": "hello"
  }
}
```
A second consequence of reformatting data partition is that the journal for previous boot is lost which was also checked.
- Moving the EBS volume to a different instance makes it unreadable
- lockdown mode works
```
bash-5.2# apiclient get settings.motd
{
  "settings": {
    "motd": "hello"
  }
}
bash-5.2# apiclient lockdown
01:21:33 [INFO] Lockdown completed
bash-5.2# apiclient get settings.motd
Failed to get settings: Failed GET request to '/?prefix=settings.motd': Status 500 when GETing /?prefix=settings.motd: Data store error during get_prefix 'settings.motd' for Live: Data store integrity violation at /var/lib/bottlerocket/datastore/current/live: Live datastore missing
```
- (A)I went through journal and it didn't find any errors during all this experiments
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
