### PR TITLE
Set ephemeral storage allowlist via packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Third Party Package Updates
 * Update `libcrypto`, `libdevmapper`, `libncurses`, `libelf`, and `libffi` ([#998])
+* Replace hardcoded ephemeral-storage bind-dir allowlist with package-contributed drop-in fragments in `/usr/lib/bottlerocket/ephemeral-storage.d/` ([#1001])
 
 ## Build Changes
 
@@ -11,6 +12,7 @@
 
 [#991]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/991
 [#998]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/998
+[#1001]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/1001
 
 # v15.0.0 (2026-07-23)
 

--- a/packages/containerd-1.7/containerd-1.7.spec
+++ b/packages/containerd-1.7/containerd-1.7.spec
@@ -24,6 +24,7 @@ Source4: containerd-config-toml_k8s_nvidia_containerd_sock
 Source5: containerd-tmpfiles.conf
 Source6: containerd-cri-base-json
 Source7: snapshotter-toml
+Source8: ephemeral-storage.conf
 
 # Mount for writing containerd configuration
 Source100: etc-containerd.mount
@@ -134,6 +135,8 @@ install -d %{buildroot}%{_cross_unitdir}/containerd.service.d
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-pigz.conf
 
+install -D -p -m 0644 %{S:8} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/containerd.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files
@@ -148,6 +151,7 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/0
 %{_cross_templatedir}/containerd-cri-base-json
 %{_cross_templatedir}/snapshotter-toml
 %{_cross_tmpfilesdir}/containerd.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/containerd.conf
 %{_cross_bindir}/containerd
 %{_cross_bindir}/containerd-shim
 %{_cross_bindir}/containerd-shim-runc-v1

--- a/packages/containerd-1.7/ephemeral-storage.conf
+++ b/packages/containerd-1.7/ephemeral-storage.conf
@@ -1,0 +1,2 @@
+# Contributed by containerd package
+/var/lib/containerd

--- a/packages/containerd-2.2/containerd-2.2.spec
+++ b/packages/containerd-2.2/containerd-2.2.spec
@@ -23,6 +23,7 @@ Source4: containerd-config-toml_k8s_nvidia_containerd_sock
 Source5: containerd-tmpfiles.conf
 Source6: containerd-cri-base-json
 Source7: snapshotter-toml
+Source8: ephemeral-storage.conf
 
 # Mount for writing containerd configuration
 Source100: etc-containerd.mount
@@ -128,6 +129,8 @@ install -d %{buildroot}%{_cross_unitdir}/containerd.service.d
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-pigz.conf
 
+install -D -p -m 0644 %{S:8} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/containerd.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files
@@ -142,6 +145,7 @@ install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/0
 %{_cross_templatedir}/containerd-cri-base-json
 %{_cross_templatedir}/snapshotter-toml
 %{_cross_tmpfilesdir}/containerd.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/containerd.conf
 %{_cross_bindir}/containerd
 %{_cross_bindir}/containerd-shim-runc-v2
 %{_cross_bindir}/ctr

--- a/packages/containerd-2.2/ephemeral-storage.conf
+++ b/packages/containerd-2.2/ephemeral-storage.conf
@@ -1,0 +1,2 @@
+# Contributed by containerd package
+/var/lib/containerd

--- a/packages/docker-engine-25/docker-engine-25.spec
+++ b/packages/docker-engine-25/docker-engine-25.spec
@@ -25,6 +25,7 @@ Source2: docker.socket
 Source3: docker-sysusers.conf
 Source4: daemon-json
 Source5: daemon-nvidia-json
+Source6: ephemeral-storage.conf
 
 # Create container storage mount point.
 Source100: prepare-var-lib-docker.service
@@ -92,6 +93,8 @@ install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/docker-daemon-json
 install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/docker-daemon-nvidia-json
 
+install -D -p -m 0644 %{S:6} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/docker.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files
@@ -103,6 +106,7 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/docker-daemon-nvidia
 %{_cross_sysusersdir}/docker.conf
 %{_cross_templatedir}/docker-daemon-json
 %{_cross_templatedir}/docker-daemon-nvidia-json
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/docker.conf
 %{_cross_bindir}/dockerd
 %{_cross_bindir}/docker-proxy
 %changelog

--- a/packages/docker-engine-25/ephemeral-storage.conf
+++ b/packages/docker-engine-25/ephemeral-storage.conf
@@ -1,0 +1,2 @@
+# Contributed by docker-engine package
+/var/lib/docker

--- a/packages/docker-engine-29/docker-engine-29.spec
+++ b/packages/docker-engine-29/docker-engine-29.spec
@@ -26,6 +26,7 @@ Source3: docker-sysusers.conf
 Source4: daemon-json
 Source5: daemon-nvidia-json
 Source6: docker-engine-tmpfiles.conf
+Source7: ephemeral-storage.conf
 
 # Create container storage mount point.
 Source100: prepare-var-lib-docker.service
@@ -100,6 +101,8 @@ install -p -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/docker-daemon-nvidia
 install -d %{buildroot}%{_cross_tmpfilesdir}
 install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/docker-engine.conf
 
+install -D -p -m 0644 %{S:7} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/docker.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %files
@@ -112,6 +115,7 @@ install -p -m 0644 %{S:6} %{buildroot}%{_cross_tmpfilesdir}/docker-engine.conf
 %{_cross_templatedir}/docker-daemon-json
 %{_cross_templatedir}/docker-daemon-nvidia-json
 %{_cross_tmpfilesdir}/docker-engine.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/docker.conf
 %{_cross_bindir}/dockerd
 %{_cross_bindir}/docker-proxy
 

--- a/packages/docker-engine-29/ephemeral-storage.conf
+++ b/packages/docker-engine-29/ephemeral-storage.conf
@@ -1,0 +1,2 @@
+# Contributed by docker-engine package
+/var/lib/docker

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -32,6 +32,7 @@ Source108: pause-repositories
 Source109: version.go
 Source110: ecs-defaults.conf
 Source111: ecs-nvidia.conf
+Source112: ephemeral-storage.conf
 
 # Mount for writing ECS agent configuration
 Source200: etc-systemd-system-ecs.service.d.mount
@@ -177,6 +178,8 @@ ln -rs %{buildroot}%{_cross_sysconfdir}/pki/tls/certs/ca-bundle.crt %{buildroot}
 install -d %{buildroot}%{_cross_datadir}/logdog.d
 install -p -m 0644 %{S:300} %{buildroot}%{_cross_datadir}/logdog.d
 
+install -D -p -m 0644 %{S:112} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/ecs-agent.conf
+
 %files
 %{_cross_attribution_file}
 %{_cross_attribution_vendor_dir}
@@ -189,6 +192,7 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_datadir}/logdog.d
 %{_cross_sysctldir}/90-ecs.conf
 %{_cross_libdir}/amazon-ecs-agent/amazon-ecs-pause.tar
 %{_cross_datadir}/logdog.d/logdog.ecs.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/ecs-agent.conf
 %{_cross_bindir}/amazon-ecs-agent
 
 %files config

--- a/packages/ecs-agent/ephemeral-storage.conf
+++ b/packages/ecs-agent/ephemeral-storage.conf
@@ -1,0 +1,2 @@
+# Contributed by ecs-agent package
+/var/log/ecs

--- a/packages/host-ctr/ephemeral-storage.conf
+++ b/packages/host-ctr/ephemeral-storage.conf
@@ -1,0 +1,2 @@
+# Contributed by host-ctr package
+/var/lib/host-containerd

--- a/packages/host-ctr/host-ctr.spec
+++ b/packages/host-ctr/host-ctr.spec
@@ -14,6 +14,7 @@ Requires: %{_cross_os}containerd
 Source10: host-containerd.service
 Source11: host-containerd-tmpfiles.conf
 Source12: host-containerd-config.toml
+Source13: ephemeral-storage.conf
 
 # Mount for writing host-ctr configuration
 Source100: etc-host-containers.mount.in
@@ -46,6 +47,8 @@ install -p -m 0644 %{S:11} %{buildroot}%{_cross_tmpfilesdir}/host-containerd.con
 install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/host-containerd
 install -p -m 0644 %{S:12} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/host-containerd/config.toml
 
+install -D -p -m 0644 %{S:13} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/host-containerd.conf
+
 %cross_scan_attribution go-vendor vendor
 
 %files
@@ -55,5 +58,6 @@ install -p -m 0644 %{S:12} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/
 %{_cross_tmpfilesdir}/host-containerd.conf
 %{_cross_factorydir}%{_cross_sysconfdir}/host-containerd/config.toml
 %{_cross_bindir}/host-ctr
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/host-containerd.conf
 
 %changelog

--- a/packages/kubernetes-1.31/ephemeral-storage.conf
+++ b/packages/kubernetes-1.31/ephemeral-storage.conf
@@ -1,0 +1,3 @@
+# Contributed by kubelet package
+/var/lib/kubelet
+/var/log/pods

--- a/packages/kubernetes-1.31/kubernetes-1.31.spec
+++ b/packages/kubernetes-1.31/kubernetes-1.31.spec
@@ -56,6 +56,7 @@ Source13: etc-kubernetes-pki-private.mount
 Source14: credential-provider-config-yaml
 Source15: logdog.kubelet.conf
 Source16: multi-user-uphold-kubelet.conf
+Source17: ephemeral-storage.conf
 
 # ExecStartPre drop-ins
 Source20: prestart-load-pause-ctr.conf
@@ -182,6 +183,8 @@ ln -rs \
 install -d %{buildroot}%{_cross_datadir}/logdog.d
 install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 
+install -D -p -m 0644 %{S:17} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
+
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
@@ -216,6 +219,7 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
 %{_cross_bindir}/kubelet
 
 %files -n %{_cross_os}kube-proxy-1.31

--- a/packages/kubernetes-1.32/ephemeral-storage.conf
+++ b/packages/kubernetes-1.32/ephemeral-storage.conf
@@ -1,0 +1,3 @@
+# Contributed by kubelet package
+/var/lib/kubelet
+/var/log/pods

--- a/packages/kubernetes-1.32/kubernetes-1.32.spec
+++ b/packages/kubernetes-1.32/kubernetes-1.32.spec
@@ -55,6 +55,7 @@ Source13: etc-kubernetes-pki-private.mount
 Source14: credential-provider-config-yaml
 Source15: logdog.kubelet.conf
 Source16: multi-user-uphold-kubelet.conf
+Source17: ephemeral-storage.conf
 
 # ExecStartPre drop-ins
 Source20: prestart-load-pause-ctr.conf
@@ -181,6 +182,8 @@ ln -rs \
 install -d %{buildroot}%{_cross_datadir}/logdog.d
 install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 
+install -D -p -m 0644 %{S:17} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
+
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
@@ -215,6 +218,7 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
 %{_cross_bindir}/kubelet
 
 %files -n %{_cross_os}kube-proxy-1.32

--- a/packages/kubernetes-1.33/ephemeral-storage.conf
+++ b/packages/kubernetes-1.33/ephemeral-storage.conf
@@ -1,0 +1,3 @@
+# Contributed by kubelet package
+/var/lib/kubelet
+/var/log/pods

--- a/packages/kubernetes-1.33/kubernetes-1.33.spec
+++ b/packages/kubernetes-1.33/kubernetes-1.33.spec
@@ -55,6 +55,7 @@ Source13: etc-kubernetes-pki-private.mount
 Source14: credential-provider-config-yaml
 Source15: logdog.kubelet.conf
 Source16: multi-user-uphold-kubelet.conf
+Source17: ephemeral-storage.conf
 
 # ExecStartPre drop-ins
 Source20: prestart-load-pause-ctr.conf
@@ -181,6 +182,8 @@ ln -rs \
 install -d %{buildroot}%{_cross_datadir}/logdog.d
 install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 
+install -D -p -m 0644 %{S:17} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
+
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
@@ -215,6 +218,7 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
 %{_cross_bindir}/kubelet
 
 %files -n %{_cross_os}kube-proxy-1.33

--- a/packages/kubernetes-1.34/ephemeral-storage.conf
+++ b/packages/kubernetes-1.34/ephemeral-storage.conf
@@ -1,0 +1,3 @@
+# Contributed by kubelet package
+/var/lib/kubelet
+/var/log/pods

--- a/packages/kubernetes-1.34/kubernetes-1.34.spec
+++ b/packages/kubernetes-1.34/kubernetes-1.34.spec
@@ -55,6 +55,7 @@ Source13: etc-kubernetes-pki-private.mount
 Source14: credential-provider-config-yaml
 Source15: logdog.kubelet.conf
 Source16: multi-user-uphold-kubelet.conf
+Source17: ephemeral-storage.conf
 
 # ExecStartPre drop-ins
 Source20: prestart-load-pause-ctr.conf
@@ -184,6 +185,8 @@ ln -rs \
 install -d %{buildroot}%{_cross_datadir}/logdog.d
 install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 
+install -D -p -m 0644 %{S:17} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
+
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
@@ -218,6 +221,7 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_templatedir}/pod-infra-container-image
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
 %{_cross_bindir}/kubelet
 
 %files -n %{_cross_os}kube-proxy-1.34

--- a/packages/kubernetes-1.35/ephemeral-storage.conf
+++ b/packages/kubernetes-1.35/ephemeral-storage.conf
@@ -1,0 +1,3 @@
+# Contributed by kubelet package
+/var/lib/kubelet
+/var/log/pods

--- a/packages/kubernetes-1.35/kubernetes-1.35.spec
+++ b/packages/kubernetes-1.35/kubernetes-1.35.spec
@@ -56,6 +56,7 @@ Source14: credential-provider-config-yaml
 Source15: logdog.kubelet.conf
 Source16: multi-user-uphold-kubelet.conf
 Source17: kubelet-env-nvidia
+Source18: ephemeral-storage.conf
 
 # ExecStartPre drop-ins
 Source20: prestart-load-pause-ctr.conf
@@ -183,6 +184,8 @@ ln -rs \
 install -d %{buildroot}%{_cross_datadir}/logdog.d
 install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 
+install -D -p -m 0644 %{S:18} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
+
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
@@ -218,6 +221,7 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
 %{_cross_bindir}/kubelet
 
 %files -n %{_cross_os}kube-proxy-1.35

--- a/packages/kubernetes-1.36/ephemeral-storage.conf
+++ b/packages/kubernetes-1.36/ephemeral-storage.conf
@@ -1,0 +1,3 @@
+# Contributed by kubelet package
+/var/lib/kubelet
+/var/log/pods

--- a/packages/kubernetes-1.36/kubernetes-1.36.spec
+++ b/packages/kubernetes-1.36/kubernetes-1.36.spec
@@ -56,6 +56,7 @@ Source14: credential-provider-config-yaml
 Source15: logdog.kubelet.conf
 Source16: multi-user-uphold-kubelet.conf
 Source17: kubelet-env-nvidia
+Source18: ephemeral-storage.conf
 
 # ExecStartPre drop-ins
 Source20: prestart-load-pause-ctr.conf
@@ -186,6 +187,8 @@ ln -rs \
 install -d %{buildroot}%{_cross_datadir}/logdog.d
 install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
 
+install -D -p -m 0644 %{S:18} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
+
 install -d %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
 install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
@@ -221,6 +224,7 @@ install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-containe
 %{_cross_libexecdir}/kubernetes/kubelet-plugins
 %{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
 %{_cross_datadir}/logdog.d/logdog.kubelet.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
 %{_cross_bindir}/kubelet
 
 %files -n %{_cross_os}kube-proxy-1.36

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -741,6 +741,7 @@ for p in apiclient ; do
 done
 
 install -d %{buildroot}%{_cross_datadir}/bottlerocket
+install -d %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d
 
 install -d %{buildroot}%{_cross_sysusersdir}
 install -p -m 0644 %{S:2} %{buildroot}%{_cross_sysusersdir}/api.conf
@@ -818,6 +819,7 @@ install -p -m 0644 %{S:400} %{S:401} %{S:402} %{buildroot}%{_cross_licensedir}
 %{_cross_bindir}/apiserver
 %{_cross_unitdir}/apiserver.service
 %{_cross_sysusersdir}/api.conf
+%dir %{_cross_libdir}/bottlerocket/ephemeral-storage.d
 
 %files -n %{_cross_os}apiclient
 

--- a/packages/soci-snapshotter/ephemeral-storage.conf
+++ b/packages/soci-snapshotter/ephemeral-storage.conf
@@ -1,0 +1,2 @@
+# Contributed by soci-snapshotter package
+/var/lib/soci-snapshotter

--- a/packages/soci-snapshotter/soci-snapshotter.spec
+++ b/packages/soci-snapshotter/soci-snapshotter.spec
@@ -15,6 +15,7 @@ Source1: bundled-soci-snapshotter-%{gover}.tar.gz
 Source2: bundled-cmd.tar.gz
 Source3: soci-config-toml
 Source4: k8s-snapshotter-conf
+Source5: ephemeral-storage.conf
 Source100: etc-soci-snapshotter.mount.in
 Source101: soci-snapshotter.service
 Source102: soci-snapshotter.socket
@@ -87,6 +88,8 @@ install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/soci-config-toml
 install -p -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/k8s-snapshotter-conf
 
+install -D -p -m 0644 %{S:5} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/soci-snapshotter.conf
+
 %cross_scan_attribution --clarify %{S:1000} go-vendor vendor
 
 %post igzip -p <lua>
@@ -104,6 +107,7 @@ posix.symlink("%{_cross_bindir}/unpigz", "%{_cross_bindir}/soci-gunzip")
 %{_cross_attribution_file}
 %{_cross_templatedir}/soci-config-toml
 %{_cross_bindir}/soci-snapshotter-grpc
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/soci-snapshotter.conf
 
 %files pigz
 # No files provided by pigz but required for packaging.

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "simple-settings-plugin",
  "simplelog",
  "snafu",
+ "tempfile",
  "thar-be-updates",
  "tokio",
  "toml",

--- a/sources/api/apiserver/Cargo.toml
+++ b/sources/api/apiserver/Cargo.toml
@@ -41,5 +41,6 @@ generate-readme.workspace = true
 
 [dev-dependencies]
 maplit.workspace = true
+tempfile.workspace = true
 toml.workspace = true
 simple-settings-plugin.workspace = true

--- a/sources/api/apiserver/src/server/ephemeral_storage.rs
+++ b/sources/api/apiserver/src/server/ephemeral_storage.rs
@@ -38,9 +38,10 @@ static EPHEMERAL_PATH: &str = "/dev/disk/ephemeral";
 static EPHEMERAL_EBS_PATH: &str = "/dev/disk/ephemeral-ebs";
 /// Key ID to use for ephemeral storage encryption
 static EPHEMERAL_STORAGE_KEY_ID: &str = "ephemeral-storage";
+static BIND_DIRS_DROPIN_DIR: &str = "/usr/lib/bottlerocket/ephemeral-storage.d";
 
 pub struct BindDirs {
-    pub allowed_exact: HashSet<&'static str>,
+    pub allowed_exact: HashSet<String>,
     pub allowed_prefixes: HashSet<&'static str>,
     pub disallowed_contains: HashSet<&'static str>,
 }
@@ -174,7 +175,7 @@ pub fn initialize(
 
 /// Binds the specified directories to the pre-configured array, creating those directories if
 /// they do not exist.
-pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
+pub fn bind(dirs: Vec<String>) -> Result<()> {
     let device_name = EPHEMERAL_STORAGE_LINK;
     if !std::fs::exists(device_name).is_ok_and(|x| x) {
         info!("ephemeral storage not initialized, skipping binding");
@@ -182,12 +183,8 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
     }
 
     let dirs = if dirs.is_empty() {
-        let allowed_dirs = allowed_bind_dirs(variant);
-        allowed_dirs
-            .allowed_exact
-            .into_iter()
-            .map(|s| s.to_string())
-            .collect()
+        let allowed_dirs = allowed_bind_dirs()?;
+        allowed_dirs.allowed_exact.into_iter().collect()
     } else {
         dirs
     };
@@ -198,9 +195,9 @@ pub fn bind(variant: &str, dirs: Vec<String>) -> Result<()> {
         .map(|dir| dir.trim_end_matches("/").to_string())
         .collect();
 
-    let allowed_dirs = allowed_bind_dirs(variant);
+    let allowed_dirs = allowed_bind_dirs()?;
     for dir in &dirs {
-        let exact_match = allowed_dirs.allowed_exact.contains(dir.as_str());
+        let exact_match = allowed_dirs.allowed_exact.contains(dir);
         let prefix_match = allowed_dirs
             .allowed_prefixes
             .iter()
@@ -448,28 +445,85 @@ fn discover_disks(path: &str) -> Result<Vec<String>> {
     Ok(filenames)
 }
 
-/// allowed_bind_dirs returns a set of the directories that can be bound to ephemeral storage, which
-/// varies based on the variant, a set of the prefixes of directories that are allowed to be bound.
+/// read_bind_dir_dropins reads newline-delimited absolute paths from all files in the specified
+/// directory, skipping comments and blank lines. Returns an error if any entry is unreadable or
+/// if a fragment contains an invalid path (non-absolute or containing "..").
+fn read_bind_dir_dropins(dir: &str) -> Result<HashSet<String>> {
+    let mut paths = HashSet::new();
+
+    // If the directory doesn't exist, return empty set (graceful no-op)
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(paths),
+        Err(e) => {
+            return Err(e).context(error::ReadDropinDirSnafu { dir });
+        }
+    };
+
+    for entry in entries {
+        let entry = entry.context(error::ReadDropinDirEntrySnafu { dir })?;
+
+        let path = entry.path();
+        ensure!(
+            path.is_file(),
+            error::InvalidDropinEntrySnafu {
+                path: &path,
+                reason: "not a regular file",
+            }
+        );
+
+        let content =
+            fs::read_to_string(&path).context(error::ReadDropinFileSnafu { path: &path })?;
+
+        for line in content.lines() {
+            let line = line.trim();
+
+            // Skip comments and blank lines
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            // Trim trailing slash
+            let line = line.trim_end_matches('/');
+
+            // Reject non-absolute paths
+            ensure!(
+                line.starts_with('/'),
+                error::InvalidDropinEntrySnafu {
+                    path: &path,
+                    reason: format!("non-absolute path: {line}"),
+                }
+            );
+
+            // Reject paths containing ".."
+            ensure!(
+                !line.contains(".."),
+                error::InvalidDropinEntrySnafu {
+                    path: &path,
+                    reason: format!("path contains '..': {line}"),
+                }
+            );
+
+            paths.insert(line.to_string());
+        }
+    }
+
+    Ok(paths)
+}
+
+/// allowed_bind_dirs returns a set of the directories that can be bound to ephemeral storage,
+/// a set of the prefixes of directories that are allowed to be bound,
 /// and a set of substrings that are disallowed in the directory name.
-pub fn allowed_bind_dirs(variant: &str) -> BindDirs {
-    let mut allowed_exact = HashSet::from(["/var/lib/containerd", "/var/lib/host-containerd"]);
-    if variant.contains("k8s") {
-        allowed_exact.insert("/var/lib/kubelet");
-        allowed_exact.insert("/var/log/pods");
-        allowed_exact.insert("/var/lib/soci-snapshotter");
-    }
-    if variant.contains("ecs") {
-        allowed_exact.insert("/var/lib/docker");
-        allowed_exact.insert("/var/log/ecs");
-    }
+pub fn allowed_bind_dirs() -> Result<BindDirs> {
+    let allowed_exact = read_bind_dir_dropins(BIND_DIRS_DROPIN_DIR)?;
     let allowed_prefixes = HashSet::from(["/mnt/"]);
     let disallowed_contains = HashSet::from(["..", "/mnt/.ephemeral"]);
 
-    BindDirs {
+    Ok(BindDirs {
         allowed_exact,
         allowed_prefixes,
         disallowed_contains,
-    }
+    })
 }
 
 /// scans the raid array to identify if it has been created already
@@ -704,6 +758,29 @@ pub mod error {
 
         #[snafu(display("Cannot bind directory '{}': directory is masked", dir.display()))]
         DirectoryAlreadyMasked { dir: PathBuf },
+
+        #[snafu(display(
+            "Failed to read ephemeral-storage drop-in directory '{}': {}",
+            dir,
+            source
+        ))]
+        ReadDropinDir { dir: String, source: std::io::Error },
+
+        #[snafu(display(
+            "Failed to read entry in ephemeral-storage drop-in directory '{}': {}",
+            dir,
+            source
+        ))]
+        ReadDropinDirEntry { dir: String, source: std::io::Error },
+
+        #[snafu(display("Failed to read ephemeral-storage drop-in file '{}': {}", path.display(), source))]
+        ReadDropinFile {
+            path: PathBuf,
+            source: std::io::Error,
+        },
+
+        #[snafu(display("Invalid entry in ephemeral-storage drop-in '{}': {}", path.display(), reason))]
+        InvalidDropinEntry { path: PathBuf, reason: String },
     }
 }
 
@@ -712,30 +789,111 @@ pub type Result<T> = std::result::Result<T, error::Error>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::tempdir;
 
     #[test]
-    fn test_bind_with_default_dirs_k8s() {
-        let variant = "aws-k8s-1.33";
-        let allowed_dirs = allowed_bind_dirs(variant);
+    fn test_read_bind_dir_dropins_union_and_dedup() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
 
-        for dir in [
-            "/var/lib/kubelet",
-            "/var/lib/containerd",
-            "/var/lib/soci-snapshotter",
-            "/var/log/pods",
-        ] {
-            assert!(allowed_dirs.allowed_exact.contains(dir));
-        }
+        // Create two fragment files with some overlapping paths
+        fs::write(
+            dir_path.join("kubelet.conf"),
+            "/var/lib/kubelet\n/var/lib/containerd\n/var/log/pods\n",
+        )
+        .unwrap();
+        fs::write(
+            dir_path.join("soci-snapshotter.conf"),
+            "/var/lib/containerd\n/var/lib/soci-snapshotter\n",
+        )
+        .unwrap();
+
+        let result = read_bind_dir_dropins(dir_path.to_str().unwrap()).unwrap();
+
+        // Should have union of all paths (4 unique paths)
+        assert_eq!(result.len(), 4);
+        assert!(result.contains("/var/lib/kubelet"));
+        assert!(result.contains("/var/lib/containerd"));
+        assert!(result.contains("/var/log/pods"));
+        assert!(result.contains("/var/lib/soci-snapshotter"));
     }
 
     #[test]
-    fn test_bind_with_default_dirs_ecs() {
-        let variant = "aws-ecs-2";
-        let allowed_dirs = allowed_bind_dirs(variant);
+    fn test_read_bind_dir_dropins_skip_comments_and_blanks() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
 
-        for dir in ["/var/lib/docker", "/var/lib/containerd", "/var/log/ecs"] {
-            assert!(allowed_dirs.allowed_exact.contains(dir));
-        }
+        // Create fragment with comments and blank lines
+        fs::write(
+            dir_path.join("test.conf"),
+            "# This is a comment\n\n/var/lib/kubelet\n  \n# Another comment\n/var/log/pods\n\n",
+        )
+        .unwrap();
+
+        let result = read_bind_dir_dropins(dir_path.to_str().unwrap()).unwrap();
+
+        // Should only have the two valid paths
+        assert_eq!(result.len(), 2);
+        assert!(result.contains("/var/lib/kubelet"));
+        assert!(result.contains("/var/log/pods"));
+    }
+
+    #[test]
+    fn test_read_bind_dir_dropins_trim_trailing_slash() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        // Create fragment with paths that have trailing slashes
+        fs::write(
+            dir_path.join("test.conf"),
+            "/var/lib/kubelet/\n/var/log/pods/\n",
+        )
+        .unwrap();
+
+        let result = read_bind_dir_dropins(dir_path.to_str().unwrap()).unwrap();
+
+        // Should have paths without trailing slashes
+        assert_eq!(result.len(), 2);
+        assert!(result.contains("/var/lib/kubelet"));
+        assert!(result.contains("/var/log/pods"));
+        assert!(!result.contains("/var/lib/kubelet/"));
+        assert!(!result.contains("/var/log/pods/"));
+    }
+
+    #[test]
+    fn test_read_bind_dir_dropins_reject_non_absolute_path() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        fs::write(
+            dir_path.join("test.conf"),
+            "/var/lib/kubelet\nrelative/path\n",
+        )
+        .unwrap();
+
+        let result = read_bind_dir_dropins(dir_path.to_str().unwrap());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_bind_dir_dropins_reject_dotdot_path() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        fs::write(dir_path.join("test.conf"), "/var/../etc/passwd\n").unwrap();
+
+        let result = read_bind_dir_dropins(dir_path.to_str().unwrap());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_bind_dir_dropins_nonexistent_dir() {
+        // Call with a directory that doesn't exist
+        let result = read_bind_dir_dropins("/nonexistent/path/to/nowhere").unwrap();
+
+        // Should return empty set without error
+        assert!(result.is_empty());
     }
 
     #[test]

--- a/sources/api/apiserver/src/server/error.rs
+++ b/sources/api/apiserver/src/server/error.rs
@@ -131,6 +131,11 @@ pub enum Error {
         source: ephemeral_storage::error::Error,
     },
 
+    #[snafu(display("Unable to read ephemeral storage allowed dirs: {}", source))]
+    EphemeralAllowedDirs {
+        source: ephemeral_storage::error::Error,
+    },
+
     #[snafu(display("Unable to make {} key '{}': {}", key_type, name, source))]
     NewKey {
         key_type: String,

--- a/sources/api/apiserver/src/server/mod.rs
+++ b/sources/api/apiserver/src/server/mod.rs
@@ -812,9 +812,7 @@ async fn initialize_ephemeral_storage(cfg: web::Json<Init>) -> Result<HttpRespon
 }
 /// Bind directories to ephemeral storage (mount array, bind, and unmount)
 async fn bind_ephemeral_storage(cfg: web::Json<Bind>) -> Result<HttpResponse> {
-    let os_info = controller::get_os_info()?;
-    ephemeral_storage::bind(&os_info.variant_id, cfg.0.targets)
-        .context(error::EphemeralBindSnafu {})?;
+    ephemeral_storage::bind(cfg.0.targets).context(error::EphemeralBindSnafu {})?;
     Ok(HttpResponse::NoContent().finish()) // 204
 }
 
@@ -855,20 +853,15 @@ async fn list_ephemeral_storage_dirs(
     req: HttpRequest,
     query: web::Query<HashMap<String, String>>,
 ) -> Result<HttpResponse> {
-    let os_info = controller::get_os_info()?;
-
-    let allowed_dirs = ephemeral_storage::allowed_bind_dirs(&os_info.variant_id);
+    let allowed_dirs =
+        ephemeral_storage::allowed_bind_dirs().context(error::EphemeralAllowedDirsSnafu {})?;
     let mut text_response = String::new();
     for dir in &allowed_dirs.allowed_exact {
         text_response.push_str(dir);
         text_response.push('\n');
     }
 
-    let allowed: Vec<String> = allowed_dirs
-        .allowed_exact
-        .iter()
-        .map(|x| String::from(*x))
-        .collect();
+    let allowed: Vec<String> = allowed_dirs.allowed_exact.into_iter().collect();
     list_ephemeral_response(req, query, allowed, text_response).await
 }
 
@@ -1039,6 +1032,7 @@ impl ResponseError for error::Error {
             EphemeralBind { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             EphemeralInitialize { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             EphemeralListDisks { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            EphemeralAllowedDirs { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             InvalidMetadata { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ConfigApplierFork { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ConfigApplierStart { .. } => StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-core-kit/issues/1000 (1000!)

**Description of changes:**

Package configuration files alongside packages that provide paths allowlisted by the ephemeral storage utility. This way, the allowlist can be built via package installation and is no longer gated by variant name.

For ephemeral storage logic, replace the variant-name-sniffing `allowed_bind_dirs(variant)` with a reader that sources exact-match paths from package-contributed fragments in `/usr/lib/bottlerocket/ephemeral-storage.d/`. Each package that owns a bind-target directory ships its own fragment, so the allowlist is determined by variant package composition rather than substring matching on the variant name.

Prefix and disallowed rules remain hardcoded apiserver policy.

The drop-ins are in /usr/lib, which is part of the readonly fs, so they can't be modified, nor can a new file be written to `/usr/lib/bottlerocket/ephemeral-storage.d/`

**Testing done:**

Unit tests and manual testing below:

Built custom `aws-k8s-1.33` and `aws-ecs-2` images from these changes containing the drop-ins. 

**`aws-k8s-1.33`**

```
$ ls /usr/lib/bottlerocket/ephemeral-storage.d/
containerd.conf
host-containerd.conf
kubelet.conf
soci-snapshotter.conf
```

Absent (as expected): `docker.conf`, `ecs-agent.conf`

Drop-in contents:

| File | Contents |
|------|----------|
| `kubelet.conf` | `/var/lib/kubelet`, `/var/log/pods` |
| `soci-snapshotter.conf` | `/var/lib/soci-snapshotter` |
| `containerd.conf` | `/var/lib/containerd` |
| `host-containerd.conf` | `/var/lib/host-containerd` |



```
$ apiclient ephemeral-storage list-dirs
/var/lib/kubelet
/var/log/pods
/var/lib/soci-snapshotter
/var/lib/containerd
/var/lib/host-containerd
```

**Correctly absent:** `/var/lib/docker`, `/var/log/ecs`


**`aws-ecs-2`**

```
$ ls /usr/lib/bottlerocket/ephemeral-storage.d/
containerd.conf
docker.conf
ecs-agent.conf
host-containerd.conf
```

Absent (as expected): `kubelet.conf`, `soci-snapshotter.conf`

Drop-in file contents

| File | Contents |
|------|----------|
| `ecs-agent.conf` | `/var/log/ecs` |
| `docker.conf` | `/var/lib/docker` |
| `containerd.conf` | `/var/lib/containerd` |
| `host-containerd.conf` | `/var/lib/host-containerd` |



```
$ apiclient ephemeral-storage list-dirs output
/var/lib/docker
/var/log/ecs
/var/lib/containerd
/var/lib/host-containerd
```

**Correctly absent:** `/var/lib/kubelet`, `/var/log/pods`, `/var/lib/soci-snapshotter`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
