### PR TITLE
Prepare core-kit release v16.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v16.3.0 (2026-09-04)
+
+## OS Changes
+* Add support for plain-mode encryption with `dm-crypt` in `rottweiler` ([#1024])
+* Support `ephemeral-encryption-keys` with plain-mode encryption in `ephemeral-storage` ([#1024])
+
+[#1024]: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/1024
+
 # v16.2.0 (2026-09-03)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "16.2.0"
+release-version = "16.3.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]


### PR DESCRIPTION
**Description of changes:**
- twoliter and changelog updates for core-kit v16.3.0 release


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
