### PR TITLE
nvidia-k8s-device-plugin: update to v0.19.3

### DIFF
--- a/packages/nvidia-k8s-device-plugin/Cargo.toml
+++ b/packages/nvidia-k8s-device-plugin/Cargo.toml
@@ -12,9 +12,9 @@ path = "../packages.rs"
 releases-url = "https://github.com/NVIDIA/k8s-device-plugin/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.19.2/v0.19.2.tar.gz"
-path = "k8s-device-plugin-0.19.2.tar.gz"
-sha512 = "0fb1221b063ff1eca7c35a4dd58558e1b6569f51ea085f804515005e8a3f3c2e8f73241af441e19253f35d656528e8672870445cf2371eab84dde2343ae3211c"
+url = "https://github.com/NVIDIA/k8s-device-plugin/archive/v0.19.3/v0.19.3.tar.gz"
+path = "k8s-device-plugin-0.19.3.tar.gz"
+sha512 = "6744b42628bb1ffe70db16770ca5a443034bfdacf613b5241befdf118ffd4f3c262b454e0a694df6e2332e4217f0f81c53f459a5b97351fecfe582ac481ea0f8"
 
 [build-dependencies]
 glibc = { path = "../glibc" }

--- a/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
+++ b/packages/nvidia-k8s-device-plugin/nvidia-k8s-device-plugin.spec
@@ -2,7 +2,7 @@
 %global gorepo k8s-device-plugin
 %global goimport %{goproject}/%{gorepo}
 
-%global gover 0.19.2
+%global gover 0.19.3
 %global rpmver %{gover}
 
 Name: %{_cross_os}nvidia-k8s-device-plugin


### PR DESCRIPTION
**Description of changes:**

- Update `nvidia-k8s-device-plugin` to v0.19.3.

**Testing done:**

Built the `aws-k8s-1.36-nvidia` AMI against the updated kit and validated on a `g4dn.xlarge` GPU node.

#### 1. NVIDIA CUDA smoke

| Variant | Arch | Instance | Passed | Failed |
|---|---|---|---|---|
| aws-k8s-1.36-nvidia | x86_64 | g4dn.xlarge | 429 | 0 |

GPU detected, `nvidia.com/gpu` scheduling works, all CUDA sample workloads (vectorAdd, immaTensorCoreGemm, reductionMultiBlockCG, …) completed.

#### 2. OCI hooks validation

Per the device-plugin / container-toolkit testing runbook, verified the OCI hooks in the container spec for both device-list strategies:

- **CDI** (`device-list-strategy=cdi-cri`): no `prestart` hook; only `createContainer` hooks (`create-symlinks`, `update-ldcache`, `disable-device-node-modification`).
- **Legacy** (`device-list-strategy=volume-mounts`): `prestart` hook present (`nvidia-container-runtime-hook prestart`).

No new/unexpected hooks were introduced by v0.19.3 (the `disable-device-node-modification` hook comes from nvidia-container-toolkit v1.19, which is unchanged in this PR).

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
