### PR TITLE
aws-signing-helper: update to v1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Third Party Package Updates
 * Update `libcrypto`, `libdevmapper`, `libncurses`, `libelf`, and `libffi` ([#998])
 * Replace hardcoded ephemeral-storage bind-dir allowlist with package-contributed drop-in fragments in `/usr/lib/bottlerocket/ephemeral-storage.d/` ([#1001])
+* update aws-signing-helper to v1.8.4 ([#1003])
 
 ## Build Changes
 
@@ -14,6 +15,7 @@
 [#996]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/996
 [#998]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/998
 [#1001]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/1001
+[#1003]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/1003
 
 # v15.0.0 (2026-07-23)
 

--- a/packages/aws-signing-helper/Cargo.toml
+++ b/packages/aws-signing-helper/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/rolesanywhere-credential-helper/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.8.2/rolesanywhere-credential-helper-v1.8.2.tar.gz"
-sha512 = "316a36195e99146ce0b5f48dc446c3b151d85ca282fcbf227773e39ffd916cb52af94b8d16eb227c034736dc33c5095a8cd1e1bc0dc846dff246458f66122885"
+url = "https://github.com/aws/rolesanywhere-credential-helper/archive/v1.8.4/rolesanywhere-credential-helper-v1.8.4.tar.gz"
+sha512 = "2429d2e2e6660bfef177710348b10002205ef71ab696a328f9a8cef8850919b0ef2953e047548cea38f710c37171d867ef6423bca843ae2ec44ae8cd5a4b8958"
 bundle-modules = [ "go" ]
 
 [build-dependencies]

--- a/packages/aws-signing-helper/aws-signing-helper.spec
+++ b/packages/aws-signing-helper/aws-signing-helper.spec
@@ -2,7 +2,7 @@
 %global gorepo rolesanywhere-credential-helper
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 1.8.2
+%global gover 1.8.4
 %global rpmver %{gover}
 
 %global _dwz_low_mem_die_limit 0


### PR DESCRIPTION
**Description of changes:**
* Bumps aws-signing-helper to v1.8.4

**Testing done:**
Nvidia smoke and SOCI smoke


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
