### PR TITLE
twoliter: bump sdk to v0.79.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -4,7 +4,7 @@ project-vendor = "Bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.78.0"
+version = "0.79.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.78.0"
-digest = "6dm8z91Cwe5BgAudM4XlkWPaF88bspeLBrjZ38VhKUs="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.79.0"
+digest = "B/dAUOA5VWlAWwbti5D/Q577BaupO87OqlcmQXiHvew="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,5 +7,5 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.78.0"
+version = "0.79.0"
 vendor = "bottlerocket"

--- a/sources/api/apiserver/src/bin/apiserver.rs
+++ b/sources/api/apiserver/src/bin/apiserver.rs
@@ -154,7 +154,7 @@ async fn run() -> Result<()> {
     };
     info!(
         "Starting server at {} with {} thread{} and datastore at {}",
-        &args.socket_path, threads, threads_suffix, &args.datastore_path,
+        args.socket_path, threads, threads_suffix, args.datastore_path,
     );
 
     serve(

--- a/sources/api/apiserver/src/server/controller.rs
+++ b/sources/api/apiserver/src/server/controller.rs
@@ -391,7 +391,7 @@ where
         let item_data = datastore
             .get_prefix(&item_prefix, committed)
             .with_context(|_| error::DataStoreSnafu {
-                op: format!("get_prefix '{}' for {:?}", &item_prefix, committed),
+                op: format!("get_prefix '{}' for {:?}", item_prefix, committed),
             })?;
 
         ensure!(
@@ -498,7 +498,7 @@ pub(crate) fn get_metadata_for_data_keys<D: DataStore, S: AsRef<str>>(
 // key is always before its successors.
 fn sort_metadata(metadata: HashMap<Key, HashMap<Key, String>>) -> Vec<(Key, HashMap<Key, String>)> {
     let mut metadata_sorted: Vec<_> = metadata.into_iter().collect();
-    metadata_sorted.sort_by(|(k1, _), (k2, _)| k1.segments().len().cmp(&k2.segments().len()));
+    metadata_sorted.sort_by_key(|(k1, _)| k1.segments().len());
     metadata_sorted.to_vec()
 }
 

--- a/sources/api/bootstrap-containers/src/main.rs
+++ b/sources/api/bootstrap-containers/src/main.rs
@@ -518,7 +518,7 @@ where
         // Continue to handle other bootstrap containers if we fail one
         if let Err(e) = handle_bootstrap_container(name, container_details) {
             failed += 1;
-            error!("Failed to handle bootstrap container '{}': {}", &name, e);
+            error!("Failed to handle bootstrap container '{}': {}", name, e);
         }
     }
 

--- a/sources/api/datastore/src/deserialization/pairs.rs
+++ b/sources/api/datastore/src/deserialization/pairs.rs
@@ -285,18 +285,18 @@ where
                     return None;
                 }
             };
-            trace!("Visiting key '{}', struct name '{}'", key, &struct_name);
+            trace!("Visiting key '{}', struct name '{}'", key, struct_name);
 
             // At the top level (None path) we start with struct_name as Key, otherwise append
             // struct_name.
-            trace!("Old path: {:?}", &self.path);
+            trace!("Old path: {:?}", self.path);
             let path = match self.path {
                 None => match Key::from_segments(KeyType::Data, &[&struct_name]) {
                     Ok(key) => key,
                     Err(e) => {
                         error!(
                             "Tried to construct invalid key from struct name '{}', skipping: {}",
-                            &struct_name, e
+                            struct_name, e
                         );
                         return None;
                     }
@@ -306,18 +306,18 @@ where
                     Err(e) => {
                         error!(
                             "Appending '{}' to existing key '{}' resulted in invalid key, skipping: {}",
-                            old_path, &struct_name, e
+                            old_path, struct_name, e
                         );
                         return None;
                     }
                 }
             };
