### PR TITLE
os: disable metricdog if in-place-updates is false

### DIFF
--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -101,7 +101,6 @@ Requires: %{_cross_os}certdog
 Requires: %{_cross_os}driverdog
 Requires: %{_cross_os}ghostdog
 Requires: %{_cross_os}logdog
-Requires: %{_cross_os}metricdog
 Requires: %{_cross_os}prairiedog
 Requires: %{_cross_os}schnauzer
 Requires: %{_cross_os}settings-committer
@@ -118,6 +117,7 @@ Requires: (%{_cross_os}bork or %{_cross_os}image-feature(no-in-place-updates))
 Requires: (%{_cross_os}migration or %{_cross_os}image-feature(no-in-place-updates))
 Requires: (%{_cross_os}thar-be-updates or %{_cross_os}image-feature(no-in-place-updates))
 Requires: (%{_cross_os}updog or %{_cross_os}image-feature(no-in-place-updates))
+Requires: (%{_cross_os}metricdog or %{_cross_os}image-feature(no-in-place-updates))
 
 Requires: (%{_cross_os}signpost or %{_cross_os}image-feature(uki-image))
 


### PR DESCRIPTION
**Description of changes:**
- disable metricdog if in-place-updates is false
- we found that `metricdog` requires [settings.updates] tying it with in-place-updates. The interrelation can be found in the template:
```
bash-5.2# cat /usr/share/templates/metricdog-toml
[required-extensions]
aws = "v1"
metrics = "v1"
std = { version = "v1", helpers = ["join_array"] }
updates = "v1"
+++
metrics_url = "{{settings.metrics.metrics-url}}"
send_metrics = {{settings.metrics.send-metrics}}
service_checks = [{{join_array ", " settings.metrics.service-checks}}]
seed = {{settings.updates.seed}}
version_lock = "{{settings.updates.version-lock}}"
ignore_waves = {{settings.updates.ignore-waves}}
{{#if settings.aws.region}}
region = "{{settings.aws.region}}"
{{else}}
region = "global"
{{/if}}
```

**Testing done:**
- AMI boots - no failed units in k8s-1.36 variants, in experimental variant the service wasn't present
```
bash-5.2# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "841ea622",
    "pretty_name": "Bottlerocket OS 1.64.0 (aws-k8s-1.36)",
    "variant_id": "aws-k8s-1.36",
    "version_id": "1.64.0"
  }
}
bash-5.2# systemctl status metricdog.service
○ metricdog.service - Send a Metricdog Ping
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/metricdog.service; static)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 00-fips-go.conf, 10-requires-tmp.conf
     Active: inactive (dead)
TriggeredBy: ● metricdog.timer
```

```
bash-5.2# systemctl status metricdog.service
Unit metricdog.service could not be found.
bash-5.2# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0869ee03-dirty",
    "pretty_name": "Bottlerocket OS 1.64.0 (aws-xyz-nvidia-fips)",
    "variant_id": "aws-xyz-nvidia-fips",
    "version_id": "1.64.0"
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
