### PR TITLE
packages: add containerd-2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "conntrack-tools",
  "containerd-1_7",
  "containerd-2_2",
+ "containerd-2_3",
  "coreutils",
  "cri-tools",
  "dbus-broker",
@@ -249,6 +250,13 @@ dependencies = [
 
 [[package]]
 name = "containerd-2_2"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "containerd-2_3"
 version = "0.1.0"
 dependencies = [
  "glibc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "packages/conntrack-tools",
   "packages/containerd-1.7",
   "packages/containerd-2.2",
+  "packages/containerd-2.3",
   "packages/coreutils",
   "packages/cri-tools",
   "packages/libcryptsetup",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -27,6 +27,7 @@ cni-plugins = { path = "../../packages/cni-plugins" }
 conntrack-tools = { path = "../../packages/conntrack-tools" }
 containerd-1_7 = { path = "../../packages/containerd-1.7" }
 containerd-2_2 = { path = "../../packages/containerd-2.2" }
+containerd-2_3 = { path = "../../packages/containerd-2.3" }
 coreutils = { path = "../../packages/coreutils" }
 cri-tools = { path = "../../packages/cri-tools" }
 dbus-broker = { path = "../../packages/dbus-broker" }

--- a/packages/containerd-2.3/1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
+++ b/packages/containerd-2.3/1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
@@ -1,0 +1,72 @@
+From f6f4f959862cad73cc44d07b088f449ae6c69066 Mon Sep 17 00:00:00 2001
+From: Henry Wang <henwang@amazon.com>
+Date: Thu, 10 Apr 2025 20:50:50 +0000
+Subject: [PATCH] Revert "Don't allow io_uring related syscalls in the
+ RuntimeDefault seccomp profile."
+
+This reverts commit a48ddf4a208b24eadea82f0eac62e236f2acf004.
+---
+ contrib/seccomp/seccomp_default.go      |  3 +++
+ contrib/seccomp/seccomp_default_test.go | 36 -------------------------
+ 2 files changed, 3 insertions(+), 36 deletions(-)
+ delete mode 100644 contrib/seccomp/seccomp_default_test.go
+
+diff --git a/contrib/seccomp/seccomp_default.go b/contrib/seccomp/seccomp_default.go
+index 55d673fcb..1135f2391 100644
+--- a/contrib/seccomp/seccomp_default.go
++++ b/contrib/seccomp/seccomp_default.go
+@@ -188,6 +188,9 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
+ 				"ioprio_set",
+ 				"io_setup",
+ 				"io_submit",
++				"io_uring_enter",
++				"io_uring_register",
++				"io_uring_setup",
+ 				"ipc",
+ 				"kill",
+ 				"landlock_add_rule",
+diff --git a/contrib/seccomp/seccomp_default_test.go b/contrib/seccomp/seccomp_default_test.go
+deleted file mode 100644
+index 53e386809..000000000
+--- a/contrib/seccomp/seccomp_default_test.go
++++ /dev/null
+@@ -1,36 +0,0 @@
+-package seccomp
+-
+-import (
+-	"testing"
+-
+-	"github.com/opencontainers/runtime-spec/specs-go"
+-)
+-
+-func TestIOUringIsNotAllowed(t *testing.T) {
+-
+-	disallowed := map[string]bool{
+-		"io_uring_enter":    true,
+-		"io_uring_register": true,
+-		"io_uring_setup":    true,
+-	}
+-
+-	got := DefaultProfile(&specs.Spec{
+-		Process: &specs.Process{
+-			Capabilities: &specs.LinuxCapabilities{
+-				Bounding: []string{},
+-			},
+-		},
+-	})
+-
+-	for _, config := range got.Syscalls {
+-		if config.Action != specs.ActAllow {
+-			continue
+-		}
+-
+-		for _, name := range config.Names {
+-			if disallowed[name] {
+-				t.Errorf("found disallowed io_uring related syscalls")
+-			}
+-		}
+-	}
+-}
+-- 
+2.45.0
+

--- a/packages/containerd-2.3/1002-transfer-service-fallback-to-credentials.toml-for-re.patch
+++ b/packages/containerd-2.3/1002-transfer-service-fallback-to-credentials.toml-for-re.patch
@@ -1,0 +1,137 @@
+From 98bca202890467862de25819e0a1284e9afcfeeb Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Thu, 29 Jan 2026 21:52:41 +0000
+Subject: [PATCH] transfer-service: fallback to credentials.toml for registry
+ auth
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ core/transfer/registry/registry.go | 87 ++++++++++++++++++++++++++++--
+ 1 file changed, 83 insertions(+), 4 deletions(-)
+
+diff --git a/core/transfer/registry/registry.go b/core/transfer/registry/registry.go
+index a903bddfa..0f56c8a46 100644
+--- a/core/transfer/registry/registry.go
++++ b/core/transfer/registry/registry.go
+@@ -18,13 +18,18 @@ package registry
+ 
+ import (
+ 	"context"
++	"encoding/base64"
+ 	"errors"
+ 	"fmt"
+ 	"io"
+ 	"net/http"
++	"os"
++	"path/filepath"
+ 	"strings"
+ 	"sync"
+ 
++	"github.com/pelletier/go-toml/v2"
++
+ 	transfertypes "github.com/containerd/containerd/api/types/transfer"
+ 	"github.com/containerd/containerd/v2/core/remotes"
+ 	"github.com/containerd/containerd/v2/core/remotes/docker"
+@@ -39,6 +44,76 @@ import (
+ 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+ )
+ 
++// hostDirectory converts ":port" to "_port_" in directory names.
++// Matches containerd's config/hosts.go encoding.
++func hostDirectory(host string) string {
++	idx := strings.LastIndex(host, ":")
++	if idx > 0 {
++		return host[:idx] + "_" + host[idx+1:] + "_"
++	}
++	return host
++}
++
++func loadHostCredentials(ctx context.Context, hostDir, host string) (string, string, error) {
++	if hostDir == "" {
++		return "", "", nil
++	}
++	// Try encoded path first (registry_5000_), then literal (registry:5000)
++	paths := []string{filepath.Join(hostDir, hostDirectory(host), "credentials.toml")}
++	if hostDirectory(host) != host {
++		paths = append(paths, filepath.Join(hostDir, host, "credentials.toml"))
++	}
++	var d []byte
++	var err error
++	var credPath string
++	for _, p := range paths {
++		d, err = os.ReadFile(p)
++		if err == nil {
++			credPath = p
++			break
++		}
++		if !os.IsNotExist(err) {
++			return "", "", err
++		}
++	}
++	if d == nil {
++		return "", "", nil
++	}
++	var c struct {
++		Username      string `toml:"username"`
++		Password      string `toml:"password"`
++		IdentityToken string `toml:"identitytoken"`
++		Auth          string `toml:"auth"`
++	}
++	if err := toml.Unmarshal(d, &c); err != nil {
++		log.G(ctx).WithError(err).Warnf("failed to parse credentials from %s", credPath)
++		return "", "", nil
++	}
++	if c.Username != "" || c.Password != "" {
++		log.G(ctx).WithField("path", credPath).Debug("using fallback credentials (username/password)")
++		return c.Username, c.Password, nil
++	}
++	if c.IdentityToken != "" {
++		log.G(ctx).WithField("path", credPath).Debug("using fallback credentials (identity token)")
++		return "", c.IdentityToken, nil
++	}
++	if c.Auth != "" {
++		dec, err := base64.StdEncoding.DecodeString(c.Auth)
++		if err != nil {
++			log.G(ctx).WithError(err).Warnf("failed to decode auth from %s", credPath)
++			return "", "", nil
++		}
++		user, passwd, ok := strings.Cut(string(dec), ":")
++		if !ok {
++			log.G(ctx).Warnf("invalid auth format in %s", credPath)
++			return "", "", nil
++		}
++		log.G(ctx).WithField("path", credPath).Debug("using fallback credentials (auth)")
++		return user, strings.Trim(passwd, "\x00"), nil
++	}
++	return "", "", nil
++}
++
+ func init() {
+ 	// TODO: Move this to separate package?
+ 	plugins.Register(&transfertypes.OCIRegistry{}, &OCIRegistry{})
+@@ -134,8 +209,10 @@ func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry,
+ 			if err != nil {
+ 				return "", "", err
+ 			}
+-
+-			return c.Username, c.Secret, nil
++			if c.Username != "" || c.Secret != "" {
++				return c.Username, c.Secret, nil
++			}
++			return loadHostCredentials(ctx, ropts.hostDir, host)
+ 		}
+ 	}
+ 	if ropts.defaultScheme != "" {
+@@ -376,8 +453,10 @@ func (r *OCIRegistry) UnmarshalAny(ctx context.Context, sm streaming.StreamGette
+ 				if err != nil {
+ 					return "", "", err
+ 				}
+-
+-				return c.Username, c.Secret, nil
++				if c.Username != "" || c.Secret != "" {
++					return c.Username, c.Secret, nil
++				}
++				return loadHostCredentials(ctx, s.Resolver.HostDir, host)
+ 			}
+ 		}
+ 		r.headers = http.Header{}

--- a/packages/containerd-2.3/1003-ctr-default-hosts-dir-to-etc-containerd-certs.d.patch
+++ b/packages/containerd-2.3/1003-ctr-default-hosts-dir-to-etc-containerd-certs.d.patch
@@ -1,0 +1,25 @@
+From 5996f17f4b3287148255c0cd89dee981f83dc0c2 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Fri, 30 Jan 2026 19:08:27 +0000
+Subject: [PATCH] ctr: default hosts-dir to /etc/containerd/certs.d
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ cmd/ctr/commands/commands.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmd/ctr/commands/commands.go b/cmd/ctr/commands/commands.go
+index 946da78ed..d4b7a3a87 100644
+--- a/cmd/ctr/commands/commands.go
++++ b/cmd/ctr/commands/commands.go
+@@ -72,8 +72,8 @@ var (
+ 			Usage: "Refresh token for authorization server",
+ 		},
+ 		&cli.StringFlag{
+-			Name: "hosts-dir",
+-			// compatible with "/etc/docker/certs.d"
++			Name:  "hosts-dir",
++			Value: "/etc/containerd/certs.d",
+ 			Usage: "Custom hosts configuration directory",
+ 		},
+ 		&cli.StringFlag{

--- a/packages/containerd-2.3/Cargo.toml
+++ b/packages/containerd-2.3/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "containerd-2_3"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+package-name = "containerd-2.3"
+releases-url = "https://github.com/containerd/containerd/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/containerd/containerd/archive/v2.3.4/containerd-2.3.4.tar.gz"
+sha512 = "cf8be1759399fb9e3b7c84d353a876b8f599b74fb3094a288333cf0b61a743b74484cbde7eab96576b214c92caf7de65ef94813bb3670e079585c371a438f6b4"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/containerd-2.3/clarify.toml
+++ b/packages/containerd-2.3/clarify.toml
@@ -1,0 +1,12 @@
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT"
+license-files = [
+    { path = "LICENSE", hash = 0x617d80bc },
+]
+
+[clarify."github.com/grpc-ecosystem/go-grpc-middleware/v2"]
+expression = "Apache-2.0"
+license-files = [
+    { path = "COPYRIGHT", hash = 0x4bba7b1 },
+    { path = "LICENSE", hash = 0x6a39c900 }
+]

--- a/packages/containerd-2.3/containerd-2.3.spec
+++ b/packages/containerd-2.3/containerd-2.3.spec
@@ -1,0 +1,162 @@
+%global goproject github.com/containerd
+%global gorepo containerd
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 2.3.4
+%global rpmver %{gover}
+%global gitrev db8809540e1a7a9da5d518876894933ff55692ab
+
+%global package_priority_epoch 0
+%global _dwz_low_mem_die_limit 0
+
+Name: %{_cross_os}%{gorepo}-2.3
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: An industry-standard container runtime
+License: Apache-2.0
+URL: https://%{goimport}
+Source0: https://%{goimport}/archive/v%{gover}/%{gorepo}-%{gover}.tar.gz
+Source1: containerd.service
+Source2: containerd-config-toml_k8s_containerd_sock
+Source3: containerd-config-toml_basic
+Source4: containerd-config-toml_k8s_nvidia_containerd_sock
+Source5: containerd-tmpfiles.conf
+Source6: containerd-cri-base-json
+Source7: snapshotter-toml
+Source8: ephemeral-storage.conf
+
+# Mount for writing containerd configuration
+Source100: etc-containerd.mount
+
+# Create container storage mount point.
+Source110: prepare-var-lib-containerd.service
+
+# Drop-ins to disable igzip or pigz if the other implementation is preferred.
+Source200: containerd-disable-igzip.conf
+Source201: containerd-disable-pigz.conf
+
+Source1000: clarify.toml
+
+# Patch to support moving from containerd-1.7 to 2.x
+Patch1001: 1001-Revert-Don-t-allow-io_uring-related-syscalls-in-the-.patch
+# Patch for transfer service to fall back to file for registry creds.
+Patch1002: 1002-transfer-service-fallback-to-credentials.toml-for-re.patch
+# Patch to make ctr use hosts.toml for registry mirrors by default
+Patch1003: 1003-ctr-default-hosts-dir-to-etc-containerd-certs.d.patch
+
+BuildRequires: git
+BuildRequires: %{_cross_os}glibc-devel
+Requires: %{_cross_os}runc
+Requires: %{name}(optimized-gunzip)
+
+Provides: %{_cross_os}%{gorepo} = %{package_priority_epoch}:
+Conflicts: %{_cross_os}%{gorepo}
+
+%description
+%{summary}.
+
+%package pigz
+Summary: Prefer pigz for gzip decompression
+Requires: %{_cross_os}pigz
+Requires: %{name}
+Provides: %{_cross_os}%{gorepo}-pigz = %{package_priority_epoch}:
+Conflicts: %{name}-igzip
+Provides: %{name}(optimized-gunzip) = 1:
+
+%description pigz
+%{summary}.
+
+%package igzip
+Summary: Prefer igzip for gzip decompression
+Requires: %{_cross_os}igzip
+Requires: %{name}
+Provides: %{_cross_os}%{gorepo}-igzip = %{package_priority_epoch}:
+Conflicts: %{name}-pigz
+%if "%{_cross_arch}" == "x86_64"
+Provides: %{name}(optimized-gunzip) = 2:
+%else
+Provides: %{name}(optimized-gunzip) = 0:
+%endif
+
+%description igzip
+%{summary}.
+
+%prep
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
+
+%build
+%set_cross_go_flags
+
+# containerd 2.3 requires Go 1.26 (go.mod toolchain directive go1.26.x); select
+# the 1.26 toolchain from the SDK instead of the default.
+export GO_MAJOR="1.26"
+
+export BUILDTAGS="no_btrfs selinux"
+export LD_VERSION="-X github.com/containerd/containerd/v2/version.Version=%{gover}+bottlerocket"
+export LD_REVISION="-X github.com/containerd/containerd/v2/version.Revision=%{gitrev}"
+
+declare -a BUILD_ARGS
+BUILD_ARGS=(
+  -tags="${BUILDTAGS}"
+  -ldflags="${GOLDFLAGS} ${LD_VERSION} ${LD_REVISION}"
+)
+
+for bin in \
+  containerd \
+  containerd-shim-runc-v2 \
+  ctr ;
+do
+  go build "${BUILD_ARGS[@]}" -o ${bin} ./cmd/${bin}
+done
+
+%install
+install -d %{buildroot}%{_cross_bindir}
+for bin in \
+  containerd \
+  containerd-shim-runc-v2 \
+  ctr ;
+do
+  install -p -m 0755 ${bin} %{buildroot}%{_cross_bindir}
+done
+
+install -d %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:1} %{S:100} %{S:110} %{buildroot}%{_cross_unitdir}
+
+install -d %{buildroot}%{_cross_templatedir}
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/containerd
+install -p -m 0644 %{S:2} %{S:3} %{S:4} %{S:6} %{S:7} %{buildroot}%{_cross_templatedir}
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:5} %{buildroot}%{_cross_tmpfilesdir}/containerd.conf
+
+install -d %{buildroot}%{_cross_unitdir}/containerd.service.d
+install -p -m 0644 %{S:200} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
+install -p -m 0644 %{S:201} %{buildroot}%{_cross_unitdir}/containerd.service.d/005-disable-pigz.conf
+
+install -D -p -m 0644 %{S:8} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/containerd.conf
+
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
+
+%files
+%license LICENSE NOTICE
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+%{_cross_unitdir}/containerd.service
+%{_cross_unitdir}/etc-containerd.mount
+%{_cross_unitdir}/prepare-var-lib-containerd.service
+%dir %{_cross_factorydir}%{_cross_sysconfdir}/containerd
+%{_cross_templatedir}/containerd-config-toml*
+%{_cross_templatedir}/containerd-cri-base-json
+%{_cross_templatedir}/snapshotter-toml
+%{_cross_tmpfilesdir}/containerd.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/containerd.conf
+%{_cross_bindir}/containerd
+%{_cross_bindir}/containerd-shim-runc-v2
+%{_cross_bindir}/ctr
+%files pigz
+%{_cross_unitdir}/containerd.service.d/005-disable-igzip.conf
+
+%files igzip
+%{_cross_unitdir}/containerd.service.d/005-disable-pigz.conf
+
+%changelog

--- a/packages/containerd-2.3/containerd-config-toml_basic
+++ b/packages/containerd-2.3/containerd-config-toml_basic
@@ -1,0 +1,34 @@
++++
+version = 3
+root = "/var/lib/containerd"
+state = "/run/containerd"
+disabled_plugins = [
+    "io.containerd.internal.v1.opt",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.snapshotter.v1.blockfile",
+    "io.containerd.snapshotter.v1.devmapper",
+    "io.containerd.snapshotter.v1.native",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.grpc.v1.cri",
+    "io.containerd.tracing.processor.v1.otlp",
+]
+
+imports = ["/etc/containerd/config.d/*.toml"]
+
+[grpc]
+address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.transfer.v1.local"]
+max_concurrent_downloads = 10
+concurrent_layer_fetch_buffer = 0
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+snapshotter = "overlayfs"
+differ = "walking"
+{{#if (eq os.arch "aarch64")}}
+platform = "linux/arm64"
+{{else}}
+{{#if (eq os.arch "x86_64")}}
+platform = "linux/amd64"
+{{/if}}
+{{/if}}

--- a/packages/containerd-2.3/containerd-config-toml_k8s_containerd_sock
+++ b/packages/containerd-2.3/containerd-config-toml_k8s_containerd_sock
@@ -1,0 +1,77 @@
+[required-extensions]
+container-registry = "v1"
+container-runtime = "v1"
+kubernetes = "v1"
+std = { version = "v1", helpers = ["join_array", "default"]}
++++
+version = 3
+root = "/var/lib/containerd"
+state = "/run/containerd"
+disabled_plugins = [
+    "io.containerd.internal.v1.opt",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.snapshotter.v1.blockfile",
+    "io.containerd.snapshotter.v1.devmapper",
+    "io.containerd.snapshotter.v1.native",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.tracing.processor.v1.otlp",
+]
+
+imports = ["/etc/containerd/config.d/*.toml"]
+
+[grpc]
+address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.cri.v1.images"]
+use_local_image_pull = false
+
+# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
+[plugins."io.containerd.cri.v1.images".pinned_images]
+sandbox = "localhost/kubernetes/pause:0.1.0"
+
+[plugins."io.containerd.cri.v1.runtime"]
+device_ownership_from_security_context = {{default false settings.kubernetes.device-ownership-from-security-context}}
+enable_selinux = true
+{{#if settings.container-runtime.max-container-log-line-size}}
+max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-ports}}
+enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-icmp}}
+enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp}}
+{{/if}}
+
+[plugins."io.containerd.transfer.v1.local"]
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+{{#if settings.container-runtime.max-concurrent-unpacks}}
+max_concurrent_unpacks = {{settings.container-runtime.max-concurrent-unpacks}}
+{{/if}}
+concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+snapshotter = "overlayfs"
+differ = "walking"
+{{#if (eq os.arch "aarch64")}}
+platform = "linux/arm64"
+{{else}}
+{{#if (eq os.arch "x86_64")}}
+platform = "linux/amd64"
+{{/if}}
+{{/if}}
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
+SystemdCgroup = true
+
+[plugins."io.containerd.cri.v1.runtime".cni]
+bin_dirs = [ "/opt/cni/bin" ]
+conf_dir = "/etc/cni/net.d"
+
+[plugins."io.containerd.cri.v1.images".registry]
+config_path = "/etc/containerd/certs.d"

--- a/packages/containerd-2.3/containerd-config-toml_k8s_nvidia_containerd_sock
+++ b/packages/containerd-2.3/containerd-config-toml_k8s_nvidia_containerd_sock
@@ -1,0 +1,99 @@
+[required-extensions]
+container-registry = "v1"
+container-runtime = "v1"
+kubernetes = "v1"
+std = { version = "v1", helpers = ["join_array", "default"]}
++++
+version = 3
+root = "/var/lib/containerd"
+state = "/run/containerd"
+disabled_plugins = [
+    "io.containerd.internal.v1.opt",
+    "io.containerd.internal.v1.tracing",
+    "io.containerd.snapshotter.v1.blockfile",
+    "io.containerd.snapshotter.v1.devmapper",
+    "io.containerd.snapshotter.v1.native",
+    "io.containerd.snapshotter.v1.zfs",
+    "io.containerd.tracing.processor.v1.otlp",
+]
+
+imports = ["/etc/containerd/config.d/*.toml"]
+
+[grpc]
+address = "/run/containerd/containerd.sock"
+
+[plugins."io.containerd.cri.v1.images"]
+use_local_image_pull = false
+
+# Pause container image is specified here, shares the same image as kubelet's pod-infra-container-image
+[plugins."io.containerd.cri.v1.images".pinned_images]
+sandbox = "localhost/kubernetes/pause:0.1.0"
+
+[plugins."io.containerd.cri.v1.runtime"]
+device_ownership_from_security_context = {{default false settings.kubernetes.device-ownership-from-security-context}}
+enable_selinux = true
+{{#if settings.container-runtime.max-container-log-line-size}}
+max_container_log_line_size = {{settings.container-runtime.max-container-log-line-size}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-ports}}
+enable_unprivileged_ports = {{settings.container-runtime.enable-unprivileged-ports}}
+{{/if}}
+{{#if settings.container-runtime.enable-unprivileged-icmp}}
+enable_unprivileged_icmp = {{settings.container-runtime.enable-unprivileged-icmp}}
+{{/if}}
+
+[plugins."io.containerd.transfer.v1.local"]
+{{#if settings.container-runtime.max-concurrent-downloads}}
+max_concurrent_downloads = {{settings.container-runtime.max-concurrent-downloads}}
+{{/if}}
+{{#if settings.container-runtime.max-concurrent-unpacks}}
+max_concurrent_unpacks = {{settings.container-runtime.max-concurrent-unpacks}}
+{{/if}}
+concurrent_layer_fetch_buffer = {{default 0 settings.container-runtime.concurrent-download-chunk-size}}
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+snapshotter = "overlayfs"
+differ = "walking"
+{{#if (eq os.arch "aarch64")}}
+platform = "linux/arm64"
+{{else}}
+{{#if (eq os.arch "x86_64")}}
+platform = "linux/amd64"
+{{/if}}
+{{/if}}
+
+[plugins."io.containerd.cri.v1.runtime".containerd]
+default_runtime_name = "nvidia"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+# CDI only nvidia container runtime
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-cdi]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+# legacy only nvidia container runtime
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-legacy]
+runtime_type = "io.containerd.runc.v2"
+base_runtime_spec = "/etc/containerd/cri-base.json"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-cdi.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime.cdi"
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia-legacy.options]
+SystemdCgroup = true
+BinaryName = "nvidia-container-runtime.legacy"
+
+[plugins."io.containerd.cri.v1.runtime".cni]
+bin_dirs = [ "/opt/cni/bin" ]
+conf_dir = "/etc/cni/net.d"
+
+[plugins."io.containerd.cri.v1.images".registry]
+config_path = "/etc/containerd/certs.d"

--- a/packages/containerd-2.3/containerd-cri-base-json
+++ b/packages/containerd-2.3/containerd-cri-base-json
@@ -1,0 +1,164 @@
+[required-extensions]
+oci-defaults = { version = "v1", helpers = ["oci_defaults"] }
++++
+{
+    "ociVersion": "1.2.0",
+    "process": {
+        "user": {
+            "uid": 0,
+            "gid": 0
+        },
+        "cwd": "/",
+        {{~#if settings.oci-defaults.capabilities~}}
+        "capabilities": {
+            {{~oci_defaults "containerd" settings.oci-defaults.capabilities~}}
+        },
+        {{~/if~}}
+        {{~#if settings.oci-defaults.resource-limits~}}
+        "rlimits": [
+            {{~oci_defaults "containerd" settings.oci-defaults.resource-limits~}}
+        ],
+        {{~/if~}}
+        "noNewPrivileges": true
+    },
+    "root": {
+        "path": "rootfs"
+    },
+    "mounts": [
+        {
+            "destination": "/proc",
+            "type": "proc",
+            "source": "proc",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/dev",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/pts",
+            "type": "devpts",
+            "source": "devpts",
+            "options": [
+                "nosuid",
+                "noexec",
+                "newinstance",
+                "ptmxmode=0666",
+                "mode=0620",
+                "gid=5"
+            ]
+        },
+        {
+            "destination": "/dev/shm",
+            "type": "tmpfs",
+            "source": "shm",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "mode=1777",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/dev/mqueue",
+            "type": "mqueue",
+            "source": "mqueue",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev"
+            ]
+        },
+        {
+            "destination": "/sys",
+            "type": "sysfs",
+            "source": "sysfs",
+            "options": [
+                "nosuid",
+                "noexec",
+                "nodev",
+                "ro"
+            ]
+        },
+        {
+            "destination": "/run",
+            "type": "tmpfs",
+            "source": "tmpfs",
+            "options": [
+                "nosuid",
+                "strictatime",
+                "mode=755",
+                "size=65536k"
+            ]
+        },
+        {
+            "destination": "/usr/local/sbin/modprobe",
+            "source": "/usr/bin/kmod",
+            "options": [
+                "exec",
+                "bind",
+                "ro"
+            ]
+        }
+    ],
+    "linux": {
+        "resources": {
+            "devices": [
+                {
+                    "allow": false,
+                    "access": "rwm"
+                }
+            ]
+        },
+        "cgroupsPath": "/default",
+        "namespaces": [
+            {
+                "type": "pid"
+            },
+            {
+                "type": "ipc"
+            },
+            {
+                "type": "uts"
+            },
+            {
+                "type": "mount"
+            },
+            {
+                "type": "network"
+            }
+        ],
+        "maskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap",
+            "/proc/scsi"
+        ],
+        "readonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+        ]
+    }
+}

--- a/packages/containerd-2.3/containerd-disable-igzip.conf
+++ b/packages/containerd-2.3/containerd-disable-igzip.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=CONTAINERD_DISABLE_IGZIP=1

--- a/packages/containerd-2.3/containerd-disable-pigz.conf
+++ b/packages/containerd-2.3/containerd-disable-pigz.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=CONTAINERD_DISABLE_PIGZ=1

--- a/packages/containerd-2.3/containerd-tmpfiles.conf
+++ b/packages/containerd-2.3/containerd-tmpfiles.conf
@@ -1,0 +1,3 @@
+d /etc/cni/net.d - - - -
+d /etc/containerd/config.d - - - -
+L+ /opt/containerd/image-verifier - - - - ../civ

--- a/packages/containerd-2.3/containerd.service
+++ b/packages/containerd-2.3/containerd.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network-online.target configured.target
+Wants=network-online.target configured.target
+Requires=configure-snapshotter.service
+
+[Service]
+Slice=runtime.slice
+EnvironmentFile=/etc/network/proxy.env
+ExecStart=/usr/bin/containerd
+Type=notify
+Delegate=yes
+KillMode=process
+TimeoutSec=0
+RestartSec=2
+Restart=always
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/containerd-2.3/ephemeral-storage.conf
+++ b/packages/containerd-2.3/ephemeral-storage.conf
@@ -1,0 +1,2 @@
+# Contributed by containerd package
+/var/lib/containerd

--- a/packages/containerd-2.3/etc-containerd.mount
+++ b/packages/containerd-2.3/etc-containerd.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Containerd Configuration Directory (/etc/containerd)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/etc/containerd
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,mode=0750,context=system_u:object_r:etc_secret_t:s0
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/containerd-2.3/prepare-var-lib-containerd.service
+++ b/packages/containerd-2.3/prepare-var-lib-containerd.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Prepare Containerd Directory (/var/lib/containerd)
+DefaultDependencies=no
+RequiresMountsFor=/var
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+
+# Remove an existing symlink, if present. Intentionally not recursive!
+ExecStartPre=-/usr/bin/rm -f /var/lib/containerd
+
+# Create /var/lib/containerd so it is available for bind mounts.
+ExecStart=/usr/bin/mkdir -p /var/lib/containerd
+
+# Suppress warning if directory exists.
+StandardError=null
+
+RemainAfterExit=true
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/containerd-2.3/snapshotter-toml
+++ b/packages/containerd-2.3/snapshotter-toml
@@ -1,0 +1,26 @@
+[required-extensions]
+container-runtime = "v1"
+std = { version = "v1" }
++++
+{{#if settings.container-runtime.snapshotter}}
+{{#if (eq settings.container-runtime.snapshotter "soci" )}}
+[plugins."io.containerd.cri.v1.images"]
+snapshotter = "soci"
+
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+platform = "linux"
+snapshotter = "soci"
+
+# Plug soci snapshotter into containerd
+[proxy_plugins.soci]
+capabilities = ["remap-ids"]
+type = "snapshot"
+address = "/run/soci-snapshotter/soci-snapshotter.sock"
+[proxy_plugins.soci.exports]
+root = "/var/lib/soci-snapshotter"
+enable_remote_snapshot_annotations = "true"
+{{else}}
+[plugins."io.containerd.cri.v1.images"]
+snapshotter = "overlayfs"
+{{/if}}
+{{/if}}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Introduces containerd `2.3.4` as a new package. 2.3 is the first LTS in the 2.x line (supported to ~April 2028); containerd 2.2 goes EOL 2026-11-06, about a month after EKS 1.37 GA so the k8s-1.37 variants can't ship on it. No variant adopts it in this PR.

Upstream changelogs:
- [containerd 2.3.0](https://github.com/containerd/containerd/releases/tag/v2.3.0)
- [containerd 2.3.1](https://github.com/containerd/containerd/releases/tag/v2.3.1)
- [containerd 2.3.2](https://github.com/containerd/containerd/releases/tag/v2.3.2)
- [containerd 2.3.3](https://github.com/containerd/containerd/releases/tag/v2.3.3)
- [containerd 2.3.4](https://github.com/containerd/containerd/releases/tag/v2.3.4)

**Patch changes:** none. All three patches from `containerd-2.2` apply cleanly to 2.3.4 and carry forward unchanged.

**Other changes:** added `export GO_MAJOR="1.26"` to `%build` in the spec — containerd 2.3's `go.mod` declares `go 1.26.3`, newer than the SDK default.

**Testing done**

**1. Binary versions (verified on a running node):**

```
bash-5.2# containerd --version
containerd github.com/containerd/containerd/v2 2.3.4+bottlerocket db8809540e1a7a9da5d518876894933ff55692ab
bash-5.2# ctr --version
ctr github.com/containerd/containerd/v2 2.3.4+bottlerocket
```

**2. Conformance testing:** 26/26 variant/arch combos passing.

| Phase | Arch | Instance | Variants Tested | Result |
|-------|------|----------|-----------------|--------|
| A | x86_64 | m5.xlarge | aws-k8s-1.33, 1.33-fips, 1.34, 1.34-fips, 1.35, 1.35-fips, 1.36, 1.36-fips | ✅ All passing |
| B | aarch64 | m6g.xlarge | aws-k8s-1.33, 1.33-fips, 1.34, 1.34-fips, 1.35, 1.35-fips, 1.36, 1.36-fips | ✅ All passing |
| C | x86_64 | g5.xlarge / g4dn.xlarge | aws-k8s-1.33-nvidia, 1.34-nvidia, 1.35-nvidia, 1.36-nvidia, 1.36-nvidia-fips | ✅ All passing |
| D | aarch64 | g5g.2xlarge | aws-k8s-1.33-nvidia, 1.34-nvidia, 1.35-nvidia, 1.36-nvidia, 1.36-nvidia-fips | ✅ All passing |

<details><summary>Full conformance results per variant/arch</summary>

| Variant | Arch | K8s Version | Tests | Instance |
|---------|------|-------------|-------|----------|
| aws-k8s-1.33 | x86_64 | 1.33 | 421/421 | m5.xlarge |
| aws-k8s-1.33-fips | x86_64 | 1.33 | 421/421 | m5.xlarge |
| aws-k8s-1.33-nvidia | x86_64 | 1.33 | 421/421 | g5.xlarge |
| aws-k8s-1.34 | x86_64 | 1.34 | 426/426 | m5.xlarge |
| aws-k8s-1.34-fips | x86_64 | 1.34 | 426/426 | m5.xlarge |
| aws-k8s-1.34-nvidia | x86_64 | 1.34 | 426/426 | g4dn.xlarge |
| aws-k8s-1.35 | x86_64 | 1.35 | 444/444 | m5.xlarge |
| aws-k8s-1.35-fips | x86_64 | 1.35 | 444/444 | m5.xlarge |
| aws-k8s-1.35-nvidia | x86_64 | 1.35 | 444/444 | g4dn.xlarge |
| aws-k8s-1.36 | x86_64 | 1.36 | 451/451 | m5.xlarge |
| aws-k8s-1.36-fips | x86_64 | 1.36 | 451/451 | m5.xlarge |
| aws-k8s-1.36-nvidia | x86_64 | 1.36 | 451/451 | g5.xlarge |
| aws-k8s-1.36-nvidia-fips | x86_64 | 1.36 | 451/451 | g4dn.xlarge |
| aws-k8s-1.33 | aarch64 | 1.33 | 421/421 | m6g.xlarge |
| aws-k8s-1.33-fips | aarch64 | 1.33 | 421/421 | m6g.xlarge |
| aws-k8s-1.33-nvidia | aarch64 | 1.33 | 421/421 | g5g.2xlarge |
| aws-k8s-1.34 | aarch64 | 1.34 | 426/426 | m6g.xlarge |
| aws-k8s-1.34-fips | aarch64 | 1.34 | 426/426 | m6g.xlarge |
| aws-k8s-1.34-nvidia | aarch64 | 1.34 | 426/426 | g5g.2xlarge |
| aws-k8s-1.35 | aarch64 | 1.35 | 444/444 | m6g.xlarge |
| aws-k8s-1.35-fips | aarch64 | 1.35 | 444/444 | m6g.xlarge |
| aws-k8s-1.35-nvidia | aarch64 | 1.35 | 444/444 | g5g.2xlarge |
| aws-k8s-1.36 | aarch64 | 1.36 | 451/451 | m6g.xlarge |
| aws-k8s-1.36-fips | aarch64 | 1.36 | 451/451 | m6g.xlarge |
| aws-k8s-1.36-nvidia | aarch64 | 1.36 | 451/451 | g5g.2xlarge |
| aws-k8s-1.36-nvidia-fips | aarch64 | 1.36 | 451/451 | g5g.2xlarge |

A version-skew run (aws-k8s-1.36 nodes against a 1.37 beta control plane, `conformance:v1.37.0-beta.0`) also passed with 0 failures.

</details>

**3. Seccomp defaults ([containerd#13409](https://github.com/containerd/containerd/pull/13409)):**
containerd 2.3.1 hardened the default seccomp socket policy to block `AF_ALG`, and Bottlerocket's patch `1001` re-allows io_uring in that same code — so the two interact. We ran three probes on a 2.3.4 node and confirmed `AF_ALG` is blocked under `RuntimeDefault` (`errno=1`, EPERM), works under `Unconfined` (proving the block is seccomp-only, not kernel), and that `io_uring_setup(2)` still succeeds under `RuntimeDefault` (`fd=3`) — patch `1001` survives the rebase. Note this makes `AF_ALG` unavailable to `RuntimeDefault` workloads on 2.3+; upstream behavior, no BR patch re-allows it.

<details><summary>Probe results</summary>

```
t1a  AF_ALG, seccompProfile=RuntimeDefault  -> AF_ALG=BLOCKED errno=1
t1b  AF_ALG, seccompProfile=Unconfined      -> AF_ALG=OK
t1c  io_uring_setup(2), RuntimeDefault      -> IO_URING=OK fd=3
```

</details>

**4. Sandbox image resolution ([containerd#13759](https://github.com/containerd/containerd/pull/13759)):** containerd 2.3.4 normalizes sandbox image references, and Bottlerocket pins `sandbox = "localhost/kubernetes/pause:0.1.0"`, so the pinned local reference could have been rewritten. Confirmed it still resolves — the `io.cri-containerd.pinned` label shows CRI recognized it as the configured sandbox image, and `journalctl -u containerd` shows only local `ImageCreate`/`ImageUpdate` events with no registry pull attempts.

```
bash-5.2# ctr -n k8s.io images ls | grep pause
localhost/kubernetes/pause:0.1.0  ... io.cri-containerd.image=managed,io.cri-containerd.pinned=pinned
```

**5. CRI stats ([containerd#12629](https://github.com/containerd/containerd/pull/12629)):**
containerd 2.3.0 added a background collector that computes `UsageNanoCores` for the kubelet Summary API (relates to Kubernetes KEP-2371). Verified on a cgroup v2 node under a `stress --cpu 1 --vm 1 --vm-bytes 200M` pod that the field is populated with a plausible rate.

```
pod  cpu usageNanoCores : 1999589326   (~2 cores; --cpu 1 --vm 1 runs two busy workers)
pod  mem workingSetBytes:  147410944   (~140 MiB resident of the 200 MiB allocation)
node cpu usageNanoCores : 2033703578
```

**6. Shim lifecycle across a containerd restart ([#12786](https://github.com/containerd/containerd/pull/12786) bootstrap protocol, [#13803](https://github.com/containerd/containerd/pull/13803) start-response corruption, [#13857](https://github.com/containerd/containerd/pull/13857) orphaned shims):**
containerd 2.3.0 replaced the shim bootstrap mechanism and 2.3.4 carries two fixes to it, so shim re-adoption is new code on this path. Conformance never restarts containerd, so we tested it directly: with a single-container pod and a two-container pod pinned to one node, we restarted `containerd.service` and confirmed the shims survived and were re-adopted rather than recreated.

Note two Bottlerocket specifics: `containerd.service` sets `KillMode=process`, so systemd leaves the shim children running — that is the mechanism being exercised. And `kubelet.service` sets `BindsTo=containerd.service`, so kubelet restarts alongside containerd and the node is briefly `NotReady`; that is expected, not a regression.

<details><summary>Before / after on the node and from the cluster</summary>

containerd was restarted (MainPID `1844` → `3949`). All six shim PIDs are unchanged and their elapsed times grew continuously across the restart, i.e. the processes were never respawned:

```
PID    namespace / id            etimes BEFORE -> AFTER
1985   k8s.io  d50a1f98...            135 -> 145
1988   k8s.io  56ad3439...            135 -> 145
2365   default control                128 -> 139     (host-containerd, unaffected)
2427   default admin                  128 -> 138     (host-containerd, unaffected)
3172   k8s.io  c4c4957f...             88 ->  99
3179   k8s.io  3b434f42...             88 ->  99
shim count: 6 -> 6   (no orphans, none lost)
```

Container identity and restart counts unchanged, and the marker file written at container start still holds its original value — proving the same container filesystems, not recreated ones:

```
                 BEFORE                          AFTER
shim-a  app      restarts=0 id=7643f9d9d3d84bbe  restarts=0 id=7643f9d9d3d84bbe
shim-b  c1       restarts=0 id=89e322964c86a1f6  restarts=0 id=89e322964c86a1f6
shim-b  c2       restarts=0 id=d68963704071bb96  restarts=0 id=d68963704071bb96
/tmp/marker      original-1787769572             original-1787769572
```

`journalctl -u containerd` showed no load failures or protocol errors, and a pod created after the restart ran successfully (`post-restart-ok`), confirming containerd was left fully functional.
</details>

**7. SOCI snapshotter ([#13071](https://github.com/containerd/containerd/pull/13071)):**
containerd 2.3.0 began passing two additional labels to snapshotters when unpacking image layers —`containerd.io/snapshot/diff-id` and `containerd.io/snapshot/parent-chain-id`. Bottlerocket ships `soci-snapshotter` 0.15.0 as an **external proxy-snapshotter plugin** (separate process over gRPC), so that label contract is a cross-process interface which the compiler cannot check. SOCI is also opt-in (`settings.container-runtime.snapshotter = "soci"`, default `overlayfs`), so none of the tests above exercise it, and its failure mode is a **silent fallback to overlayfs** where pods still run and lazy loading is simply gone. Tested explicitly on a node booted with the SOCI setting.

<details><summary>SOCI verification</summary>

Setting applied and plugin healthy:

```
bash-5.2# cat /etc/containerd/selected-snapshotter
SELECTED_SNAPSHOTTER="soci"
bash-5.2# systemctl is-active soci-snapshotter
active
bash-5.2# ctr plugins ls | grep soci
io.containerd.snapshotter.v1    soci    linux/amd64    ok
```

The decisive check — SOCI served every snapshot and overlayfs served none, ruling out silent fallback:

```
bash-5.2# ctr -n k8s.io snapshot --snapshotter soci ls
KEY                                                                PARENT                     KIND
1041125a31414aee2d5b8c28a1198640853bdc5de8783fbfd396e741c4285205   sha256:fd8b371c477c...     Active
4d2d28a089bcafe987570b65796174b876703215075bdc745702d2c7a75012d0   sha256:1a4ca3b283ff...     Active
sha256:1a4ca3b283ff4b5a8b456ffe0d24e9f989457d36fcb7c18861ca0cb757dae144                       Committed
... (many more)

bash-5.2# ctr -n k8s.io snapshot --snapshotter overlayfs ls
KEY PARENT KIND        <-- empty
```

The test pod's sandbox is traceable to a SOCI-managed snapshot — containerd logged `RunPodSandbox for name:"soci-a" ... returns sandbox id "4d2d28a089bcafe98..."`, and that same ID appears as an `Active` snapshot in the soci list above.

Neither `journalctl -u soci-snapshotter` nor `journalctl -u containerd` reported any snapshot/label errors; containerd logged `Get image filesystem path "/var/lib/soci-snapshotter" for snapshotter "soci"`.

</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