-            trace!("New path: {}", &path);
+            trace!("New path: {}", path);
 
             if !segments.is_empty() {
                 if structs_done.contains(&struct_name) {
                     // We've handled this structure with a recursive call, so we're done.
-                    trace!("Already handled struct '{}', skipping", &struct_name);
+                    trace!("Already handled struct '{}', skipping", struct_name);
                     None
                 } else {
                     // Otherwise, mark it, and recurse.
@@ -332,13 +332,13 @@ where
                         // Remove the prefix - should always work, but log and skip the key otherwise
                         .filter_map(|new_key| new_key
                                     .strip_prefix(&struct_name)
-                                    .map_err(|e| error!("Key starting with segment '{}' couldn't remove it as prefix: {}", &struct_name, e)).ok())
+                                    .map_err(|e| error!("Key starting with segment '{}' couldn't remove it as prefix: {}", struct_name, e)).ok())
                         .collect();
 
                     // And here's what MapDeserializer expects, the key and deserializer for it
                     trace!(
                         "Recursing for struct '{}' with keys: {:?}",
-                        &struct_name,
+                        struct_name,
                         keys
                     );
                     Some((

--- a/sources/api/datastore/src/filesystem.rs
+++ b/sources/api/datastore/src/filesystem.rs
@@ -563,7 +563,7 @@ impl DataStore for FilesystemDataStore {
 
         // Pull out just the keys so we can log them and return them
         let pending_keys = pending_data.into_keys().collect();
-        debug!("Found pending keys: {:?}", &pending_keys);
+        debug!("Found pending keys: {:?}", pending_keys);
 
         // Delete pending from the filesystem, same as a commit
         let path = self.base_path(&pending);

--- a/sources/api/datastore/src/lib.rs
+++ b/sources/api/datastore/src/lib.rs
@@ -258,7 +258,7 @@ pub trait DataStore {
                 trace!(
                     "Pulling metadata '{}' from datastore for key: {}",
                     meta_key,
-                    &data_key
+                    data_key
                 );
                 let value = self
                     .get_metadata(&meta_key, &data_key, committed)?

--- a/sources/api/datastore/src/serialization/pairs.rs
+++ b/sources/api/datastore/src/serialization/pairs.rs
@@ -349,7 +349,7 @@ impl ser::SerializeMap for Serializer<'_> {
         // meaning it's in quoted form.
         let key = Key::new(KeyType::Data, &key_str).map_err(|e| {
             error::InvalidKeySnafu {
-                msg: format!("serialized map key '{}' not valid as Key: {}", &key_str, e),
+                msg: format!("serialized map key '{}' not valid as Key: {}", key_str, e),
             }
             .into_error(NoSource)
         })?;
@@ -408,7 +408,7 @@ impl ser::SerializeStruct for Serializer<'_> {
             "Recursively serializing struct with new root '{}' from prefix '{:?}' and key '{}'",
             new_root,
             self.prefix,
-            &key
+            key
         );
         value.serialize(Serializer::new(self.output, Some(new_root)))
     }

--- a/sources/api/host-containers/src/main.rs
+++ b/sources/api/host-containers/src/main.rs
@@ -480,7 +480,7 @@ fn run() -> Result<()> {
         if is_container_affected(&changed_settings, name.as_ref()) {
             if let Err(e) = handle_host_container(name, image_details) {
                 failed += 1;
-                error!("Failed to handle host container '{}': {}", &name, e);
+                error!("Failed to handle host container '{}': {}", name, e);
             }
         }
     }

--- a/sources/api/schnauzer/src/helpers/mod.rs
+++ b/sources/api/schnauzer/src/helpers/mod.rs
@@ -384,7 +384,7 @@ pub fn join_node_taints(
 ) -> Result<(), RenderError> {
     trace!("Starting join_node_taints helper");
     let template_name = template_name(renderctx);
-    trace!("Template name: {}", &template_name);
+    trace!("Template name: {}", template_name);
 
     trace!("Number of params: {}", helper.params().len());
     check_param_count(helper, template_name, 1)?;
@@ -854,7 +854,7 @@ pub fn kube_reserve_memory(
 ) -> Result<(), RenderError> {
     trace!("Starting kube_reserve_memory helper");
     let template_name = template_name(renderctx);
-    trace!("Template name: {}", &template_name);
+    trace!("Template name: {}", template_name);
 
     trace!("Number of params: {}", helper.params().len());
     check_param_count(helper, template_name, 2)?;
@@ -921,7 +921,7 @@ pub fn kube_reserve_cpu(
 ) -> Result<(), RenderError> {
     trace!("Starting kube_reserve_cpu helper");
     let template_name = template_name(renderctx);
-    trace!("Template name: {}", &template_name);
+    trace!("Template name: {}", template_name);
 
     trace!("Number of params: {}", helper.params().len());
     check_param_count(helper, template_name, 1)?;
@@ -973,7 +973,7 @@ pub fn localhost_aliases(
     // To give context to our errors, get the template name, if available.
     trace!("Starting localhost_aliases helper");
     let template_name = template_name(renderctx);
-    trace!("Template name: {}", &template_name);
+    trace!("Template name: {}", template_name);
 
     // Check number of parameters, must be exactly three (IP version, hostname, hosts overrides)
     trace!("Number of params: {}", helper.params().len());
@@ -1091,7 +1091,7 @@ pub fn etc_hosts_entries(
     // To give context to our errors, get the template name, if available.
     trace!("Starting etc_hosts_entries helper");
     let template_name = template_name(renderctx);
-    trace!("Template name: {}", &template_name);
+    trace!("Template name: {}", template_name);
 
     // Check number of parameters, must be exactly one (hosts overrides)
     trace!("Number of params: {}", helper.params().len());
@@ -1156,7 +1156,7 @@ pub fn ecs_metadata_service_limits(
     // To give context to our errors, get the template name, if available.
     trace!("Starting ecs_metadata_service_limits helper");
     let template_name = template_name(renderctx);
-    trace!("Template name: {}", &template_name);
+    trace!("Template name: {}", template_name);
 
     // Check number of parameters, must be exactly two (metadata_service_rps and
     // metadata_service_burst)
@@ -1337,7 +1337,7 @@ pub fn oci_defaults(
     // To give context to our errors, get the template name (e.g. what file we are rendering), if available.
     debug!("Starting oci_defaults helper");
     let template_name = template_name(renderctx);
-    debug!("Template name: {}", &template_name);
+    debug!("Template name: {}", template_name);
 
     // Check number of parameters, must be exactly two (OCI spec section to render and settings values for the section)
     debug!("Number of params: {}", helper.params().len());

--- a/sources/api/schnauzer/src/helpers/stdlib/mod.rs
+++ b/sources/api/schnauzer/src/helpers/stdlib/mod.rs
@@ -175,7 +175,7 @@ pub fn base64_decode(
     // To give context to our errors, get the template name, if available.
     trace!("Starting base64_decode helper");
     let template_name = template_name(renderctx);
-    trace!("Template name: {}", &template_name);
+    trace!("Template name: {}", template_name);
 
     // Check number of parameters, must be exactly one
     trace!("Number of params: {}", helper.params().len());
@@ -298,7 +298,7 @@ pub fn join_map(
 ) -> Result<(), RenderError> {
     trace!("Starting join_map helper");
     let template_name = template_name(renderctx);
-    trace!("Template name: {}", &template_name);
+    trace!("Template name: {}", template_name);
 
     trace!("Number of params: {}", helper.params().len());
     check_param_count(helper, template_name, 4)?;
@@ -523,7 +523,7 @@ pub fn default(
 ) -> Result<(), RenderError> {
     trace!("Starting default helper");
     let template_name = template_name(renderctx);
-    trace!("Template name: {}", &template_name);
+    trace!("Template name: {}", template_name);
 
     trace!("Number of params: {}", helper.params().len());
     check_param_count(helper, template_name, 2)?;
@@ -685,7 +685,7 @@ impl HelperDef for IfNotNullHelper {
     ) -> Result<(), RenderError> {
         trace!("Starting if_not_null helper");
         let template_name = template_name(renderctx);
-        trace!("Template name: {}", &template_name);
+        trace!("Template name: {}", template_name);
 
         trace!("Number of params: {}", helper.params().len());
         check_param_count(helper, template_name, 1)?;
@@ -1033,7 +1033,7 @@ pub fn negate_or_else(
     // To give context to our errors, get the template name, if available.
     trace!("Starting negate_or_else helper");
     let template_name = template_name(renderctx);
-    trace!("Template name: {}", &template_name);
+    trace!("Template name: {}", template_name);
 
     // Check number of parameters, must be exactly two (the value to negate and the default value)
     trace!("Number of params: {}", helper.params().len());

--- a/sources/api/settings-committer/src/main.rs
+++ b/sources/api/settings-committer/src/main.rs
@@ -77,7 +77,7 @@ async fn check_pending_settings<S: AsRef<str>>(socket_path: S, transaction: &str
         serde_json::from_str(&response_body);
     match pending_result {
         Ok(pending) => {
-            debug!("Pending settings for tx {}: {:?}", transaction, &pending);
+            debug!("Pending settings for tx {}: {:?}", transaction, pending);
         }
         Err(err) => {
             warn!("Failed to parse response from {uri}: {err}");

--- a/sources/api/shibaken/src/admin_userdata.rs
+++ b/sources/api/shibaken/src/admin_userdata.rs
@@ -22,7 +22,7 @@ impl GenerateAdminUserdata {
         // Serialize user_data to a JSON string that can be read by the admin container.
         let user_data_json =
             serde_json::to_string(&user_data).context(error::SerializeJsonSnafu)?;
-        log::debug!("{}", &user_data_json);
+        log::debug!("{}", user_data_json);
 
         log::info!("Encoding user-data");
         // admin container user-data must be base64-encoded to be passed through to the admin container

--- a/sources/api/shibaken/src/warmpool/autoscaling_warm_pool.rs
+++ b/sources/api/shibaken/src/warmpool/autoscaling_warm_pool.rs
@@ -32,7 +32,7 @@ impl WarmPoolWait {
 
         fs::write(&marker_file_path, "").unwrap_or_else(|e| {
             log::warn!("Failed to create marker file '{}', warm-pool-wait service may unexpectedly run again: '{}'",
-            &marker_file_path, e);
+            marker_file_path, e);
         });
         println!("Marker file path is {marker_file_path}");
 

--- a/sources/api/storewolf/src/main.rs
+++ b/sources/api/storewolf/src/main.rs
@@ -181,14 +181,14 @@ fn parse_metadata_toml(md_toml_val: toml::Value) -> Result<Vec<model::Metadata>>
     let mut to_process = vec![(Vec::new(), md_toml_val)];
 
     while let Some((mut path, toml_value)) = to_process.pop() {
-        trace!("Current metadata table path: {:#?}", &path);
+        trace!("Current metadata table path: {:#?}", path);
 
         match toml_value {
             // A table means there is more processing to do. Add the current
             // key and value to the Vec to be processed further.
             toml::Value::Table(table) => {
                 for (key, val) in table {
-                    trace!("Found table for key '{}'", &key);
+                    trace!("Found table for key '{}'", key);
                     let mut path = path.clone();
                     if key == "setting-generator" {
                         match val {
@@ -203,8 +203,8 @@ fn parse_metadata_toml(md_toml_val: toml::Value) -> Result<Vec<model::Metadata>>
 
                                 trace!(
                                     "Found metadata key '{}' for data key '{}'",
-                                    &md_key,
-                                    &data_key
+                                    md_key,
+                                    data_key
                                 );
 
                                 // Ensure the metadata/data keys don't contain newline chars
@@ -245,8 +245,8 @@ fn parse_metadata_toml(md_toml_val: toml::Value) -> Result<Vec<model::Metadata>>
 
                 trace!(
                     "Found metadata key '{}' for data key '{}'",
-                    &md_key,
-                    &data_key
+                    md_key,
+                    data_key
                 );
 
                 // Ensure the metadata/data keys don't contain newline chars
@@ -297,7 +297,7 @@ fn populate_default_datastore<P: AsRef<Path>>(
             .list_populated_keys("", &Committed::Live)
             .context(error::QueryDataSnafu)?;
     } else {
-        info!("Creating datastore at: {}", &live_path.display());
+        info!("Creating datastore at: {}", live_path.display());
         create_new_datastore(&base_path, version).context(error::DatastoreCreationSnafu)?;
     }
 
@@ -345,7 +345,7 @@ fn populate_default_datastore<P: AsRef<Path>>(
 
         trace!(
             "Writing other default data to datastore: {:#?}",
-            &other_defaults_to_write
+            other_defaults_to_write
         );
         datastore
             .set_keys(&other_defaults_to_write, &datastore::Committed::Live)
@@ -392,7 +392,7 @@ fn populate_default_data(
 
         trace!(
             "Writing default settings to datastore: {:#?}",
-            &settings_to_write
+            settings_to_write
         );
         let pending = datastore::Committed::Pending {
             tx: constants::LAUNCH_TRANSACTION.to_string(),
@@ -614,14 +614,14 @@ fn run() -> Result<()> {
     }
 
     // Create the datastore if it doesn't exist
-    info!("Populating datastore at: {}", &args.data_store_base_path);
+    info!("Populating datastore at: {}", args.data_store_base_path);
     populate_default_datastore(&args.data_store_base_path, args.version)?;
     info!("Datastore populated");
 
     // Create the inventory file symlink and any necessary parent directories
     info!(
         "Creating inventory file symlink at: {}",
-        &args.inventory_symlink_path
+        args.inventory_symlink_path
     );
     create_inventory_symlink(&args.inventory_file_path, &args.inventory_symlink_path)?;
     info!("Inventory symlink created");

--- a/sources/api/sundog/src/main.rs
+++ b/sources/api/sundog/src/main.rs
@@ -193,7 +193,7 @@ where
     let generators: HashMap<String, SettingsGenerator> = serde_json::from_str(&response_body)
         .context(error::ResponseJsonSnafu { method: "GET", uri })?;
 
-    trace!("Generators: {:?}", &generators);
+    trace!("Generators: {:?}", generators);
 
     Ok(generators)
 }
@@ -231,7 +231,7 @@ where
         populated_settings.insert(k);
     }
 
-    trace!("Found populated settings: {:#?}", &populated_settings);
+    trace!("Found populated settings: {:#?}", populated_settings);
     Ok(populated_settings)
 }
 
@@ -349,7 +349,7 @@ where
             continue;
         }
 
-        debug!("Running generator: '{}'", &generator);
+        debug!("Running generator: '{}'", generator);
 
         // Split on space, assume the first item is the command
         // and the rest are args.
@@ -431,7 +431,7 @@ where
             })?
             .trim()
             .to_string();
-        trace!("Generator '{}' output: {}", &generator, &output_raw);
+        trace!("Generator '{}' output: {}", generator, output_raw);
 
         // Next, we deserialize the text into a Value that can represent any JSON type.
         let output_value: serde_json::Value =
@@ -449,7 +449,7 @@ where
             datastore::serialize_scalar(&output_value).context(error::SerializeScalarSnafu {
                 value: output_value,
             })?;
-        trace!("Serialized output: {}", &serialized_output);
+        trace!("Serialized output: {}", serialized_output);
 
         // Add the setting to the appropriate map
         if generator_object.strength == Strength::Strong {
@@ -489,7 +489,7 @@ where
         strength
     );
     let method = "PATCH";
-    trace!("Settings to {} to {}: {}", method, uri, &request_body);
+    trace!("Settings to {} to {}: {}", method, uri, request_body);
     let (code, response_body) =
         apiclient::raw_request(socket_path.as_ref(), uri, method, Some(request_body))
             .await

--- a/sources/api/thar-be-registries/src/host_ns.rs
+++ b/sources/api/thar-be-registries/src/host_ns.rs
@@ -32,7 +32,7 @@ impl Endpoint {
         }
 
         // Parse bare hostname with https:// prefix (handles registry:5000/v2/path)
-        if let Ok(url) = Url::parse(&format!("https://{}", &self.0)) {
+        if let Ok(url) = Url::parse(&format!("https://{}", self.0)) {
             if let Some(_host) = url.host_str() {
                 return !url.path().is_empty() && url.path() != "/";
             }

--- a/sources/api/thar-be-registries/src/main.rs
+++ b/sources/api/thar-be-registries/src/main.rs
@@ -136,7 +136,7 @@ fn write_hosts_toml(base_dir: &Path, mirror: &Mirror) -> Result<()> {
     let server = match host.as_str() {
         "*" => None,
         DOCKER_HUB_HOST => Some(format!("https://{}", DOCKER_HUB_REGISTRY)),
-        _ => Some(format!("{}://{}", &scheme, host)),
+        _ => Some(format!("{}://{}", scheme, host)),
     };
 
     let mut ns = HostNamespace {

--- a/sources/api/thar-be-settings/src/config.rs
+++ b/sources/api/thar-be-settings/src/config.rs
@@ -64,11 +64,11 @@ pub async fn render_config_files(
         if !metadata.should_render() {
             info!(
                 "File {} already exists and overwrite-path-if-present=false, skipping render of config file",
-                &metadata.path,
+                metadata.path,
             );
             continue;
         }
-        debug!("Rendering {}", &name);
+        debug!("Rendering {}", name);
 
         let try_rendered =
             schnauzer::render_template_file(template_importer, &metadata.template_path.as_ref())
@@ -88,18 +88,18 @@ pub async fn render_config_files(
                     rendered,
                     &metadata.mode,
                 )),
-                Err(err) => warn!("Unable to render template '{}': {}", &name, err),
+                Err(err) => warn!("Unable to render template '{}': {}", name, err),
             }
         }
     }
-    trace!("Rendered configs: {:?}", &rendered_configs);
+    trace!("Rendered configs: {:?}", rendered_configs);
     Ok(rendered_configs)
 }
 
 /// Write all the configuration files to disk
 pub fn write_config_files(rendered_configs: &[RenderedConfigFile]) -> Result<()> {
     for cfg in rendered_configs {
-        debug!("Writing {:?}", &cfg.path);
+        debug!("Writing {:?}", cfg.path);
         cfg.write_to_disk()?;
     }
     Ok(())
@@ -113,8 +113,8 @@ pub fn reload_config_files(rendered_configs: &[RenderedConfigFile]) -> Result<()
     {
         let mut args = SYSTEMCTL_DAEMON_RELOAD.split(' ');
         let program = args.next().expect("failed to split on space");
-        trace!("Command: {}", &program);
-        trace!("Args: {:?}", &args);
+        trace!("Command: {}", program);
+        trace!("Args: {:?}", args);
 
         let result = Command::new(program).args(args).output().context(
             error::CommandExecutionFailureSnafu {

--- a/sources/api/thar-be-settings/src/lib.rs
+++ b/sources/api/thar-be-settings/src/lib.rs
@@ -34,7 +34,7 @@ pub fn get_changed_settings() -> Result<HashSet<String>> {
     io::stdin()
         .read_to_string(&mut input)
         .context(error::ReadInputSnafu { from: "stdin" })?;
-    trace!("Raw input from stdin: {}", &input);
+    trace!("Raw input from stdin: {}", input);
 
     // Settings should be a vec of strings
     debug!("Parsing stdin as JSON");
@@ -43,7 +43,7 @@ pub fn get_changed_settings() -> Result<HashSet<String>> {
             reason: "Input must be a JSON array of strings",
             input,
         })?;
-    trace!("Parsed input: {:?}", &changed_settings);
+    trace!("Parsed input: {:?}", changed_settings);
 
     Ok(changed_settings)
 }

--- a/sources/api/thar-be-settings/src/main.rs
+++ b/sources/api/thar-be-settings/src/main.rs
@@ -164,7 +164,7 @@ async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             // Create a HashSet of affected services
             info!(
                 "Requesting affected services for settings: {:?}",
-                &changed_settings
+                changed_settings
             );
             let services =
                 service::get_affected_services(&args.socket_path, Some(changed_settings)).await?;

--- a/sources/api/thar-be-settings/src/service.rs
+++ b/sources/api/thar-be-settings/src/service.rs
@@ -105,7 +105,7 @@ where
         schnauzer::v1::get_json(socket_path, uri, Some(query))
             .await
             .context(error::GetJsonSnafu { uri })?;
-    trace!("API response: {:?}", &setting_to_services_map);
+    trace!("API response: {:?}", setting_to_services_map);
 
     Ok(setting_to_services_map)
 }
@@ -128,7 +128,7 @@ where
     let service_map: model::Services = schnauzer::v1::get_json(socket_path, uri, query)
         .await
         .context(error::GetJsonSnafu { uri })?;
-    trace!("Service metadata: {:?}", &service_map);
+    trace!("Service metadata: {:?}", service_map);
 
     Ok(service_map)
 }
@@ -156,15 +156,15 @@ impl ServiceRestart for Service {
         for restart_command in restart_commands {
             // Split on space, assume the first item is the command
             // and the rest are args.
-            debug!("Restart command: {:?}", &restart_command);
+            debug!("Restart command: {:?}", restart_command);
             let mut command_strings = restart_command.split(' ');
             let command = command_strings
                 .next()
                 .context(error::InvalidRestartCommandSnafu {
                     command: restart_command.as_str(),
                 })?;
-            trace!("Command: {}", &command);
-            trace!("Args: {:?}", &command_strings);
+            trace!("Command: {}", command);
+            trace!("Args: {:?}", command_strings);
 
             // Go execute the restart command
             let mut process_command = Command::new(command);

--- a/sources/early-boot-config/early-boot-config/src/main.rs
+++ b/sources/early-boot-config/early-boot-config/src/main.rs
@@ -220,10 +220,10 @@ async fn run() -> Result<()> {
             })?
             .trim()
             .to_string();
-        trace!("Provider '{}' output: {}", &provider.display(), &output_raw);
+        trace!("Provider '{}' output: {}", provider.display(), output_raw);
 
         if output_raw.is_empty() {
-            info!("No user data found via {}", &provider.display());
+            info!("No user data found via {}", provider.display());
             continue;
         }
 

--- a/sources/imdsclient/src/lib.rs
+++ b/sources/imdsclient/src/lib.rs
@@ -189,7 +189,7 @@ impl ImdsClient {
         // Returns a list of available public keys as '0=my-public-key'.
         let public_key_list = match self.fetch_string("meta-data/public-keys").await? {
             Some(public_key_list) => {
-                debug!("available public keys '{}'", &public_key_list);
+                debug!("available public keys '{}'", public_key_list);
                 public_key_list
             }
             None => {
@@ -198,7 +198,7 @@ impl ImdsClient {
             }
         };
 
-        debug!("available public keys '{}'", &public_key_list);
+        debug!("available public keys '{}'", public_key_list);
         info!("Generating targets to fetch text of available public keys");
         let public_key_targets = build_public_key_targets(&public_key_list);
 
@@ -209,7 +209,7 @@ impl ImdsClient {
             info!(
                 "Fetching public key ({}/{})",
                 target_count,
-                &public_key_targets.len()
+                public_key_targets.len()
             );
 
             let public_key_text = self
@@ -219,12 +219,12 @@ impl ImdsClient {
             let public_key = public_key_text.trim_end();
             // Simple check to see if the text is probably an ssh key.
             if public_key.starts_with("ssh") {
-                debug!("{}", &public_key);
+                debug!("{}", public_key);
                 public_keys.push(public_key.to_string())
             } else {
                 warn!(
                     "'{}' does not appear to be a valid key. Skipping...",
-                    &public_key
+                    public_key
                 );
                 continue;
             }
@@ -284,7 +284,7 @@ impl ImdsClient {
             schema_version.as_ref(),
             target.as_ref()
         );
-        debug!("Requesting {}", &uri);
+        debug!("Requesting {}", uri);
         timeout(
             self.retry_timeout,
             Retry::start(retry_strategy(), || async {
@@ -302,7 +302,7 @@ impl ImdsClient {
                         method: "GET",
                         uri: &uri,
                     })?;
-                trace!("IMDS response: {:?}", &response);
+                trace!("IMDS response: {:?}", response);
 
                 match response.status() {
                     code @ StatusCode::OK => {
@@ -428,7 +428,7 @@ fn build_public_key_targets(public_key_list: &str) -> Vec<String> {
         } else {
             warn!(
                 "'{}' does not appear to be a valid index. Skipping...",
-                &f[0]
+                f[0]
             );
             continue;
         }

--- a/sources/static-pods/src/main.rs
+++ b/sources/static-pods/src/main.rs
@@ -159,7 +159,7 @@ fn run() -> Result<()> {
             // Continue to handle other static pods if we fail one
             if let Err(e) = handle_static_pod(name, pod) {
                 failed += 1;
-                error!("Failed to handle static pod '{}': {}", &name, e);
+                error!("Failed to handle static pod '{}': {}", name, e);
             }
         }
 

--- a/sources/updater/updog/src/main.rs
+++ b/sources/updater/updog/src/main.rs
@@ -365,7 +365,7 @@ fn list_updates(
         );
     } else {
         for u in updates {
-            eprintln!("{}", &fmt_full_version(u));
+            eprintln!("{}", fmt_full_version(u));
         }
     }
     Ok(())


### PR DESCRIPTION
**Description of changes:**

Bump Bottlerocket SDK from **v0.78.0** to **v0.79.0**.

Also address `clippy` lints associated with Rust **1.97.1**.

**Testing done:**

Built both archs on both archs.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
