### PR TITLE
util-linux: only probe supported partition tables

### DIFF
--- a/packages/util-linux/0001-libblkid-keep-only-supported-partition-probers.patch
+++ b/packages/util-linux/0001-libblkid-keep-only-supported-partition-probers.patch
@@ -1,0 +1,120 @@
+From a2eec0e376ad0c81aae91cc35d1a46aab5f7d069 Mon Sep 17 00:00:00 2001
+From: Craig Qian <qianxj@amazon.com>
+Date: Mon, 10 Aug 2026 20:43:17 +0000
+Subject: [PATCH] libblkid: only probe supported partition tables
+
+Our kernel configuration only enables MSDOS and EFI partition tables,
+so we do not need libblkid's probers for the other formats.
+
+Remove them from idinfos[] and drop the sources that no longer have any
+references. bsd, unixware, solaris_x86 and minix are still built since
+dos.c probes them for MBR partition types.
+
+Signed-off-by: Craig Qian <qianxj@amazon.com>
+---
+ libblkid/meson.build                 |  6 ------
+ libblkid/src/Makemodule.am           |  6 ------
+ libblkid/src/partitions/partitions.c | 10 ----------
+ libblkid/src/partitions/partitions.h |  6 ------
+ 4 files changed, 28 deletions(-)
+
+diff --git a/libblkid/meson.build b/libblkid/meson.build
+index 72d8f2b..ad61215 100644
+--- a/libblkid/meson.build
++++ b/libblkid/meson.build
+@@ -39,20 +39,14 @@ lib_blkid_sources = '''
+   src/verify.c
+   src/version.c
+ 
+-  src/partitions/aix.c
+   src/partitions/aix.h
+-  src/partitions/atari.c
+   src/partitions/bsd.c
+   src/partitions/dos.c
+   src/partitions/gpt.c
+-  src/partitions/mac.c
+   src/partitions/minix.c
+   src/partitions/partitions.c
+   src/partitions/partitions.h
+-  src/partitions/sgi.c
+   src/partitions/solaris_x86.c
+-  src/partitions/sun.c
+-  src/partitions/ultrix.c
+   src/partitions/unixware.c
+ 
+   src/superblocks/adaptec_raid.c
+diff --git a/libblkid/src/Makemodule.am b/libblkid/src/Makemodule.am
+index ce65d50..461efc6 100644
+--- a/libblkid/src/Makemodule.am
++++ b/libblkid/src/Makemodule.am
+@@ -26,20 +26,14 @@ libblkid_la_SOURCES = \
+ 	libblkid/src/verify.c \
+ 	libblkid/src/version.c \
+ 	\
+-	libblkid/src/partitions/aix.c \
+ 	libblkid/src/partitions/aix.h \
+-	libblkid/src/partitions/atari.c \
+ 	libblkid/src/partitions/bsd.c \
+ 	libblkid/src/partitions/dos.c \
+ 	libblkid/src/partitions/gpt.c \
+-	libblkid/src/partitions/mac.c \
+ 	libblkid/src/partitions/minix.c \
+ 	libblkid/src/partitions/partitions.c \
+ 	libblkid/src/partitions/partitions.h \
+-	libblkid/src/partitions/sgi.c \
+ 	libblkid/src/partitions/solaris_x86.c \
+-	libblkid/src/partitions/sun.c \
+-	libblkid/src/partitions/ultrix.c \
+ 	libblkid/src/partitions/unixware.c \
+ 	\
+ 	libblkid/src/superblocks/adaptec_raid.c \
+diff --git a/libblkid/src/partitions/partitions.c b/libblkid/src/partitions/partitions.c
+index 2276437..781a4d5 100644
+--- a/libblkid/src/partitions/partitions.c
++++ b/libblkid/src/partitions/partitions.c
+@@ -124,19 +124,9 @@ static void partitions_free_data(blkid_probe pr, void *data);
+  */
+ static const struct blkid_idinfo *idinfos[] =
+ {
+-	&aix_pt_idinfo,
+-	&sgi_pt_idinfo,
+-	&sun_pt_idinfo,
+ 	&dos_pt_idinfo,
+ 	&gpt_pt_idinfo,
+ 	&pmbr_pt_idinfo,	/* always after GPT */
+-	&mac_pt_idinfo,
+-	&ultrix_pt_idinfo,
+-	&bsd_pt_idinfo,
+-	&unixware_pt_idinfo,
+-	&solaris_x86_pt_idinfo,
+-	&minix_pt_idinfo,
+-	&atari_pt_idinfo
+ };
+ 
+ /*
+diff --git a/libblkid/src/partitions/partitions.h b/libblkid/src/partitions/partitions.h
+index 784e0c0..f77dd65 100644
+--- a/libblkid/src/partitions/partitions.h
++++ b/libblkid/src/partitions/partitions.h
+@@ -57,18 +57,12 @@ extern int blkid_partition_set_flags(blkid_partition par, unsigned long long fla
+ /*
+  * partition probers
+  */
+-extern const struct blkid_idinfo aix_pt_idinfo;
+ extern const struct blkid_idinfo bsd_pt_idinfo;
+ extern const struct blkid_idinfo unixware_pt_idinfo;
+ extern const struct blkid_idinfo solaris_x86_pt_idinfo;
+-extern const struct blkid_idinfo sun_pt_idinfo;
+-extern const struct blkid_idinfo sgi_pt_idinfo;
+-extern const struct blkid_idinfo mac_pt_idinfo;
+ extern const struct blkid_idinfo dos_pt_idinfo;
+ extern const struct blkid_idinfo minix_pt_idinfo;
+ extern const struct blkid_idinfo gpt_pt_idinfo;
+ extern const struct blkid_idinfo pmbr_pt_idinfo;
+-extern const struct blkid_idinfo ultrix_pt_idinfo;
+-extern const struct blkid_idinfo atari_pt_idinfo;
+ 
+ #endif /* BLKID_PARTITIONS_H */
+-- 
+2.47.3
+

--- a/packages/util-linux/util-linux.spec
+++ b/packages/util-linux/util-linux.spec
@@ -12,6 +12,9 @@ Source0: https://www.kernel.org/pub/linux/utils/util-linux/v%{majorminor}/util-l
 Source1: https://www.kernel.org/pub/linux/utils/util-linux/v%{majorminor}/util-linux-%{version}.tar.sign
 Source2: gpgkey-B0C64D14301CC6EFAEDF60E4E4B71D5EEC39C284.asc
 
+# Only probe for the partition tables our kernel configuration supports.
+Patch1: 0001-libblkid-keep-only-supported-partition-probers.patch
+
 BuildRequires: %{_cross_os}glibc-devel
 BuildRequires: %{_cross_os}libacl-devel
 BuildRequires: %{_cross_os}libncurses-devel


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes bottlerocket-os/bottlerocket#4855

**Description of changes:**
EKS worker nodes intermittently fail to boot (~1/1800 launches, more frequent on large ~1 TB volumes) because `mkfs.xfs` refuses to format the `BOTTLEROCKET-DATA` partition, wrongly reporting that it already contains an Atari filesystem.

The root cause is in libblkid. Unlike every other partition-table prober, the Atari prober has no magic number — it identifies a partition table purely from loose structural heuristics. On a freshly-encrypted EBS volume, the pseudorandom bytes that back never-written blocks can coincidentally satisfy those heuristics, so libblkid reports a phantom atari partition table on `BOTTLEROCKET-DATA`. `mkfs.xfs` then sees an "existing filesystem" and refuses to format, and `prepare-local-fs.service` fails, blocking boot. (See also [util-linux#1116](https://github.com/util-linux/util-linux/issues/1116) and [rook#7940](https://github.com/rook/rook/issues/7940).)

Bottlerocket only ever creates and consumes GPT partition tables (plus the DOS/pMBR protective MBR that GPT requires). This patch restricts libblkid's partition-prober set to gpt, dos, and pmbr, and stops compiling the now-unreferenced legacy prober sources (aix, atari, mac, sgi, sun, ultrix) from both the automake and meson builds. This removes the Atari false positive at the source and reduces libblkid's attack surface by not building parsers Bottlerocket never uses.

bsd, unixware, solaris_x86, and minix are dropped from the top-level prober array but intentionally kept in the build, because `dos.c`'s dos_nested[] table invokes them as MBR sub-probes; `aix.h` is likewise retained because `dos.c` includes it for the AIX magic-number check.

This adds Patch1: to `util-linux.spec`; `%autosetup -p1` applies it automatically.


**Testing done:**
- Verified the patch applies cleanly to util-linux 2.42.2 (`git apply --check` and `patch -p1 --dry-run`).
- Built libblkid locally and confirmed via nm that `atari_pt_idinfo` (and the other removed probers) are absent from the resulting `libblkid.so`, while dos/gpt/pmbr remain — with no undefined-reference/link errors, confirming the retained sub-probe sources still link.
- Built the core-kit with the patch (x86_64 and aarch64). 
- Built an aws-k8s-1.36 AMI and launched it on a deterministically "poisoned" EBS volume (a `BOTTLEROCKET-DATA` partition seeded with a valid Atari signature that reliably reproduces the failure on stock AMIs). Confirmed the node boots cleanly: no `mkfs.xfs ... (atari)` error, `prepare-local-fs.service` succeeds, `/local` mounts, and the system reaches multi-user. 


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
