### PR TITLE
Measure imds raw

### DIFF
--- a/packages/release/measure-user-data.service
+++ b/packages/release/measure-user-data.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Measure EC2 IMDS User Data into PCR 8
+Before=settings-applier.service early-boot-config.service
+After=tpm2.target
+ConditionSecurity=tpm2
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/rottweiler measure user-data
+
+[Install]
+RequiredBy=settings-applier.service

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -140,6 +140,7 @@ Source1606: systemd-pcrphase-preconfigured.service
 Source1607: systemd-pcrphase-sysinit.service
 Source1608: measure-settings.service
 Source1609: measure-cmdline.service
+Source1610: measure-user-data.service
 
 # TPM2-related drop-ins.
 Source1650: prepare-local-fs-encrypted.conf
@@ -306,6 +307,7 @@ install -p -m 0644 \
   %{S:1065} %{S:1066} %{S:1067} %{S:1068} \
   %{S:1600} %{S:1601} %{S:1602} %{S:1603} %{S:1604} \
   %{S:1605} %{S:1606} %{S:1607} %{S:1608} %{S:1609} \
+  %{S:1610} \
   %{S:1069} %{S:1070} \
   %{buildroot}%{_cross_unitdir}
 
@@ -560,6 +562,7 @@ ln -s preconfigured.target %{buildroot}%{_cross_unitdir}/default.target
 %dir %{_cross_unitdir}/encrypt-local-fs.service.d
 %{_cross_unitdir}/measure-cmdline.service
 %{_cross_unitdir}/measure-settings.service
+%{_cross_unitdir}/measure-user-data.service
 %{_cross_unitdir}/systemd-pcrphase-configured.service
 %{_cross_unitdir}/systemd-pcrphase-multi-user.service
 %{_cross_unitdir}/systemd-pcrphase-preconfigured.service

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -5155,10 +5155,13 @@ dependencies = [
  "generate-readme",
  "hex",
  "hkdf",
+ "imdsclient",
  "nix",
+ "reqwest 0.12.28",
  "serde",
  "sha2 0.10.9",
  "snafu",
+ "tokio",
  "walkdir",
  "zeroize",
 ]

--- a/sources/rottweiler/Cargo.toml
+++ b/sources/rottweiler/Cargo.toml
@@ -11,12 +11,17 @@ bottlerocket-image-features.workspace = true
 envy.workspace = true
 hex.workspace = true
 hkdf = { workspace = true, features = ["std"] }
+imdsclient.workspace = true
 nix = { workspace = true, features = ["fs", "ioctl", "mount"] }
 serde = { workspace = true, features = ["derive"] }
 sha2.workspace = true
 snafu.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }
 walkdir.workspace = true
 zeroize = { workspace = true, features = ["alloc", "derive"] }
+
+[dev-dependencies]
+reqwest.workspace = true
 
 [build-dependencies]
 generate-readme.workspace = true

--- a/sources/rottweiler/README.md
+++ b/sources/rottweiler/README.md
@@ -32,6 +32,7 @@ interface for encrypting and managing encrypted storage resources including:
 
 #### TPM Measurement Operations
 - `measure settings` - Measure OS settings into PCR 8
+- `measure user-data` - Measure EC2 IMDS user data into PCR 8
 - `measure kernel-command-line` - Measure kernel command line into PCR 9
 - `measure pcrphase <phase>` - Measure boot phase into PCR 11
   - Valid phases: `sysinit`, `preconfigured`, `configured`, `ready`, `shutdown`, `final`

--- a/sources/rottweiler/src/main.rs
+++ b/sources/rottweiler/src/main.rs
@@ -29,6 +29,7 @@ interface for encrypting and managing encrypted storage resources including:
 
 ### TPM Measurement Operations
 - `measure settings` - Measure OS settings into PCR 8
+- `measure user-data` - Measure EC2 IMDS user data into PCR 8
 - `measure kernel-command-line` - Measure kernel command line into PCR 9
 - `measure pcrphase <phase>` - Measure boot phase into PCR 11
   - Valid phases: `sysinit`, `preconfigured`, `configured`, `ready`, `shutdown`, `final`
