### PR TITLE
Freshness ssm docker ecs

### DIFF
--- a/packages/amazon-ssm-agent/Cargo.toml
+++ b/packages/amazon-ssm-agent/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/aws/amazon-ssm-agent/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.4515.0/amazon-ssm-agent-3.3.4515.0.tar.gz"
-sha512 = "9b4114c3bb13e2692658a9303609dac81f0cf84c1403d3859190b775777b8584dcd8fe5bafd6df17535de4c9f4366959d3d5c21be363cd7d1dde138d6037764f"
+url = "https://github.com/aws/amazon-ssm-agent/archive/3.3.5068.0/amazon-ssm-agent-3.3.5068.0.tar.gz"
+sha512 = "270369da809a2801a94bb2ce1b6dcff7df393f07192fbd7d3047c337b83034b61aaba1eba7ba48bd3e23eabf9db520a10a020dcb170ffe57744b7117e5ce44f2"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/amazon-ssm-agent/amazon-ssm-agent.spec
+++ b/packages/amazon-ssm-agent/amazon-ssm-agent.spec
@@ -3,7 +3,7 @@
 %global goimport %{goproject}/%{gorepo}
 
 Name: %{_cross_os}amazon-ssm-agent
-Version: 3.3.4515.0
+Version: 3.3.5068.0
 Release: 1%{?dist}
 Summary: An agent to enable remote management of EC2 instances
 License: Apache-2.0

--- a/packages/docker-engine-25/Cargo.toml
+++ b/packages/docker-engine-25/Cargo.toml
@@ -12,8 +12,8 @@ path = "../packages.rs"
 releases-url = "https://github.com/moby/moby/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/moby/moby/archive/v25.0.13/moby-25.0.13.tar.gz"
-sha512 = "bf7254b2977e085eae717b09965f8f8865a89323c2f160d26fdceb8ef74d6871d24be391e4950683c4867bb68b728d9cd822165934c6abbf4ea67a7b24877287"
+url = "https://github.com/moby/moby/archive/v25.0.17/moby-25.0.17.tar.gz"
+sha512 = "dd52266db3cda52bb68d031acae9b77215c339706fb4a8bd30d1008987409f67fc0bccc8327e239db9232959f777672fa6f69420432548976c769a7c32f61529"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/docker-engine-25/docker-engine-25.spec
+++ b/packages/docker-engine-25/docker-engine-25.spec
@@ -3,9 +3,9 @@
 %global goorg github.com/docker
 %global goimport %{goorg}/docker
 
-%global gover 25.0.13
+%global gover 25.0.17
 %global rpmver %{gover}
-%global gitrev 165516eb478021fdc99976e5aadc26bf73c1e51b
+%global gitrev 35c78414205f6210072469caa5554ecccef4d859
 
 %global source_date_epoch 1363394400
 

--- a/packages/ecs-agent/Cargo.toml
+++ b/packages/ecs-agent/Cargo.toml
@@ -14,8 +14,8 @@ releases-url = "https://github.com/aws/amazon-ecs-agent/releases"
 
 [[package.metadata.build-package.external-files]]
 # Verify the Git submodule commit of amazon-vpc-cni-plugins matches what is shipped in ../amazon-vpc-cni-plugins
-url = "https://github.com/aws/amazon-ecs-agent/archive/v1.103.2/amazon-ecs-agent-1.103.2.tar.gz"
-sha512 = "5a2bcfe27f711e856e9b479691967c3ef112c8fd4f11fda5e5e4e0be71486b392f2b5f6479b48717a136c20b54db69c9b02f66403a95bc272d9586f186f8bdde"
+url = "https://github.com/aws/amazon-ecs-agent/archive/v1.106.1/amazon-ecs-agent-1.106.1.tar.gz"
+sha512 = "d50fac97e06ef53840a7ba6b2740efc2d0cff8887c966254a3890333e3ff101578057bd5ff7134588621ec4cd2119a53effb40111c296491fe59049e998fe457"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/ecs-agent/ecs-agent.spec
+++ b/packages/ecs-agent/ecs-agent.spec
@@ -2,10 +2,10 @@
 %global agent_gorepo amazon-ecs-agent
 %global agent_goimport %{agent_goproject}/%{agent_gorepo}
 
-%global agent_gover 1.103.2
+%global agent_gover 1.106.1
 
 # git rev-parse --short=8
-%global agent_gitrev 08149542
+%global agent_gitrev fd3c035e
 
 # Construct reproducible tar archives
 # See https://reproducible-builds.org/docs/archives/


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
- amazon-ssm-agent: 3.3.4515.0 → 3.3.5068.0
- docker-engine-25: 25.0.13 → 25.0.17
- ecs-agent: 1.103.2 → 1.106.1


**Testing done:**
Internal tests pass for the `aws-ecs-2` variant on both platforms

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
