### PR TITLE
packages: add kubernetes-1.37 and ecr-credential-provider-1.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "kubernetes-1_34",
  "kubernetes-1_35",
  "kubernetes-1_36",
+ "kubernetes-1_37",
  "libacl",
  "libaio",
  "libattr",
@@ -548,6 +549,13 @@ dependencies = [
 
 [[package]]
 name = "kubernetes-1_36"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "kubernetes-1_37"
 version = "0.1.0"
 dependencies = [
  "glibc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "ecr-credential-provider-1_34",
  "ecr-credential-provider-1_35",
  "ecr-credential-provider-1_36",
+ "ecr-credential-provider-1_37",
  "ecs-agent",
  "ecs-gpu-init",
  "erofs-utils",
@@ -382,6 +383,13 @@ dependencies = [
 
 [[package]]
 name = "ecr-credential-provider-1_36"
+version = "0.1.0"
+dependencies = [
+ "glibc",
+]
+
+[[package]]
+name = "ecr-credential-provider-1_37"
 version = "0.1.0"
 dependencies = [
  "glibc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
   "packages/kubernetes-1.34",
   "packages/kubernetes-1.35",
   "packages/kubernetes-1.36",
+  "packages/kubernetes-1.37",
   "packages/libacl",
   "packages/libaio",
   "packages/libattr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
   "packages/ecr-credential-provider-1.34",
   "packages/ecr-credential-provider-1.35",
   "packages/ecr-credential-provider-1.36",
+  "packages/ecr-credential-provider-1.37",
   "packages/ecs-agent",
   "packages/ecs-gpu-init",
   "packages/erofs-utils",

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -44,6 +44,7 @@ ecr-credential-provider-1_33 = { path = "../../packages/ecr-credential-provider-
 ecr-credential-provider-1_34 = { path = "../../packages/ecr-credential-provider-1.34" }
 ecr-credential-provider-1_35 = { path = "../../packages/ecr-credential-provider-1.35" }
 ecr-credential-provider-1_36 = { path = "../../packages/ecr-credential-provider-1.36" }
+ecr-credential-provider-1_37 = { path = "../../packages/ecr-credential-provider-1.37" }
 ecs-agent = { path = "../../packages/ecs-agent" }
 ecs-gpu-init = { path = "../../packages/ecs-gpu-init" }
 erofs-utils = { path = "../../packages/erofs-utils" }

--- a/kits/bottlerocket-core-kit/Cargo.toml
+++ b/kits/bottlerocket-core-kit/Cargo.toml
@@ -66,6 +66,7 @@ kubernetes-1_33 = { path = "../../packages/kubernetes-1.33" }
 kubernetes-1_34 = { path = "../../packages/kubernetes-1.34" }
 kubernetes-1_35 = { path = "../../packages/kubernetes-1.35" }
 kubernetes-1_36 = { path = "../../packages/kubernetes-1.36" }
+kubernetes-1_37 = { path = "../../packages/kubernetes-1.37" }
 libacl = { path = "../../packages/libacl" }
 libaio = { path = "../../packages/libaio" }
 libattr = { path = "../../packages/libattr" }

--- a/packages/ecr-credential-provider-1.37/0001-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+++ b/packages/ecr-credential-provider-1.37/0001-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
@@ -1,0 +1,31 @@
+From 99df7b5980be2e66d2bbb32b405d24e0d64dbe85 Mon Sep 17 00:00:00 2001
+From: Sam Berning <bernings@amazon.com>
+Date: Fri, 7 Nov 2025 02:21:18 +0000
+Subject: [PATCH] ecr-credential-provider: hardcode ECR endpoint for
+ eusc-de-east-1
+
+Signed-off-by: Sam Berning <bernings@amazon.com>
+---
+ cmd/ecr-credential-provider/main.go | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/ecr-credential-provider/main.go b/cmd/ecr-credential-provider/main.go
+index b61bd789..15642223 100644
+--- a/cmd/ecr-credential-provider/main.go
++++ b/cmd/ecr-credential-provider/main.go
+@@ -75,7 +75,11 @@ func defaultECRProvider(ctx context.Context, region string) (ECR, error) {
+ 		return nil, err
+ 	}
+ 
+-	return ecr.NewFromConfig(cfg), nil
++	return ecr.NewFromConfig(cfg, func(o *ecr.Options) {
++		if region == "eusc-de-east-1" {
++			o.BaseEndpoint = aws.String("https://api.ecr.eusc-de-east-1.amazonaws.eu")
++		}
++	}), nil
+ }
+ 
+ func publicECRProvider(ctx context.Context) (ECRPublic, error) {
+-- 
+2.42.0
+

--- a/packages/ecr-credential-provider-1.37/Cargo.toml
+++ b/packages/ecr-credential-provider-1.37/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+# "." is not allowed in crate names, but we want a friendlier name for the
+# directory and spec file, so we override it below.
+name = "ecr-credential-provider-1_37"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+package-name = "ecr-credential-provider-1.37"
+releases-url = "https://github.com/kubernetes/cloud-provider-aws/releases"
+
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/kubernetes/cloud-provider-aws/archive/refs/tags/v1.37.0.tar.gz"
+sha512 = "920d83a1773788849bfa5e680f084d46b26c76526c01f3edf6c3ca18d2774244c1011531e5fe154f2acc90e1d53aae03ad6bccc2f4d1ef356f1df1879f212bef"
+path = "cloud-provider-aws-1.37.0.tar.gz"
+bundle-modules = [ "go" ]
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/ecr-credential-provider-1.37/clarify.toml
+++ b/packages/ecr-credential-provider-1.37/clarify.toml
@@ -1,0 +1,12 @@
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT AND BSD-3-Clause AND Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x617d80bc },
+]
+
+[clarify."github.com/grpc-ecosystem/go-grpc-middleware/v2"]
+expression = "Apache-2.0"
+license-files = [
+    { path = "COPYRIGHT", hash = 0x4bba7b1 },
+    { path = "LICENSE", hash = 0x6a39c900 }
+]

--- a/packages/ecr-credential-provider-1.37/ecr-credential-provider-1.37.spec
+++ b/packages/ecr-credential-provider-1.37/ecr-credential-provider-1.37.spec
@@ -1,0 +1,54 @@
+%global goproject github.com/kubernetes
+%global gorepo cloud-provider-aws
+%global goimport %{goproject}/%{gorepo}
+
+%global gover 1.37.0
+%global rpmver 1.37.0
+
+%global _dwz_low_mem_die_limit 0
+
+Name: %{_cross_os}ecr-credential-provider-1.37
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: Amazon ECR credential provider
+License: Apache-2.0
+URL: https://github.com/kubernetes/cloud-provider-aws
+
+Source: cloud-provider-aws-%{gover}.tar.gz
+Source1: bundled-cloud-provider-aws-%{gover}.tar.gz
+Source1000: clarify.toml
+
+Patch0001: 0001-ecr-credential-provider-hardcode-ECR-endpoint-for-eu.patch
+
+BuildRequires: %{_cross_os}glibc-devel
+
+# For IAM Roles Anywhere, the signing helper might be set as the credential
+# process.
+Requires: %{_cross_os}aws-signing-helper
+
+%description
+%{summary}.
+
+%prep
+%autosetup -Sgit -n %{gorepo}-%{gover} -p1
+%setup -T -D -n %{gorepo}-%{gover} -b 1 -q
+
+%build
+%set_cross_go_flags
+
+export GOTOOLCHAIN=local
+export GO_MAJOR="1.26"
+
+go build -ldflags="${GOLDFLAGS}" -o=ecr-credential-provider cmd/ecr-credential-provider/*.go
+
+%install
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
+install -p -m 0755 ecr-credential-provider %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet/plugins
+
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
+
+%files
+%license LICENSE
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+%{_cross_libexecdir}/kubernetes/kubelet/plugins/ecr-credential-provider

--- a/packages/kubernetes-1.37/.gitignore
+++ b/packages/kubernetes-1.37/.gitignore
@@ -1,0 +1,1 @@
+/*-EKS-PATCH-*.patch

--- a/packages/kubernetes-1.37/Cargo.toml
+++ b/packages/kubernetes-1.37/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+# "." is not allowed in crate names, but we want a friendlier name for the
+# directory and spec file, so we override it below.
+name = "kubernetes-1_37"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "../build.rs"
+
+[lib]
+path = "../packages.rs"
+
+[package.metadata.build-package]
+package-name = "kubernetes-1.37"
+
+[[package.metadata.build-package.external-files]]
+url = "https://distro.eks.amazonaws.com/kubernetes-1-37/releases/2/artifacts/kubernetes/v1.37.0/kubernetes-src.tar.gz"
+sha512 = "159d2804df070e83d0a7821bad32de47ab6332a96e20e6526799a4b44b9ab9225243696802769a8d0e5326ae06b6d5ba1a7f7785b1f41d9e5aa09e8546f7dc5a"
+
+[build-dependencies]
+glibc = { path = "../glibc" }

--- a/packages/kubernetes-1.37/clarify.toml
+++ b/packages/kubernetes-1.37/clarify.toml
@@ -1,0 +1,69 @@
+[clarify."github.com/JeffAshton/win_pdh"]
+expression = "BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0xb221dcc9 },
+]
+
+[clarify."github.com/daviddengcn/go-colortext"]
+expression = "BSD-3-Clause AND MIT"
+license-files = [
+    { path = "LICENSE", hash = 0x9769fae1 },
+]
+
+[clarify."github.com/ghodss/yaml"]
+expression = "MIT AND BSD-3-Clause"
+license-files = [
+    { path = "LICENSE", hash = 0xcdf3ae00 },
+]
+
+[clarify."github.com/heketi/heketi"]
+# kubernetes only uses code that is under LGPLv3+/Apache 2.0, not the code that is GPLv2+/LGPLv3+
+expression = "LGPL-3.0-or-later OR Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x3c4b96d1 },
+    { path = "LICENSE-APACHE2", hash = 0x438c8616 },
+    { path = "COPYING-LGPLV3", hash = 0xf0bccb3a },
+]
+skip-files = [ "COPYING-GPLV2" ]
+
+[clarify."github.com/go-bindata/go-bindata"]
+expression = "CC0-1.0"
+license-files = [
+    { path = "LICENSE", hash = 0x393fafd6 },
+]
+
+[clarify."github.com/miekg/dns"]
+expression = "BSD-3-Clause"
+license-files = [
+    { path = "COPYRIGHT", hash = 0xe41dd36c },
+    { path = "LICENSE", hash = 0xfc8f12ff },
+]
+
+[clarify."sigs.k8s.io/yaml"]
+expression = "MIT AND BSD-3-Clause AND Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x617d80bc },
+]
+
+[clarify."honnef.co/go/tools"]
+expression = "MIT AND BSD-3-Clause AND Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0xad378ed2 },
+    { path = "LICENSE-THIRD-PARTY", hash = 0x546425eb },
+    { path = "lint/LICENSE", hash = 0xc6b58232 },
+    { path = "ssa/LICENSE", hash = 0xe656fb62 },
+]
+
+[clarify."github.com/storageos/go-api"]
+expression = "MIT AND BSD-2-Clause"
+license-files = [
+    { path = "LICENCE", hash = 0x67a6861e },
+]
+skip-files = ["licence.go", "types/licence.go"]
+
+[clarify."github.com/grpc-ecosystem/go-grpc-middleware/v2"]
+expression = "Apache-2.0"
+license-files = [
+    { path = "COPYRIGHT", hash = 0x4bba7b1 },
+    { path = "LICENSE", hash = 0x6a39c900 },
+]

--- a/packages/kubernetes-1.37/credential-provider-config-yaml
+++ b/packages/kubernetes-1.37/credential-provider-config-yaml
@@ -1,0 +1,42 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes  = "v1"
+std = { version = "v1", helpers = ["default"] }
++++
+apiVersion: kubelet.config.k8s.io/v1
+kind: CredentialProviderConfig
+providers:
+{{#if settings.kubernetes.credential-providers}}
+{{#each settings.kubernetes.credential-providers}}
+{{#if this.enabled}}
+  - name: {{@key}}
+    matchImages:
+{{#each this.image-patterns}}
+      - "{{this}}"
+{{/each}}
+    defaultCacheDuration: "{{default "12h" this.cache-duration}}"
+    apiVersion: credentialprovider.kubelet.k8s.io/v1
+{{#if (eq @key "ecr-credential-provider")}}
+    env:
+{{else}}
+{{#if this.environment}}
+    env:
+{{/if}}
+{{/if}}
+{{#if this.environment}}
+{{#each this.environment}}
+      - name: {{@key}}
+        value: '{{this}}'
+{{/each}}
+{{/if}}
+{{#if (eq @key "ecr-credential-provider")}}
+      - name: HOME
+        value: '/root'
+{{#if @root.settings.aws.profile}}
+      - name: AWS_PROFILE
+        value: '{{@root.settings.aws.profile}}'
+{{/if}}
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}

--- a/packages/kubernetes-1.37/dockershim-symlink.conf
+++ b/packages/kubernetes-1.37/dockershim-symlink.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/ln -sf ./containerd/containerd.sock /run/dockershim.sock

--- a/packages/kubernetes-1.37/ephemeral-storage.conf
+++ b/packages/kubernetes-1.37/ephemeral-storage.conf
@@ -1,0 +1,3 @@
+# Contributed by kubelet package
+/var/lib/kubelet
+/var/log/pods

--- a/packages/kubernetes-1.37/etc-kubernetes-pki-private.mount
+++ b/packages/kubernetes-1.37/etc-kubernetes-pki-private.mount
@@ -1,0 +1,16 @@
+[Unit]
+Description=Kubernetes PKI private directory (/etc/kubernetes/pki/private)
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=selinux-policy-files.service
+Wants=selinux-policy-files.service
+
+[Mount]
+What=tmpfs
+Where=/etc/kubernetes/pki/private
+Type=tmpfs
+Options=nosuid,nodev,noexec,noatime,context=system_u:object_r:etc_secret_t:s0,mode=0700
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/kubernetes-1.37/kubelet-bootstrap-kubeconfig
+++ b/packages/kubernetes-1.37/kubelet-bootstrap-kubeconfig
@@ -1,0 +1,25 @@
+[required-extensions]
+kubernetes = "v1"
++++
+---
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+{{#if settings.kubernetes.api-server}}
+    certificate-authority: "/etc/kubernetes/pki/ca.crt"
+    server: "{{settings.kubernetes.api-server}}"
+{{/if}}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+{{#if settings.kubernetes.bootstrap-token}}
+  user:
+    token: "{{settings.kubernetes.bootstrap-token}}"
+{{/if}}

--- a/packages/kubernetes-1.37/kubelet-config
+++ b/packages/kubernetes-1.37/kubelet-config
@@ -1,0 +1,228 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["kube_reserve_cpu", "kube_reserve_memory"] }
+std = { version = "v1", helpers = ["any_enabled", "if_not_null", "default"] }
++++
+---
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+{{#if settings.kubernetes.standalone-mode}}
+address: 127.0.0.1
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
+{{else}}
+address: 0.0.0.0
+authentication:
+  anonymous:
+    enabled: false
+  webhook:
+    cacheTTL: 2m0s
+    enabled: true
+  x509:
+    clientCAFile: "/etc/kubernetes/pki/ca.crt"
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 5m0s
+    cacheUnauthorizedTTL: 30s
+{{/if}}
+clusterDomain: {{settings.kubernetes.cluster-domain}}
+{{#if settings.kubernetes.cluster-dns-ip}}
+clusterDNS:
+{{#each settings.kubernetes.cluster-dns-ip}}
+- {{this}}
+{{else}}
+- {{settings.kubernetes.cluster-dns-ip}}
+{{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-hard}}
+evictionHard:
+  {{#each settings.kubernetes.eviction-hard}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-soft}}
+evictionSoft:
+  {{#each settings.kubernetes.eviction-soft}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-soft-grace-period}}
+evictionSoftGracePeriod:
+  {{#each settings.kubernetes.eviction-soft-grace-period}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{/if}}
+{{#if settings.kubernetes.eviction-max-pod-grace-period}}
+evictionMaxPodGracePeriod: {{settings.kubernetes.eviction-max-pod-grace-period}}
+{{/if}}
+{{#if settings.kubernetes.allowed-unsafe-sysctls}}
+allowedUnsafeSysctls: {{settings.kubernetes.allowed-unsafe-sysctls}}
+{{/if}}
+{{#if settings.kubernetes.registry-qps includeZero=true}}
+registryPullQPS: {{settings.kubernetes.registry-qps}}
+{{/if}}
+{{#if settings.kubernetes.registry-burst includeZero=true}}
+registryBurst: {{settings.kubernetes.registry-burst}}
+{{/if}}
+{{#if settings.kubernetes.event-qps includeZero=true}}
+eventRecordQPS: {{settings.kubernetes.event-qps}}
+{{/if}}
+{{#if settings.kubernetes.event-burst includeZero=true}}
+eventBurst: {{settings.kubernetes.event-burst}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-qps includeZero=true}}
+kubeAPIQPS: {{settings.kubernetes.kube-api-qps}}
+{{/if}}
+{{#if settings.kubernetes.kube-api-burst includeZero=true}}
+kubeAPIBurst: {{settings.kubernetes.kube-api-burst}}
+{{/if}}
+kubeReserved:
+  cpu: "{{kube_reserve_cpu settings.kubernetes.kube-reserved.cpu}}"
+  {{#if settings.kubernetes.kube-reserved.memory}}
+  memory: "{{settings.kubernetes.kube-reserved.memory}}"
+  {{else}}
+  {{#if settings.kubernetes.max-pods}}
+  memory: "{{kube_reserve_memory settings.kubernetes.max-pods settings.kubernetes.kube-reserved.memory}}"
+  {{/if}}
+  {{/if}}
+  ephemeral-storage: "{{default "1Gi" settings.kubernetes.kube-reserved.ephemeral-storage}}"
+  {{#if settings.kubernetes.kube-reserved.pid}}
+  pid: "{{settings.kubernetes.kube-reserved.pid}}"
+  {{/if}}
+{{#unless settings.kubernetes.reserved-cpus}}
+kubeReservedCgroup: "/runtime"
+{{/unless}}
+{{#if settings.kubernetes.system-reserved}}
+systemReserved:
+  {{#each settings.kubernetes.system-reserved}}
+  {{@key}}: "{{this}}"
+  {{/each}}
+{{#unless settings.kubernetes.reserved-cpus}}
+systemReservedCgroup: "/system"
+{{/unless}}
+{{/if}}
+cpuCFSQuota: {{default true settings.kubernetes.cpu-cfs-quota-enforced}}
+cpuManagerPolicy: {{default "none" settings.kubernetes.cpu-manager-policy}}
+{{#if settings.kubernetes.cpu-manager-reconcile-period}}
+cpuManagerReconcilePeriod: {{settings.kubernetes.cpu-manager-reconcile-period}}
+{{/if}}
+{{#if settings.kubernetes.cpu-manager-policy-options}}
+cpuManagerPolicyOptions:
+{{#each settings.kubernetes.cpu-manager-policy-options}}
+    {{this}}: "true"
+{{/each}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-scope}}
+topologyManagerScope: {{settings.kubernetes.topology-manager-scope}}
+{{/if}}
+{{#if settings.kubernetes.topology-manager-policy}}
+topologyManagerPolicy: {{settings.kubernetes.topology-manager-policy}}
+{{/if}}
+podPidsLimit: {{default 1048576 settings.kubernetes.pod-pids-limit}}
+{{#if settings.kubernetes.image-gc-high-threshold-percent includeZero=true}}
+imageGCHighThresholdPercent: {{settings.kubernetes.image-gc-high-threshold-percent}}
+{{/if}}
+{{#if settings.kubernetes.image-gc-low-threshold-percent includeZero=true}}
+imageGCLowThresholdPercent: {{settings.kubernetes.image-gc-low-threshold-percent}}
+{{/if}}
+{{#if settings.kubernetes.provider-id}}
+providerID: {{settings.kubernetes.provider-id}}
+{{/if}}
+resolvConf: "/run/netdog/resolv.conf"
+hairpinMode: hairpin-veth
+readOnlyPort: 0
+cgroupDriver: systemd
+cgroupRoot: "/"
+runtimeRequestTimeout: 15m
+protectKernelDefaults: true
+serializeImagePulls: false
+seccompDefault: {{default false settings.kubernetes.seccomp-default}}
+{{#if (and (default "" settings.kubernetes.server-certificate) (default "" settings.kubernetes.server-key))}}
+tlsCertFile: "/etc/kubernetes/pki/kubelet-server.crt"
+tlsPrivateKeyFile: "/etc/kubernetes/pki/private/kubelet-server.key"
+{{else}}
+serverTLSBootstrap: {{settings.kubernetes.server-tls-bootstrap}}
+{{/if}}
+tlsCipherSuites:
+- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+volumePluginDir: "/var/lib/kubelet/plugins/volume/exec"
+maxPods: {{default 110 settings.kubernetes.max-pods}}
+{{#if_not_null settings.kubernetes.static-pods-enabled}}
+{{#if settings.kubernetes.static-pods-enabled}}
+staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if}}
+{{else}}
+staticPodPath: "/etc/kubernetes/static-pods/"
+{{/if_not_null}}
+{{#if settings.kubernetes.container-log-max-size includeZero=true}}
+containerLogMaxSize: {{settings.kubernetes.container-log-max-size}}
+{{/if}}
+{{#if settings.kubernetes.container-log-max-files includeZero=true}}
+containerLogMaxFiles: {{settings.kubernetes.container-log-max-files}}
+{{/if}}
+{{#if settings.kubernetes.container-log-max-workers includeZero=true}}
+containerLogMaxWorkers: {{settings.kubernetes.container-log-max-workers}}
+{{/if}}
+{{#if settings.kubernetes.container-log-monitor-interval}}
+containerLogMonitorInterval: {{settings.kubernetes.container-log-monitor-interval}}
+{{/if}}
+{{#if settings.kubernetes.shutdown-grace-period}}
+shutdownGracePeriod: {{settings.kubernetes.shutdown-grace-period}}
+{{/if}}
+{{#if settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+shutdownGracePeriodCriticalPods: {{settings.kubernetes.shutdown-grace-period-for-critical-pods}}
+{{/if}}
+{{#if settings.kubernetes.memory-manager-reserved-memory}}
+{{#if (any_enabled settings.kubernetes.memory-manager-reserved-memory)}}
+{{#if settings.kubernetes.memory-manager-policy}}
+memoryManagerPolicy: {{settings.kubernetes.memory-manager-policy}}
+{{/if}}
+reservedMemory:
+{{#each settings.kubernetes.memory-manager-reserved-memory}}
+{{#if this.enabled}}
+  - numaNode: {{@key}}
+    limits:
+{{#if this.memory}}
+      memory: {{this.memory}}
+{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}
+{{/if}}
+{{#if settings.kubernetes.reserved-cpus}}
+reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
+{{/if}}
+failSwapOn: false
+failCgroupV1: false
+{{#if settings.kubernetes.memory-swap-behavior}}
+memorySwap:
+  swapBehavior: {{settings.kubernetes.memory-swap-behavior}}
+{{/if}}
+{{#if settings.kubernetes.single-process-oom-kill}}
+singleProcessOOMKill: {{settings.kubernetes.single-process-oom-kill}}
+{{/if}}
+{{#if settings.kubernetes.image-minimum-gc-age}}
+imageMinimumGCAge: {{settings.kubernetes.image-minimum-gc-age}}
+{{/if}}
+{{#if settings.kubernetes.image-maximum-gc-age}}
+imageMaximumGCAge: {{settings.kubernetes.image-maximum-gc-age}}
+{{/if}}
+{{#if settings.kubernetes.ids-per-pod}}
+idsPerPod: {{settings.kubernetes.ids-per-pod}}
+{{/if}}
+{{#if settings.kubernetes.max-parallel-image-pulls}}
+maxParallelImagePulls: {{settings.kubernetes.max-parallel-image-pulls}}
+{{/if}}
+featureGates:
+  DynamicResourceAllocation: true
+  MutableCSINodeAllocatableCount: true

--- a/packages/kubernetes-1.37/kubelet-config
+++ b/packages/kubernetes-1.37/kubelet-config
@@ -199,6 +199,12 @@ reservedMemory:
 {{/each}}
 {{/if}}
 {{/if}}
+{{#if settings.kubernetes.memory-reservation-policy}}
+memoryReservationPolicy: {{settings.kubernetes.memory-reservation-policy}}
+{{/if}}
+{{#if settings.kubernetes.memory-throttling-factor}}
+memoryThrottlingFactor: {{settings.kubernetes.memory-throttling-factor}}
+{{/if}}
 {{#if settings.kubernetes.reserved-cpus}}
 reservedSystemCPUs: {{settings.kubernetes.reserved-cpus}}
 {{/if}}

--- a/packages/kubernetes-1.37/kubelet-env
+++ b/packages/kubernetes-1.37/kubelet-env
@@ -1,0 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["join_node_taints"] }
+std = { version = "v1", helpers = ["join_map"] }
++++
+NODE_IP={{settings.kubernetes.node-ip}}
+NODE_LABELS={{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
+NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}

--- a/packages/kubernetes-1.37/kubelet-env-nvidia
+++ b/packages/kubernetes-1.37/kubelet-env-nvidia
@@ -1,0 +1,7 @@
+[required-extensions]
+kubernetes = { version = "v1", helpers = ["join_node_taints"] }
+std = { version = "v1", helpers = ["join_map"] }
++++
+NODE_IP={{settings.kubernetes.node-ip}}
+NODE_LABELS=nvidia.com/gpu.present=true,{{join_map "=" "," "no-fail-if-missing" settings.kubernetes.node-labels}}
+NODE_TAINTS={{join_node_taints settings.kubernetes.node-taints}}

--- a/packages/kubernetes-1.37/kubelet-exec-start-conf
+++ b/packages/kubernetes-1.37/kubelet-exec-start-conf
@@ -1,0 +1,37 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["any_enabled", "default"] }
++++
+[Service]
+ExecStart=
+ExecStart=/usr/bin/kubelet \
+{{#unless settings.kubernetes.standalone-mode}}
+    --cloud-provider {{default "external" settings.kubernetes.cloud-provider}} \
+    --kubeconfig /etc/kubernetes/kubelet/kubeconfig \
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
+    --bootstrap-kubeconfig /etc/kubernetes/kubelet/bootstrap-kubeconfig \
+{{/if}}
+{{else}}
+    --cloud-provider "" \
+{{/unless}}
+    --config /etc/kubernetes/kubelet/config \
+    --container-runtime-endpoint={{default "unix:///run/containerd/containerd.sock" settings.kubernetes.container-runtime-endpoint}} \
+    --root-dir /var/lib/kubelet \
+    --cert-dir /var/lib/kubelet/pki \
+{{#if settings.kubernetes.credential-providers}}
+{{#if (any_enabled settings.kubernetes.credential-providers)}}
+    --image-credential-provider-bin-dir /usr/libexec/kubernetes/kubelet/plugins \
+    --image-credential-provider-config /etc/kubernetes/kubelet/credential-provider-config.yaml \
+{{/if}}
+{{/if}}
+{{#if settings.kubernetes.hostname-override}}
+    --hostname-override {{settings.kubernetes.hostname-override}} \
+{{/if}}
+    --node-ip ${NODE_IP} \
+    --node-labels "${NODE_LABELS}" \
+    --register-with-taints "${NODE_TAINTS}" \
+{{#if settings.kubernetes.log-level includeZero=true}}
+    -v {{settings.kubernetes.log-level}} \
+{{/if}}
+    --config-dir=/etc/kubernetes/kubelet/config.d \
+    --runtime-cgroups=/runtime.slice/containerd.service

--- a/packages/kubernetes-1.37/kubelet-kubeconfig
+++ b/packages/kubernetes-1.37/kubelet-kubeconfig
@@ -1,0 +1,43 @@
+[required-extensions]
+aws = { version = "v1", optional = true }
+kubernetes = "v1"
++++
+---
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+{{#if settings.kubernetes.api-server}}
+    certificate-authority: "/etc/kubernetes/pki/ca.crt"
+    server: "{{settings.kubernetes.api-server}}"
+{{/if}}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubelet
+  name: kubelet
+current-context: kubelet
+users:
+- name: kubelet
+{{#if (eq settings.kubernetes.authentication-mode "aws")}}
+{{#if settings.kubernetes.cluster-name}}
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: "/usr/bin/aws-iam-authenticator"
+      args:
+      - token
+      - "-i"
+      - "{{settings.kubernetes.cluster-name}}"
+      {{#if settings.aws.region}}
+      - "--region"
+      - "{{settings.aws.region}}"
+      {{/if}}
+{{/if}}
+{{/if}}
+{{#if (eq settings.kubernetes.authentication-mode "tls")}}
+  user:
+    client-certificate: "/var/lib/kubelet/pki/kubelet-client-current.pem"
+    client-key: "/var/lib/kubelet/pki/kubelet-client-current.pem"
+{{/if}}

--- a/packages/kubernetes-1.37/kubelet-server-crt
+++ b/packages/kubernetes-1.37/kubelet-server-crt
@@ -1,0 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
+{{~#if settings.kubernetes.server-certificate~}}
+{{base64_decode settings.kubernetes.server-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.37/kubelet-server-key
+++ b/packages/kubernetes-1.37/kubelet-server-key
@@ -1,0 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
+{{~#if settings.kubernetes.server-key~}}
+{{base64_decode settings.kubernetes.server-key}}
+{{~/if~}}

--- a/packages/kubernetes-1.37/kubelet-sysctl.conf
+++ b/packages/kubernetes-1.37/kubelet-sysctl.conf
@@ -1,0 +1,8 @@
+# Overcommit handling mode - 1: Always overcommit
+vm.overcommit_memory = 1
+
+# Reserve well-known EKS add-on ports to prevent containerd's CRI streaming
+# server from grabbing them via ephemeral port assignment (stream_server_port=0).
+# This is a guardrail for environments where ip_local_port_range has been widened.
+# Explicit binds by add-on pods are unaffected.
+net.ipv4.ip_local_reserved_ports = 2703,9808,9809,10249,10250,10256,61678,61679

--- a/packages/kubernetes-1.37/kubelet.service
+++ b/packages/kubernetes-1.37/kubelet.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Kubelet
+Documentation=https://github.com/kubernetes/kubernetes
+After=containerd.service configured.target
+Wants=configured.target
+BindsTo=containerd.service
+
+[Service]
+Slice=runtime.slice
+Type=notify
+EnvironmentFile=/etc/network/proxy.env
+EnvironmentFile=/etc/kubernetes/kubelet/env
+ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
+# Must be overridden by a drop-in file or `kubelet` won't start
+ExecStart=/usr/bin/false
+
+Restart=always
+RestartForceExitStatus=SIGPIPE
+RestartSec=5
+Delegate=yes
+KillMode=process
+CPUAccounting=true
+MemoryAccounting=true
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/kubernetes-1.37/kubernetes-1.37.spec
+++ b/packages/kubernetes-1.37/kubernetes-1.37.spec
@@ -1,0 +1,232 @@
+# After this upstream change, the linker flags `-s -w` are always added unless
+# DBG=1 is set in the environment, which would set compiler flags to disable
+# optimizations and inlining:
+#  https://github.com/kubernetes/kubernetes/pull/108371
+#
+# For now, work around this by indicating that no debug package is expected.
+%global debug_package %{nil}
+
+%global goproject github.com/kubernetes
+%global gorepo kubernetes
+%global goimport %{goproject}/%{gorepo}
+
+%global releasever 2
+%global gover 1.37.0
+%global rpmver %{gover}
+
+%global _dwz_low_mem_die_limit 0
+
+# Construct reproducible tar archives
+# See https://reproducible-builds.org/docs/archives/
+%global source_date_epoch 1234567890
+%global tar_cf tar --sort=name --mtime="@%{source_date_epoch}" --owner=0 --group=0 --numeric-owner -cf
+
+# The kubernetes build process expects the cross-compiler to be specified via `KUBE_*_CC`
+# Here we generate that variable to use bottlerocket-specific compile aliases
+# Examples of the generated variable:
+# KUBE_LINUX_AMD64_CC=x86_64-bottlerocket-linux-gnu-gcc
+# KUBE_LINUX_ARM64_CC=aarch64-bottlerocket-linux-gnu-gcc
+%global kube_cc %{shrink: \
+  %{lua: print(string.upper( \
+     rpm.expand("KUBE_%{_cross_go_os}_%{_cross_go_arch}_CC=")) .. \
+     rpm.expand("%{_cross_target}-gcc")) }}
+
+Name: %{_cross_os}%{gorepo}
+Version: %{rpmver}
+Release: 1%{?dist}
+Summary: Container cluster management
+# base Apache-2.0, third_party Apache-2.0 AND BSD-3-Clause
+License: Apache-2.0 AND BSD-3-Clause
+URL: https://%{goimport}
+Source0: https://distro.eks.amazonaws.com/kubernetes-1-37/releases/%{releasever}/artifacts/kubernetes/v%{gover}/kubernetes-src.tar.gz
+Source1: kubelet.service
+Source2: kubelet-env
+Source3: kubelet-config
+Source4: kubelet-kubeconfig
+Source5: kubernetes-ca-crt
+Source6: kubelet-exec-start-conf
+Source7: kubelet-bootstrap-kubeconfig
+Source8: kubernetes-tmpfiles.conf
+Source9: kubelet-sysctl.conf
+Source10: prepare-var-lib-kubelet.service
+Source11: kubelet-server-crt
+Source12: kubelet-server-key
+Source13: etc-kubernetes-pki-private.mount
+Source14: credential-provider-config-yaml
+Source15: logdog.kubelet.conf
+Source16: multi-user-uphold-kubelet.conf
+Source17: kubelet-env-nvidia
+Source18: ephemeral-storage.conf
+
+# ExecStartPre drop-ins
+Source20: prestart-load-pause-ctr.conf
+Source21: dockershim-symlink.conf
+Source22: make-kubelet-dirs.conf
+
+# pause image components
+Source100: pause-config.json
+Source101: pause-manifest.json
+Source102: pod-infra-container-image
+
+
+Source1000: clarify.toml
+
+BuildRequires: git
+BuildRequires: rsync
+BuildRequires: %{_cross_os}glibc-devel
+
+%description
+%{summary}.
+
+%package -n %{_cross_os}kubelet-1.37
+Summary: Container cluster node agent
+Requires: %{_cross_os}conntrack-tools
+Requires: %{_cross_os}containerd
+Requires: %{_cross_os}findutils
+Requires: %{_cross_os}ecr-credential-provider-1.37
+Requires: %{_cross_os}aws-iam-authenticator
+Requires: %{_cross_os}static-pods
+
+%description -n %{_cross_os}kubelet-1.37
+%{summary}.
+
+%package -n %{_cross_os}kube-proxy-1.37
+Summary: Container cluster node proxy
+Requires: %{_cross_os}kubelet-1.37
+
+%description -n %{_cross_os}kube-proxy-1.37
+%{summary}.
+
+%prep
+%autosetup -Sgit -c -n %{gorepo}-%{gover} -p1
+
+# third_party licenses
+# multiarch/qemu-user-static ignored, we're not using it
+cp third_party/forked/gonum/graph/LICENSE LICENSE.gonum.graph
+cp third_party/forked/shell2junit/LICENSE LICENSE.shell2junit
+cp third_party/forked/golang/LICENSE LICENSE.golang
+cp third_party/forked/golang/PATENTS PATENTS.golang
+
+%build
+export FORCE_HOST_GO=1
+export GO_MAJOR="1.26"
+
+# Build codegen programs with the host toolchain.
+make hack/update-codegen.sh
+
+# Build kubelet and kube-proxy with the target toolchain.
+%set_cross_go_flags
+unset CC
+export KUBE_BUILD_PLATFORMS="linux/%{_cross_go_arch}"
+export %{kube_cc}
+export GOFLAGS="${GOFLAGS} -tags=dockerless"
+export GOLDFLAGS="${GOLDFLAGS}"
+# don't build kube-proxy statically as we use linkermode=external which requires CGO
+export KUBE_CGO_OVERRIDES="kube-proxy"
+make WHAT="cmd/kubelet"
+make WHAT="cmd/kube-proxy"
+
+# build the pause container
+cd build/pause/linux/
+
+# Build static pause executable for container image.
+mkdir -p rootfs/usr/bin
+%{_cross_triple}-musl-gcc %{_cross_cflags} %{_cross_ldflags} -static-pie pause.c -o rootfs/pause
+
+# Construct container image.
+mkdir -p image/rootfs
+%tar_cf image/rootfs/layer.tar -C rootfs .
+DIGEST=$(sha256sum image/rootfs/layer.tar | sed -e 's/ .*//')
+install -m 0644 %{S:100} image/config.json
+sed -i "s/~~digest~~/${DIGEST}/" image/config.json
+install -m 0644 %{S:101} image/manifest.json
+
+%tar_cf ../../../_output/local/bin/linux/%{_cross_go_arch}/kubernetes-pause.tar -C image .
+
+%install
+output="./_output/local/bin/linux/%{_cross_go_arch}"
+install -d %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kubelet %{buildroot}%{_cross_bindir}
+install -p -m 0755 ${output}/kube-proxy %{buildroot}%{_cross_bindir}
+
+install -d %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:1} %{S:10} %{S:13} %{buildroot}%{_cross_unitdir}
+
+install -d %{buildroot}%{_cross_unitdir}/multi-user.target.d
+install -p -m 0644 %{S:16} %{buildroot}%{_cross_unitdir}/multi-user.target.d/10-kubelet-service.conf
+
+install -d %{buildroot}%{_cross_unitdir}/kubelet.service.d
+install -p -m 0644 %{S:20} %{S:21} %{S:22} %{buildroot}%{_cross_unitdir}/kubelet.service.d
+
+mkdir -p %{buildroot}%{_cross_templatedir}
+install -m 0644 %{S:2} %{buildroot}%{_cross_templatedir}/kubelet-env
+install -m 0644 %{S:17} %{buildroot}%{_cross_templatedir}/kubelet-env-nvidia
+install -m 0644 %{S:3} %{buildroot}%{_cross_templatedir}/kubelet-config
+install -m 0644 %{S:4} %{buildroot}%{_cross_templatedir}/kubelet-kubeconfig
+install -m 0644 %{S:5} %{buildroot}%{_cross_templatedir}/kubernetes-ca-crt
+install -m 0644 %{S:6} %{buildroot}%{_cross_templatedir}/kubelet-exec-start-conf
+install -m 0644 %{S:7} %{buildroot}%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
+install -m 0644 %{S:11} %{buildroot}%{_cross_templatedir}/kubelet-server-crt
+install -m 0644 %{S:12} %{buildroot}%{_cross_templatedir}/kubelet-server-key
+install -m 0644 %{S:14} %{buildroot}%{_cross_templatedir}/credential-provider-config-yaml
+
+install -d %{buildroot}%{_cross_tmpfilesdir}
+install -p -m 0644 %{S:8} %{buildroot}%{_cross_tmpfilesdir}/kubernetes.conf
+
+install -d %{buildroot}%{_cross_sysctldir}
+install -p -m 0644 %{S:9} %{buildroot}%{_cross_sysctldir}/90-kubelet.conf
+
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes
+ln -rs \
+  %{buildroot}%{_sharedstatedir}/kubelet/plugins \
+  %{buildroot}%{_cross_libexecdir}/kubernetes/kubelet-plugins
+
+%cross_scan_attribution --clarify %{S:1000} go-vendor vendor
+
+install -d %{buildroot}%{_cross_datadir}/logdog.d
+install -p -m 0644 %{S:15} %{buildroot}%{_cross_datadir}/logdog.d
+
+install -D -p -m 0644 %{S:18} %{buildroot}%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
+
+install -d %{buildroot}%{_cross_libexecdir}/kubernetes
+install -p -m 0644 ${output}/kubernetes-pause.tar %{buildroot}%{_cross_libexecdir}/kubernetes
+install -p -m 0644 %{S:102} %{buildroot}%{_cross_templatedir}/pod-infra-container-image
+
+%files -n %{_cross_os}kubelet-1.37
+%license LICENSE LICENSE.gonum.graph LICENSE.shell2junit LICENSE.golang PATENTS.golang
+%{_cross_attribution_file}
+%{_cross_attribution_vendor_dir}
+%{_cross_unitdir}/kubelet.service
+%{_cross_unitdir}/prepare-var-lib-kubelet.service
+%{_cross_unitdir}/etc-kubernetes-pki-private.mount
+%dir %{_cross_unitdir}/kubelet.service.d
+%{_cross_unitdir}/kubelet.service.d/prestart-load-pause-ctr.conf
+%{_cross_unitdir}/kubelet.service.d/make-kubelet-dirs.conf
+%{_cross_unitdir}/kubelet.service.d/dockershim-symlink.conf
+%dir %{_cross_unitdir}/multi-user.target.d
+%{_cross_unitdir}/multi-user.target.d/10-kubelet-service.conf
+%dir %{_cross_templatedir}
+%{_cross_templatedir}/kubelet-env
+%{_cross_templatedir}/kubelet-env-nvidia
+%{_cross_templatedir}/kubelet-config
+%{_cross_templatedir}/pod-infra-container-image
+%{_cross_templatedir}/kubelet-kubeconfig
+%{_cross_templatedir}/kubelet-bootstrap-kubeconfig
+%{_cross_templatedir}/kubelet-exec-start-conf
+%{_cross_templatedir}/kubernetes-ca-crt
+%{_cross_templatedir}/kubelet-server-crt
+%{_cross_templatedir}/kubelet-server-key
+%{_cross_templatedir}/credential-provider-config-yaml
+%{_cross_tmpfilesdir}/kubernetes.conf
+%{_cross_sysctldir}/90-kubelet.conf
+%dir %{_cross_libexecdir}/kubernetes
+%{_cross_libexecdir}/kubernetes/kubelet-plugins
+%{_cross_libexecdir}/kubernetes/kubernetes-pause.tar
+%{_cross_datadir}/logdog.d/logdog.kubelet.conf
+%{_cross_libdir}/bottlerocket/ephemeral-storage.d/kubelet.conf
+%{_cross_bindir}/kubelet
+
+%files -n %{_cross_os}kube-proxy-1.37
+%{_cross_bindir}/kube-proxy
+
+%changelog

--- a/packages/kubernetes-1.37/kubernetes-ca-crt
+++ b/packages/kubernetes-1.37/kubernetes-ca-crt
@@ -1,0 +1,7 @@
+[required-extensions]
+kubernetes = "v1"
+std = { version = "v1", helpers = ["base64_decode"] }
++++
+{{~#if settings.kubernetes.cluster-certificate~}}
+{{base64_decode settings.kubernetes.cluster-certificate}}
+{{~/if~}}

--- a/packages/kubernetes-1.37/kubernetes-tmpfiles.conf
+++ b/packages/kubernetes-1.37/kubernetes-tmpfiles.conf
@@ -1,0 +1,8 @@
+d /etc/kubernetes/static-pods - - - -
+L /etc/kubernetes/manifests - - - - static-pods
+L /etc/kubernetes/secrets-store-csi-providers  - - - - /var/lib/kubelet/providers/secrets-store
+r! /var/lib/kubelet/cpu_manager_state
+L /etc/kubernetes/node-feature-discovery/features.d - - - - /var/lib/kubelet/node-feature-discovery/features.d
+d /opt/csi/mountpoint-s3 - - - -
+L+ /opt/mountpoint-s3-csi - - - - /opt/csi/mountpoint-s3
+d /etc/kubernetes/kubelet/config.d - - - -

--- a/packages/kubernetes-1.37/logdog.kubelet.conf
+++ b/packages/kubernetes-1.37/logdog.kubelet.conf
@@ -1,0 +1,3 @@
+exec kube-status systemctl status kube* -l --no-pager
+file ipamd.log /var/log/aws-routed-eni/ipamd.log
+file plugin.log /var/log/aws-routed-eni/plugin.log

--- a/packages/kubernetes-1.37/make-kubelet-dirs.conf
+++ b/packages/kubernetes-1.37/make-kubelet-dirs.conf
@@ -1,0 +1,5 @@
+[Service]
+# Create the backing directories for symlinks in /etc
+ExecStartPre=/usr/bin/mkdir -p \
+    /var/lib/kubelet/providers/secrets-store \
+    /var/lib/kubelet/node-feature-discovery/features.d

--- a/packages/kubernetes-1.37/multi-user-uphold-kubelet.conf
+++ b/packages/kubernetes-1.37/multi-user-uphold-kubelet.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=kubelet.service

--- a/packages/kubernetes-1.37/pause-config.json
+++ b/packages/kubernetes-1.37/pause-config.json
@@ -1,0 +1,1 @@
+{"author":"Bottlerocket","config":{"Cmd":["/pause"],"ArgsEscaped":true},"created":"2014-12-12T01:12:53.332832423Z","history":[{"created":"2014-12-12T01:12:53.332832423Z","author":"Bottlerocket","created_by":"Bottlerocket","empty_layer":true}],"os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:~~digest~~"]}}

--- a/packages/kubernetes-1.37/pause-manifest.json
+++ b/packages/kubernetes-1.37/pause-manifest.json
@@ -1,0 +1,1 @@
+[{"Config":"config.json","RepoTags":["localhost/kubernetes/pause:0.1.0"],"Layers":["rootfs/layer.tar"]}]

--- a/packages/kubernetes-1.37/pod-infra-container-image
+++ b/packages/kubernetes-1.37/pod-infra-container-image
@@ -1,0 +1,6 @@
+[required-extensions]
+kubernetes = { version = "v1", optional = true }
++++
+{{~#if settings.kubernetes.pod-infra-container-image~}}
+DEPRECATED_SETTING=settings.kubernetes.pod-infra-container-image
+{{~/if~}}

--- a/packages/kubernetes-1.37/prepare-var-lib-kubelet.service
+++ b/packages/kubernetes-1.37/prepare-var-lib-kubelet.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Prepare Kubelet Directory (/var/lib/kubelet)
+DefaultDependencies=no
+RequiresMountsFor=/var
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+
+# Remove an existing symlink, if present. Intentionally not recursive!
+ExecStartPre=-/usr/bin/rm -f /var/lib/kubelet
+
+# Create /var/lib/kubelet so it is available for bind mounts.
+ExecStart=/usr/bin/mkdir -p /var/lib/kubelet
+
+# Suppress warning if directory exists.
+StandardError=null
+
+RemainAfterExit=true
+
+[Install]
+WantedBy=local-fs.target

--- a/packages/kubernetes-1.37/prestart-load-pause-ctr.conf
+++ b/packages/kubernetes-1.37/prestart-load-pause-ctr.conf
@@ -1,0 +1,19 @@
+[Service]
+Environment=ACTIVE_SNAPSHOTTER=overlayfs
+EnvironmentFile=-/var/cache/containerd/active-snapshotter
+
+# load the built-in pause image
+ExecStartPre=/usr/bin/ctr \
+    --namespace=k8s.io \
+    image import \
+    --snapshotter=${ACTIVE_SNAPSHOTTER} \
+    --local \
+    --all-platforms \
+    /usr/libexec/kubernetes/kubernetes-pause.tar
+
+# label it to prevent it from being removed
+ExecStartPre=/usr/bin/ctr \
+    --namespace=k8s.io \
+    image label \
+    localhost/kubernetes/pause:0.1.0 \
+    io.cri-containerd.pinned=pinned

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1543,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-model-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "darling",
  "quote",
@@ -1552,8 +1552,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-modeled-types"
-version = "0.17.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+version = "0.18.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "base64",
  "bottlerocket-model-derive",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "serde",
  "serde_plain",
@@ -1598,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-scalar-derive"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-scalar",
  "darling",
@@ -1622,8 +1622,8 @@ dependencies = [
 
 [[package]]
 name = "bottlerocket-settings-models"
-version = "0.25.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+version = "0.27.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -1676,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-settings-sdk"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "argh",
  "bottlerocket-template-helper",
@@ -1689,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-string-impls-for"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "serde",
 ]
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "bottlerocket-template-helper"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5668,7 +5668,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-autoscaling"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5681,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-aws"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5694,7 +5694,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-commands"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5708,7 +5708,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-bootstrap-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5721,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-cloudformation"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5734,7 +5734,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-registry"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5747,7 +5747,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5760,7 +5760,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-container-runtime-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-dns"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5789,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ecs"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-host-containers"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5815,7 +5815,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-image-verifier-plugins"
 version = "0.2.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5827,8 +5827,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kernel"
-version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+version = "0.2.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5841,7 +5841,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-kubelet-device-plugins"
 version = "0.4.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5853,8 +5853,8 @@ dependencies = [
 
 [[package]]
 name = "settings-extension-kubernetes"
-version = "0.10.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+version = "0.11.0"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5868,7 +5868,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-measurement"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5882,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-metrics"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5895,7 +5895,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-motd"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-settings-sdk",
  "bottlerocket-string-impls-for",
@@ -5908,7 +5908,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-network"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5921,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-ntp"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5934,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-nvidia-container-runtime"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5947,7 +5947,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-defaults"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5961,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-oci-hooks"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5974,7 +5974,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-pki"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",
@@ -5987,7 +5987,7 @@ dependencies = [
 [[package]]
 name = "settings-extension-updates"
 version = "0.1.0"
-source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.25.0#797f2d460eb32b204f7aa1b72be38f6106edb9c4"
+source = "git+https://github.com/bottlerocket-os/bottlerocket-settings-sdk?tag=bottlerocket-settings-models-v0.27.0#9b41692ad51fb822e1c9a51ddbdc3354fa01be10"
 dependencies = [
  "bottlerocket-model-derive",
  "bottlerocket-modeled-types",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -234,13 +234,13 @@ base64 = "0.22"
 
 [workspace.dependencies.bottlerocket-modeled-types]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.25.0"
-version = "0.17.0"
+tag = "bottlerocket-settings-models-v0.27.0"
+version = "0.18.0"
 
 [workspace.dependencies.bottlerocket-settings-models]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.25.0"
-version = "0.25.0"
+tag = "bottlerocket-settings-models-v0.27.0"
+version = "0.27.0"
 
 [workspace.dependencies.bottlerocket-settings-plugin]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
@@ -249,7 +249,7 @@ version = "0.1.0"
 
 [workspace.dependencies.settings-extension-oci-defaults]
 git = "https://github.com/bottlerocket-os/bottlerocket-settings-sdk"
-tag = "bottlerocket-settings-models-v0.25.0"
+tag = "bottlerocket-settings-models-v0.27.0"
 version = "0.1.0"
 
 [profile.release]


### PR DESCRIPTION
**Issue number:**

Related https://github.com/bottlerocket-os/bottlerocket/issues/4915

**Description of changes:**

Add initial Kubernetes 1.37 support:

- Add the `kubernetes-1.37` package using EKS-D `v1.37.0` GA sources.
- Add `ecr-credential-provider-1.37` using `cloud-provider-aws` `v1.37.0`.
- Update `packages/kubernetes-1.37/kubelet-exec-start-conf` to remove the upstream-removed kubelet `--containerd` flag; runtime configuration continues through `--container-runtime-endpoint`.
- Render the optional Kubernetes [MemoryQoS settings (KEP-2570)](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2570-memory-qos/README.md) in the kubelet configuration.

The containerd 2.3 package is tracked separately in #1023.

The MemoryQoS templates depend on [bottlerocket-settings-sdk#147](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/147). After that PR is merged and a new `bottlerocket-settings-models` release is published, this PR will be updated to consume the released settings model before merge. The temporary local settings SDK source pin used to build the test AMI is intentionally not included here.

**Testing done:**

Kubernetes 1.37 RC candidate testing covered:

| Area | Coverage | Result |
|---|---|---|
| Core-kit and AMI builds | x86_64 and aarch64; standard, FIPS, NVIDIA, and NVIDIA FIPS variants | PASS |
| Kubernetes conformance | 8/8 variant/architecture combinations; 463/463 conformance specs per combination | PASS |
| ECR credential provider | Packaged v1 provider on standard and FIPS, x86_64 and aarch64; private ECR image pulls on x86_64 | PASS |
| Storage | EBS CSI filesystem and raw-block provisioning, SELinux labeling, reboot/remount, and data persistence | PASS |
| NVIDIA and DRA | Physical GPU allocation, CDI injection, restart/reboot recovery, FIPS, and aarch64 coverage | PASS |
| Targeted node features | MemoryQoS, Pod-level resources and resource managers, CRI stats, kubelet metrics, certificates, trust bundles, storage recovery, EnvFiles, and hostname override | PASS |
| VMware hybrid nodes | Standard and FIPS variants using IAM Roles Anywhere and SSM credentials | PASS, 4/4 |

Focused MemoryQoS validation is documented in [bottlerocket-settings-sdk#147](https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/147). Verified Bottlerocket API values, kubelet configuration rendering, cgroup v2 memory protection, and throttling under bounded memory pressure.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