@@ -54,8 +55,9 @@ mod system;
 
 type Result<T> = std::result::Result<T, Whatever>;
 
+#[tokio::main(flavor = "current_thread")]
 #[snafu::report]
-fn main() -> Result<()> {
+async fn main() -> Result<()> {
     // Support aliases: "dir" -> "directory", "bdev" -> "block-device"
     // Only replace in resource-type subcommand positions
     let mut args: Vec<String> = std::env::args().collect();
@@ -155,6 +157,7 @@ fn main() -> Result<()> {
         },
         Command::Measure(cmd) => match cmd.resource {
             MeasureResource::Settings(_) => measure::os_settings(),
+            MeasureResource::UserData(_) => measure::user_data().await,
             MeasureResource::KernelCommandLine(_) => measure::kernel_command_line(),
             MeasureResource::Pcrphase(cmd) => measure::pcrphase(&cmd.phase.to_string()),
         },
@@ -461,6 +464,7 @@ struct MeasureCmd {
 #[argh(subcommand)]
 enum MeasureResource {
     Settings(MeasureSettingsCmd),
+    UserData(MeasureUserDataCmd),
     KernelCommandLine(MeasureKernelCommandLineCmd),
     Pcrphase(MeasurePcrphaseCmd),
 }
@@ -469,6 +473,11 @@ enum MeasureResource {
 #[argh(subcommand, name = "settings")]
 /// Measure OS settings into PCR
 struct MeasureSettingsCmd {}
+
+#[derive(FromArgs)]
+#[argh(subcommand, name = "user-data")]
+/// Measure EC2 IMDS user data into PCR
+struct MeasureUserDataCmd {}
 
 #[derive(FromArgs)]
 #[argh(subcommand, name = "kernel-command-line")]

--- a/sources/rottweiler/src/measure.rs
+++ b/sources/rottweiler/src/measure.rs
@@ -22,7 +22,7 @@ const PCR_PHASE: u32 = 11;
 /// Domain-separation prefix for a present (possibly empty) EC2 IMDS user-data payload.
 ///
 /// The digest input is this prefix concatenated with the raw user-data bytes exactly as
-/// returned by IMDS (HTTP 200), with no decompression, decoding, or trimming applied.
+/// returned by IMDS with no decompression, decoding, or trimming applied.
 const USER_DATA_PRESENT_PREFIX: &[u8] = b"ec2-imds-user-data:v1:";
 
 /// Domain-separation marker for an absent EC2 IMDS user-data payload.
@@ -41,20 +41,13 @@ pub fn os_settings() -> Result<()> {
 /// Measure EC2 IMDS user data into PCR 8.
 ///
 /// This extends PCR 8 exactly once, regardless of whether user data is present, empty, or
-/// absent, so that PCR 8 receives a uniform, deterministic number of extends on every boot of
-/// every variant. The three cases are domain-separated so a verifier can tell them apart:
+/// absent. The three cases are domain-separated so a verifier can tell them apart:
 ///
-/// - Present (HTTP 200, non-empty body): `USER_DATA_PRESENT_PREFIX` followed by the raw bytes.
-/// - Present but empty (HTTP 200, empty body): `USER_DATA_PRESENT_PREFIX` followed by zero
+/// - Present: `USER_DATA_PRESENT_PREFIX` followed by the raw bytes.
+/// - Present but empty: `USER_DATA_PRESENT_PREFIX` followed by zero
 ///   bytes. This naturally yields a digest distinct from the absent marker below, since the
 ///   prefix bytes alone differ from `USER_DATA_ABSENT_MARKER`'s bytes.
-/// - Absent (HTTP 404 - no user data supplied, or IMDS disabled): `USER_DATA_ABSENT_MARKER`.
-///
-/// The bytes are measured exactly as IMDS returns them: no gzip decompression, base64
-/// handling, TOML parsing, or trimming is applied. A genuine IMDS failure (network error,
-/// token failure, throttling/5xx exhausting imdsclient's own retries) is propagated as an
-/// error rather than measured as a fallback value, so a broken fetch cannot be mistaken for a
-/// successful "absent" measurement.
+/// - Absent: `USER_DATA_ABSENT_MARKER`.
 pub async fn user_data() -> Result<()> {
     let user_data = system::fetch_imds_userdata().await?;
     let digest_input = frame_user_data(user_data.as_deref().map(|v| v.as_slice()));
@@ -62,10 +55,6 @@ pub async fn user_data() -> Result<()> {
 }
 
 /// Build the domain-separated digest input for a `user_data()` measurement.
-///
-/// `None` represents "absent" (IMDS HTTP 404); `Some(bytes)` represents "present", where
-/// `bytes` may be empty. See the doc comment on `user_data()` and the constants above for the
-/// exact framing rules.
 fn frame_user_data(user_data: Option<&[u8]>) -> Zeroizing<Vec<u8>> {
     match user_data {
         Some(raw) => {

--- a/sources/rottweiler/src/measure.rs
+++ b/sources/rottweiler/src/measure.rs
@@ -1,6 +1,7 @@
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use snafu::prelude::*;
 use std::fs;
+use zeroize::Zeroizing;
 
 use crate::system;
 
@@ -18,10 +19,65 @@ const PCR_KERNEL_COMMAND_LINE: u32 = 9;
 /// PCR for boot phase measurements
 const PCR_PHASE: u32 = 11;
 
+/// Domain-separation prefix for a present (possibly empty) EC2 IMDS user-data payload.
+///
+/// The digest input is this prefix concatenated with the raw user-data bytes exactly as
+/// returned by IMDS (HTTP 200), with no decompression, decoding, or trimming applied.
+const USER_DATA_PRESENT_PREFIX: &[u8] = b"ec2-imds-user-data:v1:";
+
+/// Domain-separation marker for an absent EC2 IMDS user-data payload.
+///
+/// This value is measured verbatim (it is not combined with any additional bytes), and is
+/// deliberately distinct from `USER_DATA_PRESENT_PREFIX` with an empty payload so a verifier
+/// can always distinguish "user data present but zero-length" from "user data absent".
+const USER_DATA_ABSENT_MARKER: &[u8] = b"ec2-imds-user-data:v1:absent";
+
 /// Measure OS settings into PCR 8
 pub fn os_settings() -> Result<()> {
     let data = system::apiclient_get_settings()?;
     extend_pcr(PCR_SETTINGS, &data)
+}
+
+/// Measure EC2 IMDS user data into PCR 8.
+///
+/// This extends PCR 8 exactly once, regardless of whether user data is present, empty, or
+/// absent, so that PCR 8 receives a uniform, deterministic number of extends on every boot of
+/// every variant. The three cases are domain-separated so a verifier can tell them apart:
+///
+/// - Present (HTTP 200, non-empty body): `USER_DATA_PRESENT_PREFIX` followed by the raw bytes.
+/// - Present but empty (HTTP 200, empty body): `USER_DATA_PRESENT_PREFIX` followed by zero
+///   bytes. This naturally yields a digest distinct from the absent marker below, since the
+///   prefix bytes alone differ from `USER_DATA_ABSENT_MARKER`'s bytes.
+/// - Absent (HTTP 404 - no user data supplied, or IMDS disabled): `USER_DATA_ABSENT_MARKER`.
+///
+/// The bytes are measured exactly as IMDS returns them: no gzip decompression, base64
+/// handling, TOML parsing, or trimming is applied. A genuine IMDS failure (network error,
+/// token failure, throttling/5xx exhausting imdsclient's own retries) is propagated as an
+/// error rather than measured as a fallback value, so a broken fetch cannot be mistaken for a
+/// successful "absent" measurement.
+pub async fn user_data() -> Result<()> {
+    let user_data = system::fetch_imds_userdata().await?;
+    let digest_input = frame_user_data(user_data.as_deref().map(|v| v.as_slice()));
+    extend_pcr(PCR_SETTINGS, &digest_input)
+}
+
+/// Build the domain-separated digest input for a `user_data()` measurement.
+///
+/// `None` represents "absent" (IMDS HTTP 404); `Some(bytes)` represents "present", where
+/// `bytes` may be empty. See the doc comment on `user_data()` and the constants above for the
+/// exact framing rules.
+fn frame_user_data(user_data: Option<&[u8]>) -> Zeroizing<Vec<u8>> {
+    match user_data {
+        Some(raw) => {
+            let mut framed = Zeroizing::new(Vec::with_capacity(
+                USER_DATA_PRESENT_PREFIX.len() + raw.len(),
+            ));
+            framed.extend_from_slice(USER_DATA_PRESENT_PREFIX);
+            framed.extend_from_slice(raw);
+            framed
+        }
+        None => Zeroizing::new(USER_DATA_ABSENT_MARKER.to_vec()),
+    }
 }
 
 /// Measure kernel command line into PCR 9
@@ -42,4 +98,63 @@ fn extend_pcr(pcr: u32, data: &[u8]) -> Result<()> {
     let sha384 = hex::encode(Sha384::digest(data));
     let sha512 = hex::encode(Sha512::digest(data));
     system::tpm2_pcrextend(pcr, &sha256, &sha384, &sha512)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn present_nonempty_uses_prefix_and_bytes() {
+        let framed = frame_user_data(Some(b"#!/bin/bash\necho hi\n"));
+        let mut expected = USER_DATA_PRESENT_PREFIX.to_vec();
+        expected.extend_from_slice(b"#!/bin/bash\necho hi\n");
+        assert_eq!(framed.as_slice(), expected.as_slice());
+    }
+
+    #[test]
+    fn present_empty_is_just_the_prefix() {
+        let framed = frame_user_data(Some(b""));
+        assert_eq!(framed.as_slice(), USER_DATA_PRESENT_PREFIX);
+    }
+
+    #[test]
+    fn absent_uses_the_absent_marker() {
+        let framed = frame_user_data(None);
+        assert_eq!(framed.as_slice(), USER_DATA_ABSENT_MARKER);
+    }
+
+    #[test]
+    fn present_empty_and_absent_are_distinct() {
+        let present_empty = frame_user_data(Some(b""));
+        let absent = frame_user_data(None);
+        assert_ne!(present_empty.as_slice(), absent.as_slice());
+    }
+
+    #[test]
+    fn present_empty_and_absent_digests_are_distinct() {
+        let present_empty = frame_user_data(Some(b""));
+        let absent = frame_user_data(None);
+        assert_ne!(
+            Sha256::digest(present_empty.as_slice()),
+            Sha256::digest(absent.as_slice())
+        );
+    }
+
+    #[test]
+    fn raw_bytes_are_not_altered_by_framing() {
+        // Framing must not decompress, decode, or trim the payload - verify a gzip-looking
+        // binary blob and bytes with leading/trailing whitespace survive untouched.
+        let raw: &[u8] = &[0x1f, 0x8b, 0x08, 0x00, b' ', b'\n', b' '];
+        let framed = frame_user_data(Some(raw));
+        assert!(framed.ends_with(raw));
+        assert_eq!(&framed[USER_DATA_PRESENT_PREFIX.len()..], raw);
+    }
+
+    #[test]
+    fn different_present_payloads_yield_different_digests() {
+        let a = frame_user_data(Some(b"payload-a"));
+        let b = frame_user_data(Some(b"payload-b"));
+        assert_ne!(Sha256::digest(a.as_slice()), Sha256::digest(b.as_slice()));
+    }
 }

--- a/sources/rottweiler/src/system.rs
+++ b/sources/rottweiler/src/system.rs
@@ -193,11 +193,6 @@ pub fn tpm2_pcrextend(pcr: u32, sha256: &str, sha384: &str, sha512: &str) -> Res
 }
 
 /// Fetch EC2 IMDS user data, returning the raw bytes exactly as IMDS returns them.
-///
-/// Returns `Ok(None)` only when IMDS answers with HTTP 404 (no user data was supplied at
-/// launch, or the IMDS HTTP endpoint is disabled). Any other failure is returned as an error
-/// rather than treated as "absent", so a broken measurement is never mistaken for a successful
-/// one.
 pub async fn fetch_imds_userdata() -> Result<Option<Zeroizing<Vec<u8>>>> {
     let mut client = imdsclient::ImdsClient::new();
     client
@@ -208,14 +203,13 @@ pub async fn fetch_imds_userdata() -> Result<Option<Zeroizing<Vec<u8>>>> {
 }
 
 /// Convert an `imdsclient::Error` from the user-data fetch into a `snafu::Whatever` error
-/// message that is safe to print to stderr and the systemd journal.
+/// message that is safe to print.
 fn describe_imds_userdata_error(e: imdsclient::Error) -> snafu::Whatever {
     match e {
         imdsclient::Error::Response { code, .. } => snafu::Whatever::without_source(format!(
             "failed to fetch user data from IMDS: unexpected response status {}",
             code
         )),
-        // Skip the source to prevent leaking user data to the console
         _ => snafu::Whatever::without_source("failed to fetch user data from IMDS".to_string()),
     }
 }

--- a/sources/rottweiler/src/system.rs
+++ b/sources/rottweiler/src/system.rs
@@ -1,3 +1,4 @@
+use snafu::FromString;
 use snafu::prelude::*;
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -189,4 +190,70 @@ pub fn tpm2_pcrextend(pcr: u32, sha256: &str, sha384: &str, sha512: &str) -> Res
         None,
     )?;
     Ok(())
+}
+
+/// Fetch EC2 IMDS user data, returning the raw bytes exactly as IMDS returns them.
+///
+/// Returns `Ok(None)` only when IMDS answers with HTTP 404 (no user data was supplied at
+/// launch, or the IMDS HTTP endpoint is disabled). Any other failure is returned as an error
+/// rather than treated as "absent", so a broken measurement is never mistaken for a successful
+/// one.
+pub async fn fetch_imds_userdata() -> Result<Option<Zeroizing<Vec<u8>>>> {
+    let mut client = imdsclient::ImdsClient::new();
+    client
+        .fetch_userdata()
+        .await
+        .map(|opt| opt.map(Zeroizing::new))
+        .map_err(describe_imds_userdata_error)
+}
+
+/// Convert an `imdsclient::Error` from the user-data fetch into a `snafu::Whatever` error
+/// message that is safe to print to stderr and the systemd journal.
+fn describe_imds_userdata_error(e: imdsclient::Error) -> snafu::Whatever {
+    match e {
+        imdsclient::Error::Response { code, .. } => snafu::Whatever::without_source(format!(
+            "failed to fetch user data from IMDS: unexpected response status {}",
+            code
+        )),
+        // Skip the source to prevent leaking user data to the console
+        _ => snafu::Whatever::without_source("failed to fetch user data from IMDS".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A response body standing in for secret-bearing user data, used only to assert it never
+    /// appears in the sanitized error message.
+    const SECRET_USER_DATA: &str = "super-secret-bootstrap-token=abc123";
+
+    #[test]
+    fn response_error_surfaces_status_code_but_not_body() {
+        let err = imdsclient::Error::Response {
+            method: "GET".to_string(),
+            uri: "http://169.254.169.254/latest/user-data".to_string(),
+            code: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            response_body: SECRET_USER_DATA.to_string(),
+        };
+        let message = describe_imds_userdata_error(err).to_string();
+        assert!(
+            !message.contains(SECRET_USER_DATA),
+            "sanitized error message must never contain the IMDS response body: {}",
+            message
+        );
+        assert!(
+            message.contains("500"),
+            "sanitized error message should surface the HTTP status code: {}",
+            message
+        );
+    }
+
+    #[test]
+    fn other_errors_fall_back_to_a_fixed_opaque_message() {
+        let err = imdsclient::Error::FailedFetchToken;
+        let message = describe_imds_userdata_error(err).to_string();
+        assert!(!message.contains(SECRET_USER_DATA));
+        assert_eq!(message, "failed to fetch user data from IMDS");
+    }
 }


### PR DESCRIPTION
**Description of changes:**

PCR8 now includes two measurements:

- First, the IMDS raw user data
- Second, the API values themselves

**Testing done:**

New systemd service runs and re-played the measurements my self offline, predicting the actual PCR8 values.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
